### PR TITLE
[codex] Add ingest run history table

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -89,6 +89,8 @@ CREATE TABLE IF NOT EXISTS ingest_run_sources (
 
 CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
   ON ingest_run_sources(source_name, run_id DESC);
+CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at);
+CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id);
 """
 
 # Additive columns to add when upgrading existing databases
@@ -166,7 +168,7 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
-    # Ingest run records populated by the scheduler/ingest instrumentation slice
+    # Ingest run telemetry from issue #50. Stats endpoints read these tables.
     """
     CREATE TABLE IF NOT EXISTS ingest_runs (
       id SERIAL PRIMARY KEY,
@@ -188,6 +190,8 @@ POSTGRES_SCHEMA = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run ON ingest_run_sources(source_name, run_id DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at)",
+    "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id)",
 ]
 
 

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -68,6 +68,27 @@ CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
   title, summary, reason, tags, source_name,
   content=articles, content_rowid=id
 );
+
+CREATE TABLE IF NOT EXISTS ingest_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms INTEGER,
+  total_new INTEGER,
+  total_errors INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS ingest_run_sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER REFERENCES ingest_runs(id),
+  source_name TEXT NOT NULL,
+  articles_found INTEGER,
+  articles_new INTEGER,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id);
 """
 
 # Additive columns to add when upgrading existing databases
@@ -145,6 +166,29 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
+    # Ingest run history tables from Slice 2; Slice 3 reads these for history.
+    """
+    CREATE TABLE IF NOT EXISTS ingest_runs (
+      id BIGSERIAL PRIMARY KEY,
+      started_at TIMESTAMPTZ NOT NULL,
+      finished_at TIMESTAMPTZ,
+      duration_ms INTEGER,
+      total_new INTEGER,
+      total_errors INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ingest_run_sources (
+      id BIGSERIAL PRIMARY KEY,
+      run_id BIGINT REFERENCES ingest_runs(id),
+      source_name TEXT NOT NULL,
+      articles_found INTEGER,
+      articles_new INTEGER,
+      error_message TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id)",
 ]
 
 

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -59,6 +59,24 @@ CREATE TABLE IF NOT EXISTS articles (
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS ingest_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms INTEGER,
+  total_new INTEGER,
+  total_errors INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS ingest_run_sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER REFERENCES ingest_runs(id),
+  source_name TEXT NOT NULL,
+  articles_found INTEGER,
+  articles_new INTEGER,
+  error_message TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_articles_status ON articles(status);
 CREATE INDEX IF NOT EXISTS idx_articles_category ON articles(category);
 CREATE INDEX IF NOT EXISTS idx_articles_discovered ON articles(discovered_at DESC);
@@ -149,6 +167,26 @@ POSTGRES_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_articles_category ON articles(category)",
     "CREATE INDEX IF NOT EXISTS idx_articles_discovered ON articles(discovered_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_articles_source ON articles(source_slug)",
+    """
+    CREATE TABLE IF NOT EXISTS ingest_runs (
+      id           SERIAL PRIMARY KEY,
+      started_at   TIMESTAMPTZ NOT NULL,
+      finished_at  TIMESTAMPTZ,
+      duration_ms  INTEGER,
+      total_new    INTEGER,
+      total_errors INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ingest_run_sources (
+      id             SERIAL PRIMARY KEY,
+      run_id         INTEGER REFERENCES ingest_runs(id),
+      source_name    TEXT NOT NULL,
+      articles_found INTEGER,
+      articles_new   INTEGER,
+      error_message  TEXT
+    )
+    """,
     # PostgreSQL FTS via tsvector — added as a generated column if not present
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS fts_vector tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(summary,'') || ' ' || coalesce(tags,''))) STORED",
     "CREATE INDEX IF NOT EXISTS idx_articles_fts ON articles USING gin(fts_vector)",

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -68,6 +68,27 @@ CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
   title, summary, reason, tags, source_name,
   content=articles, content_rowid=id
 );
+
+CREATE TABLE IF NOT EXISTS ingest_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms INTEGER,
+  total_new INTEGER,
+  total_errors INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS ingest_run_sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER REFERENCES ingest_runs(id),
+  source_name TEXT NOT NULL,
+  articles_found INTEGER,
+  articles_new INTEGER,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
+  ON ingest_run_sources(source_name, run_id DESC);
 """
 
 # Additive columns to add when upgrading existing databases
@@ -145,6 +166,28 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
+    # Ingest run records populated by the scheduler/ingest instrumentation slice
+    """
+    CREATE TABLE IF NOT EXISTS ingest_runs (
+      id SERIAL PRIMARY KEY,
+      started_at TIMESTAMPTZ NOT NULL,
+      finished_at TIMESTAMPTZ,
+      duration_ms INTEGER,
+      total_new INTEGER,
+      total_errors INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ingest_run_sources (
+      id SERIAL PRIMARY KEY,
+      run_id INTEGER REFERENCES ingest_runs(id),
+      source_name TEXT NOT NULL,
+      articles_found INTEGER,
+      articles_new INTEGER,
+      error_message TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run ON ingest_run_sources(source_name, run_id DESC)",
 ]
 
 

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import re
+import threading
+import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from html import unescape
@@ -10,7 +13,8 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import feedparser
 
-from .db import connect, init_db, insert_article_sql, row_to_dict, search_articles_sql
+from .db import connect, init_db, insert_article_sql, is_postgres, row_to_dict, search_articles_sql
+from .ingest_events import ingest_events
 from .sources import DEFAULT_SOURCES, SourceDefinition
 
 try:
@@ -32,6 +36,16 @@ except ImportError:
         return len(sa & sb) / len(sa | sb)
 
 DEDUP_TITLE_THRESHOLD = 0.85
+_INGEST_RUN_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class SourceIngestOutcome:
+    source_name: str
+    articles_found: int
+    articles_new: int
+    duration_seconds: float
+    error_message: str | None = None
 
 TRACKING_PARAMS = {
     "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
@@ -210,13 +224,14 @@ def sync_sources(db_path: Path | None = None) -> None:
             )
 
 
-def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
+def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> SourceIngestOutcome:
     """Fetch and insert articles for a single source. Returns count inserted."""
     from .scraper import scrape_source
 
     checked_at = now_iso()
     inserted = 0
     fetched = 0
+    started = time.perf_counter()
 
     try:
         if source.kind == "scraped_page":
@@ -276,8 +291,11 @@ def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
                         (now_iso(), canonical_id),
                     )
                 else:
+                    sql = insert_article_sql()
+                    if not is_postgres():
+                        sql = sql.replace("%s", "?")
                     cursor = conn.execute(
-                        insert_article_sql(),
+                        sql,
                         (url, url, title, source.slug, source.name, source.category, source.kind,
                          entry.get("date"), summary, reason, score, tags),
                     )
@@ -301,21 +319,125 @@ def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
                    WHERE slug=?""",
                 (checked_at, error_msg, source.slug),
             )
-        raise
+        return SourceIngestOutcome(
+            source_name=source.name,
+            articles_found=fetched,
+            articles_new=0,
+            duration_seconds=time.perf_counter() - started,
+            error_message=error_msg,
+        )
 
-    return inserted
+    return SourceIngestOutcome(
+        source_name=source.name,
+        articles_found=fetched,
+        articles_new=inserted,
+        duration_seconds=time.perf_counter() - started,
+    )
+
+
+def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
+    """Fetch and insert articles for a single source. Returns count inserted."""
+    outcome = _ingest_source(source, db_path)
+    if outcome.error_message is not None:
+        raise RuntimeError(outcome.error_message)
+    return outcome.articles_new
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    if isinstance(row, dict):
+        return row[key]
+    try:
+        return row[key]
+    except Exception:
+        return row[index]
+
+
+def _create_ingest_run(db_path: Path | None, started_at: str) -> int:
+    init_db(db_path)
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO ingest_runs(started_at) VALUES (?) RETURNING id",
+            (started_at,),
+        ).fetchone()
+    return int(_row_value(row, "id", 0))
+
+
+def _record_ingest_source(run_id: int, outcome: SourceIngestOutcome, db_path: Path | None) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                outcome.source_name,
+                outcome.articles_found,
+                outcome.articles_new,
+                outcome.error_message,
+            ),
+        )
+
+
+def _finish_ingest_run(
+    run_id: int,
+    db_path: Path | None,
+    finished_at: str,
+    duration_ms: int,
+    total_new: int,
+    total_errors: int,
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE ingest_runs
+               SET finished_at=?, duration_ms=?, total_new=?, total_errors=?
+             WHERE id=?
+            """,
+            (finished_at, duration_ms, total_new, total_errors, run_id),
+        )
+
+
+def _format_source_log(outcome: SourceIngestOutcome) -> str:
+    if outcome.error_message:
+        return f"✗ {outcome.source_name} — {outcome.error_message}"
+    article_word = "article" if outcome.articles_new == 1 else "articles"
+    return f"✓ {outcome.source_name} — {outcome.articles_new} new {article_word} ({outcome.duration_seconds:.1f}s)"
 
 
 def ingest_all(db_path: Path | None = None) -> dict[str, int]:
-    sync_sources(db_path)
-    results: dict[str, int] = {}
-    for source in DEFAULT_SOURCES:
-        if not source.enabled:
-            continue
+    with _INGEST_RUN_LOCK:
+        sync_sources(db_path)
+        run_started_at = now_iso()
+        run_started = time.perf_counter()
+        run_id = _create_ingest_run(db_path, run_started_at)
+        ingest_events.start_run(run_id, f"Ingest run #{run_id} started at {run_started_at}")
+
+        results: dict[str, int] = {}
+        total_new = 0
+        total_errors = 0
         try:
-            results[source.slug] = ingest_source(source, db_path)
-        except Exception:
-            results[source.slug] = -1
+            for source in DEFAULT_SOURCES:
+                if not source.enabled:
+                    continue
+                outcome = _ingest_source(source, db_path)
+                _record_ingest_source(run_id, outcome, db_path)
+                ingest_events.append_line(_format_source_log(outcome))
+                if outcome.error_message is not None:
+                    results[source.slug] = -1
+                    total_errors += 1
+                else:
+                    results[source.slug] = outcome.articles_new
+                    total_new += outcome.articles_new
+        finally:
+            duration_seconds = time.perf_counter() - run_started
+            duration_ms = int(duration_seconds * 1000)
+            _finish_ingest_run(run_id, db_path, now_iso(), duration_ms, total_new, total_errors)
+            article_word = "article" if total_new == 1 else "articles"
+            error_text = f", {total_errors} error{'s' if total_errors != 1 else ''}" if total_errors else ""
+            ingest_events.complete_run(
+                f"Summary — {total_new} new {article_word}{error_text} ({duration_seconds:.1f}s)"
+            )
     return results
 
 

