### PR TITLE
fix: CI/CD self-hosted runner setup (#30, #31, #32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI / CD
 
 # Runs tests + typecheck on every PR.
 # On push to main: also builds the Docker image, pushes it to GHCR, and
-# deploys to the mini PC over SSH.
+# deploys to the mini PC via a self-hosted runner running directly on the machine.
 #
 # Branch is 'main'. If you rename it to 'master', update the two filters below.
 on:
@@ -84,30 +84,15 @@ jobs:
             ${{ env.IMAGE }}:latest
 
   # ── 3. DEPLOY ──────────────────────────────────────────────────────────────
-  # SSHes into the mini PC and updates the running service.
+  # Runs directly on the self-hosted runner (the mini PC itself) — no SSH hop
+  # needed. The runner process on the mini PC picks up the job and executes
+  # the deploy commands locally.
   #
   # Concurrency: cancel-in-progress: false means a second push waits rather
   # than racing.  Never cancel a deploy mid-flight.
   #
   # ┌──────────────────────────────────────────────────────────────────────┐
   # │  SECRETS — add in: GitHub repo → Settings → Secrets → Actions       │
-  # │                                                                      │
-  # │  DEPLOY_HOST      IP or hostname of the mini PC                      │
-  # │                   e.g. "192.168.1.42"  or  "minipc.example.com"      │
-  # │                                                                      │
-  # │  DEPLOY_USER      SSH login name on the mini PC                      │
-  # │                   e.g. "ioachim"                                     │
-  # │                                                                      │
-  # │  DEPLOY_SSH_KEY   The *private* half of an SSH key pair.             │
-  # │                   The *public* half must be in                       │
-  # │                   ~/.ssh/authorized_keys on the mini PC.             │
-  # │                                                                      │
-  # │                   Generate a dedicated deploy key (don't reuse your  │
-  # │                   personal key):                                      │
-  # │                     ssh-keygen -t ed25519 -C deploy -f /tmp/deploy   │
-  # │                     # /tmp/deploy     → DEPLOY_SSH_KEY secret        │
-  # │                     # /tmp/deploy.pub → append to mini PC            │
-  # │                     #                  ~/.ssh/authorized_keys         │
   # │                                                                      │
   # │  GHCR_TOKEN       A GitHub Personal Access Token with the            │
   # │                   *read:packages* scope (nothing else).               │
@@ -118,43 +103,18 @@ jobs:
   # │                   SHORTCUT: if you make the GHCR package public      │
   # │                   (repo Settings → Packages → Change visibility),    │
   # │                   you can skip GHCR_TOKEN entirely and remove the    │
-  # │                   docker-login lines from the deploy script below.   │
-  # │                                                                      │
-  # │  OPTIONAL variable (Settings → Variables, not Secrets):              │
-  # │  DEPLOY_PORT      SSH port if not 22  (e.g. "2222")                 │
+  # │                   docker-login lines from the deploy step below.     │
   # └──────────────────────────────────────────────────────────────────────┘
   deploy:
     name: Deploy to mini PC
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     environment: production
     concurrency:
       group: deploy-production
       cancel-in-progress: false
 
     steps:
-      # Lay down the private key and trust the host's key.
-      # ssh-keyscan does a live fetch from DEPLOY_HOST — this requires the
-      # SSH port to be reachable from GitHub's runner IPs. If your mini PC
-      # is only on a LAN, you'll need port-forwarding or a tunnel.
-      - name: Configure SSH
-        run: |
-          install -dm700 ~/.ssh
-          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -H -p "${{ vars.DEPLOY_PORT || '22' }}" \
-            "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts
-
-      # ── Option A: Helm / Kubernetes ──────────────────────────────────────
-      # Assumes the mini PC has:
-      #   • The repo checked out at ~/news-dashboard  (git pull updates the chart)
-      #   • kubectl pointing at the local cluster
-      #   • helm installed
-      #
-      # CONFIGURE: adjust the --set flags (namespace, nodePort, hostPaths,
-      # etc.) to match your actual deployment. The deployment name below
-      # follows the Helm convention release-name + chart-name; verify yours
-      # with: kubectl -n <ns> get deploy
       - name: Deploy (Helm)
         env:
           SHA: ${{ github.sha }}
@@ -162,13 +122,6 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
         run: |
-          ssh -i ~/.ssh/id_deploy \
-              -p "${{ vars.DEPLOY_PORT || '22' }}" \
-              -o StrictHostKeyChecking=yes \
-              -o BatchMode=yes \
-              "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
-              "SHA='${SHA}' IMG='${IMG}' GHCR_TOKEN='${GHCR_TOKEN}' GHCR_ACTOR='${GHCR_ACTOR}' bash -s" \
-              << 'REMOTE'
           set -euo pipefail
 
           # Authenticate to GHCR so the cluster node can pull the image.
@@ -202,50 +155,11 @@ jobs:
             --set ingress.enabled=false
 
           # Wait for the new pods to become ready.
-          # CONFIGURE: replace the deployment name if yours differs.
           kubectl -n news-dashboard rollout status \
             deployment/news-dashboard-news-dashboard --timeout=120s
-          REMOTE
-
-      # ── Option B: docker compose (use instead of Option A) ──────────────
-      # Assumes the repo is checked out at ~/news-dashboard and
-      # docker-compose.yml has an 'image:' key (not just 'build:').
-      # The IMAGE_TAG env var must be consumed by your compose file, e.g.:
-      #   image: ghcr.io/ioachim-hub/news-dashboard:${IMAGE_TAG:-latest}
-      #
-      # To switch to this option: comment out the "Deploy (Helm)" step above
-      # and uncomment the block below.
-      #
-      # - name: Deploy (docker compose)
-      #   env:
-      #     SHA: ${{ github.sha }}
-      #     IMG: ${{ env.IMAGE }}
-      #     GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-      #     GHCR_ACTOR: ${{ github.actor }}
-      #   run: |
-      #     ssh -i ~/.ssh/id_deploy \
-      #         -p "${{ vars.DEPLOY_PORT || '22' }}" \
-      #         -o StrictHostKeyChecking=yes \
-      #         -o BatchMode=yes \
-      #         "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
-      #         "SHA='${SHA}' IMG='${IMG}' GHCR_TOKEN='${GHCR_TOKEN}' GHCR_ACTOR='${GHCR_ACTOR}' bash -s" \
-      #         << 'REMOTE'
-      #     set -euo pipefail
-      #     echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
-      #     docker pull "${IMG}:${SHA}"
-      #     cd ~/news-dashboard && git pull --ff-only
-      #     IMAGE_TAG="${SHA}" docker compose up -d --no-build
-      #     REMOTE
 
       # Basic liveness check — verifies the new container is actually serving.
-      # CONFIGURE: change the URL/port to match your setup.
-      # Remove this step if the app isn't reachable on localhost from the mini PC.
       - name: Smoke test
         run: |
-          ssh -i ~/.ssh/id_deploy \
-              -p "${{ vars.DEPLOY_PORT || '22' }}" \
-              -o StrictHostKeyChecking=yes \
-              -o BatchMode=yes \
-              "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
-              "curl -sf --max-time 10 --retry 6 --retry-delay 5 \
-                 http://localhost:30088/api/health | grep '\"status\":\"ok\"'"
+          curl -sf --max-time 10 --retry 6 --retry-delay 5 \
+            http://localhost:30088/api/health | grep '"status":"ok"'

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -1,0 +1,156 @@
+# Self-hosted GitHub Actions runner setup
+
+The CD deploy job runs on a self-hosted GitHub Actions runner installed directly
+on the mini PC (production machine). This gives the runner direct access to
+`kubectl`, `helm`, and the local Kubernetes cluster — no SSH hop from GitHub's
+cloud infrastructure is needed.
+
+## Prerequisites — tools that must be installed
+
+Install these on the mini PC **before** registering the runner.
+
+| Tool | Required version | Install command |
+|------|-----------------|-----------------|
+| Git  | any recent      | `sudo apt install git` |
+| Node.js | 22.x (matches CI) | see [NodeSource](https://github.com/nodesource/distributions) |
+| npm  | bundled with Node | — |
+| Docker | 24+ | [Docker Engine install guide](https://docs.docker.com/engine/install/) |
+| kubectl | matches cluster | [kubectl install](https://kubernetes.io/docs/tasks/tools/) |
+| helm | 3.x | [Helm install](https://helm.sh/docs/intro/install/) |
+
+Verify they are accessible to the user that will run the runner:
+
+```bash
+git --version
+node --version   # should print v22.x
+npm --version
+docker info
+kubectl get nodes
+helm version
+```
+
+## Step 1 — Register the runner
+
+1. Go to **https://github.com/ioachim-hub/news-dashboard/settings/actions/runners**
+2. Click **New self-hosted runner**
+3. Select **Linux / x64**
+4. Follow the on-screen download and configuration steps:
+
+```bash
+mkdir -p ~/actions-runner && cd ~/actions-runner
+# Download and extract the runner tarball (copy exact URL from the GitHub UI)
+curl -o actions-runner-linux-x64.tar.gz -L <URL_FROM_GITHUB_UI>
+tar xzf actions-runner-linux-x64.tar.gz
+
+# Register — use the token shown on the GitHub UI; it expires in 1 hour
+./config.sh --url https://github.com/ioachim-hub/news-dashboard \
+            --token <REGISTRATION_TOKEN_FROM_GITHUB_UI> \
+            --name ioachim-minipc \
+            --labels self-hosted
+```
+
+Accept the defaults for the work folder (`_work`).
+
+## Step 2 — Install as a systemd service
+
+Run the helper script that ships with the runner to create and enable a systemd
+unit. This ensures the runner restarts automatically on reboot.
+
+```bash
+cd ~/actions-runner
+sudo ./svc.sh install   # creates /etc/systemd/system/actions.runner.*.service
+sudo ./svc.sh start
+sudo systemctl status "actions.runner.*"
+```
+
+Check that the runner appears as **Idle** in the GitHub UI at
+`https://github.com/ioachim-hub/news-dashboard/settings/actions/runners`.
+
+To manage the service later:
+
+```bash
+sudo systemctl stop    "actions.runner.*"
+sudo systemctl start   "actions.runner.*"
+sudo systemctl restart "actions.runner.*"
+```
+
+## Step 3 — Environment variables and secrets
+
+The deploy workflow reads one GitHub Actions secret. Add it at
+**https://github.com/ioachim-hub/news-dashboard/settings/secrets/actions**:
+
+| Secret name  | Description |
+|--------------|-------------|
+| `GHCR_TOKEN` | A GitHub Personal Access Token (classic) with **`read:packages`** scope only. Used to authenticate Docker and to refresh the Kubernetes imagePullSecret on every deploy. Generate at https://github.com/settings/tokens — set a 1-year expiry and rotate when it expires. |
+
+`GITHUB_TOKEN` is provided automatically by GitHub for the test and publish jobs;
+no manual secret is needed for it.
+
+If the GHCR package is made **public** (repo Settings → Packages → Change
+visibility), `GHCR_TOKEN` is not required and the `docker login` / `kubectl
+create secret` lines in the workflow can be removed.
+
+No environment variables need to be set at the OS level for the runner user
+beyond what the tool installs already place in `PATH`. If `kubectl` or `helm`
+are not in the runner user's `PATH`, add them to `~/.profile` for that user.
+
+## Step 4 — First-time cluster check
+
+Confirm `kubectl` is pointing at the correct cluster and the namespace exists:
+
+```bash
+kubectl get nodes
+kubectl create namespace news-dashboard --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The `helm upgrade --install ... --create-namespace` flag in the workflow also
+creates the namespace automatically on first deploy.
+
+## How the full flow works after setup
+
+```
+git push origin main
+  └─ test job      (ubuntu-latest)    pytest + tsc/vite build
+  └─ publish job   (ubuntu-latest)    docker build + push to GHCR with :<sha>
+  └─ deploy job    (self-hosted)
+       ├─ docker login ghcr.io
+       ├─ docker pull <image>:<sha>
+       ├─ kubectl apply imagePullSecret
+       ├─ git pull --ff-only (sync chart changes)
+       ├─ helm upgrade --set image.tag=<sha>
+       ├─ kubectl rollout status --timeout=120s
+       └─ curl http://localhost:30088/api/health smoke test
+```
+
+The deploy job uses `concurrency: group=deploy-production, cancel-in-progress: false`
+so rapid pushes queue rather than race.
+
+## Troubleshooting
+
+**Runner shows Offline in GitHub UI**
+```bash
+sudo systemctl restart "actions.runner.*"
+journalctl -u "actions.runner.*" -n 50
+```
+
+**`kubectl` / `helm` not found during deploy**
+Add the missing binary's directory to `~/.profile` for the runner user and
+restart the runner service.
+
+**Image pull backoff in pods**
+```bash
+kubectl -n news-dashboard get secret ghcr-pull-secret
+# If missing, re-run the workflow or create it manually:
+kubectl -n news-dashboard create secret docker-registry ghcr-pull-secret \
+  --docker-server=ghcr.io \
+  --docker-username=<github-actor> \
+  --docker-password=<GHCR_TOKEN>
+```
+
+**Helm "release not found" error**
+This is harmless — `--install` creates the release on first run.
+
+**Deployment name**
+The Helm release name `news-dashboard` + chart name `news-dashboard` produces
+`news-dashboard-news-dashboard` for pods and deployments. This is expected
+(Helm double-name pattern).


### PR DESCRIPTION
## Summary

- **#30**: Switch deploy job to `runs-on: [self-hosted]` — removes the SSH hop entirely; the runner on the mini PC executes deploy commands directly (helm upgrade, kubectl rollout, smoke test via localhost)
- **#31**: Add `docs/runner-setup.md` documenting runner installation, systemd service setup, required tools (Node 22, npm, Docker, kubectl, helm, git), and the one secret needed (`GHCR_TOKEN`)
- **#32**: All action versions already at v4/v5/v6 in this repo — confirmed `actions/checkout@v4`, `actions/setup-node@v4`, `actions/setup-python@v5`, `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v6` are current

## Root cause

The previous deploy job ran on `ubuntu-latest` (GitHub cloud) and SSHed into the LAN-hosted mini PC. That connection can never complete from outside the local network. Switching to `runs-on: [self-hosted]` makes the job execute directly on the mini PC — no network traversal needed.

## Test plan

- [ ] Register a self-hosted runner on the mini PC following `docs/runner-setup.md`
- [ ] Merge this PR and push a commit to `main`
- [ ] Confirm the deploy job is picked up by the self-hosted runner (not a cloud runner)
- [ ] Confirm helm upgrade completes and smoke test passes

Closes #30
Closes #31
Closes #32