### PR TITLE
[codex] Add source health table

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -68,6 +68,27 @@ CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
   title, summary, reason, tags, source_name,
   content=articles, content_rowid=id
 );
+
+CREATE TABLE IF NOT EXISTS ingest_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms INTEGER,
+  total_new INTEGER,
+  total_errors INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS ingest_run_sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER REFERENCES ingest_runs(id),
+  source_name TEXT NOT NULL,
+  articles_found INTEGER,
+  articles_new INTEGER,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
+  ON ingest_run_sources(source_name, run_id DESC);
 """
 
 # Additive columns to add when upgrading existing databases
@@ -145,6 +166,28 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
+    # Ingest run records populated by the scheduler/ingest instrumentation slice
+    """
+    CREATE TABLE IF NOT EXISTS ingest_runs (
+      id SERIAL PRIMARY KEY,
+      started_at TIMESTAMPTZ NOT NULL,
+      finished_at TIMESTAMPTZ,
+      duration_ms INTEGER,
+      total_new INTEGER,
+      total_errors INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ingest_run_sources (
+      id SERIAL PRIMARY KEY,
+      run_id INTEGER REFERENCES ingest_runs(id),
+      source_name TEXT NOT NULL,
+      articles_found INTEGER,
+      articles_new INTEGER,
+      error_message TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run ON ingest_run_sources(source_name, run_id DESC)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -21,6 +21,7 @@ from .scheduler import (
     start_scheduler,
     stop_scheduler,
 )
+from .source_health import list_source_health
 
 app = FastAPI(title="News Dashboard", version="0.3.0")
 app.add_middleware(
@@ -119,6 +120,11 @@ def sources() -> dict:
             "SELECT * FROM sources ORDER BY category, priority DESC, name"
         ).fetchall()
         return {"items": [row_to_dict(row) for row in rows]}
+
+
+@app.get("/api/sources/health")
+def sources_health() -> dict:
+    return {"items": list_source_health()}
 
 
 @app.patch("/api/sources/{slug}/enabled")

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db, row_to_dict
+
+
+def _clean_error(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return None
+    if "Traceback" in text:
+        candidates = [
+            line
+            for line in lines
+            if not line.startswith("Traceback")
+            and not line.startswith("File ")
+            and not line.startswith("raise ")
+            and not line.startswith("^")
+        ]
+        text = candidates[-1] if candidates else lines[-1]
+    else:
+        text = lines[0]
+    return text[:180] + ("..." if len(text) > 180 else "")
+
+
+def _source_key(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def list_source_health(db_path: Path | None = None) -> list[dict[str, Any]]:
+    init_db(db_path)
+    with connect(db_path) as conn:
+        source_rows = conn.execute(
+            "SELECT * FROM sources ORDER BY category, priority DESC, name"
+        ).fetchall()
+        run_rows = conn.execute(
+            """
+            SELECT source_name, articles_new, error_message
+            FROM ingest_run_sources
+            ORDER BY run_id DESC, id DESC
+            """
+        ).fetchall()
+
+    health_by_slug: dict[str, dict[str, Any]] = {}
+    aliases: dict[str, str] = {}
+
+    for row in source_rows:
+        source = row_to_dict(row)
+        slug = str(source["slug"])
+        last_error = _clean_error(source.get("last_error"))
+        item = {
+            "slug": slug,
+            "name": source["name"],
+            "category": source["category"],
+            "enabled": source["enabled"],
+            "last_checked_at": source.get("last_checked_at"),
+            "last_error": last_error,
+            "error_streak": 0,
+            "articles_last_run": _as_int(source.get("last_inserted_count")),
+            "status": "ERROR" if last_error else "OK",
+        }
+        health_by_slug[slug] = item
+        aliases[_source_key(source.get("slug"))] = slug
+        aliases[_source_key(source.get("name"))] = slug
+
+    latest_seen: set[str] = set()
+    streak_closed: set[str] = set()
+
+    for row in run_rows:
+        run = row_to_dict(row)
+        slug = aliases.get(_source_key(run.get("source_name")))
+        if not slug:
+            continue
+
+        item = health_by_slug[slug]
+        error = _clean_error(run.get("error_message"))
+        if slug not in latest_seen:
+            item["articles_last_run"] = _as_int(run.get("articles_new"))
+            latest_seen.add(slug)
+
+        if slug in streak_closed:
+            continue
+
+        if error:
+            item["error_streak"] += 1
+            if not item["last_error"]:
+                item["last_error"] = error
+        else:
+            streak_closed.add(slug)
+
+    for slug, item in health_by_slug.items():
+        if slug in latest_seen:
+            item["status"] = "ERROR" if item["error_streak"] > 0 else "OK"
+        else:
+            item["status"] = "ERROR" if item["last_error"] else "OK"
+
+    return sorted(
+        health_by_slug.values(),
+        key=lambda item: (
+            -_as_int(item["error_streak"]),
+            0 if item["status"] == "ERROR" else 1,
+            str(item["name"]).lower(),
+        ),
+    )

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -13,6 +13,7 @@ from news_dashboard.ingest import (
     set_article_status,
     sync_sources,
 )
+from news_dashboard.source_health import list_source_health
 from news_dashboard.sources import DEFAULT_SOURCES, SourceDefinition
 
 
@@ -61,6 +62,66 @@ def test_source_error_tracked(tmp_path: Path) -> None:
         row = conn.execute("SELECT last_error, last_checked_at FROM sources WHERE slug=?", (bad.slug,)).fetchone()
         assert row["last_error"] is not None, "last_error should be set on failure"
         assert row["last_checked_at"] is not None, "last_checked_at should be set even on failure"
+
+
+def test_source_health_error_streak_resets_after_success(tmp_path: Path) -> None:
+    db = tmp_path / "streak.db"
+    sync_sources(db)
+    with connect(db) as conn:
+        for run_id, error in ((1, "timeout"), (2, "HTTP 500"), (3, None)):
+            conn.execute(
+                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
+            )
+            conn.execute(
+                """
+                INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+                VALUES (?, 'Python Insider', 10, ?, ?)
+                """,
+                (run_id, 3 if error is None else 0, error),
+            )
+
+    python = next(item for item in list_source_health(db) if item["slug"] == "python-insider")
+    assert python["error_streak"] == 0
+    assert python["articles_last_run"] == 3
+    assert python["status"] == "OK"
+
+
+def test_source_health_counts_leading_errors_and_sorts_first(tmp_path: Path) -> None:
+    db = tmp_path / "leading-errors.db"
+    sync_sources(db)
+    with connect(db) as conn:
+        for run_id in (1, 2, 3):
+            conn.execute(
+                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
+            )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (1, 'Python Insider', 8, 2, NULL)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (2, 'Python Insider', 0, 0, 'Feed fetch failed: timeout')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (3, 'Python Insider', 0, 0, 'Traceback (most recent call last):\n  File "feed.py", line 1\nTimeoutError: connection timed out')
+            """
+        )
+
+    items = list_source_health(db)
+    python = next(item for item in items if item["slug"] == "python-insider")
+    assert python["error_streak"] == 2
+    assert python["articles_last_run"] == 0
+    assert python["status"] == "ERROR"
+    assert python["last_error"] == "TimeoutError: connection timed out"
+    assert items[0]["slug"] == "python-insider"
 
 
 # ──────────────────────────────────────────────

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   askAI,
   fetchArticles,
   fetchSchedulerStatus,
+  fetchSourceHealth,
   fetchSources,
   fetchSummary,
   ingestNow,
@@ -15,7 +16,7 @@ import {
   updateSourceEnabled,
 } from './api'
 import type { SchedulerStatus } from './api'
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
 
@@ -429,9 +430,78 @@ interface SchedulerTabProps {
   ingesting: boolean
 }
 
+function SourceHealthTable({ items, loading }: { items: SourceHealth[]; loading: boolean }) {
+  const sorted = useMemo(() => {
+    return [...items].sort((a, b) => {
+      if (b.error_streak !== a.error_streak) return b.error_streak - a.error_streak
+      if (a.status !== b.status) return a.status === 'ERROR' ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+  }, [items])
+
+  if (loading) {
+    return (
+      <div className="source-health-loading">
+        <div className="skeleton sk-line" style={{ width: '70%' }} />
+        <div className="skeleton sk-line" style={{ width: '55%' }} />
+        <div className="skeleton sk-line" style={{ width: '62%' }} />
+      </div>
+    )
+  }
+
+  if (sorted.length === 0) {
+    return <p className="source-health-empty">No sources configured.</p>
+  }
+
+  return (
+    <div className="source-health-table-wrap">
+      <table className="source-health-table">
+        <thead>
+          <tr>
+            <th>Source name</th>
+            <th>Last checked</th>
+            <th>Status</th>
+            <th>Articles last run</th>
+            <th>Error streak</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((source) => (
+            <tr key={source.slug} className={source.status === 'ERROR' ? 'source-health-row-error' : undefined}>
+              <td>
+                <span className="source-health-name">{source.name}</span>
+                <span className="source-health-category">{source.category.replace(/-/g, ' ')}</span>
+              </td>
+              <td>{source.last_checked_at ? relativeTime(source.last_checked_at) : 'Never'}</td>
+              <td>
+                <span className={`source-health-status ${source.status.toLowerCase()}`}>
+                  {source.status}
+                </span>
+              </td>
+              <td>{source.articles_last_run}</td>
+              <td>
+                <span className="source-health-streak" title={source.last_error ?? undefined}>
+                  {source.error_streak}
+                </span>
+                {source.last_error && (
+                  <span className="source-health-last-error" title={source.last_error}>
+                    {source.last_error}
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [status, setStatus] = useState<SchedulerStatus | null>(null)
   const [loadingStatus, setLoadingStatus] = useState(true)
+  const [sourceHealth, setSourceHealth] = useState<SourceHealth[]>([])
+  const [loadingSourceHealth, setLoadingSourceHealth] = useState(true)
   const [customMinutes, setCustomMinutes] = useState('')
   const [actionPending, setActionPending] = useState(false)
   const [tabMessage, setTabMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
@@ -448,8 +518,20 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     }
   }
 
+  async function loadHealth() {
+    setLoadingSourceHealth(true)
+    try {
+      setSourceHealth(await fetchSourceHealth())
+    } catch (err) {
+      setTabMessage({ text: err instanceof Error ? err.message : 'Failed to load source health', kind: 'error' })
+    } finally {
+      setLoadingSourceHealth(false)
+    }
+  }
+
   useEffect(() => {
     void loadStatus()
+    void loadHealth()
   }, [])
 
   useEffect(() => {
@@ -503,6 +585,11 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     } finally {
       setActionPending(false)
     }
+  }
+
+  async function handleFetchNow() {
+    await onFetchNow()
+    await loadHealth()
   }
 
   if (loadingStatus) {
@@ -595,12 +682,17 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           </button>
           <button
             className="scheduler-fetch-btn"
-            onClick={() => void onFetchNow()}
+            onClick={() => void handleFetchNow()}
             disabled={ingesting || actionPending}
           >
             {ingesting ? '⟳ Fetching…' : '↻ Fetch now'}
           </button>
         </div>
+      </div>
+
+      <div className="scheduler-card scheduler-card--wide">
+        <h3 className="scheduler-card-title">Source Health</h3>
+        <SourceHealthTable items={sourceHealth} loading={loadingSourceHealth} />
       </div>
     </div>
   )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -30,6 +30,11 @@ export async function searchArticles(q: string, limit = 50): Promise<Article[]> 
 
 export async function fetchSources(): Promise<Source[]> {
   const data = await requestJson<{ items: Source[] }>('/api/sources')
+  return data.items
+}
+
+export async function fetchSourceHealth(): Promise<SourceHealth[]> {
+  const data = await requestJson<{ items: SourceHealth[] }>('/api/sources/health')
   return data.items
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -901,6 +901,118 @@ ul { list-style: none; }
   word-break: break-all;
 }
 
+/* ===== SCHEDULER SOURCE HEALTH ===== */
+.scheduler-card--wide {
+  grid-column: 1 / -1;
+}
+
+.source-health-loading {
+  display: grid;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.source-health-empty {
+  color: var(--text-3);
+  font-size: 13px;
+}
+
+.source-health-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.source-health-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.source-health-table th,
+.source-health-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: 12px;
+  vertical-align: top;
+}
+
+.source-health-table th {
+  color: var(--text-3);
+  background: var(--surface-alt);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+
+.source-health-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.source-health-row-error {
+  background: #fff1f2;
+}
+
+[data-theme="dark"] .source-health-row-error {
+  background: rgba(127, 29, 29, .16);
+}
+
+.source-health-name,
+.source-health-category,
+.source-health-last-error {
+  display: block;
+}
+
+.source-health-name {
+  color: var(--text-1);
+  font-weight: 650;
+}
+
+.source-health-category {
+  margin-top: 2px;
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.source-health-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.source-health-status.ok {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.source-health-status.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.source-health-streak {
+  color: var(--text-1);
+  font-weight: 700;
+}
+
+.source-health-last-error {
+  max-width: 360px;
+  margin-top: 3px;
+  color: #b91c1c;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ===== SKELETON LOADER ===== */
 @keyframes shimmer {
   0%   { background-position: -400% 0; }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,18 @@ export interface Source {
   last_inserted_count?: number
 }
 
+export interface SourceHealth {
+  slug: string
+  name: string
+  category: string
+  enabled: number
+  last_checked_at?: string | null
+  last_error?: string | null
+  error_streak: number
+  articles_last_run: number
+  status: 'OK' | 'ERROR'
+}
+
 export interface Summary {
   byStatus: Record<string, number>
   byCategory: Record<string, number>


### PR DESCRIPTION
## Summary
- Adds `/api/sources/health` with source status, articles from latest run, and leading error streak computation from `ingest_run_sources`.
- Adds the issue #50 run-table schema defensively so the health query has the expected tables while remaining scoped to source health.
- Adds a Scheduler tab Source Health table sorted with erroring sources first, with OK/ERROR badges, row tinting, and sanitized last-error display.

Refs #51

## Verification
- `PYTHONPATH=backend python3 -m pytest`
- `npm run build`
- Browser sanity check at `http://127.0.0.1:8001/`: Scheduler table rendered with 33 configured source rows and expected columns.