--- a/backend/news_dashboard/ingest_events.py
+++ b/backend/news_dashboard/ingest_events.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass
+from typing import Iterator
+
+
+@dataclass(frozen=True)
+class IngestStreamEvent:
+    event: str
+    data: str = ""
+
+
+class IngestEventHub:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._subscribers: set[queue.Queue[IngestStreamEvent]] = set()
+        self._current_lines: list[str] = []
+        self._last_completed_lines: list[str] = []
+        self._active_run_id: int | None = None
+
+    def subscribe(self) -> tuple[queue.Queue[IngestStreamEvent], list[IngestStreamEvent]]:
+        subscriber: queue.Queue[IngestStreamEvent] = queue.Queue()
+        with self._lock:
+            lines = self._current_lines if self._active_run_id is not None else self._last_completed_lines
+            replay = [IngestStreamEvent("reset"), *(IngestStreamEvent("line", line) for line in lines)]
+            self._subscribers.add(subscriber)
+        return subscriber, replay
+
+    def unsubscribe(self, subscriber: queue.Queue[IngestStreamEvent]) -> None:
+        with self._lock:
+            self._subscribers.discard(subscriber)
+
+    def start_run(self, run_id: int, header_line: str) -> None:
+        with self._lock:
+            self._active_run_id = run_id
+            self._current_lines = []
+            subscribers = list(self._subscribers)
+        self._broadcast(IngestStreamEvent("reset"), subscribers)
+        self.append_line(header_line)
+
+    def append_line(self, line: str) -> None:
+        event = IngestStreamEvent("line", line)
+        with self._lock:
+            if self._active_run_id is not None:
+                self._current_lines.append(line)
+            subscribers = list(self._subscribers)
+        self._broadcast(event, subscribers)
+
+    def complete_run(self, summary_line: str) -> None:
+        self.append_line(summary_line)
+        with self._lock:
+            self._last_completed_lines = list(self._current_lines)
+            self._current_lines = []
+            self._active_run_id = None
+
+    def snapshot_last_completed(self) -> list[str]:
+        with self._lock:
+            return list(self._last_completed_lines)
+
+    def reset_for_tests(self) -> None:
+        with self._lock:
+            self._current_lines = []
+            self._last_completed_lines = []
+            self._active_run_id = None
+            subscribers = list(self._subscribers)
+        self._broadcast(IngestStreamEvent("reset"), subscribers)
+
+    def _broadcast(
+        self,
+        event: IngestStreamEvent,
+        subscribers: list[queue.Queue[IngestStreamEvent]] | None = None,
+    ) -> None:
+        targets = subscribers
+        if targets is None:
+            with self._lock:
+                targets = list(self._subscribers)
+        for subscriber in targets:
+            subscriber.put(event)
+
+
+ingest_events = IngestEventHub()
+
+
+def format_sse_event(event: IngestStreamEvent) -> str:
+    payload = [f"event: {event.event}"]
+    if event.data:
+        for line in event.data.splitlines():
+            payload.append(f"data: {line}")
+    else:
+        payload.append("data:")
+    return "\n".join(payload) + "\n\n"
+
+
+def stream_ingest_events() -> Iterator[str]:
+    subscriber, replay = ingest_events.subscribe()
+    try:
+        for event in replay:
+            yield format_sse_event(event)
+        while True:
+            try:
+                yield format_sse_event(subscriber.get(timeout=15))
+            except queue.Empty:
+                yield ": heartbeat\n\n"
+    except GeneratorExit:
+        return
+    finally:
+        ingest_events.unsubscribe(subscriber)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from .db import connect, describe_database, init_db, row_to_dict
 from .ingest import ingest_all, list_articles, search_articles, set_article_status, sync_sources
