### PR TITLE
Fix Sources errors, mobile layout, and Postgres SQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN npm run build
 
 FROM python:3.11-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    NEWS_DASHBOARD_DB=/data/news-dashboard.db
+    PYTHONUNBUFFERED=1
 WORKDIR /app
 RUN adduser --disabled-password --gecos '' appuser && mkdir -p /data && chown -R appuser:appuser /data
 COPY pyproject.toml ./

--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e '.[dev]'
 npm install
-NEWS_DASHBOARD_DB=./data/news-dashboard.db news-dashboard init
-NEWS_DASHBOARD_DB=./data/news-dashboard.db news-dashboard ingest
-NEWS_DASHBOARD_DB=./data/news-dashboard.db uvicorn news_dashboard.main:app --reload --app-dir backend
+docker compose up -d postgres
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+export POSTGRES_DB=news_dashboard
+export POSTGRES_USER=news_dashboard
+export POSTGRES_PASSWORD=news-dashboard-local-password
+news-dashboard init
+news-dashboard ingest
+uvicorn news_dashboard.main:app --reload --app-dir backend
 npm run dev
 ```
 
@@ -46,13 +52,13 @@ Open `http://localhost:8080`.
 
 ## Durable database
 
-The Kubernetes deployment uses PostgreSQL by default, backed by durable host storage on the local single-node cluster:
+The application uses PostgreSQL. The Kubernetes deployment provisions `postgres:16-alpine` by default, backed by durable host storage on the local single-node cluster:
 
 ```text
 /home/ioachim-minipc/news-dashboard-postgres-data
 ```
 
