### PR TITLE
fix(mobile): two-row topbar layout on small screens

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -383,45 +383,6 @@ function AskPanel({ result, loading }: AskPanelProps) {
 }
 
 
-// ===== AskPanel =====
-
-interface AskPanelProps {
-  result: AskResponse | null
-  loading: boolean
-}
-
-function AskPanel({ result, loading }: AskPanelProps) {
-  if (loading) {
-    return (
-      <div className="ask-panel">
-        <div className="ask-loading">
-          <span className="skeleton sk-line" style={{ width: '80%' }} />
-          <span className="skeleton sk-line" style={{ width: '60%' }} />
-        </div>
-      </div>
-    )
-  }
-  if (!result) return null
-  return (
-    <div className="ask-panel">
-      <p className="ask-answer">{result.answer}</p>
-      {result.sources.length > 0 && (
-        <div className="ask-sources">
-          <p className="ask-sources-label">Sources</p>
-          <ol className="ask-sources-list">
-            {result.sources.map((s, i) => (
-              <li key={s.id}>
-                <span className="ask-source-num">[{i + 1}]</span>{' '}
-                <a href={s.url} target="_blank" rel="noreferrer">{s.title}</a>
-              </li>
-            ))}
-          </ol>
-        </div>
-      )}
-    </div>
-  )
-}
-
 // ===== App =====
 
 /** #28 — Sources panel: bottom sheet on mobile, sidebar on desktop */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -382,6 +382,46 @@ function AskPanel({ result, loading }: AskPanelProps) {
   )
 }
 
+
+// ===== AskPanel =====
+
+interface AskPanelProps {
+  result: AskResponse | null
+  loading: boolean
+}
+
+function AskPanel({ result, loading }: AskPanelProps) {
+  if (loading) {
+    return (
+      <div className="ask-panel">
+        <div className="ask-loading">
+          <span className="skeleton sk-line" style={{ width: '80%' }} />
+          <span className="skeleton sk-line" style={{ width: '60%' }} />
+        </div>
+      </div>
+    )
+  }
+  if (!result) return null
+  return (
+    <div className="ask-panel">
+      <p className="ask-answer">{result.answer}</p>
+      {result.sources.length > 0 && (
+        <div className="ask-sources">
+          <p className="ask-sources-label">Sources</p>
+          <ol className="ask-sources-list">
+            {result.sources.map((s, i) => (
+              <li key={s.id}>
+                <span className="ask-source-num">[{i + 1}]</span>{' '}
+                <a href={s.url} target="_blank" rel="noreferrer">{s.title}</a>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ===== App =====
 
 /** #28 — Sources panel: bottom sheet on mobile, sidebar on desktop */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -957,12 +957,41 @@ ul { list-style: none; }
   font-style: italic;
 }
 
-/* ===== MOBILE SMALL TWEAKS ===== */
+/* ===== RESPONSIVE ===== */
 @media (max-width: 767px) {
-  .topbar { padding: 8px 0; }
+  .topbar { padding: 6px 0; }
   .topbar-sub { display: none; }
-  .fetch-btn-label { display: none; }
-  .fetch-btn { padding: 0 11px; }
+
+  /* Two-row topbar on small screens (≤767 px):
+     Row 1: brand title (flex: 1) + fetch button (flex: none, right-aligned)
+     Row 2: search input (full width) */
+  .topbar-inner {
+    flex-wrap: wrap;
+    row-gap: 8px;
+    align-items: center;
+  }
+  .topbar-brand {
+    flex: 1 1 auto;
+  }
+  .fetch-btn {
+    flex: none;
+    order: 2;
+    padding: 0 14px;
+  }
+  .fetch-btn-label {
+    display: inline;
+    font-size: 12px;
+  }
+  .topbar-search {
+    order: 3;
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+  .topbar-search input {
+    font-size: 15px;
+    min-height: 44px;
+  }
+
   .page { padding: 0 12px; padding-bottom: max(48px, calc(48px + env(safe-area-inset-bottom))); }
   .tabs-wrap { margin: 0 -12px; padding: 0 12px; }
   .section-header { padding: 14px 0 10px; }


### PR DESCRIPTION
## Summary

On viewports ≤767 px the topbar now reflows into two rows instead of cramming everything into a single non-wrapping flex row:

- **Row 1:** brand/title expands (`flex: 1 1 auto`) with the Fetch Now button right-aligned (`order: 2`) — label kept visible at `font-size: 12px`
- **Row 2:** search input spans full width (`order: 3`, `flex: 1 1 100%`) with `font-size: 15px` and `min-height: 44px` for comfortable mobile typing/tap targets

Desktop layout (>767 px) is completely unchanged.

## Test plan

- [ ] Resize browser to ≤767 px — confirm brand + fetch button appear on row 1, search input on row 2 at full width
- [ ] Resize to ≥768 px — confirm single-row layout is unchanged
- [ ] Tap the search input on a phone — confirm comfortable tap target and legible font size
- [ ] Click "Fetch now" on mobile — confirm button is reachable and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)