### PR TITLE
[codex] Implement stats dashboard

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -89,6 +89,8 @@ CREATE TABLE IF NOT EXISTS ingest_run_sources (
 
 CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
   ON ingest_run_sources(source_name, run_id DESC);
+CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at);
+CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id);
 """
 
 # Additive columns to add when upgrading existing databases
@@ -166,7 +168,7 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
-    # Ingest run records populated by the scheduler/ingest instrumentation slice
+    # Ingest run telemetry from issue #50. Stats endpoints read these tables.
     """
     CREATE TABLE IF NOT EXISTS ingest_runs (
       id SERIAL PRIMARY KEY,
@@ -188,6 +190,8 @@ POSTGRES_SCHEMA = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run ON ingest_run_sources(source_name, run_id DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at)",
+    "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id)",
 ]
 
 

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -68,6 +68,27 @@ CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
   title, summary, reason, tags, source_name,
   content=articles, content_rowid=id
 );
+
+CREATE TABLE IF NOT EXISTS ingest_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms INTEGER,
+  total_new INTEGER,
+  total_errors INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS ingest_run_sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER REFERENCES ingest_runs(id),
+  source_name TEXT NOT NULL,
+  articles_found INTEGER,
+  articles_new INTEGER,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at);
+CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id);
 """
 
 # Additive columns to add when upgrading existing databases
@@ -145,6 +166,29 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
+    # Ingest run telemetry from issue #50. Stats endpoints read these tables.
+    """
+    CREATE TABLE IF NOT EXISTS ingest_runs (
+      id BIGSERIAL PRIMARY KEY,
+      started_at TIMESTAMPTZ NOT NULL,
+      finished_at TIMESTAMPTZ,
+      duration_ms INTEGER,
+      total_new INTEGER,
+      total_errors INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ingest_run_sources (
+      id BIGSERIAL PRIMARY KEY,
+      run_id INTEGER REFERENCES ingest_runs(id),
+      source_name TEXT NOT NULL,
+      articles_found INTEGER,
+      articles_new INTEGER,
+      error_message TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at)",
+    "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id)",
 ]
 
 

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -68,6 +68,27 @@ CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
   title, summary, reason, tags, source_name,
   content=articles, content_rowid=id
 );
