### PR TITLE
[codex] Use OpenAI only for Ask AI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
 
@@ -143,9 +142,6 @@ jobs:
           ai_secret_args=()
           if [ -n "$OPENAI_API_KEY" ]; then
             ai_secret_args+=(--from-literal=OPENAI_API_KEY="$OPENAI_API_KEY")
-          fi
-          if [ -n "$ANTHROPIC_API_KEY" ]; then
-            ai_secret_args+=(--from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY")
           fi
 
           ai_helm_args=()

--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ npm run dev
 
 Open `http://localhost:5173`.
 
-Ask AI requires both provider keys in the backend environment:
+Ask AI requires an OpenAI key in the backend environment:
 
 ```bash
 export OPENAI_API_KEY=...
-export ANTHROPIC_API_KEY=...
 ```
 
 ## Container
@@ -55,8 +54,7 @@ For Kubernetes, create a Secret and point Helm at it:
 
 ```bash
 kubectl create secret generic news-dashboard-ai \
-  --from-literal=OPENAI_API_KEY=... \
-  --from-literal=ANTHROPIC_API_KEY=...
+  --from-literal=OPENAI_API_KEY=...
 
 helm upgrade --install news-dashboard ./helm/news-dashboard \
   --set app.ai.existingSecret=news-dashboard-ai

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -1,7 +1,7 @@
 """AI Q&A feature: embedding generation and retrieval-augmented answering.
 
 Embedding model : text-embedding-3-small (OpenAI)
-Answer model    : claude-haiku-4-5 (Anthropic)
+Answer model    : gpt-4o-mini (OpenAI)
 Storage         : articles.embedding BLOB (serialized float32 numpy array)
 Retrieval       : pure-Python cosine similarity (no sqlite-vss needed)
 """
@@ -13,6 +13,7 @@ from typing import Any
 
 MIN_ARTICLES = 5   # refuse to answer if fewer than this many articles are embedded
 TOP_K = 8          # articles to include as context
+DEFAULT_ANSWER_MODEL = "gpt-4o-mini"
 
 
 class MissingAICredentialsError(RuntimeError):
@@ -51,6 +52,22 @@ def _embed(text: str) -> list[float]:
         input=text,
     )
     return response.data[0].embedding
+
+
+def _answer(system_prompt: str, user_prompt: str) -> str:
+    """Generate an answer with OpenAI using the same key as embeddings."""
+    from openai import OpenAI  # lazy import — optional dep at import time
+
+    client = OpenAI(api_key=_require_env("OPENAI_API_KEY", "use Ask AI"))
+    response = client.chat.completions.create(
+        model=os.getenv("OPENAI_ANSWER_MODEL", DEFAULT_ANSWER_MODEL),
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        max_tokens=1024,
+    )
+    return response.choices[0].message.content or ""
 
 
 # ── Cosine similarity ──────────────────────────────────────────────────────
@@ -188,19 +205,8 @@ def ask(query: str, db_path: Any = None) -> dict:
         f"Question: {query}"
     )
 
-    # 6. Call claude-haiku-4-5 for the answer
-    import anthropic  # lazy import
-
-    client = anthropic.Anthropic(
-        api_key=_require_env("ANTHROPIC_API_KEY", "generate answers")
-    )
-    message = client.messages.create(
-        model="claude-haiku-4-5",
-        max_tokens=1024,
-        system=system_prompt,
-        messages=[{"role": "user", "content": user_prompt}],
-    )
-    answer_text = message.content[0].text if message.content else ""
+    # 6. Call OpenAI for the answer
+    answer_text = _answer(system_prompt, user_prompt)
 
     # 7. Return answer + deduplicated source list (top-k order)
     sources = [

--- a/backend/tests/test_ai_credentials.py
+++ b/backend/tests/test_ai_credentials.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from news_dashboard.embeddings import MissingAICredentialsError, _require_env
+from news_dashboard.embeddings import (
+    DEFAULT_ANSWER_MODEL,
+    MissingAICredentialsError,
+    _answer,
+    _require_env,
+)
 
 
 def test_require_env_returns_configured_value(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -18,3 +23,42 @@ def test_require_env_raises_clear_error_when_missing(
 
     with pytest.raises(MissingAICredentialsError, match="Ask AI requires OPENAI_API_KEY"):
         _require_env("OPENAI_API_KEY", "generate article embeddings")
+
+
+def test_answer_uses_openai_api_key_and_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeMessage:
+        content = "answer text"
+
+    class FakeChoice:
+        message = FakeMessage()
+
+    class FakeResponse:
+        choices = [FakeChoice()]
+
+    class FakeCompletions:
+        def create(self, **kwargs: object) -> FakeResponse:
+            calls.append(kwargs)
+            return FakeResponse()
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeOpenAI:
+        def __init__(self, api_key: str) -> None:
+            calls.append({"api_key": api_key})
+            self.chat = FakeChat()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_ANSWER_MODEL", raising=False)
+    import sys
+    from types import SimpleNamespace
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=FakeOpenAI))
+
+    assert _answer("system", "user") == "answer text"
+    assert calls[0] == {"api_key": "test-key"}
+    assert calls[1]["model"] == DEFAULT_ANSWER_MODEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       POSTGRES_USER: news_dashboard
       POSTGRES_PASSWORD: news-dashboard-local-password
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -103,7 +103,7 @@ After ≥ 100 saved/read articles exist:
 
 ### Embeddings / vector search (v1.2)
 
-- Embed title + summary via a local model (e.g., `sentence-transformers`) or the Anthropic API.
+- Embed title + summary via OpenAI.
 - Store in a separate `article_embeddings` table as a BLOB or via SQLite-VSS.
 - Enables semantic search and similarity grouping.
 
@@ -121,13 +121,13 @@ POST /api/ask
 Implementation:
 1. Run `/api/search?q=<question_keywords>` to retrieve candidate articles.
 2. Bundle up to N articles (title + summary + date + source) into a prompt.
-3. Call Claude with the bundle and question.
+3. Call OpenAI with the bundle and question.
 4. Return answer + article IDs used as citations.
 
 Privacy/security:
 - Endpoint is internal-only (behind Caddy basic_auth).
 - No article content is sent to external APIs unless the user explicitly enables the AI hook.
-- Anthropic API key stored as an environment secret, never in source.
+- OpenAI API key stored as an environment secret, never in source.
 - The AI hook is behind an `AI_ENABLED=1` env flag — disabled by default.
 
 ### Privacy/security boundaries

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -63,12 +63,6 @@ spec:
                   name: {{ .Values.app.ai.existingSecret | quote }}
                   key: {{ .Values.app.ai.openaiApiKeyKey | quote }}
                   optional: true
-            - name: ANTHROPIC_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.ai.existingSecret | quote }}
-                  key: {{ .Values.app.ai.anthropicApiKeyKey | quote }}
-                  optional: true
 {{- end }}
           ports:
             - containerPort: 8080

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -31,10 +31,9 @@ persistence:
 app:
   databasePath: /data/news-dashboard.db
   ai:
-    # Optional: pre-existing Secret with OPENAI_API_KEY and ANTHROPIC_API_KEY.
+    # Optional: pre-existing Secret with OPENAI_API_KEY.
     existingSecret: ""
     openaiApiKeyKey: OPENAI_API_KEY
-    anthropicApiKeyKey: ANTHROPIC_API_KEY
 
 postgresql:
   enabled: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
   "typer>=0.12.0",
   "psycopg[binary]>=3.2.0",
   "apscheduler>=3.10.0",
-  "anthropic>=0.40.0",
   "openai>=1.50.0",
   "numpy>=1.26.0",
   "rapidfuzz>=3.0.0",

--- a/scripts/deploy-local-k8s.sh
+++ b/scripts/deploy-local-k8s.sh
@@ -5,10 +5,17 @@
 # Usage:
 #   ./scripts/deploy-local-k8s.sh [TAG]
 #
+# Ask AI requires OPENAI_API_KEY in this shell.
+#
 # TAG defaults to the current git SHA.  Pass 'latest' only for quick local
 # testing — never rely on 'latest' for real deploys (imagePullPolicy won't
 # re-pull if the tag is already cached).
 set -euo pipefail
+
+AI_HELM_ARGS=()
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  AI_HELM_ARGS+=(--set app.ai.existingSecret=news-dashboard-ai)
+fi
 
 REPO="${REPO:-localhost:5000/news-dashboard}"
 TAG="${1:-$(git rev-parse --short HEAD)}"
@@ -18,6 +25,13 @@ echo "→ Building ${IMAGE}"
 docker build -t "${IMAGE}" .
 echo "→ Pushing ${IMAGE}"
 docker push "${IMAGE}"
+
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  echo "→ Applying AI credentials secret"
+  kubectl -n news-dashboard create secret generic news-dashboard-ai \
+    --from-literal=OPENAI_API_KEY="${OPENAI_API_KEY}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
 
 echo "→ Deploying with Helm (tag=${TAG})"
 helm upgrade --install news-dashboard ./helm/news-dashboard \
@@ -29,6 +43,7 @@ helm upgrade --install news-dashboard ./helm/news-dashboard \
   --set service.nodePort=30088 \
   --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data \
   --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data \
+  "${AI_HELM_ARGS[@]}" \
   --set ingress.enabled=false
 
 echo "→ Waiting for Postgres"


### PR DESCRIPTION
## Summary
- Use OpenAI for both Ask AI embeddings and answer generation.
- Remove the Anthropic SDK dependency and all `ANTHROPIC_API_KEY` app/deploy wiring.
- Keep `OPENAI_API_KEY` as the single required provider key, with optional `OPENAI_ANSWER_MODEL` override for the answer model.
- Update Docker Compose, Helm, CI deploy wiring, docs, and regression tests.

## Root cause
Ask AI previously used OpenAI for embeddings but Anthropic for answer generation, so the feature still failed unless `ANTHROPIC_API_KEY` was also configured. The desired setup is one provider key: `OPENAI_API_KEY`.

## Validation
- `python3 -m pytest`
- `git diff --check`
- `bash -n scripts/deploy-local-k8s.sh`
- Targeted scan for `ANTHROPIC_API_KEY`, Anthropic SDK imports, and Claude answer model references in Ask AI/config/deploy files

## Notes
- PR #59 was closed as superseded because it still wired `ANTHROPIC_API_KEY`.
- I could not run `helm template` locally because `helm` is not installed in this environment.