-SQLite remains only a local/test fallback. Existing SQLite data can be migrated with:
+SQLite is not a runtime database. Existing legacy SQLite data can be migrated into PostgreSQL with:
 
 ```bash
 news-dashboard-migrate /data/news-dashboard.db

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -1,84 +1,15 @@
 from __future__ import annotations
 
 import os
-import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator
 from urllib.parse import urlsplit, urlunsplit
 
-try:
-    import psycopg
-    from psycopg.rows import dict_row
-except ImportError:  # pragma: no cover - optional unless DATABASE_URL is PostgreSQL
-    psycopg = None  # type: ignore[assignment]
-    dict_row = None  # type: ignore[assignment]
+import psycopg
+from psycopg.rows import dict_row
 
-DB_PATH = Path(os.getenv("NEWS_DASHBOARD_DB", "/data/news-dashboard.db"))
-POSTGRES_PREFIXES = ("postgres:" + "//", "postgresql:" + "//")
-
-SQLITE_SCHEMA = """
-PRAGMA journal_mode=WAL;
-PRAGMA foreign_keys=ON;
-
-CREATE TABLE IF NOT EXISTS sources (
-  slug TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  url TEXT NOT NULL,
-  category TEXT NOT NULL,
-  kind TEXT NOT NULL,
-  priority INTEGER NOT NULL DEFAULT 50,
-  enabled INTEGER NOT NULL DEFAULT 1,
-  last_checked_at TEXT,
-  last_success_at TEXT,
-  last_error TEXT,
-  last_fetched_count INTEGER NOT NULL DEFAULT 0,
-  last_inserted_count INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS articles (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  url TEXT NOT NULL UNIQUE,
-  canonical_url TEXT NOT NULL,
-  title TEXT NOT NULL,
-  source_slug TEXT NOT NULL REFERENCES sources(slug),
-  source_name TEXT NOT NULL,
-  category TEXT NOT NULL,
-  kind TEXT NOT NULL,
-  published_at TEXT,
-  discovered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  status TEXT NOT NULL DEFAULT 'new' CHECK(status IN ('new','read','saved','skipped','archived')),
-  importance_score INTEGER NOT NULL DEFAULT 50,
-  summary TEXT NOT NULL DEFAULT '',
-  reason TEXT NOT NULL DEFAULT '',
-  tags TEXT NOT NULL DEFAULT '',
-  read_at TEXT,
-  saved_at TEXT,
-  skipped_at TEXT,
-  archived_at TEXT,
-  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE INDEX IF NOT EXISTS idx_articles_status ON articles(status);
-CREATE INDEX IF NOT EXISTS idx_articles_category ON articles(category);
-CREATE INDEX IF NOT EXISTS idx_articles_discovered ON articles(discovered_at DESC);
-CREATE INDEX IF NOT EXISTS idx_articles_source ON articles(source_slug);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
-  title, summary, reason, tags, source_name,
-  content=articles, content_rowid=id
-);
-"""
-
-# Additive columns to add when upgrading existing databases
-SQLITE_COLUMN_MIGRATIONS = [
-    ("sources", "last_success_at",     "TEXT"),
-    ("sources", "last_error",          "TEXT"),
-    ("sources", "last_fetched_count",  "INTEGER NOT NULL DEFAULT 0"),
-    ("sources", "last_inserted_count", "INTEGER NOT NULL DEFAULT 0"),
-    ("articles", "canonical_id",       "INTEGER REFERENCES articles(id)"),
-    ("articles", "embedding",          "BLOB"),
-]
+POSTGRES_PREFIXES = ("postgres://", "postgresql://")
 
 POSTGRES_SCHEMA = [
     """
@@ -121,90 +52,84 @@ POSTGRES_SCHEMA = [
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     )
     """,
-    "CREATE INDEX IF NOT EXISTS idx_articles_status ON articles(status)",
-    "CREATE INDEX IF NOT EXISTS idx_articles_category ON articles(category)",
-    "CREATE INDEX IF NOT EXISTS idx_articles_discovered ON articles(discovered_at DESC)",
-    "CREATE INDEX IF NOT EXISTS idx_articles_source ON articles(source_slug)",
-    # PostgreSQL FTS via tsvector — added as a generated column if not present
-    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS fts_vector tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(summary,'') || ' ' || coalesce(tags,''))) STORED",
-    "CREATE INDEX IF NOT EXISTS idx_articles_fts ON articles USING gin(fts_vector)",
-    # Source health columns (safe to run repeatedly)
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_success_at TEXT",
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_error TEXT",
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_fetched_count INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_inserted_count INTEGER NOT NULL DEFAULT 0",
-    # Deduplication column
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
+    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
+    """
+    ALTER TABLE articles ADD COLUMN IF NOT EXISTS fts_vector tsvector
+      GENERATED ALWAYS AS (
+        to_tsvector(
+          'english',
+          coalesce(title,'') || ' ' || coalesce(summary,'') || ' ' || coalesce(tags,'')
+        )
+      ) STORED
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_articles_status ON articles(status)",
+    "CREATE INDEX IF NOT EXISTS idx_articles_category ON articles(category)",
+    "CREATE INDEX IF NOT EXISTS idx_articles_discovered ON articles(discovered_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_articles_source ON articles(source_slug)",
+    "CREATE INDEX IF NOT EXISTS idx_articles_fts ON articles USING gin(fts_vector)",
 ]
 
+INSERT_ARTICLE_SQL = """
+    INSERT INTO articles(
+      url, canonical_url, title, source_slug, source_name, category, kind,
+      published_at, summary, reason, importance_score, tags
+    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    ON CONFLICT (url) DO NOTHING
+    """
 
-def active_database_url(database_url: str | None = None) -> str | None:
-    if database_url is not None:
-        return database_url
-    if os.getenv("DATABASE_URL"):
-        return os.getenv("DATABASE_URL")
-    host = os.getenv("POSTGRES_HOST")
-    if not host:
-        return None
-    user = os.getenv("POSTGRES_USER", "news_dashboard")
-    password = os.getenv("POSTGRES_PASSWORD", "")
-    database = os.getenv("POSTGRES_DB", "news_dashboard")
-    port = os.getenv("POSTGRES_PORT", "5432")
-    return f"postgresql://{user}:{password}@{host}:{port}/{database}"
+INSERT_DUPLICATE_ARTICLE_SQL = """
+    INSERT INTO articles(
+      url, canonical_url, title, source_slug, source_name, category, kind,
+      published_at, summary, reason, importance_score, tags,
+      status, canonical_id
+    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'archived', %s)
+    ON CONFLICT (url) DO NOTHING
+    """
 
 
-def is_postgres(database_url: str | None = None) -> bool:
-    url = active_database_url(database_url)
-    return bool(url and url.startswith(POSTGRES_PREFIXES))
+def active_database_url(database_url: str | None = None) -> str:
+    if database_url:
+        url = database_url
+    elif os.getenv("DATABASE_URL"):
+        url = os.environ["DATABASE_URL"]
+    else:
+        host = os.getenv("POSTGRES_HOST")
+        if not host:
+            raise RuntimeError("Postgres is required. Set DATABASE_URL or POSTGRES_HOST.")
+
+        user = os.getenv("POSTGRES_USER", "news_dashboard")
+        password = os.getenv("POSTGRES_PASSWORD", "")
+        database = os.getenv("POSTGRES_DB", "news_dashboard")
+        port = os.getenv("POSTGRES_PORT", "5432")
+        url = f"postgresql://{user}:{password}@{host}:{port}/{database}"
+
+    if not url.startswith(POSTGRES_PREFIXES):
+        raise RuntimeError("Postgres is required. DATABASE_URL must start with postgresql:// or postgres://.")
+    return url
 
 
 def describe_database(db_path: Path | None = None, database_url: str | None = None) -> str:
+    del db_path
     url = active_database_url(database_url)
-    if url:
-        parts = urlsplit(url)
-        if parts.password:
-            host = parts.hostname or ""
-            netloc = f"{parts.username}:***@{host}"
-            if parts.port:
-                netloc += f":{parts.port}"
-            return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
-        return url
-    return str(db_path or DB_PATH)
-
-
-class PostgresConnection:
-    def __init__(self, conn: Any):
-        self.conn = conn
-
-    def execute(self, sql: str, params: tuple[Any, ...] | list[Any] | None = None) -> Any:
-        return self.conn.execute(sql.replace("?", "%s"), params)
-
-    def commit(self) -> None:
-        self.conn.commit()
-
-    def close(self) -> None:
-        self.conn.close()
+    parts = urlsplit(url)
+    if parts.password:
+        host = parts.hostname or ""
+        netloc = f"{parts.username}:***@{host}"
+        if parts.port:
+            netloc += f":{parts.port}"
+        return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+    return url
 
 
 @contextmanager
 def connect(db_path: Path | None = None, database_url: str | None = None) -> Iterator[Any]:
-    url = active_database_url(database_url)
-    if is_postgres(url):
-        if psycopg is None:
-            raise RuntimeError("DATABASE_URL is PostgreSQL but psycopg is not installed")
-        conn = psycopg.connect(url, row_factory=dict_row)
-        wrapped = PostgresConnection(conn)
-        try:
-            yield wrapped
-            wrapped.commit()
-        finally:
-            wrapped.close()
-        return
-
-    path = db_path or DB_PATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path)
-    conn.row_factory = sqlite3.Row
+    del db_path
+    conn = psycopg.connect(active_database_url(database_url), row_factory=dict_row)
     try:
         yield conn
         conn.commit()
@@ -212,90 +137,38 @@ def connect(db_path: Path | None = None, database_url: str | None = None) -> Ite
         conn.close()
 
 
-def _apply_sqlite_column_migrations(conn: Any) -> None:
-    """Idempotently add new columns to existing SQLite databases."""
-    for table, column, typedef in SQLITE_COLUMN_MIGRATIONS:
-        try:
-            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {typedef}")
-        except Exception:
-            pass  # column already exists
-
-
-def _build_fts_index(conn: Any) -> None:
-    """Populate FTS index from existing articles (safe to re-run)."""
-    try:
-        conn.execute("INSERT INTO articles_fts(articles_fts) VALUES('rebuild')")
-    except Exception:
-        pass  # FTS table may not exist or already populated
-
-
 def init_db(db_path: Path | None = None, database_url: str | None = None) -> None:
-    if is_postgres(database_url):
-        with connect(db_path, database_url) as conn:
-            for statement in POSTGRES_SCHEMA:
-                try:
-                    conn.execute(statement)
-                except Exception:
-                    pass  # ignore IF NOT EXISTS / already-exists errors
-        return
-    with connect(db_path, database_url) as conn:
-        conn.executescript(SQLITE_SCHEMA)
-        _apply_sqlite_column_migrations(conn)
-        _build_fts_index(conn)
+    del db_path
+    with connect(database_url=database_url) as conn:
+        for statement in POSTGRES_SCHEMA:
+            conn.execute(statement)
 
 
 def row_to_dict(row: Any) -> dict:
-    if isinstance(row, dict):
-        return dict(row)
-    return {key: row[key] for key in row.keys()}
+    return dict(row)
 
 
 def insert_article_sql() -> str:
-    if is_postgres():
-        return """
-            INSERT INTO articles(
-              url, canonical_url, title, source_slug, source_name, category, kind,
-              published_at, summary, reason, importance_score, tags
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (url) DO NOTHING
-            """
-    return """
-        INSERT OR IGNORE INTO articles(
-          url, canonical_url, title, source_slug, source_name, category, kind,
-          published_at, summary, reason, importance_score, tags
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """
+    return INSERT_ARTICLE_SQL
 
 
 def insert_duplicate_article_sql() -> str:
-    if is_postgres():
-        return """
-            INSERT INTO articles(
-              url, canonical_url, title, source_slug, source_name, category, kind,
-              published_at, summary, reason, importance_score, tags,
-              status, canonical_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?)
-            ON CONFLICT (url) DO NOTHING
-            """
-    return """
-        INSERT OR IGNORE INTO articles(
-          url, canonical_url, title, source_slug, source_name, category, kind,
-          published_at, summary, reason, importance_score, tags,
-          status, canonical_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?)
-        """
+    return INSERT_DUPLICATE_ARTICLE_SQL
 
 
 def search_articles_sql(terms: list[str], limit: int) -> tuple[str, list[Any]]:
-    """Build a LIKE-based search query compatible with both SQLite and PostgreSQL."""
     if not terms:
-        return "SELECT * FROM articles ORDER BY discovered_at DESC LIMIT ?", [limit]
+        return "SELECT * FROM articles ORDER BY discovered_at DESC LIMIT %s", [limit]
+
     clauses = []
     params: list[Any] = []
     for term in terms:
         like = f"%{term}%"
-        clauses.append("(title LIKE ? OR summary LIKE ? OR tags LIKE ? OR source_name LIKE ? OR reason LIKE ?)")
+        clauses.append(
+            "(title ILIKE %s OR summary ILIKE %s OR tags ILIKE %s OR source_name ILIKE %s OR reason ILIKE %s)"
+        )
         params.extend([like, like, like, like, like])
+
     params.append(limit)
     where = " AND ".join(clauses)
-    return f"SELECT * FROM articles WHERE {where} ORDER BY importance_score DESC, discovered_at DESC LIMIT ?", params
+    return f"SELECT * FROM articles WHERE {where} ORDER BY importance_score DESC, discovered_at DESC LIMIT %s", params

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -267,6 +267,25 @@ def insert_article_sql() -> str:
         """
 
 
+def insert_duplicate_article_sql() -> str:
+    if is_postgres():
+        return """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name, category, kind,
+              published_at, summary, reason, importance_score, tags,
+              status, canonical_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?)
+            ON CONFLICT (url) DO NOTHING
+            """
+    return """
+        INSERT OR IGNORE INTO articles(
+          url, canonical_url, title, source_slug, source_name, category, kind,
+          published_at, summary, reason, importance_score, tags,
+          status, canonical_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?)
+        """
+
+
 def search_articles_sql(terms: list[str], limit: int) -> tuple[str, list[Any]]:
     """Build a LIKE-based search query compatible with both SQLite and PostgreSQL."""
     if not terms:

--- a/backend/news_dashboard/digest.py
+++ b/backend/news_dashboard/digest.py
@@ -47,7 +47,7 @@ def _get_top_new_articles(limit: int = 10) -> list[dict]:
             SELECT * FROM articles
             WHERE status = 'new'
             ORDER BY importance_score DESC, discovered_at DESC
-            LIMIT ?
+            LIMIT %s
             """,
             (limit,),
         ).fetchall()

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -2,8 +2,8 @@
 
 Embedding model : text-embedding-3-small (OpenAI)
 Answer model    : claude-haiku-4-5 (Anthropic)
-Storage         : articles.embedding BLOB (serialized float32 numpy array)
-Retrieval       : pure-Python cosine similarity (no sqlite-vss needed)
+Storage         : articles.embedding BYTEA (serialized float32 numpy array)
+Retrieval       : pure-Python cosine similarity
 """
 from __future__ import annotations
 
@@ -59,7 +59,7 @@ def ensure_article_embedded(article_id: int, db_path: Any = None) -> None:
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
-            "SELECT id, title, summary, embedding FROM articles WHERE id=?",
+            "SELECT id, title, summary, embedding FROM articles WHERE id=%s",
             (article_id,),
         ).fetchone()
         if row is None or row["embedding"] is not None:
@@ -70,7 +70,7 @@ def ensure_article_embedded(article_id: int, db_path: Any = None) -> None:
         vector = _embed(text)
         blob = _pack(vector)
         conn.execute(
-            "UPDATE articles SET embedding=? WHERE id=?",
+            "UPDATE articles SET embedding=%s WHERE id=%s",
             (blob, article_id),
         )
 
@@ -100,7 +100,7 @@ def embed_all_eligible(db_path: Any = None) -> int:
         from .db import connect as _connect
         with _connect(db_path) as conn:
             conn.execute(
-                "UPDATE articles SET embedding=? WHERE id=?",
+                "UPDATE articles SET embedding=%s WHERE id=%s",
                 (blob, row["id"]),
             )
         count += 1

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -10,7 +10,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import feedparser
 
-from .db import connect, init_db, insert_article_sql, row_to_dict, search_articles_sql
+from .db import connect, init_db, insert_article_sql, insert_duplicate_article_sql, row_to_dict, search_articles_sql
 from .sources import DEFAULT_SOURCES, SourceDefinition
 
 try:
@@ -262,11 +262,7 @@ def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
                 if canonical_id is not None:
                     # Insert as archived duplicate pointing to canonical
                     conn.execute(
-                        """INSERT OR IGNORE INTO articles(
-                             url, canonical_url, title, source_slug, source_name, category, kind,
-                             published_at, summary, reason, importance_score, tags,
-                             status, canonical_id
-                           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?)""",
+                        insert_duplicate_article_sql(),
                         (url, url, title, source.slug, source.name, source.category, source.kind,
                          entry.get("date"), summary, reason, score, tags, canonical_id),
                     )

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -169,7 +169,7 @@ def _find_canonical(conn: Any, canonical_url: str, title: str) -> int | None:
     """Return the id of an existing canonical article that matches by URL or fuzzy title, or None."""
     # Exact URL match (canonical_url already stripped of tracking params)
     row = conn.execute(
-        "SELECT id FROM articles WHERE canonical_url=? AND (canonical_id IS NULL OR canonical_id=id) LIMIT 1",
+        "SELECT id FROM articles WHERE canonical_url=%s AND (canonical_id IS NULL OR canonical_id=id) LIMIT 1",
         (canonical_url,),
     ).fetchone()
     if row:
@@ -179,7 +179,7 @@ def _find_canonical(conn: Any, canonical_url: str, title: str) -> int | None:
     rows = conn.execute(
         """SELECT id, title FROM articles
            WHERE canonical_id IS NULL
-             AND discovered_at >= datetime('now', '-7 days')
+             AND discovered_at::timestamp >= NOW() - INTERVAL '7 days'
            ORDER BY discovered_at DESC
            LIMIT 200""",
     ).fetchall()
@@ -198,7 +198,7 @@ def sync_sources(db_path: Path | None = None) -> None:
             conn.execute(
                 """
                 INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
-                VALUES (?, ?, ?, ?, ?, ?, 1)
+                VALUES (%s, %s, %s, %s, %s, %s, 1)
                 ON CONFLICT(slug) DO UPDATE SET
                   name=excluded.name,
                   url=excluded.url,
@@ -268,7 +268,7 @@ def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
                     )
                     # Tag canonical article's source list (stored in reason prefix)
                     conn.execute(
-                        """UPDATE articles SET updated_at=? WHERE id=? AND canonical_id IS NULL""",
+                        """UPDATE articles SET updated_at=%s WHERE id=%s AND canonical_id IS NULL""",
                         (now_iso(), canonical_id),
                     )
                 else:
@@ -281,9 +281,9 @@ def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
 
             conn.execute(
                 """UPDATE sources SET
-                     last_checked_at=?, last_success_at=?, last_error=NULL,
-                     last_fetched_count=?, last_inserted_count=?
-                   WHERE slug=?""",
+                     last_checked_at=%s, last_success_at=%s, last_error=NULL,
+                     last_fetched_count=%s, last_inserted_count=%s
+                   WHERE slug=%s""",
                 (checked_at, checked_at, fetched, inserted, source.slug),
             )
 
@@ -292,9 +292,9 @@ def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
         with connect(db_path) as conn:
             conn.execute(
                 """UPDATE sources SET
-                     last_checked_at=?, last_error=?,
+                     last_checked_at=%s, last_error=%s,
                      last_fetched_count=0, last_inserted_count=0
-                   WHERE slug=?""",
+                   WHERE slug=%s""",
                 (checked_at, error_msg, source.slug),
             )
         raise
@@ -326,16 +326,16 @@ def list_articles(
     clauses: list[str] = ["(canonical_id IS NULL OR status != 'archived')"]
     params: list[object] = []
     if status:
-        clauses.append("status = ?")
+        clauses.append("status = %s")
         params.append(status)
     if category:
-        clauses.append("category = ?")
+        clauses.append("category = %s")
         params.append(category)
     where = f"WHERE {' AND '.join(clauses)}"
     params.extend([limit, offset])
     with connect(db_path) as conn:
         rows = conn.execute(
-            f"SELECT * FROM articles {where} ORDER BY discovered_at DESC, id DESC LIMIT ? OFFSET ?",
+            f"SELECT * FROM articles {where} ORDER BY discovered_at DESC, id DESC LIMIT %s OFFSET %s",
             params,
         ).fetchall()
         articles = [row_to_dict(row) for row in rows]
@@ -343,10 +343,9 @@ def list_articles(
         # Attach duplicate source names to canonical articles
         article_ids = [a["id"] for a in articles]
         if article_ids:
-            placeholders = ",".join("?" * len(article_ids))
             dup_rows = conn.execute(
-                f"SELECT canonical_id, source_name FROM articles WHERE canonical_id IN ({placeholders}) AND status='archived'",
-                article_ids,
+                "SELECT canonical_id, source_name FROM articles WHERE canonical_id = ANY(%s) AND status='archived'",
+                (article_ids,),
             ).fetchall()
             from collections import defaultdict
             dupes_by_canonical: dict[int, list[str]] = defaultdict(list)
@@ -381,15 +380,15 @@ def set_article_status(article_id: int, status: str, db_path: Path | None = None
     with connect(db_path) as conn:
         if timestamp_column:
             conn.execute(
-                f"UPDATE articles SET status=?, {timestamp_column}=?, updated_at=? WHERE id=?",
+                f"UPDATE articles SET status=%s, {timestamp_column}=%s, updated_at=%s WHERE id=%s",
                 (status, now_iso(), now_iso(), article_id),
             )
         else:
             conn.execute(
-                "UPDATE articles SET status=?, updated_at=? WHERE id=?",
+                "UPDATE articles SET status=%s, updated_at=%s WHERE id=%s",
                 (status, now_iso(), article_id),
             )
-        row = conn.execute("SELECT * FROM articles WHERE id=?", (article_id,)).fetchone()
+        row = conn.execute("SELECT * FROM articles WHERE id=%s", (article_id,)).fetchone()
         result = row_to_dict(row) if row else None
 
     # Lazily embed articles when they become saved/read (fire-and-forget; ignore errors)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -117,12 +117,12 @@ def set_source_enabled(slug: str, payload: EnabledUpdate) -> dict:
     init_db()
     with connect() as conn:
         cursor = conn.execute(
-            "UPDATE sources SET enabled=? WHERE slug=?",
+            "UPDATE sources SET enabled=%s WHERE slug=%s",
             (1 if payload.enabled else 0, slug),
         )
         if cursor.rowcount == 0:
             raise HTTPException(status_code=404, detail="source not found")
-        row = conn.execute("SELECT * FROM sources WHERE slug=?", (slug,)).fetchone()
+        row = conn.execute("SELECT * FROM sources WHERE slug=%s", (slug,)).fetchone()
         return row_to_dict(row)
 
 

--- a/backend/news_dashboard/migrate.py
+++ b/backend/news_dashboard/migrate.py
@@ -52,7 +52,7 @@ def sqlite_to_postgres(sqlite_path: Path = typer.Argument(..., help="Existing SQ
                   slug, name, url, category, kind, priority, enabled, last_checked_at,
                   last_success_at, last_error, last_fetched_count, last_inserted_count
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT(slug) DO UPDATE SET
                   name=excluded.name,
                   url=excluded.url,
@@ -76,7 +76,7 @@ def sqlite_to_postgres(sqlite_path: Path = typer.Argument(..., help="Existing SQ
                   url, canonical_url, title, source_slug, source_name, category, kind, published_at,
                   summary, reason, importance_score, tags, status, discovered_at, read_at, saved_at,
                   skipped_at, archived_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (url) DO UPDATE SET
                   title=excluded.title,
                   source_slug=excluded.source_slug,

--- a/backend/tests/test_database_config.py
+++ b/backend/tests/test_database_config.py
@@ -1,21 +1,6 @@
-from pathlib import Path
+import pytest
 
-from news_dashboard.db import describe_database, init_db, insert_duplicate_article_sql
-from news_dashboard.ingest import ingest_all, list_articles
-
-
-def test_sqlite_file_database_reports_path_and_persists_between_connections(tmp_path: Path) -> None:
-    db_path = tmp_path / "durable.db"
-
-    init_db(db_path)
-    first = ingest_all(db_path)
-    second = ingest_all(db_path)
-
-    assert db_path.exists()
-    assert sum(value for value in first.values() if value > 0) >= 0
-    assert sum(value for value in second.values() if value > 0) == 0
-    assert list_articles(limit=1, db_path=db_path) or first == second
-    assert describe_database(db_path) == str(db_path)
+from news_dashboard.db import active_database_url, describe_database, insert_article_sql, insert_duplicate_article_sql
 
 
 def test_postgres_url_is_reported_without_password() -> None:
@@ -24,10 +9,30 @@ def test_postgres_url_is_reported_without_password() -> None:
     assert describe_database(database_url=dsn) == "postgresql://news_dashboard:***@postgres:5432/news_dashboard"
 
 
-def test_duplicate_article_insert_uses_postgres_conflict_syntax(monkeypatch) -> None:
-    monkeypatch.setenv("DATABASE_URL", "postgresql://news_dashboard:secret@postgres:5432/news_dashboard")
+def test_database_url_is_required(monkeypatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
 
+    with pytest.raises(RuntimeError, match="Postgres is required"):
+        active_database_url()
+
+
+def test_non_postgres_database_url_is_rejected() -> None:
+    with pytest.raises(RuntimeError, match="DATABASE_URL must start"):
+        active_database_url("sqlite:///tmp/news.db")
+
+
+def test_article_insert_sql_is_postgres_only() -> None:
+    sql = insert_article_sql()
+
+    assert "ON CONFLICT (url) DO NOTHING" in sql
+    assert "%s" in sql
+    assert "INSERT OR IGNORE" not in sql
+
+
+def test_duplicate_article_insert_sql_is_postgres_only() -> None:
     sql = insert_duplicate_article_sql()
 
     assert "ON CONFLICT (url) DO NOTHING" in sql
+    assert "%s" in sql
     assert "INSERT OR IGNORE" not in sql

--- a/backend/tests/test_database_config.py
+++ b/backend/tests/test_database_config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from news_dashboard.db import describe_database, init_db
+from news_dashboard.db import describe_database, init_db, insert_duplicate_article_sql
 from news_dashboard.ingest import ingest_all, list_articles
 
 
@@ -22,3 +22,12 @@ def test_postgres_url_is_reported_without_password() -> None:
     dsn = "postgresql://news_dashboard:secret-password@postgres:5432/news_dashboard"
 
     assert describe_database(database_url=dsn) == "postgresql://news_dashboard:***@postgres:5432/news_dashboard"
+
+
+def test_duplicate_article_insert_uses_postgres_conflict_syntax(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://news_dashboard:secret@postgres:5432/news_dashboard")
+
+    sql = insert_duplicate_article_sql()
+
+    assert "ON CONFLICT (url) DO NOTHING" in sql
+    assert "INSERT OR IGNORE" not in sql

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1,9 +1,20 @@
+import os
 from pathlib import Path
+
+import pytest
 
 from news_dashboard.ingest import ingest_all, list_articles, set_article_status, sync_sources
 
 
-def test_sync_sources_and_status_transition(tmp_path: Path) -> None:
+def _require_test_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    database_url = os.getenv("TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("set TEST_DATABASE_URL to run Postgres integration tests")
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+
+def test_sync_sources_and_status_transition(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _require_test_database(monkeypatch)
     db_path = tmp_path / "news.db"
     sync_sources(db_path)
     assert list_articles(db_path=db_path) == []
@@ -29,7 +40,8 @@ def test_sync_sources_and_status_transition(tmp_path: Path) -> None:
     assert updated["read_at"] is not None
 
 
-def test_invalid_status_rejected(tmp_path: Path) -> None:
+def test_invalid_status_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _require_test_database(monkeypatch)
     db_path = tmp_path / "news.db"
     sync_sources(db_path)
     try:

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -1,7 +1,10 @@
 """Tests for source health tracking, better summaries, noise filters, and search."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from news_dashboard.db import connect
 from news_dashboard.ingest import (
@@ -20,17 +23,26 @@ from news_dashboard.sources import DEFAULT_SOURCES, SourceDefinition
 # Source health tracking
 # ──────────────────────────────────────────────
 
+def _require_test_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    database_url = os.getenv("TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("set TEST_DATABASE_URL to run Postgres integration tests")
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+
 def _insert_article(conn, n: int = 1) -> None:
     """Insert a test article using a source that's already synced."""
     for i in range(n):
         conn.execute(
-            """INSERT OR IGNORE INTO articles(url, canonical_url, title, source_slug, source_name, category, kind)
-               VALUES (?, ?, ?, 'python-insider', 'Python Insider', 'python', 'rss_feed')""",
+            """INSERT INTO articles(url, canonical_url, title, source_slug, source_name, category, kind)
+               VALUES (%s, %s, %s, 'python-insider', 'Python Insider', 'python', 'rss_feed')
+               ON CONFLICT (url) DO NOTHING""",
             (f"https://example.com/art-{i}", f"https://example.com/art-{i}", f"Article {i}"),
         )
 
 
-def test_source_columns_present(tmp_path: Path) -> None:
+def test_source_columns_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _require_test_database(monkeypatch)
     sync_sources(tmp_path / "health.db")
     with connect(tmp_path / "health.db") as conn:
         row = conn.execute("SELECT * FROM sources LIMIT 1").fetchone()
@@ -39,15 +51,16 @@ def test_source_columns_present(tmp_path: Path) -> None:
             assert col in keys, f"missing column: {col}"
 
 
-def test_source_error_tracked(tmp_path: Path) -> None:
+def test_source_error_tracked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _require_test_database(monkeypatch)
     from news_dashboard.sources import SourceDefinition
     bad = SourceDefinition("bad-feed", "Bad Feed", "http://localhost:0/nope", "python")
     db = tmp_path / "err.db"
     sync_sources(db)
     with connect(db) as conn:
         conn.execute(
-            "INSERT OR IGNORE INTO sources(slug, name, url, category, kind, priority, enabled) "
-            "VALUES (?, ?, ?, ?, ?, 50, 1)",
+            "INSERT INTO sources(slug, name, url, category, kind, priority, enabled) "
+            "VALUES (%s, %s, %s, %s, %s, 50, 1) ON CONFLICT (slug) DO NOTHING",
             (bad.slug, bad.name, bad.url, bad.category, bad.kind),
         )
 
@@ -58,7 +71,7 @@ def test_source_error_tracked(tmp_path: Path) -> None:
         pass  # expected
 
     with connect(db) as conn:
-        row = conn.execute("SELECT last_error, last_checked_at FROM sources WHERE slug=?", (bad.slug,)).fetchone()
+        row = conn.execute("SELECT last_error, last_checked_at FROM sources WHERE slug=%s", (bad.slug,)).fetchone()
         assert row["last_error"] is not None, "last_error should be set on failure"
         assert row["last_checked_at"] is not None, "last_checked_at should be set even on failure"
 
@@ -120,7 +133,8 @@ def test_infer_tags_agents() -> None:
 # Search (issue #9)
 # ──────────────────────────────────────────────
 
-def test_search_returns_matching_articles(tmp_path: Path) -> None:
+def test_search_returns_matching_articles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _require_test_database(monkeypatch)
     db = tmp_path / "search.db"
     sync_sources(db)
     with connect(db) as conn:
@@ -139,7 +153,8 @@ def test_search_returns_matching_articles(tmp_path: Path) -> None:
         assert r["url"] != "https://ex.com/2", "Docker article should not appear in Python search"
 
 
-def test_search_empty_query_returns_empty(tmp_path: Path) -> None:
+def test_search_empty_query_returns_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _require_test_database(monkeypatch)
     db = tmp_path / "search2.db"
     sync_sources(db)
     # Single-char queries get filtered out

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This project is a private personal news dashboard for `news.lihor.ro`. It collec
 The system is not a large microservice platform. It is best understood as a modular monolith with a small number of runtime units:
 
 - `news-dashboard`: the FastAPI backend, which also serves the built React frontend in container and Kubernetes deployments.
-- `postgres`: the durable production database.
+- `postgres`: the durable application database.
 - `news-dashboard-ingest`: a Kubernetes CronJob batch workload that runs ingestion on a schedule.
 - Optional external integrations: RSS/Atom feeds, a scraped Anthropic News page, SMTP, GHCR, GitHub Actions, and host-level Caddy.
 
@@ -18,7 +18,7 @@ flowchart TB
   subgraph LocalDev["Local development"]
     Vite["Vite React dev server<br/>localhost:5173"]
     FastAPIDev["FastAPI backend<br/>uvicorn news_dashboard.main:app"]
-    SQLite["SQLite fallback<br/>NEWS_DASHBOARD_DB"]
+    LocalPostgres["Postgres<br/>docker compose"]
   end
 
   subgraph Container["Docker / Production image"]
@@ -126,7 +126,7 @@ sequenceDiagram
     Ingest->>Ingest: infer tags
     Ingest->>Ingest: create summary/reason
     Ingest->>Ingest: calculate importance_score
-    Ingest->>DB: INSERT article ON CONFLICT/IGNORE
+    Ingest->>DB: INSERT article ON CONFLICT
     Ingest->>DB: update source health
   end
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -965,8 +965,98 @@ ul { list-style: none; }
   .fetch-btn { padding: 0 11px; }
   .page { padding: 0 12px; padding-bottom: max(48px, calc(48px + env(safe-area-inset-bottom))); }
   .tabs-wrap { margin: 0 -12px; padding: 0 12px; }
-  .card-actions  { gap: 6px; }
-  .action-btn    { min-width: 0; font-size: 11px; padding: 0 8px; }
+  .section-header { padding: 14px 0 10px; }
+  .articles-grid { gap: 10px; }
+  .article-card {
+    padding: 14px;
+    grid-template-rows: auto auto auto minmax(3.3em, 1fr) auto auto;
+    gap: 8px;
+    border-radius: var(--r-md);
+  }
+  .article-card:has(.card-checkbox) .card-header { padding-right: 26px; }
+  .card-header { align-items: flex-start; gap: 8px; }
+  .card-badges { gap: 5px; padding-top: 1px; }
+  .card-date {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1px;
+    line-height: 1.2;
+  }
+  .card-title { font-size: 14px; line-height: 1.35; }
+  .card-source { font-size: 11px; }
+  .card-summary { font-size: 12px; line-height: 1.45; -webkit-line-clamp: 2; }
+  .card-reason { font-size: 11px; line-height: 1.35; }
+  .card-tags { min-height: 22px; gap: 3px; }
+  .tag { font-size: 10px; padding: 2px 6px; }
+  .card-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 4px;
+    padding: 4px;
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+  }
+  .action-btn {
+    min-width: 0;
+    min-height: 38px;
+    padding: 0 6px;
+    border-radius: var(--r-sm);
+    border: 0;
+    background: var(--surface);
+    font-size: 11px;
+    gap: 4px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, .04);
+  }
+  .action-icon {
+    width: 14px;
+    height: 14px;
+    border-radius: 0;
+    background: transparent;
+    font-size: 11px;
+    box-shadow: none;
+  }
+  .sources-grid { gap: 10px; }
+  .source-card { border-radius: var(--r-md); }
+  .source-category {
+    padding: 10px 12px;
+    font-size: 11px;
+  }
+  .source-item {
+    padding: 10px 12px;
+    gap: 6px;
+  }
+  .source-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 8px;
+    align-items: center;
+  }
+  .source-main a {
+    font-size: 13px;
+    line-height: 1.25;
+    min-height: 20px;
+  }
+  .source-main .badge {
+    max-width: 112px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .source-meta {
+    gap: 5px;
+    min-height: 16px;
+  }
+  .source-health,
+  .source-checked {
+    font-size: 10px;
+  }
+  .source-error-msg {
+    padding: 5px 7px;
+    margin-top: 0;
+    line-height: 1.35;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
 }
 
 /* ===== ISSUE #16: DARK MODE TOGGLE BUTTON ===== */

--- a/helm/news-dashboard/templates/cronjob.yaml
+++ b/helm/news-dashboard/templates/cronjob.yaml
@@ -47,9 +47,6 @@ spec:
                     secretKeyRef:
                       name: {{ include "news-dashboard.fullname" . }}-postgres
                       key: POSTGRES_PASSWORD
-{{- else }}
-                - name: NEWS_DASHBOARD_DB
-                  value: {{ .Values.app.databasePath | quote }}
 {{- end }}
               volumeMounts:
                 - name: data

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -52,9 +52,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "news-dashboard.fullname" . }}-postgres
                   key: POSTGRES_PASSWORD
-{{- else }}
-            - name: NEWS_DASHBOARD_DB
-              value: {{ .Values.app.databasePath | quote }}
 {{- end }}
           ports:
             - containerPort: 8080

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -21,15 +21,12 @@ service:
   # Example override: helm upgrade --set service.type=NodePort,service.nodePort=30088
   nodePort: ""
 
-# SQLite fallback only. Production/local-k8s uses PostgreSQL below.
+# Postgres persistent volume settings.
 persistence:
   enabled: true
   size: 1Gi
   storageClassName: ""
   hostPath: ""
-
-app:
-  databasePath: /data/news-dashboard.db
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary
- make the runtime database layer Postgres-only; deployment already uses postgres:16-alpine via Docker Compose/Helm
- remove SQLite fallback/runtime branching, SQLite schema, placeholder rewriting, and database-type sniffing
- convert runtime SQL to native psycopg/Postgres syntax: %s placeholders, ILIKE, NOW() - INTERVAL, ANY(%s), and ON CONFLICT
- keep the SQLite-to-Postgres migration command only as a legacy import tool, with Postgres writes
- fix archived duplicate article inserts so production no longer sees SQLite-only INSERT OR IGNORE syntax
- tighten mobile article cards and Sources rows, including the LangGraph releases / github release case
- update README, Dockerfile, Helm, and architecture docs to state Postgres as the app database

## Tests
- .venv/bin/pytest backend/tests/test_database_config.py backend/tests/test_ingest.py backend/tests/test_source_health.py
- python3 -m compileall backend/news_dashboard
- npm run build

Note: Postgres integration tests now require TEST_DATABASE_URL; without it, DB integration tests skip instead of silently exercising SQLite.