### PR TITLE
[codex] Fix card and source layout proportions

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -404,7 +404,7 @@ ul { list-style: none; }
   display: grid;
   grid-template-columns: 1fr;
   gap: 12px;
-  align-items: start;
+  align-items: stretch;
 }
 
 /* Desktop ≥768px: 2 columns */
@@ -427,14 +427,16 @@ ul { list-style: none; }
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
+  padding: 18px;
+  display: grid;
+  grid-template-rows: auto auto auto minmax(4.65em, 1fr) auto auto;
+  gap: 10px;
   box-shadow: var(--shadow-card);
   transition: box-shadow var(--t) var(--ease), border-color var(--t) var(--ease), transform var(--t) var(--ease);
-  /* Cards fill available width (grid handles it) */
   width: 100%;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
 }
 .article-card:hover {
   box-shadow: var(--shadow-hover);
@@ -448,6 +450,10 @@ ul { list-style: none; }
   justify-content: space-between;
   gap: 10px;
   min-height: 24px;
+  min-width: 0;
+}
+.article-card:has(.card-checkbox) .card-header {
+  padding-right: 30px;
 }
 .card-badges {
   min-width: 0;
@@ -464,12 +470,14 @@ ul { list-style: none; }
   color: var(--text-3);
   font-size: 11px;
   white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .card-title {
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.4;
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.35;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -482,15 +490,16 @@ ul { list-style: none; }
 .card-title a:hover { color: var(--accent); text-decoration: none; }
 
 .card-source {
-  font-size: 11px;
+  min-width: 0;
+  font-size: 12px;
   color: var(--text-3);
-  margin: -3px 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .card-summary {
+  min-width: 0;
   font-size: 13px;
   color: var(--text-2);
   line-height: 1.55;
@@ -498,19 +507,30 @@ ul { list-style: none; }
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .card-reason {
+  min-width: 0;
   font-size: 11px;
   color: var(--accent-muted);
   font-style: italic;
   line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
 }
 
 .card-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
+  min-height: 25px;
+  align-content: start;
+  overflow: hidden;
 }
 .tag {
   font-size: 11px;
@@ -525,12 +545,14 @@ ul { list-style: none; }
 .card-actions {
   display: flex;
   gap: 8px;
-  flex-wrap: wrap;
-  margin-top: 6px;
+  flex-wrap: nowrap;
+  margin-top: auto;
+  padding-top: 4px;
+  align-self: end;
 }
 .action-btn {
   flex: 1;
-  min-width: 82px;
+  min-width: 0;
   padding: 0 12px;
   min-height: 44px;
   border-radius: var(--r-md);
@@ -721,9 +743,9 @@ ul { list-style: none; }
   .sources-sheet       { display: none !important; }
 
   /* Show desktop sidebar layout */
-  .sources-desktop-layout {
+.sources-desktop-layout {
     display: flex;
-    gap: 24px;
+    gap: 20px;
     align-items: start;
   }
 
@@ -733,7 +755,7 @@ ul { list-style: none; }
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--r-lg);
-    padding: 16px;
+    padding: 12px;
     box-shadow: var(--shadow-card);
     position: sticky;
     top: 72px; /* below topbar */
@@ -779,13 +801,13 @@ ul { list-style: none; }
 .sources-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 14px;
-  align-items: start;
+  gap: 12px;
+  align-items: stretch;
 }
 
 @media (min-width: 768px) {
   .sources-grid {
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   }
 }
 
@@ -793,48 +815,55 @@ ul { list-style: none; }
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
-  padding: 16px;
+  padding: 0;
   box-shadow: var(--shadow-card);
+  overflow: hidden;
 }
 
 .source-category {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
-  color: var(--text-3);
+  color: var(--text-1);
   text-transform: uppercase;
-  letter-spacing: .07em;
-  margin-bottom: 12px;
-  padding-bottom: 10px;
+  letter-spacing: .04em;
+  padding: 12px 14px;
+  background: var(--surface-alt);
   border-bottom: 1px solid var(--border);
 }
 
 .source-list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
 }
-.source-item { display: flex; flex-direction: column; gap: 4px; }
+.source-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 3px;
+  padding: 12px 14px;
+}
+.source-item + .source-item {
+  border-top: 1px solid var(--border);
+}
 
 .source-main {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  gap: 10px;
   min-height: 0;
+  min-width: 0;
 }
 .source-main a {
+  flex: 1;
+  min-width: 0;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 650;
   color: var(--text-1);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  /* #27: ensure link has enough vertical space for tap */
-  padding: 6px 0;
-  display: block;
-  min-height: 44px;
   display: flex;
   align-items: center;
+  min-height: 24px;
 }
 .source-main a:hover { color: var(--accent); text-decoration: none; }
 
@@ -843,6 +872,7 @@ ul { list-style: none; }
   align-items: center;
   gap: 6px;
   flex-wrap: wrap;
+  min-height: 18px;
 }
 .source-checked {
   font-size: 11px;
@@ -936,7 +966,7 @@ ul { list-style: none; }
   .page { padding: 0 12px; padding-bottom: max(48px, calc(48px + env(safe-area-inset-bottom))); }
   .tabs-wrap { margin: 0 -12px; padding: 0 12px; }
   .card-actions  { gap: 6px; }
-  .action-btn    { min-width: 48px; font-size: 11px; padding: 0 8px; }
+  .action-btn    { min-width: 0; font-size: 11px; padding: 0 8px; }
 }
 
 /* ===== ISSUE #16: DARK MODE TOGGLE BUTTON ===== */


### PR DESCRIPTION
## What changed

This is a follow-up to PR #43 after visual review showed the cards and Sources tab still lacked proportion and alignment.

- Makes article cards use a predictable internal grid instead of free-flowing content.
- Stretches cards per grid row so action bars line up across a row.
- Clamps and breaks long summaries/URLs so they cannot overflow into neighbouring cards.
- Reserves header space for the selection checkbox so it no longer collides with date/read-time metadata.
- Tightens Sources into structured grouped list cards with stable source-name, badge, toggle, and metadata alignment.

## Validation

- `npm run build`
- Local Vite visual QA with temporary fixture covering long URLs, uneven card content, visible checkbox, mobile viewport, and Sources layout. Fixture removed before commit.