+
+CREATE TABLE IF NOT EXISTS ingest_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms INTEGER,
+  total_new INTEGER,
+  total_errors INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS ingest_run_sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER REFERENCES ingest_runs(id),
+  source_name TEXT NOT NULL,
+  articles_found INTEGER,
+  articles_new INTEGER,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
+  ON ingest_run_sources(source_name, run_id DESC);
 """
 
 # Additive columns to add when upgrading existing databases
@@ -145,6 +166,28 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
+    # Ingest run records populated by the scheduler/ingest instrumentation slice
+    """
+    CREATE TABLE IF NOT EXISTS ingest_runs (
+      id SERIAL PRIMARY KEY,
+      started_at TIMESTAMPTZ NOT NULL,
+      finished_at TIMESTAMPTZ,
+      duration_ms INTEGER,
+      total_new INTEGER,
+      total_errors INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ingest_run_sources (
+      id SERIAL PRIMARY KEY,
+      run_id INTEGER REFERENCES ingest_runs(id),
+      source_name TEXT NOT NULL,
+      articles_found INTEGER,
+      articles_new INTEGER,
+      error_message TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run ON ingest_run_sources(source_name, run_id DESC)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -21,6 +21,7 @@ from .scheduler import (
     start_scheduler,
     stop_scheduler,
 )
+from .stats import articles_over_time, sources_volume, stats_overview
 from .source_health import list_source_health
 
 app = FastAPI(title="News Dashboard", version="0.3.0")
@@ -174,6 +175,39 @@ def scheduler_pause() -> dict:
 def scheduler_resume() -> dict:
     resume_scheduler()
     return {"paused": False, "next_run_at": get_next_ingest_at()}
+
+
+@app.get("/api/stats/overview")
+def stats_overview_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return stats_overview(from_, to)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/stats/articles-over-time")
+def stats_articles_over_time_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return {"items": articles_over_time(from_, to)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/stats/sources-volume")
+def stats_sources_volume_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return {"items": sources_volume(from_, to)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 class AskRequest(BaseModel):

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -21,6 +21,7 @@ from .scheduler import (
     start_scheduler,
     stop_scheduler,
 )
+from .stats import articles_over_time, sources_volume, stats_overview
 
 app = FastAPI(title="News Dashboard", version="0.3.0")
 app.add_middleware(
@@ -168,6 +169,39 @@ def scheduler_pause() -> dict:
 def scheduler_resume() -> dict:
     resume_scheduler()
     return {"paused": False, "next_run_at": get_next_ingest_at()}
+
+
+@app.get("/api/stats/overview")
+def stats_overview_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return stats_overview(from_, to)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/stats/articles-over-time")
+def stats_articles_over_time_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return {"items": articles_over_time(from_, to)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/stats/sources-volume")
+def stats_sources_volume_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return {"items": sources_volume(from_, to)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 class AskRequest(BaseModel):

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -21,6 +21,7 @@ from .scheduler import (
     start_scheduler,
     stop_scheduler,
 )
+from .source_health import list_source_health
 
 app = FastAPI(title="News Dashboard", version="0.3.0")
 app.add_middleware(
@@ -119,6 +120,11 @@ def sources() -> dict:
             "SELECT * FROM sources ORDER BY category, priority DESC, name"
         ).fetchall()
         return {"items": [row_to_dict(row) for row in rows]}
+
+
+@app.get("/api/sources/health")
+def sources_health() -> dict:
+    return {"items": list_source_health()}
 
 
 @app.patch("/api/sources/{slug}/enabled")

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db, row_to_dict
+
+
+def _clean_error(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return None
+    if "Traceback" in text:
+        candidates = [
+            line
+            for line in lines
+            if not line.startswith("Traceback")
+            and not line.startswith("File ")
+            and not line.startswith("raise ")
+            and not line.startswith("^")
+        ]
+        text = candidates[-1] if candidates else lines[-1]
+    else:
+        text = lines[0]
+    return text[:180] + ("..." if len(text) > 180 else "")
+
+
+def _source_key(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def list_source_health(db_path: Path | None = None) -> list[dict[str, Any]]:
+    init_db(db_path)
+    with connect(db_path) as conn:
+        source_rows = conn.execute(
+            "SELECT * FROM sources ORDER BY category, priority DESC, name"
+        ).fetchall()
+        run_rows = conn.execute(
+            """
+            SELECT source_name, articles_new, error_message
+            FROM ingest_run_sources
+            ORDER BY run_id DESC, id DESC
+            """
+        ).fetchall()
+
+    health_by_slug: dict[str, dict[str, Any]] = {}
+    aliases: dict[str, str] = {}
+
+    for row in source_rows:
+        source = row_to_dict(row)
+        slug = str(source["slug"])
+        last_error = _clean_error(source.get("last_error"))
+        item = {
+            "slug": slug,
+            "name": source["name"],
+            "category": source["category"],
+            "enabled": source["enabled"],
+            "last_checked_at": source.get("last_checked_at"),
+            "last_error": last_error,
+            "error_streak": 0,
+            "articles_last_run": _as_int(source.get("last_inserted_count")),
+            "status": "ERROR" if last_error else "OK",
+        }
+        health_by_slug[slug] = item
+        aliases[_source_key(source.get("slug"))] = slug
+        aliases[_source_key(source.get("name"))] = slug
+
+    latest_seen: set[str] = set()
+    streak_closed: set[str] = set()
+
+    for row in run_rows:
+        run = row_to_dict(row)
+        slug = aliases.get(_source_key(run.get("source_name")))
+        if not slug:
+            continue
+
+        item = health_by_slug[slug]
+        error = _clean_error(run.get("error_message"))
+        if slug not in latest_seen:
+            item["articles_last_run"] = _as_int(run.get("articles_new"))
+            latest_seen.add(slug)
+
+        if slug in streak_closed:
+            continue
+
+        if error:
+            item["error_streak"] += 1
+            if not item["last_error"]:
+                item["last_error"] = error
+        else:
+            streak_closed.add(slug)
+
+    for slug, item in health_by_slug.items():
+        if slug in latest_seen:
+            item["status"] = "ERROR" if item["error_streak"] > 0 else "OK"
+        else:
+            item["status"] = "ERROR" if item["last_error"] else "OK"
+
+    return sorted(
+        health_by_slug.values(),
+        key=lambda item: (
+            -_as_int(item["error_streak"]),
+            0 if item["status"] == "ERROR" else 1,
+            str(item["name"]).lower(),
+        ),
+    )

--- a/backend/news_dashboard/stats.py
+++ b/backend/news_dashboard/stats.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db, row_to_dict
+
+
+def parse_range(from_value: str, to_value: str) -> tuple[datetime, datetime]:
+    start = _parse_datetime(from_value)
+    end = _parse_datetime(to_value)
+    if start > end:
+        raise ValueError("'from' must be before or equal to 'to'")
+    return start, end
+
+
+def stats_overview(from_value: str, to_value: str, db_path: Path | None = None) -> dict:
+    start, end = parse_range(from_value, to_value)
+    runs, source_rows = _load_stats_rows(start, end, db_path)
+
+    total_articles = sum(_int_value(row.get("articles_found")) for row in source_rows)
+    total_new = sum(_int_value(row.get("total_new")) for row in runs)
+    if total_new == 0 and source_rows:
+        total_new = sum(_int_value(row.get("articles_new")) for row in source_rows)
+    total_errors = sum(_int_value(row.get("total_errors")) for row in runs)
+    if total_errors == 0 and source_rows:
+        total_errors = sum(1 for row in source_rows if _has_error(row.get("error_message")))
+
+    durations = [_int_value(row.get("duration_ms")) for row in runs if row.get("duration_ms") is not None]
+    latest_by_source: dict[str, dict[str, Any]] = {}
+    for row in source_rows:
+        name = str(row["source_name"])
+        current = latest_by_source.get(name)
+        if current is None or _row_sort_key(row) > _row_sort_key(current):
+            latest_by_source[name] = row
+
+    erroring_sources = sum(1 for row in latest_by_source.values() if _has_error(row.get("error_message")))
+    healthy_sources = sum(1 for row in latest_by_source.values() if not _has_error(row.get("error_message")))
+
+    return {
+        "total_articles": total_articles,
+        "total_new": total_new,
+        "total_errors": total_errors,
+        "avg_duration_ms": round(sum(durations) / len(durations)) if durations else 0,
+        "healthy_sources": healthy_sources,
+        "erroring_sources": erroring_sources,
+    }
+
+
+def articles_over_time(from_value: str, to_value: str, db_path: Path | None = None) -> list[dict]:
+    start, end = parse_range(from_value, to_value)
+    runs, _ = _load_stats_rows(start, end, db_path)
+    hourly = end - start <= timedelta(days=1)
+    counts: dict[str, int] = defaultdict(int)
+
+    for row in runs:
+        started_at = _coerce_datetime(row["started_at"])
+        if hourly:
+            bucket = started_at.replace(minute=0, second=0, microsecond=0)
+            key = bucket.isoformat()
+        else:
+            key = started_at.date().isoformat()
+        counts[key] += _int_value(row.get("total_new"))
+
+    return [
+        {"date": bucket, "new_articles": counts[bucket]}
+        for bucket in _bucket_keys(start, end, hourly)
+    ]
+
+
+def sources_volume(from_value: str, to_value: str, db_path: Path | None = None) -> list[dict]:
+    start, end = parse_range(from_value, to_value)
+    _, source_rows = _load_stats_rows(start, end, db_path)
+    totals: dict[str, int] = defaultdict(int)
+    for row in source_rows:
+        totals[str(row["source_name"])] += _int_value(row.get("articles_new"))
+    return [
+        {"source_name": source_name, "total_new": total_new}
+        for source_name, total_new in sorted(totals.items(), key=lambda item: (-item[1], item[0].lower()))
+    ]
+
+
+def _load_stats_rows(
+    start: datetime,
+    end: datetime,
+    db_path: Path | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    init_db(db_path)
+    with connect(db_path) as conn:
+        run_rows = conn.execute(
+            """
+            SELECT id, started_at, finished_at, duration_ms, total_new, total_errors
+            FROM ingest_runs
+            WHERE started_at >= ? AND started_at <= ?
+            ORDER BY started_at ASC, id ASC
+            """,
+            (_to_query_value(start), _to_query_value(end)),
+        ).fetchall()
+        runs = [row_to_dict(row) for row in run_rows]
+        run_ids = [row["id"] for row in runs]
+        if not run_ids:
+            return [], []
+
+        placeholders = ", ".join("?" for _ in run_ids)
+        source_rows = conn.execute(
+            f"""
+            SELECT
+              ingest_run_sources.id,
+              ingest_run_sources.run_id,
+              ingest_run_sources.source_name,
+              ingest_run_sources.articles_found,
+              ingest_run_sources.articles_new,
+              ingest_run_sources.error_message,
+              ingest_runs.started_at
+            FROM ingest_run_sources
+            JOIN ingest_runs ON ingest_runs.id = ingest_run_sources.run_id
+            WHERE ingest_run_sources.run_id IN ({placeholders})
+            ORDER BY ingest_runs.started_at ASC, ingest_run_sources.id ASC
+            """,
+            tuple(run_ids),
+        ).fetchall()
+    return runs, [row_to_dict(row) for row in source_rows]
+
+
+def _bucket_keys(start: datetime, end: datetime, hourly: bool) -> list[str]:
+    if hourly:
+        cursor = start.replace(minute=0, second=0, microsecond=0)
+        last = end.replace(minute=0, second=0, microsecond=0)
+        step = timedelta(hours=1)
+        keys: list[str] = []
+        while cursor <= last:
+            keys.append(cursor.isoformat())
+            cursor += step
+        return keys
+
+    cursor_date = start.date()
+    last_date = end.date()
+    keys = []
+    while cursor_date <= last_date:
+        keys.append(cursor_date.isoformat())
+        cursor_date += timedelta(days=1)
+    return keys
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"Invalid ISO datetime: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        parsed = _parse_datetime(str(value))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _to_query_value(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _int_value(value: Any) -> int:
+    if value is None:
+        return 0
+    return int(value)
+
+
+def _has_error(value: Any) -> bool:
+    return bool(str(value).strip()) if value is not None else False
+
+
+def _row_sort_key(row: dict[str, Any]) -> tuple[datetime, int]:
+    return (_coerce_datetime(row["started_at"]), _int_value(row.get("id")))

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -13,6 +13,7 @@ from news_dashboard.ingest import (
     set_article_status,
     sync_sources,
 )
+from news_dashboard.source_health import list_source_health
 from news_dashboard.sources import DEFAULT_SOURCES, SourceDefinition
 
 
@@ -61,6 +62,66 @@ def test_source_error_tracked(tmp_path: Path) -> None:
         row = conn.execute("SELECT last_error, last_checked_at FROM sources WHERE slug=?", (bad.slug,)).fetchone()
         assert row["last_error"] is not None, "last_error should be set on failure"
         assert row["last_checked_at"] is not None, "last_checked_at should be set even on failure"
+
+
+def test_source_health_error_streak_resets_after_success(tmp_path: Path) -> None:
+    db = tmp_path / "streak.db"
+    sync_sources(db)
+    with connect(db) as conn:
+        for run_id, error in ((1, "timeout"), (2, "HTTP 500"), (3, None)):
+            conn.execute(
+                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
+            )
+            conn.execute(
+                """
+                INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+                VALUES (?, 'Python Insider', 10, ?, ?)
+                """,
+                (run_id, 3 if error is None else 0, error),
+            )
+
+    python = next(item for item in list_source_health(db) if item["slug"] == "python-insider")
+    assert python["error_streak"] == 0
+    assert python["articles_last_run"] == 3
+    assert python["status"] == "OK"
+
+
+def test_source_health_counts_leading_errors_and_sorts_first(tmp_path: Path) -> None:
+    db = tmp_path / "leading-errors.db"
+    sync_sources(db)
+    with connect(db) as conn:
+        for run_id in (1, 2, 3):
+            conn.execute(
+                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
+            )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (1, 'Python Insider', 8, 2, NULL)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (2, 'Python Insider', 0, 0, 'Feed fetch failed: timeout')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (3, 'Python Insider', 0, 0, 'Traceback (most recent call last):\n  File "feed.py", line 1\nTimeoutError: connection timed out')
+            """
+        )
+
+    items = list_source_health(db)
+    python = next(item for item in items if item["slug"] == "python-insider")
+    assert python["error_streak"] == 2
+    assert python["articles_last_run"] == 0
+    assert python["status"] == "ERROR"
+    assert python["last_error"] == "TimeoutError: connection timed out"
+    assert items[0]["slug"] == "python-insider"
 
 
 # ──────────────────────────────────────────────

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.stats import articles_over_time, sources_volume, stats_overview
+
+
+def _insert_run(
+    db_path: Path,
+    run_id: int,
+    started_at: str,
+    total_new: int,
+    total_errors: int,
+    duration_ms: int,
+    sources: list[tuple[str, int, int, str | None]],
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO ingest_runs(id, started_at, finished_at, duration_ms, total_new, total_errors)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (run_id, started_at, started_at, duration_ms, total_new, total_errors),
+        )
+        for source_name, found, new, error in sources:
+            conn.execute(
+                """
+                INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (run_id, source_name, found, new, error),
+            )
+
+
+def test_overview_aggregates_run_and_source_stats(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(
+        db_path,
+        1,
+        "2026-06-01T10:00:00+00:00",
+        7,
+        1,
+        1000,
+        [
+            ("Python Insider", 10, 5, None),
+            ("Docker Blog", 4, 2, "timeout"),
+        ],
+    )
+    _insert_run(
+        db_path,
+        2,
+        "2026-06-02T10:00:00+00:00",
+        3,
+        0,
+        3000,
+        [
+            ("Python Insider", 8, 3, None),
+            ("Docker Blog", 2, 0, None),
+        ],
+    )
+
+    assert stats_overview(
+        "2026-06-01T00:00:00+00:00",
+        "2026-06-03T00:00:00+00:00",
+        db_path,
+    ) == {
+        "total_articles": 24,
+        "total_new": 10,
+        "total_errors": 1,
+        "avg_duration_ms": 2000,
+        "healthy_sources": 2,
+        "erroring_sources": 0,
+    }
+
+
+def test_articles_over_time_includes_zero_activity_days(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(db_path, 1, "2026-06-01T10:00:00+00:00", 4, 0, 1000, [])
+    _insert_run(db_path, 2, "2026-06-03T10:00:00+00:00", 6, 0, 1000, [])
+
+    assert articles_over_time(
+        "2026-06-01T00:00:00+00:00",
+        "2026-06-03T23:00:00+00:00",
+        db_path,
+    ) == [
+        {"date": "2026-06-01", "new_articles": 4},
+        {"date": "2026-06-02", "new_articles": 0},
+        {"date": "2026-06-03", "new_articles": 6},
+    ]
+
+
+def test_articles_over_time_uses_hourly_buckets_for_one_day_ranges(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(db_path, 1, "2026-06-01T10:30:00+00:00", 4, 0, 1000, [])
+    _insert_run(db_path, 2, "2026-06-01T12:00:00+00:00", 6, 0, 1000, [])
+
+    rows = articles_over_time(
+        "2026-06-01T10:00:00+00:00",
+        "2026-06-01T12:45:00+00:00",
+        db_path,
+    )
+
+    assert rows == [
+        {"date": "2026-06-01T10:00:00+00:00", "new_articles": 4},
+        {"date": "2026-06-01T11:00:00+00:00", "new_articles": 0},
+        {"date": "2026-06-01T12:00:00+00:00", "new_articles": 6},
+    ]
+
+
+def test_sources_volume_orders_by_total_new_descending(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(
+        db_path,
+        1,
+        "2026-06-01T10:00:00+00:00",
+        10,
+        0,
+        1000,
+        [
+            ("Python Insider", 10, 3, None),
+            ("Docker Blog", 10, 5, None),
+        ],
+    )
+    _insert_run(
+        db_path,
+        2,
+        "2026-06-02T10:00:00+00:00",
+        6,
+        0,
+        1000,
+        [
+            ("Python Insider", 10, 6, None),
+            ("Docker Blog", 10, 1, None),
+        ],
+    )
+
+    assert sources_volume(
+        "2026-06-01T00:00:00+00:00",
+        "2026-06-03T00:00:00+00:00",
+        db_path,
+    ) == [
+        {"source_name": "Python Insider", "total_new": 9},
+        {"source_name": "Docker Blog", "total_new": 6},
+    ]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import type {
   ArticlesOverTimePoint,
   AskResponse,
   Source,
+  SourceHealth,
   SourceVolumePoint,
   StatsOverview,
   Summary,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 import './styles.css'
 import {
   askAI,
+  fetchArticlesOverTime,
   fetchArticles,
   fetchSchedulerStatus,
   fetchSourceHealth,
   fetchSources,
+  fetchSourcesVolume,
+  fetchStatsOverview,
   fetchSummary,
   ingestNow,
   pauseScheduler,
@@ -16,7 +28,16 @@ import {
   updateSourceEnabled,
 } from './api'
 import type { SchedulerStatus } from './api'
-import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
+import type {
+  Article,
+  ArticleStatus,
+  ArticlesOverTimePoint,
+  AskResponse,
+  Source,
+  SourceVolumePoint,
+  StatsOverview,
+  Summary,
+} from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
 
@@ -412,6 +433,67 @@ const INTERVAL_PRESETS = [
   { label: '6h',  value: 360 },
 ]
 
+type StatsRangeId = 'today' | 'last7' | 'last30' | 'last90'
+
+const STATS_RANGE_OPTIONS: { id: StatsRangeId; label: string }[] = [
+  { id: 'today',  label: 'Today' },
+  { id: 'last7',  label: 'Last 7 days' },
+  { id: 'last30', label: 'Last 30 days' },
+  { id: 'last90', label: 'Last 90 days' },
+]
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next
+}
+
+function statsRange(range: StatsRangeId): { from: string; to: string } {
+  const now = new Date()
+  const today = startOfUtcDay(now)
+  const starts: Record<StatsRangeId, Date> = {
+    today,
+    last7: addDays(today, -6),
+    last30: addDays(today, -29),
+    last90: addDays(today, -89),
+  }
+  return { from: starts[range].toISOString(), to: now.toISOString() }
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat().format(value)
+}
+
+function formatDuration(ms: number): string {
+  if (!ms) return '0s'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`
+  const minutes = Math.floor(seconds / 60)
+  const rem = Math.round(seconds % 60)
+  return rem ? `${minutes}m ${rem}s` : `${minutes}m`
+}
+
+function formatTimeBucket(value: string, range: StatsRangeId): string {
+  if (range === 'today') {
+    return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
+  }
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year, month - 1, day).toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
+function formatRangeDate(value: string): string {
+  return new Date(value).toLocaleDateString([], { timeZone: 'UTC' })
+}
+
+function formatSourceLabel(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 17)}…` : value
+}
+
 function relativeCountdown(isoStr: string | null): string {
   if (!isoStr) return '—'
   const ms = new Date(isoStr).getTime() - Date.now()
@@ -506,6 +588,22 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [actionPending, setActionPending] = useState(false)
   const [tabMessage, setTabMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
   const [countdown, setCountdown] = useState<string>('—')
+  const [rangeId, setRangeId] = useState<StatsRangeId>('last7')
+  const [overview, setOverview] = useState<StatsOverview | null>(null)
+  const [articlesSeries, setArticlesSeries] = useState<ArticlesOverTimePoint[]>([])
+  const [sourceVolumes, setSourceVolumes] = useState<SourceVolumePoint[]>([])
+  const [statsLoading, setStatsLoading] = useState(true)
+  const [statsError, setStatsError] = useState<string | null>(null)
+
+  const selectedRange = useMemo(() => statsRange(rangeId), [rangeId])
+  const articlesChartData = useMemo(
+    () => articlesSeries.map((row) => ({
+      ...row,
+      label: formatTimeBucket(row.date, rangeId),
+    })),
+    [articlesSeries, rangeId],
+  )
+  const topSourceVolumes = useMemo(() => sourceVolumes.slice(0, 12), [sourceVolumes])
 
   async function loadStatus() {
     try {
@@ -529,10 +627,33 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     }
   }
 
+  async function loadStats() {
+    setStatsLoading(true)
+    setStatsError(null)
+    try {
+      const [nextOverview, nextArticlesSeries, nextSourceVolumes] = await Promise.all([
+        fetchStatsOverview(selectedRange.from, selectedRange.to),
+        fetchArticlesOverTime(selectedRange.from, selectedRange.to),
+        fetchSourcesVolume(selectedRange.from, selectedRange.to),
+      ])
+      setOverview(nextOverview)
+      setArticlesSeries(nextArticlesSeries)
+      setSourceVolumes(nextSourceVolumes)
+    } catch (err) {
+      setStatsError(err instanceof Error ? err.message : 'Failed to load statistics')
+    } finally {
+      setStatsLoading(false)
+    }
+  }
+
   useEffect(() => {
     void loadStatus()
     void loadHealth()
   }, [])
+
+  useEffect(() => {
+    void loadStats()
+  }, [selectedRange.from, selectedRange.to])
 
   useEffect(() => {
     if (!status) return
@@ -590,6 +711,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   async function handleFetchNow() {
     await onFetchNow()
     await loadHealth()
+    await loadStats()
   }
 
   if (loadingStatus) {
@@ -609,6 +731,108 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           <button className="dismiss" onClick={() => setTabMessage(null)} aria-label="Dismiss">×</button>
         </div>
       )}
+
+      <div className="stats-dashboard">
+        <div className="stats-toolbar">
+          <div>
+            <h3 className="stats-title">Statistics</h3>
+            <p className="stats-range-label">
+              {formatRangeDate(selectedRange.from)} – {formatRangeDate(selectedRange.to)}
+            </p>
+          </div>
+          <div className="stats-range-picker" role="group" aria-label="Statistics time range">
+            {STATS_RANGE_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                className={`stats-range-btn${rangeId === option.id ? ' active' : ''}`}
+                onClick={() => setRangeId(option.id)}
+                aria-pressed={rangeId === option.id}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {statsError && (
+          <div className="message-banner error stats-error" role="status">
+            <span>{statsError}</span>
+          </div>
+        )}
+
+        <div className="stats-overview-grid">
+          {[
+            { label: 'Total articles', value: overview ? formatInteger(overview.total_articles) : '—' },
+            { label: 'Total new', value: overview ? formatInteger(overview.total_new) : '—' },
+            { label: 'Total errors', value: overview ? formatInteger(overview.total_errors) : '—' },
+            { label: 'Avg run duration', value: overview ? formatDuration(overview.avg_duration_ms) : '—' },
+            {
+              label: 'Healthy sources',
+              value: overview ? formatInteger(overview.healthy_sources) : '—',
+            },
+            {
+              label: 'Erroring sources',
+              value: overview ? formatInteger(overview.erroring_sources) : '—',
+            },
+          ].map((metric) => (
+            <div className="stats-metric-card" key={metric.label}>
+              <span className="stats-metric-label">{metric.label}</span>
+              <span className="stats-metric-value">{statsLoading ? '…' : metric.value}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="stats-charts-grid">
+          <div className="stats-chart-card">
+            <h3 className="stats-chart-title">Articles Ingested Over Time</h3>
+            <div className="stats-chart-frame">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={articlesChartData} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="label" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={36} />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(37, 99, 235, 0.08)' }}
+                    formatter={(value) => [formatInteger(Number(value)), 'New articles']}
+                    labelFormatter={(_, payload) => payload?.[0]?.payload?.date ?? ''}
+                  />
+                  <Bar dataKey="new_articles" fill="var(--accent)" radius={[4, 4, 0, 0]} minPointSize={2} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="stats-chart-card">
+            <h3 className="stats-chart-title">Sources Ranked by Volume</h3>
+            <div className="stats-chart-frame">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={topSourceVolumes}
+                  layout="vertical"
+                  margin={{ top: 8, right: 8, left: 8, bottom: 4 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                  <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                  <YAxis
+                    dataKey="source_name"
+                    type="category"
+                    tick={{ fontSize: 11 }}
+                    tickFormatter={formatSourceLabel}
+                    tickLine={false}
+                    axisLine={false}
+                    width={118}
+                  />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(37, 99, 235, 0.08)' }}
+                    formatter={(value) => [formatInteger(Number(value)), 'New articles']}
+                  />
+                  <Bar dataKey="total_new" fill="var(--accent-muted)" radius={[0, 4, 4, 0]} minPointSize={2} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div className="scheduler-card">
         <h3 className="scheduler-card-title">Status</h3>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   askAI,
   fetchArticles,
   fetchSchedulerStatus,
+  fetchSourceHealth,
   fetchSources,
   fetchSummary,
   ingestNow,
@@ -15,7 +16,7 @@ import {
   updateSourceEnabled,
 } from './api'
 import type { SchedulerStatus } from './api'
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
 
@@ -429,9 +430,78 @@ interface SchedulerTabProps {
   ingesting: boolean
 }
 
+function SourceHealthTable({ items, loading }: { items: SourceHealth[]; loading: boolean }) {
+  const sorted = useMemo(() => {
+    return [...items].sort((a, b) => {
+      if (b.error_streak !== a.error_streak) return b.error_streak - a.error_streak
+      if (a.status !== b.status) return a.status === 'ERROR' ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+  }, [items])
+
+  if (loading) {
+    return (
+      <div className="source-health-loading">
+        <div className="skeleton sk-line" style={{ width: '70%' }} />
+        <div className="skeleton sk-line" style={{ width: '55%' }} />
+        <div className="skeleton sk-line" style={{ width: '62%' }} />
+      </div>
+    )
+  }
+
+  if (sorted.length === 0) {
+    return <p className="source-health-empty">No sources configured.</p>
+  }
+
+  return (
+    <div className="source-health-table-wrap">
+      <table className="source-health-table">
+        <thead>
+          <tr>
+            <th>Source name</th>
+            <th>Last checked</th>
+            <th>Status</th>
+            <th>Articles last run</th>
+            <th>Error streak</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((source) => (
+            <tr key={source.slug} className={source.status === 'ERROR' ? 'source-health-row-error' : undefined}>
+              <td>
+                <span className="source-health-name">{source.name}</span>
+                <span className="source-health-category">{source.category.replace(/-/g, ' ')}</span>
+              </td>
+              <td>{source.last_checked_at ? relativeTime(source.last_checked_at) : 'Never'}</td>
+              <td>
+                <span className={`source-health-status ${source.status.toLowerCase()}`}>
+                  {source.status}
+                </span>
+              </td>
+              <td>{source.articles_last_run}</td>
+              <td>
+                <span className="source-health-streak" title={source.last_error ?? undefined}>
+                  {source.error_streak}
+                </span>
+                {source.last_error && (
+                  <span className="source-health-last-error" title={source.last_error}>
+                    {source.last_error}
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [status, setStatus] = useState<SchedulerStatus | null>(null)
   const [loadingStatus, setLoadingStatus] = useState(true)
+  const [sourceHealth, setSourceHealth] = useState<SourceHealth[]>([])
+  const [loadingSourceHealth, setLoadingSourceHealth] = useState(true)
   const [customMinutes, setCustomMinutes] = useState('')
   const [actionPending, setActionPending] = useState(false)
   const [tabMessage, setTabMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
@@ -448,8 +518,20 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     }
   }
 
+  async function loadHealth() {
+    setLoadingSourceHealth(true)
+    try {
+      setSourceHealth(await fetchSourceHealth())
+    } catch (err) {
+      setTabMessage({ text: err instanceof Error ? err.message : 'Failed to load source health', kind: 'error' })
+    } finally {
+      setLoadingSourceHealth(false)
+    }
+  }
+
   useEffect(() => {
     void loadStatus()
+    void loadHealth()
   }, [])
 
   useEffect(() => {
@@ -503,6 +585,11 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     } finally {
       setActionPending(false)
     }
+  }
+
+  async function handleFetchNow() {
+    await onFetchNow()
+    await loadHealth()
   }
 
   if (loadingStatus) {
@@ -595,12 +682,17 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           </button>
           <button
             className="scheduler-fetch-btn"
-            onClick={() => void onFetchNow()}
+            onClick={() => void handleFetchNow()}
             disabled={ingesting || actionPending}
           >
             {ingesting ? '⟳ Fetching…' : '↻ Fetch now'}
           </button>
         </div>
+      </div>
+
+      <div className="scheduler-card scheduler-card--wide">
+        <h3 className="scheduler-card-title">Source Health</h3>
+        <SourceHealthTable items={sourceHealth} loading={loadingSourceHealth} />
       </div>
     </div>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 import './styles.css'
 import {
   askAI,
+  fetchArticlesOverTime,
   fetchArticles,
   fetchSchedulerStatus,
   fetchSources,
+  fetchSourcesVolume,
+  fetchStatsOverview,
   fetchSummary,
   ingestNow,
   pauseScheduler,
@@ -15,7 +27,16 @@ import {
   updateSourceEnabled,
 } from './api'
 import type { SchedulerStatus } from './api'
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type {
+  Article,
+  ArticleStatus,
+  ArticlesOverTimePoint,
+  AskResponse,
+  Source,
+  SourceVolumePoint,
+  StatsOverview,
+  Summary,
+} from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
 
@@ -411,6 +432,67 @@ const INTERVAL_PRESETS = [
   { label: '6h',  value: 360 },
 ]
 
+type StatsRangeId = 'today' | 'last7' | 'last30' | 'last90'
+
+const STATS_RANGE_OPTIONS: { id: StatsRangeId; label: string }[] = [
+  { id: 'today',  label: 'Today' },
+  { id: 'last7',  label: 'Last 7 days' },
+  { id: 'last30', label: 'Last 30 days' },
+  { id: 'last90', label: 'Last 90 days' },
+]
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next
+}
+
+function statsRange(range: StatsRangeId): { from: string; to: string } {
+  const now = new Date()
+  const today = startOfUtcDay(now)
+  const starts: Record<StatsRangeId, Date> = {
+    today,
+    last7: addDays(today, -6),
+    last30: addDays(today, -29),
+    last90: addDays(today, -89),
+  }
+  return { from: starts[range].toISOString(), to: now.toISOString() }
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat().format(value)
+}
+
+function formatDuration(ms: number): string {
+  if (!ms) return '0s'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`
+  const minutes = Math.floor(seconds / 60)
+  const rem = Math.round(seconds % 60)
+  return rem ? `${minutes}m ${rem}s` : `${minutes}m`
+}
+
+function formatTimeBucket(value: string, range: StatsRangeId): string {
+  if (range === 'today') {
+    return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
+  }
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year, month - 1, day).toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
+function formatRangeDate(value: string): string {
+  return new Date(value).toLocaleDateString([], { timeZone: 'UTC' })
+}
+
+function formatSourceLabel(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 17)}…` : value
+}
+
 function relativeCountdown(isoStr: string | null): string {
   if (!isoStr) return '—'
   const ms = new Date(isoStr).getTime() - Date.now()
@@ -436,6 +518,22 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [actionPending, setActionPending] = useState(false)
   const [tabMessage, setTabMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
   const [countdown, setCountdown] = useState<string>('—')
+  const [rangeId, setRangeId] = useState<StatsRangeId>('last7')
+  const [overview, setOverview] = useState<StatsOverview | null>(null)
+  const [articlesSeries, setArticlesSeries] = useState<ArticlesOverTimePoint[]>([])
+  const [sourceVolumes, setSourceVolumes] = useState<SourceVolumePoint[]>([])
+  const [statsLoading, setStatsLoading] = useState(true)
+  const [statsError, setStatsError] = useState<string | null>(null)
+
+  const selectedRange = useMemo(() => statsRange(rangeId), [rangeId])
+  const articlesChartData = useMemo(
+    () => articlesSeries.map((row) => ({
+      ...row,
+      label: formatTimeBucket(row.date, rangeId),
+    })),
+    [articlesSeries, rangeId],
+  )
+  const topSourceVolumes = useMemo(() => sourceVolumes.slice(0, 12), [sourceVolumes])
 
   async function loadStatus() {
     try {
@@ -448,9 +546,32 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     }
   }
 
+  async function loadStats() {
+    setStatsLoading(true)
+    setStatsError(null)
+    try {
+      const [nextOverview, nextArticlesSeries, nextSourceVolumes] = await Promise.all([
+        fetchStatsOverview(selectedRange.from, selectedRange.to),
+        fetchArticlesOverTime(selectedRange.from, selectedRange.to),
+        fetchSourcesVolume(selectedRange.from, selectedRange.to),
+      ])
+      setOverview(nextOverview)
+      setArticlesSeries(nextArticlesSeries)
+      setSourceVolumes(nextSourceVolumes)
+    } catch (err) {
+      setStatsError(err instanceof Error ? err.message : 'Failed to load statistics')
+    } finally {
+      setStatsLoading(false)
+    }
+  }
+
   useEffect(() => {
     void loadStatus()
   }, [])
+
+  useEffect(() => {
+    void loadStats()
+  }, [selectedRange.from, selectedRange.to])
 
   useEffect(() => {
     if (!status) return
@@ -505,6 +626,11 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     }
   }
 
+  async function handleFetchNow() {
+    await onFetchNow()
+    await loadStats()
+  }
+
   if (loadingStatus) {
     return (
       <div className="scheduler-panel">
@@ -522,6 +648,108 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           <button className="dismiss" onClick={() => setTabMessage(null)} aria-label="Dismiss">×</button>
         </div>
       )}
+
+      <div className="stats-dashboard">
+        <div className="stats-toolbar">
+          <div>
+            <h3 className="stats-title">Statistics</h3>
+            <p className="stats-range-label">
+              {formatRangeDate(selectedRange.from)} – {formatRangeDate(selectedRange.to)}
+            </p>
+          </div>
+          <div className="stats-range-picker" role="group" aria-label="Statistics time range">
+            {STATS_RANGE_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                className={`stats-range-btn${rangeId === option.id ? ' active' : ''}`}
+                onClick={() => setRangeId(option.id)}
+                aria-pressed={rangeId === option.id}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {statsError && (
+          <div className="message-banner error stats-error" role="status">
+            <span>{statsError}</span>
+          </div>
+        )}
+
+        <div className="stats-overview-grid">
+          {[
+            { label: 'Total articles', value: overview ? formatInteger(overview.total_articles) : '—' },
+            { label: 'Total new', value: overview ? formatInteger(overview.total_new) : '—' },
+            { label: 'Total errors', value: overview ? formatInteger(overview.total_errors) : '—' },
+            { label: 'Avg run duration', value: overview ? formatDuration(overview.avg_duration_ms) : '—' },
+            {
+              label: 'Healthy sources',
+              value: overview ? formatInteger(overview.healthy_sources) : '—',
+            },
+            {
+              label: 'Erroring sources',
+              value: overview ? formatInteger(overview.erroring_sources) : '—',
+            },
+          ].map((metric) => (
+            <div className="stats-metric-card" key={metric.label}>
+              <span className="stats-metric-label">{metric.label}</span>
+              <span className="stats-metric-value">{statsLoading ? '…' : metric.value}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="stats-charts-grid">
+          <div className="stats-chart-card">
+            <h3 className="stats-chart-title">Articles Ingested Over Time</h3>
+            <div className="stats-chart-frame">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={articlesChartData} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="label" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={36} />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(37, 99, 235, 0.08)' }}
+                    formatter={(value) => [formatInteger(Number(value)), 'New articles']}
+                    labelFormatter={(_, payload) => payload?.[0]?.payload?.date ?? ''}
+                  />
+                  <Bar dataKey="new_articles" fill="var(--accent)" radius={[4, 4, 0, 0]} minPointSize={2} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="stats-chart-card">
+            <h3 className="stats-chart-title">Sources Ranked by Volume</h3>
+            <div className="stats-chart-frame">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={topSourceVolumes}
+                  layout="vertical"
+                  margin={{ top: 8, right: 8, left: 8, bottom: 4 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                  <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                  <YAxis
+                    dataKey="source_name"
+                    type="category"
+                    tick={{ fontSize: 11 }}
+                    tickFormatter={formatSourceLabel}
+                    tickLine={false}
+                    axisLine={false}
+                    width={118}
+                  />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(37, 99, 235, 0.08)' }}
+                    formatter={(value) => [formatInteger(Number(value)), 'New articles']}
+                  />
+                  <Bar dataKey="total_new" fill="var(--accent-muted)" radius={[0, 4, 4, 0]} minPointSize={2} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div className="scheduler-card">
         <h3 className="scheduler-card-title">Status</h3>
@@ -595,7 +823,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           </button>
           <button
             className="scheduler-fetch-btn"
-            onClick={() => void onFetchNow()}
+            onClick={() => void handleFetchNow()}
             disabled={ingesting || actionPending}
           >
             {ingesting ? '⟳ Fetching…' : '↻ Fetch now'}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,7 @@ import type {
   ArticlesOverTimePoint,
   AskResponse,
   Source,
+  SourceHealth,
   SourceVolumePoint,
   StatsOverview,
   Summary,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,13 @@
-import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
+import type {
+  Article,
+  ArticleStatus,
+  ArticlesOverTimePoint,
+  AskResponse,
+  Source,
+  SourceVolumePoint,
+  StatsOverview,
+  Summary,
+} from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -90,4 +99,26 @@ export async function pauseScheduler(): Promise<{ paused: boolean }> {
 
 export async function resumeScheduler(): Promise<{ paused: boolean; next_run_at: string | null }> {
   return requestJson('/api/scheduler/resume', { method: 'POST' })
+}
+
+function statsParams(from: string, to: string): string {
+  return new URLSearchParams({ from, to }).toString()
+}
+
+export async function fetchStatsOverview(from: string, to: string): Promise<StatsOverview> {
+  return requestJson<StatsOverview>(`/api/stats/overview?${statsParams(from, to)}`)
+}
+
+export async function fetchArticlesOverTime(from: string, to: string): Promise<ArticlesOverTimePoint[]> {
+  const data = await requestJson<{ items: ArticlesOverTimePoint[] }>(
+    `/api/stats/articles-over-time?${statsParams(from, to)}`,
+  )
+  return data.items
+}
+
+export async function fetchSourcesVolume(from: string, to: string): Promise<SourceVolumePoint[]> {
+  const data = await requestJson<{ items: SourceVolumePoint[] }>(
+    `/api/stats/sources-volume?${statsParams(from, to)}`,
+  )
+  return data.items
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -30,6 +30,11 @@ export async function searchArticles(q: string, limit = 50): Promise<Article[]> 
 
 export async function fetchSources(): Promise<Source[]> {
   const data = await requestJson<{ items: Source[] }>('/api/sources')
+  return data.items
+}
+
+export async function fetchSourceHealth(): Promise<SourceHealth[]> {
+  const data = await requestJson<{ items: SourceHealth[] }>('/api/sources/health')
   return data.items
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,13 @@
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type {
+  Article,
+  ArticleStatus,
+  ArticlesOverTimePoint,
+  AskResponse,
+  Source,
+  SourceVolumePoint,
+  StatsOverview,
+  Summary,
+} from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -85,4 +94,26 @@ export async function pauseScheduler(): Promise<{ paused: boolean }> {
 
 export async function resumeScheduler(): Promise<{ paused: boolean; next_run_at: string | null }> {
   return requestJson('/api/scheduler/resume', { method: 'POST' })
+}
+
+function statsParams(from: string, to: string): string {
+  return new URLSearchParams({ from, to }).toString()
+}
+
+export async function fetchStatsOverview(from: string, to: string): Promise<StatsOverview> {
+  return requestJson<StatsOverview>(`/api/stats/overview?${statsParams(from, to)}`)
+}
+
+export async function fetchArticlesOverTime(from: string, to: string): Promise<ArticlesOverTimePoint[]> {
+  const data = await requestJson<{ items: ArticlesOverTimePoint[] }>(
+    `/api/stats/articles-over-time?${statsParams(from, to)}`,
+  )
+  return data.items
+}
+
+export async function fetchSourcesVolume(from: string, to: string): Promise<SourceVolumePoint[]> {
+  const data = await requestJson<{ items: SourceVolumePoint[] }>(
+    `/api/stats/sources-volume?${statsParams(from, to)}`,
+  )
+  return data.items
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1648,7 +1648,7 @@ kbd {
 /* ===== SCHEDULER TAB ===== */
 
 .scheduler-panel {
-  max-width: 600px;
+  max-width: 1100px;
   margin: 0 auto;
   padding: 16px;
   display: flex;
@@ -1657,10 +1657,156 @@ kbd {
 }
 
 .scheduler-card {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   padding: 16px 20px;
+  box-shadow: var(--shadow-card);
+}
+
+.stats-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.stats-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.stats-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-0);
+  margin: 0 0 2px;
+}
+
+.stats-range-label {
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.stats-range-picker {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.stats-range-btn {
+  min-height: 32px;
+  padding: 6px 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-1);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--t) var(--ease), border-color var(--t) var(--ease), color var(--t) var(--ease);
+}
+
+.stats-range-btn:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.stats-range-btn.active {
+  background: var(--accent-pale);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.stats-error {
+  margin: 0;
+}
+
+.stats-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stats-metric-card {
+  min-height: 86px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stats-metric-label {
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.stats-metric-value {
+  color: var(--text-0);
+  font-size: 24px;
+  font-weight: 750;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-charts-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 16px;
+}
+
+.stats-chart-card {
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 16px;
+  box-shadow: var(--shadow-card);
+}
+
+.stats-chart-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-1);
+  margin: 0 0 12px;
+}
+
+.stats-chart-frame {
+  height: 280px;
+  min-width: 0;
+}
+
+.stats-chart-card .recharts-cartesian-grid line {
+  stroke: var(--border);
+}
+
+.stats-chart-card .recharts-text {
+  fill: var(--text-2);
+}
+
+.stats-chart-card .recharts-tooltip-wrapper {
+  outline: none;
+}
+
+.stats-chart-card .recharts-default-tooltip {
+  border-color: var(--border) !important;
+  border-radius: var(--r-md);
+  background: var(--surface) !important;
+  color: var(--text-1) !important;
   box-shadow: var(--shadow-card);
 }
 
@@ -1862,4 +2008,54 @@ kbd {
 .scheduler-fetch-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+@media (max-width: 980px) {
+  .stats-overview-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .stats-charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .scheduler-panel {
+    padding: 12px 0;
+  }
+
+  .stats-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stats-range-picker {
+    justify-content: flex-start;
+  }
+
+  .stats-range-btn {
+    flex: 1 1 calc(50% - 6px);
+  }
+
+  .stats-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-metric-card {
+    min-height: 78px;
+    padding: 12px;
+  }
+
+  .stats-metric-value {
+    font-size: 20px;
+  }
+
+  .stats-chart-card {
+    padding: 12px 8px 12px 10px;
+  }
+
+  .stats-chart-frame {
+    height: 240px;
+  }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -901,6 +901,118 @@ ul { list-style: none; }
   word-break: break-all;
 }
 
+/* ===== SCHEDULER SOURCE HEALTH ===== */
+.scheduler-card--wide {
+  grid-column: 1 / -1;
+}
+
+.source-health-loading {
+  display: grid;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.source-health-empty {
+  color: var(--text-3);
+  font-size: 13px;
+}
+
+.source-health-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.source-health-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.source-health-table th,
+.source-health-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: 12px;
+  vertical-align: top;
+}
+
+.source-health-table th {
+  color: var(--text-3);
+  background: var(--surface-alt);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+
+.source-health-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.source-health-row-error {
+  background: #fff1f2;
+}
+
+[data-theme="dark"] .source-health-row-error {
+  background: rgba(127, 29, 29, .16);
+}
+
+.source-health-name,
+.source-health-category,
+.source-health-last-error {
+  display: block;
+}
+
+.source-health-name {
+  color: var(--text-1);
+  font-weight: 650;
+}
+
+.source-health-category {
+  margin-top: 2px;
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.source-health-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.source-health-status.ok {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.source-health-status.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.source-health-streak {
+  color: var(--text-1);
+  font-weight: 700;
+}
+
+.source-health-last-error {
+  max-width: 360px;
+  margin-top: 3px;
+  color: #b91c1c;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ===== SKELETON LOADER ===== */
 @keyframes shimmer {
   0%   { background-position: -400% 0; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1536,7 +1536,7 @@ kbd {
 /* ===== SCHEDULER TAB ===== */
 
 .scheduler-panel {
-  max-width: 600px;
+  max-width: 1100px;
   margin: 0 auto;
   padding: 16px;
   display: flex;
@@ -1545,10 +1545,156 @@ kbd {
 }
 
 .scheduler-card {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   padding: 16px 20px;
+  box-shadow: var(--shadow-card);
+}
+
+.stats-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.stats-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.stats-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-0);
+  margin: 0 0 2px;
+}
+
+.stats-range-label {
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.stats-range-picker {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.stats-range-btn {
+  min-height: 32px;
+  padding: 6px 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-1);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--t) var(--ease), border-color var(--t) var(--ease), color var(--t) var(--ease);
+}
+
+.stats-range-btn:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.stats-range-btn.active {
+  background: var(--accent-pale);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.stats-error {
+  margin: 0;
+}
+
+.stats-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stats-metric-card {
+  min-height: 86px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stats-metric-label {
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.stats-metric-value {
+  color: var(--text-0);
+  font-size: 24px;
+  font-weight: 750;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-charts-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 16px;
+}
+
+.stats-chart-card {
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 16px;
+  box-shadow: var(--shadow-card);
+}
+
+.stats-chart-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-1);
+  margin: 0 0 12px;
+}
+
+.stats-chart-frame {
+  height: 280px;
+  min-width: 0;
+}
+
+.stats-chart-card .recharts-cartesian-grid line {
+  stroke: var(--border);
+}
+
+.stats-chart-card .recharts-text {
+  fill: var(--text-2);
+}
+
+.stats-chart-card .recharts-tooltip-wrapper {
+  outline: none;
+}
+
+.stats-chart-card .recharts-default-tooltip {
+  border-color: var(--border) !important;
+  border-radius: var(--r-md);
+  background: var(--surface) !important;
+  color: var(--text-1) !important;
   box-shadow: var(--shadow-card);
 }
 
@@ -1750,4 +1896,54 @@ kbd {
 .scheduler-fetch-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+@media (max-width: 980px) {
+  .stats-overview-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .stats-charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .scheduler-panel {
+    padding: 12px 0;
+  }
+
+  .stats-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stats-range-picker {
+    justify-content: flex-start;
+  }
+
+  .stats-range-btn {
+    flex: 1 1 calc(50% - 6px);
+  }
+
+  .stats-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-metric-card {
+    min-height: 78px;
+    padding: 12px;
+  }
+
+  .stats-metric-value {
+    font-size: 20px;
+  }
+
+  .stats-chart-card {
+    padding: 12px 8px 12px 10px;
+  }
+
+  .stats-chart-frame {
+    height: 240px;
+  }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -54,6 +54,25 @@ export interface Summary {
   byCategory: Record<string, number>
 }
 
+export interface StatsOverview {
+  total_articles: number
+  total_new: number
+  total_errors: number
+  avg_duration_ms: number
+  healthy_sources: number
+  erroring_sources: number
+}
+
+export interface ArticlesOverTimePoint {
+  date: string
+  new_articles: number
+}
+
+export interface SourceVolumePoint {
+  source_name: string
+  total_new: number
+}
+
 export interface AskSource {
   id: number
   title: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,18 @@ export interface Source {
   last_inserted_count?: number
 }
 
+export interface SourceHealth {
+  slug: string
+  name: string
+  category: string
+  enabled: number
+  last_checked_at?: string | null
+  last_error?: string | null
+  error_streak: number
+  articles_last_run: number
+  status: 'OK' | 'ERROR'
+}
+
 export interface Summary {
   byStatus: Record<string, number>
   byCategory: Record<string, number>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -42,6 +42,25 @@ export interface Summary {
   byCategory: Record<string, number>
 }
 
+export interface StatsOverview {
+  total_articles: number
+  total_new: number
+  total_errors: number
+  avg_duration_ms: number
+  healthy_sources: number
+  erroring_sources: number
+}
+
+export interface ArticlesOverTimePoint {
+  date: string
+  new_articles: number
+}
+
+export interface SourceVolumePoint {
+  source_name: string
+  total_new: number
+}
+
 export interface AskSource {
   id: number
   title: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@vitejs/plugin-react": "latest",
         "react": "latest",
         "react-dom": "latest",
+        "recharts": "^3.8.1",
         "typescript": "latest",
         "vite": "latest"
       },
@@ -72,6 +73,42 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -340,6 +377,18 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -350,11 +399,74 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -369,6 +481,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -395,11 +513,147 @@
         }
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -410,6 +664,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -440,6 +710,25 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -788,6 +1077,87 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -836,6 +1206,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -870,6 +1246,37 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "latest",
-    "vite": "latest",
-    "typescript": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "recharts": "^3.8.1",
+    "typescript": "latest",
+    "vite": "latest"
   },
   "devDependencies": {
     "@types/react": "latest",


### PR DESCRIPTION
## Summary
- add ingest-run stats endpoints for overview, articles-over-time, and source volume
- add Scheduler tab range picker, overview cards, and Recharts bar charts
- include issue #50 ingest run table schema on main so stats can read the dependency data

## Verification
- .venv/bin/python -m pytest
- npm run lint
- npm run build
- in-app browser check at desktop and 390px mobile widths

Draft PR for #53.