+from .run_history import get_ingest_run_sources, list_ingest_runs
 from .scheduler import (
     get_interval_minutes,
     get_next_ingest_at,
@@ -64,6 +65,24 @@ def health() -> dict:
 def ingest() -> dict:
     results = ingest_all()
     return {"results": results, "inserted": sum(v for v in results.values() if v > 0)}
+
+
+@app.get("/api/ingest/runs")
+def ingest_runs(
+    from_: datetime | None = Query(default=None, alias="from"),
+    to: datetime | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=20, ge=1, le=100),
+) -> dict:
+    return list_ingest_runs(from_=from_, to=to, page=page, per_page=per_page)
+
+
+@app.get("/api/ingest/runs/{run_id}")
+def ingest_run_sources(run_id: int) -> dict:
+    sources = get_ingest_run_sources(run_id)
+    if sources is None:
+        raise HTTPException(status_code=404, detail="ingest run not found")
+    return {"items": sources}
 
 
 @app.get("/api/articles")

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -6,10 +6,12 @@ from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .db import connect, describe_database, init_db, row_to_dict
+from .ingest_events import stream_ingest_events
 from .ingest import ingest_all, list_articles, search_articles, set_article_status, sync_sources
 from .scheduler import (
     get_interval_minutes,
@@ -66,6 +68,11 @@ def health() -> dict:
 def ingest() -> dict:
     results = ingest_all()
     return {"results": results, "inserted": sum(v for v in results.values() if v > 0)}
+
+
+@app.get("/api/ingest/stream")
+def ingest_stream() -> StreamingResponse:
+    return StreamingResponse(stream_ingest_events(), media_type="text/event-stream")
 
 
 @app.get("/api/articles")

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from .db import connect, describe_database, init_db, row_to_dict
 from .ingest_events import stream_ingest_events
 from .ingest import ingest_all, list_articles, search_articles, set_article_status, sync_sources
+from .run_history import get_ingest_run_sources, list_ingest_runs
 from .scheduler import (
     get_interval_minutes,
     get_next_ingest_at,
@@ -73,6 +74,24 @@ def ingest() -> dict:
 @app.get("/api/ingest/stream")
 def ingest_stream() -> StreamingResponse:
     return StreamingResponse(stream_ingest_events(), media_type="text/event-stream")
+
+
+@app.get("/api/ingest/runs")
+def ingest_runs(
+    from_: datetime | None = Query(default=None, alias="from"),
+    to: datetime | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=20, ge=1, le=100),
+) -> dict:
+    return list_ingest_runs(from_=from_, to=to, page=page, per_page=per_page)
+
+
+@app.get("/api/ingest/runs/{run_id}")
+def ingest_run_sources(run_id: int) -> dict:
+    sources = get_ingest_run_sources(run_id)
+    if sources is None:
+        raise HTTPException(status_code=404, detail="ingest run not found")
+    return {"items": sources}
 
 
 @app.get("/api/articles")

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -21,6 +21,7 @@ from .scheduler import (
     start_scheduler,
     stop_scheduler,
 )
+from .stats import articles_over_time, sources_volume, stats_overview
 from .source_health import list_source_health
 
 app = FastAPI(title="News Dashboard", version="0.3.0")
@@ -174,6 +175,39 @@ def scheduler_pause() -> dict:
 def scheduler_resume() -> dict:
     resume_scheduler()
     return {"paused": False, "next_run_at": get_next_ingest_at()}
+
+
+@app.get("/api/stats/overview")
+def stats_overview_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return stats_overview(from_, to)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/stats/articles-over-time")
+def stats_articles_over_time_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return {"items": articles_over_time(from_, to)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/stats/sources-volume")
+def stats_sources_volume_endpoint(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+) -> dict:
+    try:
+        return {"items": sources_volume(from_, to)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 class AskRequest(BaseModel):

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -21,6 +21,7 @@ from .scheduler import (
     start_scheduler,
     stop_scheduler,
 )
+from .source_health import list_source_health
 
 app = FastAPI(title="News Dashboard", version="0.3.0")
 app.add_middleware(
@@ -119,6 +120,11 @@ def sources() -> dict:
             "SELECT * FROM sources ORDER BY category, priority DESC, name"
         ).fetchall()
         return {"items": [row_to_dict(row) for row in rows]}
+
+
+@app.get("/api/sources/health")
+def sources_health() -> dict:
+    return {"items": list_source_health()}
 
 
 @app.patch("/api/sources/{slug}/enabled")

--- a/backend/news_dashboard/run_history.py
+++ b/backend/news_dashboard/run_history.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db, row_to_dict
+
+
+def _iso(value: datetime | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _datetime_from_value(value: datetime | str | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _duration_ms(
+    started_at: datetime | str | None,
+    finished_at: datetime | str | None,
+    duration_ms: int | None,
+) -> int | None:
+    if duration_ms is not None:
+        return duration_ms
+    start = _datetime_from_value(started_at)
+    end = _datetime_from_value(finished_at)
+    if not start or not end:
+        return None
+    return max(0, int((end - start).total_seconds() * 1000))
+
+
+def _run_from_row(row: Any) -> dict[str, Any]:
+    data = row_to_dict(row)
+    data["duration_ms"] = _duration_ms(
+        data.get("started_at"),
+        data.get("finished_at"),
+        data.get("duration_ms"),
+    )
+    data["started_at"] = _iso(data.get("started_at"))
+    data["finished_at"] = _iso(data.get("finished_at"))
+    data["sources_run"] = int(data.get("sources_run") or 0)
+    data["total_new"] = int(data.get("total_new") or 0)
+    data["total_errors"] = int(data.get("total_errors") or 0)
+    return data
+
+
+def list_ingest_runs(
+    *,
+    from_: datetime | str | None = None,
+    to: datetime | str | None = None,
+    page: int = 1,
+    per_page: int = 20,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    init_db(db_path)
+    filters = ["finished_at IS NOT NULL"]
+    params: list[Any] = []
+    from_iso = _iso(from_)
+    to_iso = _iso(to)
+    if from_iso:
+        filters.append("started_at >= ?")
+        params.append(from_iso)
+    if to_iso:
+        filters.append("started_at <= ?")
+        params.append(to_iso)
+    where = " AND ".join(filters)
+    offset = (page - 1) * per_page
+
+    with connect(db_path) as conn:
+        total_row = conn.execute(
+            f"SELECT COUNT(*) AS count FROM ingest_runs WHERE {where}",
+            tuple(params),
+        ).fetchone()
+        total = int(total_row["count"] if isinstance(total_row, dict) else total_row[0])
+        rows = conn.execute(
+            f"""
+            SELECT
+              r.id,
+              r.started_at,
+              r.finished_at,
+              r.duration_ms,
+              (SELECT COUNT(*) FROM ingest_run_sources s WHERE s.run_id = r.id) AS sources_run,
+              COALESCE(
+                r.total_new,
+                (SELECT COALESCE(SUM(COALESCE(s.articles_new, 0)), 0) FROM ingest_run_sources s WHERE s.run_id = r.id),
+                0
+              ) AS total_new,
+              COALESCE(
+                r.total_errors,
+                (
+                  SELECT COUNT(*)
+                  FROM ingest_run_sources s
+                  WHERE s.run_id = r.id
+                    AND s.error_message IS NOT NULL
+                    AND s.error_message != ''
+                ),
+                0
+              ) AS total_errors
+            FROM ingest_runs r
+            WHERE {where}
+            ORDER BY r.started_at DESC, r.id DESC
+            LIMIT ? OFFSET ?
+            """,
+            tuple(params + [per_page, offset]),
+        ).fetchall()
+
+    return {
+        "items": [_run_from_row(row) for row in rows],
+        "page": page,
+        "per_page": per_page,
+        "total": total,
+        "has_more": offset + len(rows) < total,
+    }
+
+
+def get_ingest_run_sources(run_id: int, *, db_path: Path | None = None) -> list[dict[str, Any]] | None:
+    init_db(db_path)
+    with connect(db_path) as conn:
+        exists = conn.execute("SELECT id FROM ingest_runs WHERE id=?", (run_id,)).fetchone()
+        if not exists:
+            return None
+        rows = conn.execute(
+            """
+            SELECT
+              id,
+              run_id,
+              source_name,
+              COALESCE(articles_found, 0) AS articles_found,
+              COALESCE(articles_new, 0) AS articles_new,
+              error_message
+            FROM ingest_run_sources
+            WHERE run_id=?
+            ORDER BY id ASC
+            """,
+            (run_id,),
+        ).fetchall()
+
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        item = row_to_dict(row)
+        found = int(item.get("articles_found") or 0)
+        new = int(item.get("articles_new") or 0)
+        item["articles_found"] = found
+        item["articles_new"] = new
+        item["duplicates"] = max(0, found - new)
+        items.append(item)
+    return items

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db, row_to_dict
+
+
+def _clean_error(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return None
+    if "Traceback" in text:
+        candidates = [
+            line
+            for line in lines
+            if not line.startswith("Traceback")
+            and not line.startswith("File ")
+            and not line.startswith("raise ")
+            and not line.startswith("^")
+        ]
+        text = candidates[-1] if candidates else lines[-1]
+    else:
+        text = lines[0]
+    return text[:180] + ("..." if len(text) > 180 else "")
+
+
+def _source_key(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def list_source_health(db_path: Path | None = None) -> list[dict[str, Any]]:
+    init_db(db_path)
+    with connect(db_path) as conn:
+        source_rows = conn.execute(
+            "SELECT * FROM sources ORDER BY category, priority DESC, name"
+        ).fetchall()
+        run_rows = conn.execute(
+            """
+            SELECT source_name, articles_new, error_message
+            FROM ingest_run_sources
+            ORDER BY run_id DESC, id DESC
+            """
+        ).fetchall()
+
+    health_by_slug: dict[str, dict[str, Any]] = {}
+    aliases: dict[str, str] = {}
+
+    for row in source_rows:
+        source = row_to_dict(row)
+        slug = str(source["slug"])
+        last_error = _clean_error(source.get("last_error"))
+        item = {
+            "slug": slug,
+            "name": source["name"],
+            "category": source["category"],
+            "enabled": source["enabled"],
+            "last_checked_at": source.get("last_checked_at"),
+            "last_error": last_error,
+            "error_streak": 0,
+            "articles_last_run": _as_int(source.get("last_inserted_count")),
+            "status": "ERROR" if last_error else "OK",
+        }
+        health_by_slug[slug] = item
+        aliases[_source_key(source.get("slug"))] = slug
+        aliases[_source_key(source.get("name"))] = slug
+
+    latest_seen: set[str] = set()
+    streak_closed: set[str] = set()
+
+    for row in run_rows:
+        run = row_to_dict(row)
+        slug = aliases.get(_source_key(run.get("source_name")))
+        if not slug:
+            continue
+
+        item = health_by_slug[slug]
+        error = _clean_error(run.get("error_message"))
+        if slug not in latest_seen:
+            item["articles_last_run"] = _as_int(run.get("articles_new"))
+            latest_seen.add(slug)
+
+        if slug in streak_closed:
+            continue
+
+        if error:
+            item["error_streak"] += 1
+            if not item["last_error"]:
+                item["last_error"] = error
+        else:
+            streak_closed.add(slug)
+
+    for slug, item in health_by_slug.items():
+        if slug in latest_seen:
+            item["status"] = "ERROR" if item["error_streak"] > 0 else "OK"
+        else:
+            item["status"] = "ERROR" if item["last_error"] else "OK"
+
+    return sorted(
+        health_by_slug.values(),
+        key=lambda item: (
+            -_as_int(item["error_streak"]),
+            0 if item["status"] == "ERROR" else 1,
+            str(item["name"]).lower(),
+        ),
+    )

--- a/backend/news_dashboard/stats.py
+++ b/backend/news_dashboard/stats.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db, row_to_dict
+
+
+def parse_range(from_value: str, to_value: str) -> tuple[datetime, datetime]:
+    start = _parse_datetime(from_value)
+    end = _parse_datetime(to_value)
+    if start > end:
+        raise ValueError("'from' must be before or equal to 'to'")
+    return start, end
+
+
+def stats_overview(from_value: str, to_value: str, db_path: Path | None = None) -> dict:
+    start, end = parse_range(from_value, to_value)
+    runs, source_rows = _load_stats_rows(start, end, db_path)
+
+    total_articles = sum(_int_value(row.get("articles_found")) for row in source_rows)
+    total_new = sum(_int_value(row.get("total_new")) for row in runs)
+    if total_new == 0 and source_rows:
+        total_new = sum(_int_value(row.get("articles_new")) for row in source_rows)
+    total_errors = sum(_int_value(row.get("total_errors")) for row in runs)
+    if total_errors == 0 and source_rows:
+        total_errors = sum(1 for row in source_rows if _has_error(row.get("error_message")))
+
+    durations = [_int_value(row.get("duration_ms")) for row in runs if row.get("duration_ms") is not None]
+    latest_by_source: dict[str, dict[str, Any]] = {}
+    for row in source_rows:
+        name = str(row["source_name"])
+        current = latest_by_source.get(name)
+        if current is None or _row_sort_key(row) > _row_sort_key(current):
+            latest_by_source[name] = row
+
+    erroring_sources = sum(1 for row in latest_by_source.values() if _has_error(row.get("error_message")))
+    healthy_sources = sum(1 for row in latest_by_source.values() if not _has_error(row.get("error_message")))
+
+    return {
+        "total_articles": total_articles,
+        "total_new": total_new,
+        "total_errors": total_errors,
+        "avg_duration_ms": round(sum(durations) / len(durations)) if durations else 0,
+        "healthy_sources": healthy_sources,
+        "erroring_sources": erroring_sources,
+    }
+
+
+def articles_over_time(from_value: str, to_value: str, db_path: Path | None = None) -> list[dict]:
+    start, end = parse_range(from_value, to_value)
+    runs, _ = _load_stats_rows(start, end, db_path)
+    hourly = end - start <= timedelta(days=1)
+    counts: dict[str, int] = defaultdict(int)
+
+    for row in runs:
+        started_at = _coerce_datetime(row["started_at"])
+        if hourly:
+            bucket = started_at.replace(minute=0, second=0, microsecond=0)
+            key = bucket.isoformat()
+        else:
+            key = started_at.date().isoformat()
+        counts[key] += _int_value(row.get("total_new"))
+
+    return [
+        {"date": bucket, "new_articles": counts[bucket]}
+        for bucket in _bucket_keys(start, end, hourly)
+    ]
+
+
+def sources_volume(from_value: str, to_value: str, db_path: Path | None = None) -> list[dict]:
+    start, end = parse_range(from_value, to_value)
+    _, source_rows = _load_stats_rows(start, end, db_path)
+    totals: dict[str, int] = defaultdict(int)
+    for row in source_rows:
+        totals[str(row["source_name"])] += _int_value(row.get("articles_new"))
+    return [
+        {"source_name": source_name, "total_new": total_new}
+        for source_name, total_new in sorted(totals.items(), key=lambda item: (-item[1], item[0].lower()))
+    ]
+
+
+def _load_stats_rows(
+    start: datetime,
+    end: datetime,
+    db_path: Path | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    init_db(db_path)
+    with connect(db_path) as conn:
+        run_rows = conn.execute(
+            """
+            SELECT id, started_at, finished_at, duration_ms, total_new, total_errors
+            FROM ingest_runs
+            WHERE started_at >= ? AND started_at <= ?
+            ORDER BY started_at ASC, id ASC
+            """,
+            (_to_query_value(start), _to_query_value(end)),
+        ).fetchall()
+        runs = [row_to_dict(row) for row in run_rows]
+        run_ids = [row["id"] for row in runs]
+        if not run_ids:
+            return [], []
+
+        placeholders = ", ".join("?" for _ in run_ids)
+        source_rows = conn.execute(
+            f"""
+            SELECT
+              ingest_run_sources.id,
+              ingest_run_sources.run_id,
+              ingest_run_sources.source_name,
+              ingest_run_sources.articles_found,
+              ingest_run_sources.articles_new,
+              ingest_run_sources.error_message,
+              ingest_runs.started_at
+            FROM ingest_run_sources
+            JOIN ingest_runs ON ingest_runs.id = ingest_run_sources.run_id
+            WHERE ingest_run_sources.run_id IN ({placeholders})
+            ORDER BY ingest_runs.started_at ASC, ingest_run_sources.id ASC
+            """,
+            tuple(run_ids),
+        ).fetchall()
+    return runs, [row_to_dict(row) for row in source_rows]
+
+
+def _bucket_keys(start: datetime, end: datetime, hourly: bool) -> list[str]:
+    if hourly:
+        cursor = start.replace(minute=0, second=0, microsecond=0)
+        last = end.replace(minute=0, second=0, microsecond=0)
+        step = timedelta(hours=1)
+        keys: list[str] = []
+        while cursor <= last:
+            keys.append(cursor.isoformat())
+            cursor += step
+        return keys
+
+    cursor_date = start.date()
+    last_date = end.date()
+    keys = []
+    while cursor_date <= last_date:
+        keys.append(cursor_date.isoformat())
+        cursor_date += timedelta(days=1)
+    return keys
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"Invalid ISO datetime: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        parsed = _parse_datetime(str(value))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _to_query_value(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _int_value(value: Any) -> int:
+    if value is None:
+        return 0
+    return int(value)
+
+
+def _has_error(value: Any) -> bool:
+    return bool(str(value).strip()) if value is not None else False
+
+
+def _row_sort_key(row: dict[str, Any]) -> tuple[datetime, int]:
+    return (_coerce_datetime(row["started_at"]), _int_value(row.get("id")))

--- a/backend/tests/test_ingest_runs.py
+++ b/backend/tests/test_ingest_runs.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import news_dashboard.ingest as ingest_module
+from news_dashboard.db import connect
+from news_dashboard.ingest import ingest_all
+from news_dashboard.ingest_events import IngestStreamEvent, format_sse_event, ingest_events, stream_ingest_events
+from news_dashboard.main import app
+from news_dashboard.sources import SourceDefinition
+
+
+class ParsedFeed:
+    bozo = False
+
+    def __init__(self, entries: list[dict[str, Any]]) -> None:
+        self.entries = entries
+
+
+def test_ingest_all_writes_run_rows_and_buffers_terminal_lines(tmp_path: Path, monkeypatch: Any) -> None:
+    db_path = tmp_path / "runs.db"
+    source = SourceDefinition("test-feed", "Test Feed", "https://example.com/feed.xml", "python")
+    ingest_events.reset_for_tests()
+    monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [source])
+
+    def parse(url: str, agent: str) -> ParsedFeed:
+        assert url == source.url
+        assert "news-dashboard" in agent
+        return ParsedFeed([
+            {
+                "link": "https://example.com/article?utm_source=test",
+                "title": "Python release notes",
+                "summary": "A useful release summary.",
+            }
+        ])
+
+    monkeypatch.setattr(ingest_module.feedparser, "parse", parse)
+
+    assert ingest_all(db_path) == {"test-feed": 1}
+
+    with connect(db_path) as conn:
+        run = conn.execute("SELECT * FROM ingest_runs").fetchone()
+        sources = conn.execute("SELECT * FROM ingest_run_sources").fetchall()
+
+    assert run["finished_at"] is not None
+    assert run["duration_ms"] is not None
+    assert run["total_new"] == 1
+    assert run["total_errors"] == 0
+    assert len(sources) == 1
+    assert sources[0]["run_id"] == run["id"]
+    assert sources[0]["source_name"] == "Test Feed"
+    assert sources[0]["articles_found"] == 1
+    assert sources[0]["articles_new"] == 1
+    assert sources[0]["error_message"] is None
+
+    terminal_lines = ingest_events.snapshot_last_completed()
+    assert terminal_lines[0].startswith(f"Ingest run #{run['id']} started at ")
+    assert any(line.startswith("✓ Test Feed — 1 new article") for line in terminal_lines)
+    assert terminal_lines[-1].startswith("Summary — 1 new article")
+
+
+def test_ingest_all_records_source_errors(tmp_path: Path, monkeypatch: Any) -> None:
+    db_path = tmp_path / "errors.db"
+    source = SourceDefinition("bad-feed", "Bad Feed", "https://example.com/bad.xml", "python")
+    ingest_events.reset_for_tests()
+    monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [source])
+
+    def parse(url: str, agent: str) -> ParsedFeed:
+        raise RuntimeError("connection timeout")
+
+    monkeypatch.setattr(ingest_module.feedparser, "parse", parse)
+
+    assert ingest_all(db_path) == {"bad-feed": -1}
+
+    with connect(db_path) as conn:
+        run = conn.execute("SELECT * FROM ingest_runs").fetchone()
+        source_row = conn.execute("SELECT * FROM ingest_run_sources").fetchone()
+
+    assert run["total_new"] == 0
+    assert run["total_errors"] == 1
+    assert source_row["source_name"] == "Bad Feed"
+    assert source_row["articles_found"] == 0
+    assert source_row["articles_new"] == 0
+    assert source_row["error_message"] == "connection timeout"
+    assert any(
+        line == "✗ Bad Feed — connection timeout"
+        for line in ingest_events.snapshot_last_completed()
+    )
+
+
+def test_ingest_stream_route_is_registered() -> None:
+    assert any(route.path == "/api/ingest/stream" for route in app.routes)
+
+
+def test_ingest_stream_replays_last_completed_run() -> None:
+    ingest_events.reset_for_tests()
+    ingest_events.start_run(7, "Ingest run #7 started at 2026-06-06T12:00:00+00:00")
+    ingest_events.append_line("✓ Test Feed — 2 new articles (0.1s)")
+    ingest_events.complete_run("Summary — 2 new articles (0.1s)")
+
+    stream = stream_ingest_events()
+    try:
+        chunks = [next(stream) for _ in range(4)]
+    finally:
+        stream.close()
+
+    assert chunks[0] == format_sse_event(IngestStreamEvent("reset"))
+    assert "data: Ingest run #7 started at 2026-06-06T12:00:00+00:00" in chunks[1]
+    assert "data: ✓ Test Feed — 2 new articles (0.1s)" in chunks[2]
+    assert "data: Summary — 2 new articles (0.1s)" in chunks[3]

--- a/backend/tests/test_run_history.py
+++ b/backend/tests/test_run_history.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.run_history import get_ingest_run_sources, list_ingest_runs
+
+
+def _insert_run(
+    db_path: Path,
+    *,
+    started_at: str,
+    finished_at: str | None,
+    duration_ms: int | None = None,
+    total_new: int | None = None,
+    total_errors: int | None = None,
+) -> int:
+    with connect(db_path) as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO ingest_runs(started_at, finished_at, duration_ms, total_new, total_errors)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (started_at, finished_at, duration_ms, total_new, total_errors),
+        )
+        return int(cursor.lastrowid)
+
+
+def _insert_source(
+    db_path: Path,
+    *,
+    run_id: int,
+    source_name: str,
+    articles_found: int,
+    articles_new: int,
+    error_message: str | None = None,
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (run_id, source_name, articles_found, articles_new, error_message),
+        )
+
+
+def test_run_history_tables_are_created(tmp_path: Path) -> None:
+    db = tmp_path / "runs.db"
+    init_db(db)
+
+    with connect(db) as conn:
+        conn.execute(
+            """
+            INSERT INTO ingest_runs(started_at, finished_at, duration_ms, total_new, total_errors)
+            VALUES ('2026-06-06T10:00:00+00:00', '2026-06-06T10:00:02+00:00', 2000, 3, 0)
+            """
+        )
+        row = conn.execute("SELECT COUNT(*) AS count FROM ingest_runs").fetchone()
+
+    assert row["count"] == 1
+
+
+def test_list_ingest_runs_is_completed_reverse_chronological_and_paginated(tmp_path: Path) -> None:
+    db = tmp_path / "history.db"
+    init_db(db)
+    first = _insert_run(
+        db,
+        started_at="2026-06-06T10:00:00+00:00",
+        finished_at="2026-06-06T10:00:03+00:00",
+    )
+    second = _insert_run(
+        db,
+        started_at="2026-06-06T11:00:00+00:00",
+        finished_at="2026-06-06T11:00:01+00:00",
+    )
+    _insert_run(
+        db,
+        started_at="2026-06-06T12:00:00+00:00",
+        finished_at=None,
+    )
+    _insert_source(db, run_id=first, source_name="Python Insider", articles_found=4, articles_new=3)
+    _insert_source(db, run_id=first, source_name="Broken Feed", articles_found=0, articles_new=0, error_message="timeout")
+    _insert_source(db, run_id=second, source_name="Hacker News", articles_found=10, articles_new=2)
+
+    page = list_ingest_runs(page=1, per_page=1, db_path=db)
+
+    assert page["total"] == 2
+    assert page["has_more"] is True
+    assert [run["id"] for run in page["items"]] == [second]
+    assert page["items"][0]["sources_run"] == 1
+    assert page["items"][0]["total_new"] == 2
+    assert page["items"][0]["total_errors"] == 0
+
+    page_2 = list_ingest_runs(page=2, per_page=1, db_path=db)
+    assert [run["id"] for run in page_2["items"]] == [first]
+    assert page_2["items"][0]["duration_ms"] == 3000
+    assert page_2["items"][0]["sources_run"] == 2
+    assert page_2["items"][0]["total_new"] == 3
+    assert page_2["items"][0]["total_errors"] == 1
+
+
+def test_list_ingest_runs_filters_by_started_at_window(tmp_path: Path) -> None:
+    db = tmp_path / "filtered.db"
+    init_db(db)
+    _insert_run(
+        db,
+        started_at="2026-06-06T09:00:00+00:00",
+        finished_at="2026-06-06T09:00:01+00:00",
+        total_new=1,
+        total_errors=0,
+    )
+    expected = _insert_run(
+        db,
+        started_at="2026-06-06T10:00:00+00:00",
+        finished_at="2026-06-06T10:00:01+00:00",
+        total_new=2,
+        total_errors=0,
+    )
+
+    page = list_ingest_runs(
+        from_="2026-06-06T09:30:00+00:00",
+        to="2026-06-06T10:30:00+00:00",
+        db_path=db,
+    )
+
+    assert [run["id"] for run in page["items"]] == [expected]
+
+
+def test_get_ingest_run_sources_includes_duplicate_counts(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    init_db(db)
+    run_id = _insert_run(
+        db,
+        started_at="2026-06-06T10:00:00+00:00",
+        finished_at="2026-06-06T10:00:03+00:00",
+    )
+    _insert_source(db, run_id=run_id, source_name="Python Insider", articles_found=5, articles_new=2)
+    _insert_source(db, run_id=run_id, source_name="Broken Feed", articles_found=0, articles_new=0, error_message="timeout")
+
+    sources = get_ingest_run_sources(run_id, db_path=db)
+
+    assert sources is not None
+    assert sources[0]["duplicates"] == 3
+    assert sources[1]["error_message"] == "timeout"
+    assert get_ingest_run_sources(999, db_path=db) is None

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -13,6 +13,7 @@ from news_dashboard.ingest import (
     set_article_status,
     sync_sources,
 )
+from news_dashboard.source_health import list_source_health
 from news_dashboard.sources import DEFAULT_SOURCES, SourceDefinition
 
 
@@ -61,6 +62,66 @@ def test_source_error_tracked(tmp_path: Path) -> None:
         row = conn.execute("SELECT last_error, last_checked_at FROM sources WHERE slug=?", (bad.slug,)).fetchone()
         assert row["last_error"] is not None, "last_error should be set on failure"
         assert row["last_checked_at"] is not None, "last_checked_at should be set even on failure"
+
+
+def test_source_health_error_streak_resets_after_success(tmp_path: Path) -> None:
+    db = tmp_path / "streak.db"
+    sync_sources(db)
+    with connect(db) as conn:
+        for run_id, error in ((1, "timeout"), (2, "HTTP 500"), (3, None)):
+            conn.execute(
+                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
+            )
+            conn.execute(
+                """
+                INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+                VALUES (?, 'Python Insider', 10, ?, ?)
+                """,
+                (run_id, 3 if error is None else 0, error),
+            )
+
+    python = next(item for item in list_source_health(db) if item["slug"] == "python-insider")
+    assert python["error_streak"] == 0
+    assert python["articles_last_run"] == 3
+    assert python["status"] == "OK"
+
+
+def test_source_health_counts_leading_errors_and_sorts_first(tmp_path: Path) -> None:
+    db = tmp_path / "leading-errors.db"
+    sync_sources(db)
+    with connect(db) as conn:
+        for run_id in (1, 2, 3):
+            conn.execute(
+                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
+            )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (1, 'Python Insider', 8, 2, NULL)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (2, 'Python Insider', 0, 0, 'Feed fetch failed: timeout')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+            VALUES (3, 'Python Insider', 0, 0, 'Traceback (most recent call last):\n  File "feed.py", line 1\nTimeoutError: connection timed out')
+            """
+        )
+
+    items = list_source_health(db)
+    python = next(item for item in items if item["slug"] == "python-insider")
+    assert python["error_streak"] == 2
+    assert python["articles_last_run"] == 0
+    assert python["status"] == "ERROR"
+    assert python["last_error"] == "TimeoutError: connection timed out"
+    assert items[0]["slug"] == "python-insider"
 
 
 # ──────────────────────────────────────────────

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.stats import articles_over_time, sources_volume, stats_overview
+
+
+def _insert_run(
+    db_path: Path,
+    run_id: int,
+    started_at: str,
+    total_new: int,
+    total_errors: int,
+    duration_ms: int,
+    sources: list[tuple[str, int, int, str | None]],
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO ingest_runs(id, started_at, finished_at, duration_ms, total_new, total_errors)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (run_id, started_at, started_at, duration_ms, total_new, total_errors),
+        )
+        for source_name, found, new, error in sources:
+            conn.execute(
+                """
+                INSERT INTO ingest_run_sources(run_id, source_name, articles_found, articles_new, error_message)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (run_id, source_name, found, new, error),
+            )
+
+
+def test_overview_aggregates_run_and_source_stats(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(
+        db_path,
+        1,
+        "2026-06-01T10:00:00+00:00",
+        7,
+        1,
+        1000,
+        [
+            ("Python Insider", 10, 5, None),
+            ("Docker Blog", 4, 2, "timeout"),
+        ],
+    )
+    _insert_run(
+        db_path,
+        2,
+        "2026-06-02T10:00:00+00:00",
+        3,
+        0,
+        3000,
+        [
+            ("Python Insider", 8, 3, None),
+            ("Docker Blog", 2, 0, None),
+        ],
+    )
+
+    assert stats_overview(
+        "2026-06-01T00:00:00+00:00",
+        "2026-06-03T00:00:00+00:00",
+        db_path,
+    ) == {
+        "total_articles": 24,
+        "total_new": 10,
+        "total_errors": 1,
+        "avg_duration_ms": 2000,
+        "healthy_sources": 2,
+        "erroring_sources": 0,
+    }
+
+
+def test_articles_over_time_includes_zero_activity_days(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(db_path, 1, "2026-06-01T10:00:00+00:00", 4, 0, 1000, [])
+    _insert_run(db_path, 2, "2026-06-03T10:00:00+00:00", 6, 0, 1000, [])
+
+    assert articles_over_time(
+        "2026-06-01T00:00:00+00:00",
+        "2026-06-03T23:00:00+00:00",
+        db_path,
+    ) == [
+        {"date": "2026-06-01", "new_articles": 4},
+        {"date": "2026-06-02", "new_articles": 0},
+        {"date": "2026-06-03", "new_articles": 6},
+    ]
+
+
+def test_articles_over_time_uses_hourly_buckets_for_one_day_ranges(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(db_path, 1, "2026-06-01T10:30:00+00:00", 4, 0, 1000, [])
+    _insert_run(db_path, 2, "2026-06-01T12:00:00+00:00", 6, 0, 1000, [])
+
+    rows = articles_over_time(
+        "2026-06-01T10:00:00+00:00",
+        "2026-06-01T12:45:00+00:00",
+        db_path,
+    )
+
+    assert rows == [
+        {"date": "2026-06-01T10:00:00+00:00", "new_articles": 4},
+        {"date": "2026-06-01T11:00:00+00:00", "new_articles": 0},
+        {"date": "2026-06-01T12:00:00+00:00", "new_articles": 6},
+    ]
+
+
+def test_sources_volume_orders_by_total_new_descending(tmp_path: Path) -> None:
+    db_path = tmp_path / "stats.db"
+    init_db(db_path)
+    _insert_run(
+        db_path,
+        1,
+        "2026-06-01T10:00:00+00:00",
+        10,
+        0,
+        1000,
+        [
+            ("Python Insider", 10, 3, None),
+            ("Docker Blog", 10, 5, None),
+        ],
+    )
+    _insert_run(
+        db_path,
+        2,
+        "2026-06-02T10:00:00+00:00",
+        6,
+        0,
+        1000,
+        [
+            ("Python Insider", 10, 6, None),
+            ("Docker Blog", 10, 1, None),
+        ],
+    )
+
+    assert sources_volume(
+        "2026-06-01T00:00:00+00:00",
+        "2026-06-03T00:00:00+00:00",
+        db_path,
+    ) == [
+        {"source_name": "Python Insider", "total_new": 9},
+        {"source_name": "Docker Blog", "total_new": 6},
+    ]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -580,6 +580,46 @@ function SourceHealthTable({ items, loading }: { items: SourceHealth[]; loading:
   )
 }
 
+function IngestTerminal() {
+  const [lines, setLines] = useState<string[]>([])
+  const [connected, setConnected] = useState(false)
+  const terminalRef = useRef<HTMLPreElement | null>(null)
+
+  useEffect(() => {
+    const events = new EventSource('/api/ingest/stream')
+
+    events.onopen = () => setConnected(true)
+    events.onerror = () => setConnected(false)
+    events.addEventListener('reset', () => setLines([]))
+    events.addEventListener('line', (event) => {
+      setLines((prev) => [...prev, event.data])
+    })
+
+    return () => events.close()
+  }, [])
+
+  useEffect(() => {
+    const terminal = terminalRef.current
+    if (terminal) {
+      terminal.scrollTop = terminal.scrollHeight
+    }
+  }, [lines])
+
+  return (
+    <div className="scheduler-card scheduler-terminal-card">
+      <div className="scheduler-terminal-header">
+        <h3 className="scheduler-card-title">Ingest Terminal</h3>
+        <span className={`scheduler-terminal-status${connected ? ' connected' : ''}`}>
+          {connected ? 'Live' : 'Connecting'}
+        </span>
+      </div>
+      <pre className="scheduler-terminal" ref={terminalRef} aria-live="polite">
+        {lines.length ? lines.join('\n') : 'Waiting for ingest output...'}
+      </pre>
+    </div>
+  )
+}
+
 function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [status, setStatus] = useState<SchedulerStatus | null>(null)
   const [loadingStatus, setLoadingStatus] = useState(true)
@@ -919,6 +959,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
         <h3 className="scheduler-card-title">Source Health</h3>
         <SourceHealthTable items={sourceHealth} loading={loadingSourceHealth} />
       </div>
+      <IngestTerminal />
     </div>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -495,16 +495,6 @@ function formatInteger(value: number): string {
   return new Intl.NumberFormat().format(value)
 }
 
-function formatDuration(ms: number): string {
-  if (!ms) return '0s'
-  if (ms < 1000) return `${ms}ms`
-  const seconds = ms / 1000
-  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`
-  const minutes = Math.floor(seconds / 60)
-  const rem = Math.round(seconds % 60)
-  return rem ? `${minutes}m ${rem}s` : `${minutes}m`
-}
-
 function formatTimeBucket(value: string, range: StatsRangeId): string {
   if (range === 'today') {
     return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './styles.css'
 import {
   askAI,
   fetchArticles,
+  fetchIngestRunSources,
+  fetchIngestRuns,
   fetchSchedulerStatus,
   fetchSources,
   fetchSummary,
@@ -15,7 +17,7 @@ import {
   updateSourceEnabled,
 } from './api'
 import type { SchedulerStatus } from './api'
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, IngestRun, IngestRunSource, Source, Summary } from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
 
@@ -79,6 +81,28 @@ function relativeTime(value?: string | null): string {
   if (d < 7) return `${d}d ago`
   if (d < 30) return `${Math.floor(d / 7)}w ago`
   return date.toLocaleDateString()
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatDuration(ms?: number | null): string {
+  if (ms === null || ms === undefined) return '—'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const rest = seconds % 60
+  return rest ? `${minutes}m ${rest}s` : `${minutes}m`
 }
 
 function parseTags(tags: string): string[] {
@@ -424,6 +448,183 @@ function relativeCountdown(isoStr: string | null): string {
   return `${s}s`
 }
 
+const RUN_HISTORY_PER_PAGE = 10
+
+function RunHistoryTable({ refreshToken }: { refreshToken: number }) {
+  const [runs, setRuns] = useState<IngestRun[]>([])
+  const [page, setPage] = useState(1)
+  const [total, setTotal] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedRunId, setExpandedRunId] = useState<number | null>(null)
+  const [sourcesByRun, setSourcesByRun] = useState<Record<number, IngestRunSource[]>>({})
+  const [loadingSources, setLoadingSources] = useState<number | null>(null)
+
+  async function loadRuns(nextPage = page) {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await fetchIngestRuns(nextPage, RUN_HISTORY_PER_PAGE)
+      setRuns(data.items)
+      setTotal(data.total)
+      setHasMore(data.has_more)
+      setPage(data.page)
+      setExpandedRunId(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load run history')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadRuns(page)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, refreshToken])
+
+  async function toggleRun(runId: number) {
+    if (expandedRunId === runId) {
+      setExpandedRunId(null)
+      return
+    }
+    setExpandedRunId(runId)
+    if (sourcesByRun[runId]) return
+    setLoadingSources(runId)
+    try {
+      const items = await fetchIngestRunSources(runId)
+      setSourcesByRun((prev) => ({ ...prev, [runId]: items }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load run details')
+    } finally {
+      setLoadingSources(null)
+    }
+  }
+
+  const rangeStart = total === 0 ? 0 : (page - 1) * RUN_HISTORY_PER_PAGE + 1
+  const rangeEnd = Math.min(page * RUN_HISTORY_PER_PAGE, total)
+
+  return (
+    <div className="run-history">
+      <div className="run-history-header">
+        <h3 className="scheduler-card-title">Run History</h3>
+        <button className="run-history-refresh" onClick={() => void loadRuns(page)} disabled={loading}>
+          ↻
+        </button>
+      </div>
+
+      {error && <div className="run-history-error">{error}</div>}
+
+      {loading ? (
+        <div className="run-history-loading">
+          <span className="skeleton sk-line" />
+          <span className="skeleton sk-line" style={{ width: '72%' }} />
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="run-history-empty">No ingest runs recorded yet.</div>
+      ) : (
+        <>
+          <div className="run-history-table-wrap">
+            <table className="run-history-table">
+              <thead>
+                <tr>
+                  <th aria-label="Expand run" />
+                  <th>Started at</th>
+                  <th>Duration</th>
+                  <th>Sources run</th>
+                  <th>New articles</th>
+                  <th>Errors</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((run) => {
+                  const expanded = expandedRunId === run.id
+                  const sourceRows = sourcesByRun[run.id] ?? []
+                  return (
+                    <Fragment key={run.id}>
+                      <tr key={run.id} className={expanded ? 'expanded' : undefined}>
+                        <td>
+                          <button
+                            className="run-expand-btn"
+                            onClick={() => void toggleRun(run.id)}
+                            aria-expanded={expanded}
+                            aria-label={`${expanded ? 'Collapse' : 'Expand'} run ${run.id}`}
+                          >
+                            {expanded ? '⌄' : '›'}
+                          </button>
+                        </td>
+                        <td>
+                          <span className="run-started">{formatDateTime(run.started_at)}</span>
+                          <span className="run-relative">{relativeTime(run.started_at)}</span>
+                        </td>
+                        <td>{formatDuration(run.duration_ms)}</td>
+                        <td>{run.sources_run}</td>
+                        <td>{run.total_new}</td>
+                        <td>
+                          <span className={run.total_errors > 0 ? 'run-error-count' : undefined}>
+                            {run.total_errors}
+                          </span>
+                        </td>
+                      </tr>
+                      {expanded && (
+                        <tr key={`${run.id}-sources`} className="run-source-row">
+                          <td colSpan={6}>
+                            {loadingSources === run.id ? (
+                              <div className="run-source-loading">Loading source breakdown…</div>
+                            ) : sourceRows.length === 0 ? (
+                              <div className="run-source-empty">No per-source rows recorded for this run.</div>
+                            ) : (
+                              <table className="run-source-table">
+                                <thead>
+                                  <tr>
+                                    <th>Source name</th>
+                                    <th>Articles found</th>
+                                    <th>New</th>
+                                    <th>Duplicates</th>
+                                    <th>Error message</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {sourceRows.map((source) => (
+                                    <tr key={source.id}>
+                                      <td>{source.source_name}</td>
+                                      <td>{source.articles_found}</td>
+                                      <td>{source.articles_new}</td>
+                                      <td>{source.duplicates}</td>
+                                      <td className={source.error_message ? 'run-source-error' : 'run-source-muted'}>
+                                        {source.error_message || '—'}
+                                      </td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="run-history-pagination">
+            <span>{rangeStart}-{rangeEnd} of {total}</span>
+            <div className="run-history-page-buttons">
+              <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={loading || page === 1}>
+                ‹
+              </button>
+              <button onClick={() => setPage((p) => p + 1)} disabled={loading || !hasMore}>
+                ›
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 interface SchedulerTabProps {
   onFetchNow: () => Promise<void>
   ingesting: boolean
@@ -436,6 +637,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [actionPending, setActionPending] = useState(false)
   const [tabMessage, setTabMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
   const [countdown, setCountdown] = useState<string>('—')
+  const [historyRefresh, setHistoryRefresh] = useState(0)
 
   async function loadStatus() {
     try {
@@ -503,6 +705,11 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     } finally {
       setActionPending(false)
     }
+  }
+
+  async function handleFetchNow() {
+    await onFetchNow()
+    setHistoryRefresh((value) => value + 1)
   }
 
   if (loadingStatus) {
@@ -595,13 +802,15 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           </button>
           <button
             className="scheduler-fetch-btn"
-            onClick={() => void onFetchNow()}
+            onClick={() => void handleFetchNow()}
             disabled={ingesting || actionPending}
           >
             {ingesting ? '⟳ Fetching…' : '↻ Fetch now'}
           </button>
         </div>
       </div>
+
+      <RunHistoryTable refreshToken={historyRefresh} />
     </div>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Bar,
   BarChart,
@@ -13,6 +13,8 @@ import {
   askAI,
   fetchArticlesOverTime,
   fetchArticles,
+  fetchIngestRunSources,
+  fetchIngestRuns,
   fetchSchedulerStatus,
   fetchSourceHealth,
   fetchSources,
@@ -38,6 +40,8 @@ import type {
   SourceVolumePoint,
   StatsOverview,
   Summary,
+  IngestRun,
+  IngestRunSource,
 } from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
@@ -102,6 +106,28 @@ function relativeTime(value?: string | null): string {
   if (d < 7) return `${d}d ago`
   if (d < 30) return `${Math.floor(d / 7)}w ago`
   return date.toLocaleDateString()
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatDuration(ms?: number | null): string {
+  if (ms === null || ms === undefined) return '—'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const rest = seconds % 60
+  return rest ? `${minutes}m ${rest}s` : `${minutes}m`
 }
 
 function parseTags(tags: string): string[] {
@@ -508,6 +534,183 @@ function relativeCountdown(isoStr: string | null): string {
   return `${s}s`
 }
 
+const RUN_HISTORY_PER_PAGE = 10
+
+function RunHistoryTable({ refreshToken }: { refreshToken: number }) {
+  const [runs, setRuns] = useState<IngestRun[]>([])
+  const [page, setPage] = useState(1)
+  const [total, setTotal] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedRunId, setExpandedRunId] = useState<number | null>(null)
+  const [sourcesByRun, setSourcesByRun] = useState<Record<number, IngestRunSource[]>>({})
+  const [loadingSources, setLoadingSources] = useState<number | null>(null)
+
+  async function loadRuns(nextPage = page) {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await fetchIngestRuns(nextPage, RUN_HISTORY_PER_PAGE)
+      setRuns(data.items)
+      setTotal(data.total)
+      setHasMore(data.has_more)
+      setPage(data.page)
+      setExpandedRunId(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load run history')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadRuns(page)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, refreshToken])
+
+  async function toggleRun(runId: number) {
+    if (expandedRunId === runId) {
+      setExpandedRunId(null)
+      return
+    }
+    setExpandedRunId(runId)
+    if (sourcesByRun[runId]) return
+    setLoadingSources(runId)
+    try {
+      const items = await fetchIngestRunSources(runId)
+      setSourcesByRun((prev) => ({ ...prev, [runId]: items }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load run details')
+    } finally {
+      setLoadingSources(null)
+    }
+  }
+
+  const rangeStart = total === 0 ? 0 : (page - 1) * RUN_HISTORY_PER_PAGE + 1
+  const rangeEnd = Math.min(page * RUN_HISTORY_PER_PAGE, total)
+
+  return (
+    <div className="run-history">
+      <div className="run-history-header">
+        <h3 className="scheduler-card-title">Run History</h3>
+        <button className="run-history-refresh" onClick={() => void loadRuns(page)} disabled={loading}>
+          ↻
+        </button>
+      </div>
+
+      {error && <div className="run-history-error">{error}</div>}
+
+      {loading ? (
+        <div className="run-history-loading">
+          <span className="skeleton sk-line" />
+          <span className="skeleton sk-line" style={{ width: '72%' }} />
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="run-history-empty">No ingest runs recorded yet.</div>
+      ) : (
+        <>
+          <div className="run-history-table-wrap">
+            <table className="run-history-table">
+              <thead>
+                <tr>
+                  <th aria-label="Expand run" />
+                  <th>Started at</th>
+                  <th>Duration</th>
+                  <th>Sources run</th>
+                  <th>New articles</th>
+                  <th>Errors</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((run) => {
+                  const expanded = expandedRunId === run.id
+                  const sourceRows = sourcesByRun[run.id] ?? []
+                  return (
+                    <Fragment key={run.id}>
+                      <tr key={run.id} className={expanded ? 'expanded' : undefined}>
+                        <td>
+                          <button
+                            className="run-expand-btn"
+                            onClick={() => void toggleRun(run.id)}
+                            aria-expanded={expanded}
+                            aria-label={`${expanded ? 'Collapse' : 'Expand'} run ${run.id}`}
+                          >
+                            {expanded ? '⌄' : '›'}
+                          </button>
+                        </td>
+                        <td>
+                          <span className="run-started">{formatDateTime(run.started_at)}</span>
+                          <span className="run-relative">{relativeTime(run.started_at)}</span>
+                        </td>
+                        <td>{formatDuration(run.duration_ms)}</td>
+                        <td>{run.sources_run}</td>
+                        <td>{run.total_new}</td>
+                        <td>
+                          <span className={run.total_errors > 0 ? 'run-error-count' : undefined}>
+                            {run.total_errors}
+                          </span>
+                        </td>
+                      </tr>
+                      {expanded && (
+                        <tr key={`${run.id}-sources`} className="run-source-row">
+                          <td colSpan={6}>
+                            {loadingSources === run.id ? (
+                              <div className="run-source-loading">Loading source breakdown…</div>
+                            ) : sourceRows.length === 0 ? (
+                              <div className="run-source-empty">No per-source rows recorded for this run.</div>
+                            ) : (
+                              <table className="run-source-table">
+                                <thead>
+                                  <tr>
+                                    <th>Source name</th>
+                                    <th>Articles found</th>
+                                    <th>New</th>
+                                    <th>Duplicates</th>
+                                    <th>Error message</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {sourceRows.map((source) => (
+                                    <tr key={source.id}>
+                                      <td>{source.source_name}</td>
+                                      <td>{source.articles_found}</td>
+                                      <td>{source.articles_new}</td>
+                                      <td>{source.duplicates}</td>
+                                      <td className={source.error_message ? 'run-source-error' : 'run-source-muted'}>
+                                        {source.error_message || '—'}
+                                      </td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="run-history-pagination">
+            <span>{rangeStart}-{rangeEnd} of {total}</span>
+            <div className="run-history-page-buttons">
+              <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={loading || page === 1}>
+                ‹
+              </button>
+              <button onClick={() => setPage((p) => p + 1)} disabled={loading || !hasMore}>
+                ›
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 interface SchedulerTabProps {
   onFetchNow: () => Promise<void>
   ingesting: boolean
@@ -645,6 +848,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     [articlesSeries, rangeId],
   )
   const topSourceVolumes = useMemo(() => sourceVolumes.slice(0, 12), [sourceVolumes])
+  const [historyRefresh, setHistoryRefresh] = useState(0)
 
   async function loadStatus() {
     try {
@@ -753,6 +957,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     await onFetchNow()
     await loadHealth()
     await loadStats()
+    setHistoryRefresh((value) => value + 1)
   }
 
   if (loadingStatus) {
@@ -960,6 +1165,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
         <SourceHealthTable items={sourceHealth} loading={loadingSourceHealth} />
       </div>
       <IngestTerminal />
+      <RunHistoryTable refreshToken={historyRefresh} />
     </div>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 import './styles.css'
 import {
   askAI,
+  fetchArticlesOverTime,
   fetchArticles,
   fetchSchedulerStatus,
   fetchSourceHealth,
   fetchSources,
+  fetchSourcesVolume,
+  fetchStatsOverview,
   fetchSummary,
   ingestNow,
   pauseScheduler,
@@ -16,7 +28,17 @@ import {
   updateSourceEnabled,
 } from './api'
 import type { SchedulerStatus } from './api'
-import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
+import type {
+  Article,
+  ArticleStatus,
+  ArticlesOverTimePoint,
+  AskResponse,
+  Source,
+  SourceHealth,
+  SourceVolumePoint,
+  StatsOverview,
+  Summary,
+} from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
 
@@ -412,6 +434,67 @@ const INTERVAL_PRESETS = [
   { label: '6h',  value: 360 },
 ]
 
+type StatsRangeId = 'today' | 'last7' | 'last30' | 'last90'
+
+const STATS_RANGE_OPTIONS: { id: StatsRangeId; label: string }[] = [
+  { id: 'today',  label: 'Today' },
+  { id: 'last7',  label: 'Last 7 days' },
+  { id: 'last30', label: 'Last 30 days' },
+  { id: 'last90', label: 'Last 90 days' },
+]
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next
+}
+
+function statsRange(range: StatsRangeId): { from: string; to: string } {
+  const now = new Date()
+  const today = startOfUtcDay(now)
+  const starts: Record<StatsRangeId, Date> = {
+    today,
+    last7: addDays(today, -6),
+    last30: addDays(today, -29),
+    last90: addDays(today, -89),
+  }
+  return { from: starts[range].toISOString(), to: now.toISOString() }
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat().format(value)
+}
+
+function formatDuration(ms: number): string {
+  if (!ms) return '0s'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`
+  const minutes = Math.floor(seconds / 60)
+  const rem = Math.round(seconds % 60)
+  return rem ? `${minutes}m ${rem}s` : `${minutes}m`
+}
+
+function formatTimeBucket(value: string, range: StatsRangeId): string {
+  if (range === 'today') {
+    return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
+  }
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year, month - 1, day).toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
+function formatRangeDate(value: string): string {
+  return new Date(value).toLocaleDateString([], { timeZone: 'UTC' })
+}
+
+function formatSourceLabel(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 17)}…` : value
+}
+
 function relativeCountdown(isoStr: string | null): string {
   if (!isoStr) return '—'
   const ms = new Date(isoStr).getTime() - Date.now()
@@ -506,6 +589,22 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [actionPending, setActionPending] = useState(false)
   const [tabMessage, setTabMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
   const [countdown, setCountdown] = useState<string>('—')
+  const [rangeId, setRangeId] = useState<StatsRangeId>('last7')
+  const [overview, setOverview] = useState<StatsOverview | null>(null)
+  const [articlesSeries, setArticlesSeries] = useState<ArticlesOverTimePoint[]>([])
+  const [sourceVolumes, setSourceVolumes] = useState<SourceVolumePoint[]>([])
+  const [statsLoading, setStatsLoading] = useState(true)
+  const [statsError, setStatsError] = useState<string | null>(null)
+
+  const selectedRange = useMemo(() => statsRange(rangeId), [rangeId])
+  const articlesChartData = useMemo(
+    () => articlesSeries.map((row) => ({
+      ...row,
+      label: formatTimeBucket(row.date, rangeId),
+    })),
+    [articlesSeries, rangeId],
+  )
+  const topSourceVolumes = useMemo(() => sourceVolumes.slice(0, 12), [sourceVolumes])
 
   async function loadStatus() {
     try {
@@ -529,10 +628,33 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     }
   }
 
+  async function loadStats() {
+    setStatsLoading(true)
+    setStatsError(null)
+    try {
+      const [nextOverview, nextArticlesSeries, nextSourceVolumes] = await Promise.all([
+        fetchStatsOverview(selectedRange.from, selectedRange.to),
+        fetchArticlesOverTime(selectedRange.from, selectedRange.to),
+        fetchSourcesVolume(selectedRange.from, selectedRange.to),
+      ])
+      setOverview(nextOverview)
+      setArticlesSeries(nextArticlesSeries)
+      setSourceVolumes(nextSourceVolumes)
+    } catch (err) {
+      setStatsError(err instanceof Error ? err.message : 'Failed to load statistics')
+    } finally {
+      setStatsLoading(false)
+    }
+  }
+
   useEffect(() => {
     void loadStatus()
     void loadHealth()
   }, [])
+
+  useEffect(() => {
+    void loadStats()
+  }, [selectedRange.from, selectedRange.to])
 
   useEffect(() => {
     if (!status) return
@@ -590,6 +712,7 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   async function handleFetchNow() {
     await onFetchNow()
     await loadHealth()
+    await loadStats()
   }
 
   if (loadingStatus) {
@@ -609,6 +732,108 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           <button className="dismiss" onClick={() => setTabMessage(null)} aria-label="Dismiss">×</button>
         </div>
       )}
+
+      <div className="stats-dashboard">
+        <div className="stats-toolbar">
+          <div>
+            <h3 className="stats-title">Statistics</h3>
+            <p className="stats-range-label">
+              {formatRangeDate(selectedRange.from)} – {formatRangeDate(selectedRange.to)}
+            </p>
+          </div>
+          <div className="stats-range-picker" role="group" aria-label="Statistics time range">
+            {STATS_RANGE_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                className={`stats-range-btn${rangeId === option.id ? ' active' : ''}`}
+                onClick={() => setRangeId(option.id)}
+                aria-pressed={rangeId === option.id}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {statsError && (
+          <div className="message-banner error stats-error" role="status">
+            <span>{statsError}</span>
+          </div>
+        )}
+
+        <div className="stats-overview-grid">
+          {[
+            { label: 'Total articles', value: overview ? formatInteger(overview.total_articles) : '—' },
+            { label: 'Total new', value: overview ? formatInteger(overview.total_new) : '—' },
+            { label: 'Total errors', value: overview ? formatInteger(overview.total_errors) : '—' },
+            { label: 'Avg run duration', value: overview ? formatDuration(overview.avg_duration_ms) : '—' },
+            {
+              label: 'Healthy sources',
+              value: overview ? formatInteger(overview.healthy_sources) : '—',
+            },
+            {
+              label: 'Erroring sources',
+              value: overview ? formatInteger(overview.erroring_sources) : '—',
+            },
+          ].map((metric) => (
+            <div className="stats-metric-card" key={metric.label}>
+              <span className="stats-metric-label">{metric.label}</span>
+              <span className="stats-metric-value">{statsLoading ? '…' : metric.value}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="stats-charts-grid">
+          <div className="stats-chart-card">
+            <h3 className="stats-chart-title">Articles Ingested Over Time</h3>
+            <div className="stats-chart-frame">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={articlesChartData} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="label" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={36} />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(37, 99, 235, 0.08)' }}
+                    formatter={(value) => [formatInteger(Number(value)), 'New articles']}
+                    labelFormatter={(_, payload) => payload?.[0]?.payload?.date ?? ''}
+                  />
+                  <Bar dataKey="new_articles" fill="var(--accent)" radius={[4, 4, 0, 0]} minPointSize={2} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="stats-chart-card">
+            <h3 className="stats-chart-title">Sources Ranked by Volume</h3>
+            <div className="stats-chart-frame">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={topSourceVolumes}
+                  layout="vertical"
+                  margin={{ top: 8, right: 8, left: 8, bottom: 4 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                  <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                  <YAxis
+                    dataKey="source_name"
+                    type="category"
+                    tick={{ fontSize: 11 }}
+                    tickFormatter={formatSourceLabel}
+                    tickLine={false}
+                    axisLine={false}
+                    width={118}
+                  />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(37, 99, 235, 0.08)' }}
+                    formatter={(value) => [formatInteger(Number(value)), 'New articles']}
+                  />
+                  <Bar dataKey="total_new" fill="var(--accent-muted)" radius={[0, 4, 4, 0]} minPointSize={2} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div className="scheduler-card">
         <h3 className="scheduler-card-title">Status</h3>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   askAI,
   fetchArticles,
   fetchSchedulerStatus,
+  fetchSourceHealth,
   fetchSources,
   fetchSummary,
   ingestNow,
@@ -15,7 +16,7 @@ import {
   updateSourceEnabled,
 } from './api'
 import type { SchedulerStatus } from './api'
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
 
 type ActiveTab = 'inbox' | 'saved' | 'read' | 'skipped' | 'archived' | 'sources' | 'scheduler'
 
@@ -429,9 +430,78 @@ interface SchedulerTabProps {
   ingesting: boolean
 }
 
+function SourceHealthTable({ items, loading }: { items: SourceHealth[]; loading: boolean }) {
+  const sorted = useMemo(() => {
+    return [...items].sort((a, b) => {
+      if (b.error_streak !== a.error_streak) return b.error_streak - a.error_streak
+      if (a.status !== b.status) return a.status === 'ERROR' ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+  }, [items])
+
+  if (loading) {
+    return (
+      <div className="source-health-loading">
+        <div className="skeleton sk-line" style={{ width: '70%' }} />
+        <div className="skeleton sk-line" style={{ width: '55%' }} />
+        <div className="skeleton sk-line" style={{ width: '62%' }} />
+      </div>
+    )
+  }
+
+  if (sorted.length === 0) {
+    return <p className="source-health-empty">No sources configured.</p>
+  }
+
+  return (
+    <div className="source-health-table-wrap">
+      <table className="source-health-table">
+        <thead>
+          <tr>
+            <th>Source name</th>
+            <th>Last checked</th>
+            <th>Status</th>
+            <th>Articles last run</th>
+            <th>Error streak</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((source) => (
+            <tr key={source.slug} className={source.status === 'ERROR' ? 'source-health-row-error' : undefined}>
+              <td>
+                <span className="source-health-name">{source.name}</span>
+                <span className="source-health-category">{source.category.replace(/-/g, ' ')}</span>
+              </td>
+              <td>{source.last_checked_at ? relativeTime(source.last_checked_at) : 'Never'}</td>
+              <td>
+                <span className={`source-health-status ${source.status.toLowerCase()}`}>
+                  {source.status}
+                </span>
+              </td>
+              <td>{source.articles_last_run}</td>
+              <td>
+                <span className="source-health-streak" title={source.last_error ?? undefined}>
+                  {source.error_streak}
+                </span>
+                {source.last_error && (
+                  <span className="source-health-last-error" title={source.last_error}>
+                    {source.last_error}
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
   const [status, setStatus] = useState<SchedulerStatus | null>(null)
   const [loadingStatus, setLoadingStatus] = useState(true)
+  const [sourceHealth, setSourceHealth] = useState<SourceHealth[]>([])
+  const [loadingSourceHealth, setLoadingSourceHealth] = useState(true)
   const [customMinutes, setCustomMinutes] = useState('')
   const [actionPending, setActionPending] = useState(false)
   const [tabMessage, setTabMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
@@ -448,8 +518,20 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     }
   }
 
+  async function loadHealth() {
+    setLoadingSourceHealth(true)
+    try {
+      setSourceHealth(await fetchSourceHealth())
+    } catch (err) {
+      setTabMessage({ text: err instanceof Error ? err.message : 'Failed to load source health', kind: 'error' })
+    } finally {
+      setLoadingSourceHealth(false)
+    }
+  }
+
   useEffect(() => {
     void loadStatus()
+    void loadHealth()
   }, [])
 
   useEffect(() => {
@@ -503,6 +585,11 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
     } finally {
       setActionPending(false)
     }
+  }
+
+  async function handleFetchNow() {
+    await onFetchNow()
+    await loadHealth()
   }
 
   if (loadingStatus) {
@@ -595,12 +682,17 @@ function SchedulerTab({ onFetchNow, ingesting }: SchedulerTabProps) {
           </button>
           <button
             className="scheduler-fetch-btn"
-            onClick={() => void onFetchNow()}
+            onClick={() => void handleFetchNow()}
             disabled={ingesting || actionPending}
           >
             {ingesting ? '⟳ Fetching…' : '↻ Fetch now'}
           </button>
         </div>
+      </div>
+
+      <div className="scheduler-card scheduler-card--wide">
+        <h3 className="scheduler-card-title">Source Health</h3>
+        <SourceHealthTable items={sourceHealth} loading={loadingSourceHealth} />
       </div>
     </div>
   )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,14 @@
-import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
+import type {
+  Article,
+  ArticleStatus,
+  ArticlesOverTimePoint,
+  AskResponse,
+  Source,
+  SourceHealth,
+  SourceVolumePoint,
+  StatsOverview,
+  Summary,
+} from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -90,4 +100,26 @@ export async function pauseScheduler(): Promise<{ paused: boolean }> {
 
 export async function resumeScheduler(): Promise<{ paused: boolean; next_run_at: string | null }> {
   return requestJson('/api/scheduler/resume', { method: 'POST' })
+}
+
+function statsParams(from: string, to: string): string {
+  return new URLSearchParams({ from, to }).toString()
+}
+
+export async function fetchStatsOverview(from: string, to: string): Promise<StatsOverview> {
+  return requestJson<StatsOverview>(`/api/stats/overview?${statsParams(from, to)}`)
+}
+
+export async function fetchArticlesOverTime(from: string, to: string): Promise<ArticlesOverTimePoint[]> {
+  const data = await requestJson<{ items: ArticlesOverTimePoint[] }>(
+    `/api/stats/articles-over-time?${statsParams(from, to)}`,
+  )
+  return data.items
+}
+
+export async function fetchSourcesVolume(from: string, to: string): Promise<SourceVolumePoint[]> {
+  const data = await requestJson<{ items: SourceVolumePoint[] }>(
+    `/api/stats/sources-volume?${statsParams(from, to)}`,
+  )
+  return data.items
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, IngestRunPage, IngestRunSource, Source, Summary } from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -85,4 +85,14 @@ export async function pauseScheduler(): Promise<{ paused: boolean }> {
 
 export async function resumeScheduler(): Promise<{ paused: boolean; next_run_at: string | null }> {
   return requestJson('/api/scheduler/resume', { method: 'POST' })
+}
+
+export async function fetchIngestRuns(page = 1, perPage = 10): Promise<IngestRunPage> {
+  const params = new URLSearchParams({ page: String(page), per_page: String(perPage) })
+  return requestJson<IngestRunPage>(`/api/ingest/runs?${params}`)
+}
+
+export async function fetchIngestRunSources(runId: number): Promise<IngestRunSource[]> {
+  const data = await requestJson<{ items: IngestRunSource[] }>(`/api/ingest/runs/${runId}`)
+  return data.items
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,8 @@ import type {
   SourceVolumePoint,
   StatsOverview,
   Summary,
+  IngestRunPage,
+  IngestRunSource,
 } from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
@@ -121,5 +123,15 @@ export async function fetchSourcesVolume(from: string, to: string): Promise<Sour
   const data = await requestJson<{ items: SourceVolumePoint[] }>(
     `/api/stats/sources-volume?${statsParams(from, to)}`,
   )
+  return data.items
+}
+
+export async function fetchIngestRuns(page = 1, perPage = 10): Promise<IngestRunPage> {
+  const params = new URLSearchParams({ page: String(page), per_page: String(perPage) })
+  return requestJson<IngestRunPage>(`/api/ingest/runs?${params}`)
+}
+
+export async function fetchIngestRunSources(runId: number): Promise<IngestRunSource[]> {
+  const data = await requestJson<{ items: IngestRunSource[] }>(`/api/ingest/runs/${runId}`)
   return data.items
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Article, ArticleStatus, AskResponse, Source, Summary } from './types'
+import type { Article, ArticleStatus, AskResponse, Source, SourceHealth, Summary } from './types'
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -30,6 +30,11 @@ export async function searchArticles(q: string, limit = 50): Promise<Article[]> 
 
 export async function fetchSources(): Promise<Source[]> {
   const data = await requestJson<{ items: Source[] }>('/api/sources')
+  return data.items
+}
+
+export async function fetchSourceHealth(): Promise<SourceHealth[]> {
+  const data = await requestJson<{ items: SourceHealth[] }>('/api/sources/health')
   return data.items
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1536,7 +1536,7 @@ kbd {
 /* ===== SCHEDULER TAB ===== */
 
 .scheduler-panel {
-  max-width: 600px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 16px;
   display: flex;
@@ -1750,4 +1750,213 @@ kbd {
 .scheduler-fetch-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.run-history {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.run-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.run-history-header .scheduler-card-title {
+  margin-bottom: 0;
+}
+
+.run-history-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text-2);
+  cursor: pointer;
+}
+
+.run-history-refresh:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--accent);
+}
+
+.run-history-refresh:disabled {
+  opacity: .5;
+  cursor: default;
+}
+
+.run-history-error {
+  margin: 12px 20px 0;
+  padding: 8px 10px;
+  border-radius: var(--r-md);
+  background: #fee2e2;
+  color: #7f1d1d;
+  font-size: 12px;
+}
+
+.run-history-loading,
+.run-history-empty {
+  padding: 22px 20px;
+  color: var(--text-3);
+}
+
+.run-history-loading {
+  display: grid;
+  gap: 10px;
+}
+
+.run-history-table-wrap {
+  overflow-x: auto;
+}
+
+.run-history-table,
+.run-source-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.run-history-table th,
+.run-history-table td,
+.run-source-table th,
+.run-source-table td {
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: middle;
+  font-size: 13px;
+}
+
+.run-history-table th,
+.run-source-table th {
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+
+.run-history-table td {
+  color: var(--text-1);
+  white-space: nowrap;
+}
+
+.run-history-table tbody tr.expanded {
+  background: var(--surface-alt);
+}
+
+.run-expand-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  color: var(--text-2);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.run-expand-btn:hover {
+  border-color: var(--accent-muted);
+  color: var(--accent);
+}
+
+.run-started,
+.run-relative {
+  display: block;
+}
+
+.run-started {
+  color: var(--text-1);
+  font-weight: 600;
+}
+
+.run-relative {
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.run-error-count,
+.run-source-error {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.run-source-row td {
+  background: var(--surface-alt);
+  padding: 12px 16px 16px;
+}
+
+.run-source-table {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+.run-source-table td {
+  color: var(--text-1);
+  white-space: normal;
+}
+
+.run-source-muted,
+.run-source-empty,
+.run-source-loading {
+  color: var(--text-3);
+}
+
+.run-source-empty,
+.run-source-loading {
+  padding: 8px 0;
+  font-size: 13px;
+}
+
+.run-history-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 20px;
+  color: var(--text-3);
+  font-size: 12px;
+}
+
+.run-history-page-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.run-history-page-buttons button {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text-1);
+  cursor: pointer;
+  font-size: 17px;
+}
+
+.run-history-page-buttons button:hover:not(:disabled) {
+  border-color: var(--accent-muted);
+}
+
+.run-history-page-buttons button:disabled {
+  opacity: .45;
+  cursor: default;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1648,7 +1648,7 @@ kbd {
 /* ===== SCHEDULER TAB ===== */
 
 .scheduler-panel {
-  max-width: 600px;
+  max-width: 1100px;
   margin: 0 auto;
   padding: 16px;
   display: flex;
@@ -1657,10 +1657,156 @@ kbd {
 }
 
 .scheduler-card {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   padding: 16px 20px;
+  box-shadow: var(--shadow-card);
+}
+
+.stats-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.stats-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.stats-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-0);
+  margin: 0 0 2px;
+}
+
+.stats-range-label {
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.stats-range-picker {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.stats-range-btn {
+  min-height: 32px;
+  padding: 6px 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-1);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--t) var(--ease), border-color var(--t) var(--ease), color var(--t) var(--ease);
+}
+
+.stats-range-btn:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.stats-range-btn.active {
+  background: var(--accent-pale);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.stats-error {
+  margin: 0;
+}
+
+.stats-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stats-metric-card {
+  min-height: 86px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stats-metric-label {
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.stats-metric-value {
+  color: var(--text-0);
+  font-size: 24px;
+  font-weight: 750;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-charts-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 16px;
+}
+
+.stats-chart-card {
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 16px;
+  box-shadow: var(--shadow-card);
+}
+
+.stats-chart-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-1);
+  margin: 0 0 12px;
+}
+
+.stats-chart-frame {
+  height: 280px;
+  min-width: 0;
+}
+
+.stats-chart-card .recharts-cartesian-grid line {
+  stroke: var(--border);
+}
+
+.stats-chart-card .recharts-text {
+  fill: var(--text-2);
+}
+
+.stats-chart-card .recharts-tooltip-wrapper {
+  outline: none;
+}
+
+.stats-chart-card .recharts-default-tooltip {
+  border-color: var(--border) !important;
+  border-radius: var(--r-md);
+  background: var(--surface) !important;
+  color: var(--text-1) !important;
   box-shadow: var(--shadow-card);
 }
 
@@ -1862,4 +2008,54 @@ kbd {
 .scheduler-fetch-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+@media (max-width: 980px) {
+  .stats-overview-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .stats-charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .scheduler-panel {
+    padding: 12px 0;
+  }
+
+  .stats-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stats-range-picker {
+    justify-content: flex-start;
+  }
+
+  .stats-range-btn {
+    flex: 1 1 calc(50% - 6px);
+  }
+
+  .stats-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-metric-card {
+    min-height: 78px;
+    padding: 12px;
+  }
+
+  .stats-metric-value {
+    font-size: 20px;
+  }
+
+  .stats-chart-card {
+    padding: 12px 8px 12px 10px;
+  }
+
+  .stats-chart-frame {
+    height: 240px;
+  }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2060,6 +2060,215 @@ kbd {
   overflow-wrap: anywhere;
 }
 
+.run-history {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.run-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.run-history-header .scheduler-card-title {
+  margin-bottom: 0;
+}
+
+.run-history-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text-2);
+  cursor: pointer;
+}
+
+.run-history-refresh:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--accent);
+}
+
+.run-history-refresh:disabled {
+  opacity: .5;
+  cursor: default;
+}
+
+.run-history-error {
+  margin: 12px 20px 0;
+  padding: 8px 10px;
+  border-radius: var(--r-md);
+  background: #fee2e2;
+  color: #7f1d1d;
+  font-size: 12px;
+}
+
+.run-history-loading,
+.run-history-empty {
+  padding: 22px 20px;
+  color: var(--text-3);
+}
+
+.run-history-loading {
+  display: grid;
+  gap: 10px;
+}
+
+.run-history-table-wrap {
+  overflow-x: auto;
+}
+
+.run-history-table,
+.run-source-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.run-history-table th,
+.run-history-table td,
+.run-source-table th,
+.run-source-table td {
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: middle;
+  font-size: 13px;
+}
+
+.run-history-table th,
+.run-source-table th {
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+
+.run-history-table td {
+  color: var(--text-1);
+  white-space: nowrap;
+}
+
+.run-history-table tbody tr.expanded {
+  background: var(--surface-alt);
+}
+
+.run-expand-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  color: var(--text-2);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.run-expand-btn:hover {
+  border-color: var(--accent-muted);
+  color: var(--accent);
+}
+
+.run-started,
+.run-relative {
+  display: block;
+}
+
+.run-started {
+  color: var(--text-1);
+  font-weight: 600;
+}
+
+.run-relative {
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.run-error-count,
+.run-source-error {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.run-source-row td {
+  background: var(--surface-alt);
+  padding: 12px 16px 16px;
+}
+
+.run-source-table {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+.run-source-table td {
+  color: var(--text-1);
+  white-space: normal;
+}
+
+.run-source-muted,
+.run-source-empty,
+.run-source-loading {
+  color: var(--text-3);
+}
+
+.run-source-empty,
+.run-source-loading {
+  padding: 8px 0;
+  font-size: 13px;
+}
+
+.run-history-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 20px;
+  color: var(--text-3);
+  font-size: 12px;
+}
+
+.run-history-page-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.run-history-page-buttons button {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text-1);
+  cursor: pointer;
+  font-size: 17px;
+}
+
+.run-history-page-buttons button:hover:not(:disabled) {
+  border-color: var(--accent-muted);
+}
+
+.run-history-page-buttons button:disabled {
+  opacity: .45;
+  cursor: default;
+}
+
 @media (max-width: 980px) {
   .stats-overview-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2010,6 +2010,56 @@ kbd {
   cursor: not-allowed;
 }
 
+.scheduler-terminal-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.scheduler-terminal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.scheduler-terminal-header .scheduler-card-title {
+  margin-bottom: 0;
+}
+
+.scheduler-terminal-status {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  padding: 3px 9px;
+  background: var(--surface-alt);
+  color: var(--text-2);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.scheduler-terminal-status.connected {
+  border-color: transparent;
+  background: var(--s-read-bg);
+  color: var(--s-read-fg);
+}
+
+.scheduler-terminal {
+  min-height: 240px;
+  max-height: 420px;
+  margin: 0;
+  padding: 16px 18px;
+  overflow: auto;
+  background: #10151f;
+  color: #e5edf7;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 @media (max-width: 980px) {
   .stats-overview-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -901,6 +901,118 @@ ul { list-style: none; }
   word-break: break-all;
 }
 
+/* ===== SCHEDULER SOURCE HEALTH ===== */
+.scheduler-card--wide {
+  grid-column: 1 / -1;
+}
+
+.source-health-loading {
+  display: grid;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.source-health-empty {
+  color: var(--text-3);
+  font-size: 13px;
+}
+
+.source-health-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.source-health-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.source-health-table th,
+.source-health-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: 12px;
+  vertical-align: top;
+}
+
+.source-health-table th {
+  color: var(--text-3);
+  background: var(--surface-alt);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+
+.source-health-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.source-health-row-error {
+  background: #fff1f2;
+}
+
+[data-theme="dark"] .source-health-row-error {
+  background: rgba(127, 29, 29, .16);
+}
+
+.source-health-name,
+.source-health-category,
+.source-health-last-error {
+  display: block;
+}
+
+.source-health-name {
+  color: var(--text-1);
+  font-weight: 650;
+}
+
+.source-health-category {
+  margin-top: 2px;
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.source-health-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.source-health-status.ok {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.source-health-status.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.source-health-streak {
+  color: var(--text-1);
+  font-weight: 700;
+}
+
+.source-health-last-error {
+  max-width: 360px;
+  margin-top: 3px;
+  color: #b91c1c;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ===== SKELETON LOADER ===== */
 @keyframes shimmer {
   0%   { background-position: -400% 0; }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,3 +52,31 @@ export interface AskResponse {
   answer: string
   sources: AskSource[]
 }
+
+export interface IngestRun {
+  id: number
+  started_at: string
+  finished_at: string | null
+  duration_ms: number | null
+  sources_run: number
+  total_new: number
+  total_errors: number
+}
+
+export interface IngestRunSource {
+  id: number
+  run_id: number
+  source_name: string
+  articles_found: number
+  articles_new: number
+  duplicates: number
+  error_message?: string | null
+}
+
+export interface IngestRunPage {
+  items: IngestRun[]
+  page: number
+  per_page: number
+  total: number
+  has_more: boolean
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -54,6 +54,25 @@ export interface Summary {
   byCategory: Record<string, number>
 }
 
+export interface StatsOverview {
+  total_articles: number
+  total_new: number
+  total_errors: number
+  avg_duration_ms: number
+  healthy_sources: number
+  erroring_sources: number
+}
+
+export interface ArticlesOverTimePoint {
+  date: string
+  new_articles: number
+}
+
+export interface SourceVolumePoint {
+  source_name: string
+  total_new: number
+}
+
 export interface AskSource {
   id: number
   title: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -83,3 +83,31 @@ export interface AskResponse {
   answer: string
   sources: AskSource[]
 }
+
+export interface IngestRun {
+  id: number
+  started_at: string
+  finished_at: string | null
+  duration_ms: number | null
+  sources_run: number
+  total_new: number
+  total_errors: number
+}
+
+export interface IngestRunSource {
+  id: number
+  run_id: number
+  source_name: string
+  articles_found: number
+  articles_new: number
+  duplicates: number
+  error_message?: string | null
+}
+
+export interface IngestRunPage {
+  items: IngestRun[]
+  page: number
+  per_page: number
+  total: number
+  has_more: boolean
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,18 @@ export interface Source {
   last_inserted_count?: number
 }
 
+export interface SourceHealth {
+  slug: string
+  name: string
+  category: string
+  enabled: number
+  last_checked_at?: string | null
+  last_error?: string | null
+  error_streak: number
+  articles_last_run: number
+  status: 'OK' | 'ERROR'
+}
+
 export interface Summary {
   byStatus: Record<string, number>
   byCategory: Record<string, number>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@vitejs/plugin-react": "latest",
         "react": "latest",
         "react-dom": "latest",
+        "recharts": "^3.8.1",
         "typescript": "latest",
         "vite": "latest"
       },
@@ -72,6 +73,42 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -340,6 +377,18 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -350,11 +399,74 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -369,6 +481,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -395,11 +513,147 @@
         }
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -410,6 +664,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -440,6 +710,25 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -788,6 +1077,87 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -836,6 +1206,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -870,6 +1246,37 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "latest",
-    "vite": "latest",
-    "typescript": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "recharts": "^3.8.1",
+    "typescript": "latest",
+    "vite": "latest"
   },
   "devDependencies": {
     "@types/react": "latest",


### PR DESCRIPTION
## Summary

- Adds read-only ingest run history endpoints for paginated completed runs and per-source run breakdowns.
- Adds idempotent `ingest_runs` and `ingest_run_sources` schema definitions so this slice can run when Slice 2 is not yet merged on main.
- Adds a Scheduler tab run history table with lazy expandable source rows, pagination, empty/loading/error states, and refresh after manual fetch.

References #52.

## Verification

- `PYTHONPATH=backend python3 -m pytest`
- `npm run build`
- Browser smoke test against local Vite/FastAPI with temporary SQLite data: empty state, populated table, row expansion, and no default-viewport panel overflow.
