### PR TITLE
[codex] Wire Ask AI credentials into deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
           IMG: ${{ env.IMAGE }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
 
@@ -138,21 +140,41 @@ jobs:
             --docker-password="$GHCR_TOKEN" \
             --dry-run=client -o yaml | kubectl apply -f -
 
+          ai_secret_args=()
+          if [ -n "$OPENAI_API_KEY" ]; then
+            ai_secret_args+=(--from-literal=OPENAI_API_KEY="$OPENAI_API_KEY")
+          fi
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            ai_secret_args+=(--from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY")
+          fi
+
+          ai_helm_args=()
+          if [ ${#ai_secret_args[@]} -gt 0 ]; then
+            kubectl -n news-dashboard create secret generic news-dashboard-ai \
+              "${ai_secret_args[@]}" \
+              --dry-run=client -o yaml | kubectl apply -f -
+            ai_helm_args+=(--set app.ai.existingSecret=news-dashboard-ai)
+          fi
+
           # Sync Helm chart changes from the repo.
           cd ~/news-dashboard && git pull --ff-only
 
           # Upgrade (or install on first run). Keep the host Caddy route stable
           # by preserving the NodePort and local durable hostPath storage.
-          helm upgrade --install news-dashboard ./helm/news-dashboard \
-            --namespace news-dashboard --create-namespace \
-            --set "image.repository=${IMG}" \
-            --set "image.tag=${SHA}" \
-            --set image.pullSecretName=ghcr-pull-secret \
-            --set service.type=NodePort \
-            --set service.nodePort=30088 \
-            --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data \
-            --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data \
+          helm_args=(
+            upgrade --install news-dashboard ./helm/news-dashboard
+            --namespace news-dashboard --create-namespace
+            --set "image.repository=${IMG}"
+            --set "image.tag=${SHA}"
+            --set image.pullSecretName=ghcr-pull-secret
+            --set service.type=NodePort
+            --set service.nodePort=30088
+            --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data
+            --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data
             --set ingress.enabled=false
+            "${ai_helm_args[@]}"
+          )
+          helm "${helm_args[@]}"
 
           # Wait for the new pods to become ready.
           kubectl -n news-dashboard rollout status \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,21 +140,15 @@ jobs:
             --docker-password="$GHCR_TOKEN" \
             --dry-run=client -o yaml | kubectl apply -f -
 
-          ai_secret_args=()
-          if [ -n "$OPENAI_API_KEY" ]; then
-            ai_secret_args+=(--from-literal=OPENAI_API_KEY="$OPENAI_API_KEY")
-          fi
-          if [ -n "$ANTHROPIC_API_KEY" ]; then
-            ai_secret_args+=(--from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY")
+          if [ -z "${OPENAI_API_KEY}" ] || [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "OPENAI_API_KEY and ANTHROPIC_API_KEY GitHub Actions secrets are required for Ask AI." >&2
+            exit 1
           fi
 
-          ai_helm_args=()
-          if [ ${#ai_secret_args[@]} -gt 0 ]; then
-            kubectl -n news-dashboard create secret generic news-dashboard-ai \
-              "${ai_secret_args[@]}" \
-              --dry-run=client -o yaml | kubectl apply -f -
-            ai_helm_args+=(--set app.ai.existingSecret=news-dashboard-ai)
-          fi
+          kubectl -n news-dashboard create secret generic news-dashboard-ai \
+            --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
+            --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+            --dry-run=client -o yaml | kubectl apply -f -
 
           # Sync Helm chart changes from the repo.
           cd ~/news-dashboard && git pull --ff-only
@@ -171,8 +165,8 @@ jobs:
             --set service.nodePort=30088
             --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data
             --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data
+            --set app.ai.existingSecret=news-dashboard-ai
             --set ingress.enabled=false
-            "${ai_helm_args[@]}"
           )
           helm "${helm_args[@]}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
           IMG: ${{ env.IMAGE }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
 
@@ -138,6 +140,16 @@ jobs:
             --docker-password="$GHCR_TOKEN" \
             --dry-run=client -o yaml | kubectl apply -f -
 
+          if [ -z "${OPENAI_API_KEY}" ] || [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "OPENAI_API_KEY and ANTHROPIC_API_KEY GitHub Actions secrets are required for Ask AI." >&2
+            exit 1
+          fi
+
+          kubectl -n news-dashboard create secret generic news-dashboard-ai \
+            --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
+            --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
           # Sync Helm chart changes from the repo.
           cd ~/news-dashboard && git pull --ff-only
 
@@ -152,6 +164,7 @@ jobs:
             --set service.nodePort=30088 \
             --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data \
             --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data \
+            --set app.ai.existingSecret=news-dashboard-ai \
             --set ingress.enabled=false
 
           # Wait for the new pods to become ready.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ helm upgrade --install news-dashboard ./helm/news-dashboard \
   --set app.ai.existingSecret=news-dashboard-ai
 ```
 
+The GitHub Actions deployment expects repository secrets named
+`OPENAI_API_KEY` and `ANTHROPIC_API_KEY`; it creates the Kubernetes Secret
+automatically during deploy.
+
 ## Durable database
 
 The Kubernetes deployment uses PostgreSQL by default, backed by durable host storage on the local single-node cluster:

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -62,11 +62,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.app.ai.existingSecret | quote }}
                   key: {{ .Values.app.ai.openaiApiKeyKey | quote }}
+                  optional: true
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.app.ai.existingSecret | quote }}
                   key: {{ .Values.app.ai.anthropicApiKeyKey | quote }}
+                  optional: true
 {{- end }}
           ports:
             - containerPort: 8080

--- a/scripts/deploy-local-k8s.sh
+++ b/scripts/deploy-local-k8s.sh
@@ -5,10 +5,17 @@
 # Usage:
 #   ./scripts/deploy-local-k8s.sh [TAG]
 #
+# Ask AI requires OPENAI_API_KEY and ANTHROPIC_API_KEY in this shell.
+#
 # TAG defaults to the current git SHA.  Pass 'latest' only for quick local
 # testing — never rely on 'latest' for real deploys (imagePullPolicy won't
 # re-pull if the tag is already cached).
 set -euo pipefail
+
+if [[ -z "${OPENAI_API_KEY:-}" || -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "OPENAI_API_KEY and ANTHROPIC_API_KEY must be set before deploying Ask AI." >&2
+  exit 1
+fi
 
 REPO="${REPO:-localhost:5000/news-dashboard}"
 TAG="${1:-$(git rev-parse --short HEAD)}"
@@ -18,6 +25,12 @@ echo "→ Building ${IMAGE}"
 docker build -t "${IMAGE}" .
 echo "→ Pushing ${IMAGE}"
 docker push "${IMAGE}"
+
+echo "→ Applying AI credentials secret"
+kubectl -n news-dashboard create secret generic news-dashboard-ai \
+  --from-literal=OPENAI_API_KEY="${OPENAI_API_KEY}" \
+  --from-literal=ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+  --dry-run=client -o yaml | kubectl apply -f -
 
 echo "→ Deploying with Helm (tag=${TAG})"
 helm upgrade --install news-dashboard ./helm/news-dashboard \
@@ -29,6 +42,7 @@ helm upgrade --install news-dashboard ./helm/news-dashboard \
   --set service.nodePort=30088 \
   --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data \
   --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data \
+  --set app.ai.existingSecret=news-dashboard-ai \
   --set ingress.enabled=false
 
 echo "→ Waiting for Postgres"


### PR DESCRIPTION
## Summary
- Create/update the `news-dashboard-ai` Kubernetes Secret during CI deploys from GitHub Actions secrets.
- Pass `app.ai.existingSecret=news-dashboard-ai` into the production Helm upgrade.
- Make the manual local-k8s deploy script apply the same secret and fail clearly when AI keys are missing.

## Root cause
The backend and Helm chart support Ask AI credentials, but the automated deploy command never set `app.ai.existingSecret`, so new pods could still start without `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`.

## Validation
- `python3 -m pytest`
- `git diff --check`
- `bash -n scripts/deploy-local-k8s.sh`

## Deployment requirement
Repository secrets `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` must exist before the main-branch deploy job runs.
