### PR TITLE
[codex] Fix Ask AI credential configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ npm run dev
 
 Open `http://localhost:5173`.
 
+Ask AI requires both provider keys in the backend environment:
+
+```bash
+export OPENAI_API_KEY=...
+export ANTHROPIC_API_KEY=...
+```
+
 ## Container
 
 ```bash
@@ -43,6 +50,17 @@ docker compose up --build
 ```
 
 Open `http://localhost:8080`.
+
+For Kubernetes, create a Secret and point Helm at it:
+
+```bash
+kubectl create secret generic news-dashboard-ai \
+  --from-literal=OPENAI_API_KEY=... \
+  --from-literal=ANTHROPIC_API_KEY=...
+
+helm upgrade --install news-dashboard ./helm/news-dashboard \
+  --set app.ai.existingSecret=news-dashboard-ai
+```
 
 ## Durable database
 

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -7,11 +7,25 @@ Retrieval       : pure-Python cosine similarity (no sqlite-vss needed)
 """
 from __future__ import annotations
 
+import os
 import struct
 from typing import Any
 
 MIN_ARTICLES = 5   # refuse to answer if fewer than this many articles are embedded
 TOP_K = 8          # articles to include as context
+
+
+class MissingAICredentialsError(RuntimeError):
+    """Raised when Ask AI is used without the required provider credentials."""
+
+
+def _require_env(name: str, purpose: str) -> str:
+    value = os.getenv(name)
+    if value:
+        return value
+    raise MissingAICredentialsError(
+        f"Ask AI requires {name} to {purpose}. Set {name} in the app environment."
+    )
 
 
 # ── Embedding serialisation ────────────────────────────────────────────────
@@ -31,7 +45,7 @@ def _embed(text: str) -> list[float]:
     """Embed *text* with text-embedding-3-small via the OpenAI SDK."""
     from openai import OpenAI  # lazy import — optional dep at import time
 
-    client = OpenAI()  # reads OPENAI_API_KEY from env
+    client = OpenAI(api_key=_require_env("OPENAI_API_KEY", "generate article embeddings"))
     response = client.embeddings.create(
         model="text-embedding-3-small",
         input=text,
@@ -177,7 +191,9 @@ def ask(query: str, db_path: Any = None) -> dict:
     # 6. Call claude-haiku-4-5 for the answer
     import anthropic  # lazy import
 
-    client = anthropic.Anthropic()
+    client = anthropic.Anthropic(
+        api_key=_require_env("ANTHROPIC_API_KEY", "generate answers")
+    )
     message = client.messages.create(
         model="claude-haiku-4-5",
         max_tokens=1024,

--- a/backend/tests/test_ai_credentials.py
+++ b/backend/tests/test_ai_credentials.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard.embeddings import MissingAICredentialsError, _require_env
+
+
+def test_require_env_returns_configured_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    assert _require_env("OPENAI_API_KEY", "generate article embeddings") == "test-key"
+
+
+def test_require_env_raises_clear_error_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(MissingAICredentialsError, match="Ask AI requires OPENAI_API_KEY"):
+        _require_env("OPENAI_API_KEY", "generate article embeddings")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       POSTGRES_DB: news_dashboard
       POSTGRES_USER: news_dashboard
       POSTGRES_PASSWORD: news-dashboard-local-password
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -56,6 +56,18 @@ spec:
             - name: NEWS_DASHBOARD_DB
               value: {{ .Values.app.databasePath | quote }}
 {{- end }}
+{{- if .Values.app.ai.existingSecret }}
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.ai.existingSecret | quote }}
+                  key: {{ .Values.app.ai.openaiApiKeyKey | quote }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.ai.existingSecret | quote }}
+                  key: {{ .Values.app.ai.anthropicApiKeyKey | quote }}
+{{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -30,6 +30,11 @@ persistence:
 
 app:
   databasePath: /data/news-dashboard.db
+  ai:
+    # Optional: pre-existing Secret with OPENAI_API_KEY and ANTHROPIC_API_KEY.
+    existingSecret: ""
+    openaiApiKeyKey: OPENAI_API_KEY
+    anthropicApiKeyKey: ANTHROPIC_API_KEY
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary
- Add explicit Ask AI credential validation for OpenAI and Anthropic keys.
- Pass AI provider keys through Docker Compose for local container runs.
- Add Helm values and deployment wiring for mounting provider keys from an existing Kubernetes Secret.
- Document local and Kubernetes setup, plus tests for the credential guard.

## Root cause
Ask AI creates an OpenAI client for embeddings, but deployed and containerized environments did not provide `OPENAI_API_KEY` to the app. The backend also let the SDK raise its generic missing-credentials error instead of giving an app-specific setup hint. Ask AI also depends on `ANTHROPIC_API_KEY` for answer generation, so this PR wires both required provider credentials.

## Validation
- `python3 -m pytest`
- `git diff --check`

## Notes
- I could not run `helm template` locally because `helm` is not installed in this environment.
