### PR TITLE
feat(#80): keyboard triage + ⌘K command palette

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
+import { FocusedArticleProvider } from './contexts/focusedArticle';
 import { AppShell } from './components/AppShell';
 import { InboxPage } from './pages/InboxPage';
 import { LaterPage } from './pages/LaterPage';
@@ -78,5 +79,9 @@ const router = createBrowserRouter([
 ]);
 
 export function AppRouter() {
-  return <RouterProvider router={router} />;
+  return (
+    <FocusedArticleProvider>
+      <RouterProvider router={router} />
+    </FocusedArticleProvider>
+  );
 }

--- a/frontend/src/__tests__/keyboard.test.ts
+++ b/frontend/src/__tests__/keyboard.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useArticleListNav } from '../hooks/useArticleListNav';
+import type { useTriageMutations } from '../hooks/useTriageMutations';
+import type { WorkflowArticle } from '../lib/workflowTypes';
+
+type Mutations = ReturnType<typeof useTriageMutations>;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
+  return {
+    id: overrides.id ?? '1',
+    title: overrides.title ?? 'Test article',
+    sourceId: 'src',
+    sourceName: 'Source',
+    category: 'ai-llm',
+    url: 'https://example.com/1',
+    publishedAt: '2024-01-01T10:00:00Z',
+    ingestedAt: '2024-01-01T11:00:00Z',
+    reason: 'Reason',
+    summary: 'Summary',
+    signal: 'high',
+    tags: [],
+    bodyStatus: 'missing',
+    state: 'today',
+    starred: false,
+    ...overrides,
+  };
+}
+
+function makeMutations(): Mutations {
+  return {
+    setState: vi.fn(),
+    toggleStar: vi.fn(),
+    sendLater: vi.fn(),
+  };
+}
+
+function fireKey(key: string) {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+// ─── useArticleListNav — j/k navigation ──────────────────────────────────────
+
+describe('useArticleListNav — j/k navigation', () => {
+  const articles = [makeArticle({ id: '1' }), makeArticle({ id: '2' }), makeArticle({ id: '3' })];
+
+  it('starts at index 0', () => {
+    const { result } = renderHook(() => useArticleListNav(articles, vi.fn(), makeMutations()));
+    expect(result.current.focused).toBe(0);
+  });
+
+  it('j moves focus down', () => {
+    const { result } = renderHook(() => useArticleListNav(articles, vi.fn(), makeMutations()));
+    act(() => fireKey('j'));
+    expect(result.current.focused).toBe(1);
+  });
+
+  it('k moves focus up', () => {
+    const { result } = renderHook(() => useArticleListNav(articles, vi.fn(), makeMutations()));
+    act(() => {
+      fireKey('j');
+      fireKey('j');
+    });
+    expect(result.current.focused).toBe(2);
+    act(() => fireKey('k'));
+    expect(result.current.focused).toBe(1);
+  });
+
+  it('j does not go past the last item', () => {
+    const { result } = renderHook(() => useArticleListNav(articles, vi.fn(), makeMutations()));
+    act(() => {
+      fireKey('j');
+      fireKey('j');
+      fireKey('j');
+      fireKey('j');
+    });
+    expect(result.current.focused).toBe(2);
+  });
+
+  it('k does not go below 0', () => {
+    const { result } = renderHook(() => useArticleListNav(articles, vi.fn(), makeMutations()));
+    act(() => fireKey('k'));
+    expect(result.current.focused).toBe(0);
+  });
+});
+
+// ─── useArticleListNav — action keys ─────────────────────────────────────────
+
+describe('useArticleListNav — action keys', () => {
+  let mutations: Mutations;
+  const article = makeArticle({ id: '42' });
+  const articles = [article];
+
+  beforeEach(() => {
+    mutations = makeMutations();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('r marks article done', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('r'));
+    expect(mutations.setState).toHaveBeenCalledWith(article, 'done', 'Done');
+  });
+
+  it('d marks article done', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('d'));
+    expect(mutations.setState).toHaveBeenCalledWith(article, 'done', 'Done');
+  });
+
+  it('l sends to later', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('l'));
+    expect(mutations.sendLater).toHaveBeenCalledWith(article);
+  });
+
+  it('s toggles star', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('s'));
+    expect(mutations.toggleStar).toHaveBeenCalledWith(article);
+  });
+
+  it('x skips unstarred article', () => {
+    const unstarred = makeArticle({ starred: false });
+    renderHook(() => useArticleListNav([unstarred], vi.fn(), mutations));
+    act(() => fireKey('x'));
+    expect(mutations.setState).toHaveBeenCalledWith(unstarred, 'skipped', 'Skipped');
+  });
+
+  it('x is inert on starred article', () => {
+    const starred = makeArticle({ starred: true });
+    renderHook(() => useArticleListNav([starred], vi.fn(), mutations));
+    act(() => fireKey('x'));
+    expect(mutations.setState).not.toHaveBeenCalled();
+  });
+
+  it('e archives article', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('e'));
+    expect(mutations.setState).toHaveBeenCalledWith(article, 'archived', 'Archived');
+  });
+
+  it('o opens original URL in new tab', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('o'));
+    expect(openSpy).toHaveBeenCalledWith(article.url, '_blank');
+  });
+
+  it('Enter calls openArticle', () => {
+    const openArticle = vi.fn();
+    renderHook(() => useArticleListNav(articles, openArticle, mutations));
+    act(() => fireKey('Enter'));
+    expect(openArticle).toHaveBeenCalledWith(article);
+  });
+
+  it('ignores keys when target is an INPUT', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    void act(() => input.dispatchEvent(new KeyboardEvent('keydown', { key: 'r', bubbles: true })));
+    expect(mutations.setState).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+});

--- a/frontend/src/__tests__/palette.test.tsx
+++ b/frontend/src/__tests__/palette.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CommandPalette } from '../components/CommandPalette';
+import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import * as api from '../api';
+
+// Silence sonner in tests
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    loading: vi.fn(() => 'toast-id'),
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Mock the triage mutations so the palette doesn't need React Query internals
+vi.mock('../hooks/useTriageMutations', () => ({
+  useTriageMutations: () => ({
+    setState: vi.fn(),
+    toggleStar: vi.fn(),
+    sendLater: vi.fn(),
+  }),
+  ARTICLES_KEY: 'articles',
+}));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <FocusedArticleProvider>{children}</FocusedArticleProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ─── CommandPalette ───────────────────────────────────────────────────────────
+
+describe('CommandPalette — open / close', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Wrapper>
+        <CommandPalette open={false} onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+    expect(screen.queryByPlaceholderText(/jump to a view/i)).toBeNull();
+  });
+
+  it('shows the search input when open', () => {
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+    expect(screen.getByPlaceholderText(/jump to a view/i)).toBeTruthy();
+  });
+
+  it('calls onOpenChange(false) when Escape is pressed', async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={onOpenChange} />
+      </Wrapper>
+    );
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' });
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+});
+
+describe('CommandPalette — navigation items', () => {
+  it('shows all navigation items', () => {
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+    expect(screen.getByText('Today')).toBeTruthy();
+    expect(screen.getByText('Later')).toBeTruthy();
+    expect(screen.getByText('Starred')).toBeTruthy();
+    expect(screen.getByText('Feeds')).toBeTruthy();
+    expect(screen.getByText('Archive')).toBeTruthy();
+  });
+
+  it('shows "Refresh feeds now" action', () => {
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+    expect(screen.getByText(/refresh feeds now/i)).toBeTruthy();
+  });
+
+  it('shows keyboard shortcuts item when onShortcuts provided', () => {
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={vi.fn()} onShortcuts={vi.fn()} />
+      </Wrapper>
+    );
+    expect(screen.getByText(/keyboard shortcuts/i)).toBeTruthy();
+  });
+});
+
+describe('CommandPalette — article search', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'searchArticles').mockResolvedValue([
+      {
+        id: 10,
+        url: 'https://example.com/a',
+        title: 'Test search result',
+        source_name: 'TechCrunch',
+        category: 'ai-llm',
+        kind: 'rss',
+        published_at: '2024-01-01T10:00:00Z',
+        discovered_at: '2024-01-01T11:00:00Z',
+        status: 'new',
+        importance_score: 0.8,
+        summary: 'A summary',
+        reason: 'Why it matters',
+        tags: '[]',
+        read_at: null,
+        saved_at: null,
+        skipped_at: null,
+        archived_at: null,
+      },
+    ]);
+  });
+
+  it('calls searchArticles after typing in the input', async () => {
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+    const input = screen.getByPlaceholderText(/jump to a view/i);
+    await userEvent.type(input, 'test');
+    await waitFor(() => expect(api.searchArticles).toHaveBeenCalledWith('test', 6), {
+      timeout: 1000,
+    });
+  });
+
+  it('shows article results from the API', async () => {
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+    const input = screen.getByPlaceholderText(/jump to a view/i);
+    await userEvent.type(input, 'test');
+    await waitFor(() => expect(screen.getByText('Test search result')).toBeTruthy(), {
+      timeout: 1000,
+    });
+  });
+});
+
+describe('CommandPalette — ingest action', () => {
+  it('calls ingestNow when "Refresh feeds now" is selected', async () => {
+    const ingestSpy = vi.spyOn(api, 'ingestNow').mockResolvedValue({ inserted: 3, results: {} });
+    const onOpenChange = vi.fn();
+    render(
+      <Wrapper>
+        <CommandPalette open={true} onOpenChange={onOpenChange} />
+      </Wrapper>
+    );
+    const refreshBtn = screen.getByText(/refresh feeds now/i);
+    fireEvent.click(refreshBtn);
+    await waitFor(() => expect(ingestSpy).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -164,7 +164,14 @@ export function AppShell() {
     return (
       <>
         <Outlet />
-        <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+        <CommandPalette
+          open={paletteOpen}
+          onOpenChange={setPaletteOpen}
+          onShortcuts={() => {
+            setPaletteOpen(false);
+            setShortcutsOpen(true);
+          }}
+        />
         <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
       </>
     );
@@ -269,10 +276,6 @@ export function AppShell() {
       <CommandPalette
         open={paletteOpen}
         onOpenChange={setPaletteOpen}
-        onNavigate={(to) => {
-          setPaletteOpen(false);
-          navigate(to);
-        }}
         onShortcuts={() => {
           setPaletteOpen(false);
           setShortcutsOpen(true);

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Command } from 'cmdk';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { toast } from 'sonner';
 import {
   Inbox,
   Clock,
@@ -13,12 +15,21 @@ import {
   BarChart3,
   Archive,
   Settings,
+  FileText,
+  RefreshCw,
+  CheckCheck,
+  SkipForward,
+  ExternalLink,
 } from 'lucide-react';
+import { searchArticles, ingestNow } from '@/api';
+import { adaptArticle } from '@/api/workflowApi';
+import { useTriageMutations } from '@/hooks/useTriageMutations';
+import { useFocusedArticle } from '@/contexts/focusedArticle';
+import type { WorkflowArticle } from '@/lib/workflowTypes';
 
 interface Props {
   open: boolean;
   onOpenChange: (v: boolean) => void;
-  onNavigate?: (to: string) => void;
   onShortcuts?: () => void;
 }
 
@@ -34,67 +45,248 @@ const NAV_ITEMS = [
   { icon: Settings, label: 'Settings', to: '/settings' },
 ];
 
-export function CommandPalette({ open, onOpenChange, onNavigate, onShortcuts }: Props) {
-  const [q, setQ] = useState('');
+const GROUP_CLS =
+  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-subtle';
 
+const ITEM_CLS =
+  'flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer data-[selected=true]:bg-surface-2';
+
+export function CommandPalette({ open, onOpenChange, onShortcuts }: Props) {
+  const navigate = useNavigate();
+  const mutations = useTriageMutations();
+  const { article: focusedArticle } = useFocusedArticle();
+
+  const [q, setQ] = useState('');
+  const [searchResults, setSearchResults] = useState<WorkflowArticle[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  // Reset query when palette closes
   useEffect(() => {
-    if (!open) setQ('');
+    if (!open) {
+      setQ('');
+      setSearchResults([]);
+    }
   }, [open]);
 
-  function go(to: string) {
+  // Debounced search
+  useEffect(() => {
+    if (!q.trim()) {
+      setSearchResults([]);
+      return;
+    }
+    const doSearch = async () => {
+      setSearching(true);
+      try {
+        const raw = await searchArticles(q.trim(), 6);
+        setSearchResults(raw.map(adaptArticle));
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setSearching(false);
+      }
+    };
+    const id = setTimeout(() => {
+      void doSearch();
+    }, 250);
+    return () => clearTimeout(id);
+  }, [q]);
+
+  function close() {
     onOpenChange(false);
-    onNavigate?.(to);
+  }
+
+  function go(to: string) {
+    close();
+    navigate(to);
+  }
+
+  async function handleIngest() {
+    close();
+    const id = toast.loading('Refreshing feeds…');
+    try {
+      const result = await ingestNow();
+      toast.success(`Done — ${result.inserted} new article${result.inserted !== 1 ? 's' : ''}`, {
+        id,
+      });
+    } catch {
+      toast.error('Ingest failed', { id });
+    }
+  }
+
+  function articleAction(fn: () => void) {
+    close();
+    fn();
+  }
+
+  // #79 not merged — open original URL with TODO seam for reader navigation
+  function openArticle(a: WorkflowArticle) {
+    close();
+    // TODO(#79): navigate(`/a/${a.id}`) once the reader is implemented
+    window.open(a.url, '_blank', 'noopener,noreferrer');
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="p-0 max-w-xl overflow-hidden gap-0">
-        <Command shouldFilter={true} className="bg-popover text-popover-foreground">
+        <Command shouldFilter={false} className="bg-popover text-popover-foreground">
           <div className="flex items-center px-3 border-b border-border">
-            <Search className="size-4 text-muted-foreground" />
+            <Search className="size-4 text-muted-foreground shrink-0" />
             <Command.Input
               autoFocus
               value={q}
               onValueChange={setQ}
-              placeholder="Jump to a view…"
+              placeholder="Jump to a view, search articles, run actions…"
               className="flex h-11 w-full bg-transparent px-3 text-sm outline-none placeholder:text-subtle"
             />
+            {searching && (
+              <span className="text-[10px] text-subtle shrink-0 animate-pulse">searching…</span>
+            )}
           </div>
+
           <Command.List className="max-h-[60vh] overflow-y-auto p-2">
             <Command.Empty className="py-8 text-center text-sm text-muted-foreground">
-              No results
+              {q.trim() ? 'No articles found' : 'Type to search articles or pick an action'}
             </Command.Empty>
-            <Command.Group
-              heading="Navigation"
-              className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-subtle"
-            >
-              {NAV_ITEMS.map(({ icon: Icon, label, to }) => (
+
+            {/* Article search results */}
+            {searchResults.length > 0 && (
+              <Command.Group heading="Articles" className={GROUP_CLS}>
+                {searchResults.map((a) => (
+                  <Command.Item
+                    key={a.id}
+                    onSelect={() => openArticle(a)}
+                    className="flex flex-col items-start gap-0.5 px-2 py-2 rounded-md cursor-pointer data-[selected=true]:bg-surface-2"
+                  >
+                    <div className="flex items-center gap-2 text-[11px] text-subtle">
+                      <FileText className="size-3 shrink-0" />
+                      <span className="truncate">
+                        {a.sourceName} · {a.category}
+                      </span>
+                    </div>
+                    <div className="text-sm font-medium line-clamp-1">{a.title}</div>
+                    <div className="text-xs text-muted-foreground line-clamp-1">{a.reason}</div>
+                  </Command.Item>
+                ))}
+              </Command.Group>
+            )}
+
+            {/* Focused article actions */}
+            {focusedArticle && (
+              <Command.Group
+                heading={`On: ${focusedArticle.title.length > 50 ? focusedArticle.title.slice(0, 50) + '…' : focusedArticle.title}`}
+                className={GROUP_CLS}
+              >
                 <Command.Item
-                  key={to}
-                  onSelect={() => go(to)}
-                  className="flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer data-[selected=true]:bg-surface-2"
+                  onSelect={() =>
+                    articleAction(() => mutations.setState(focusedArticle, 'done', 'Done'))
+                  }
+                  className={ITEM_CLS}
                 >
+                  <CheckCheck className="size-4 text-muted-foreground" />
+                  <span className="text-sm">Mark Done</span>
+                  <kbd className="ml-auto font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
+                    r / d
+                  </kbd>
+                </Command.Item>
+                <Command.Item
+                  onSelect={() => articleAction(() => mutations.sendLater(focusedArticle))}
+                  className={ITEM_CLS}
+                >
+                  <Clock className="size-4 text-muted-foreground" />
+                  <span className="text-sm">Send to Later</span>
+                  <kbd className="ml-auto font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
+                    l
+                  </kbd>
+                </Command.Item>
+                <Command.Item
+                  onSelect={() => articleAction(() => mutations.toggleStar(focusedArticle))}
+                  className={ITEM_CLS}
+                >
+                  <Star className="size-4 text-muted-foreground" />
+                  <span className="text-sm">{focusedArticle.starred ? 'Unstar' : 'Star'}</span>
+                  <kbd className="ml-auto font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
+                    s
+                  </kbd>
+                </Command.Item>
+                {!focusedArticle.starred && (
+                  <Command.Item
+                    onSelect={() =>
+                      articleAction(() => mutations.setState(focusedArticle, 'skipped', 'Skipped'))
+                    }
+                    className={ITEM_CLS}
+                  >
+                    <SkipForward className="size-4 text-muted-foreground" />
+                    <span className="text-sm">Skip</span>
+                    <kbd className="ml-auto font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
+                      x
+                    </kbd>
+                  </Command.Item>
+                )}
+                <Command.Item
+                  onSelect={() =>
+                    articleAction(() => mutations.setState(focusedArticle, 'archived', 'Archived'))
+                  }
+                  className={ITEM_CLS}
+                >
+                  <Archive className="size-4 text-muted-foreground" />
+                  <span className="text-sm">Archive</span>
+                  <kbd className="ml-auto font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
+                    e
+                  </kbd>
+                </Command.Item>
+                <Command.Item
+                  onSelect={() =>
+                    articleAction(() =>
+                      window.open(focusedArticle.url, '_blank', 'noopener,noreferrer')
+                    )
+                  }
+                  className={ITEM_CLS}
+                >
+                  <ExternalLink className="size-4 text-muted-foreground" />
+                  <span className="text-sm">Open original</span>
+                  <kbd className="ml-auto font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
+                    o
+                  </kbd>
+                </Command.Item>
+              </Command.Group>
+            )}
+
+            {/* Navigation */}
+            <Command.Group heading="Navigation" className={GROUP_CLS}>
+              {NAV_ITEMS.map(({ icon: Icon, label, to }) => (
+                <Command.Item key={to} onSelect={() => go(to)} className={ITEM_CLS}>
                   <Icon className="size-4 text-muted-foreground" />
                   <span className="text-sm">{label}</span>
                 </Command.Item>
               ))}
             </Command.Group>
-            {onShortcuts && (
-              <Command.Group
-                heading="App"
-                className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-subtle"
+
+            {/* App actions */}
+            <Command.Group heading="Actions" className={GROUP_CLS}>
+              <Command.Item
+                onSelect={() => {
+                  void handleIngest();
+                }}
+                className={ITEM_CLS}
               >
+                <RefreshCw className="size-4 text-muted-foreground" />
+                <span className="text-sm">Refresh feeds now</span>
+              </Command.Item>
+              {onShortcuts && (
                 <Command.Item
-                  onSelect={onShortcuts}
-                  className="flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer data-[selected=true]:bg-surface-2"
+                  onSelect={() => {
+                    close();
+                    onShortcuts();
+                  }}
+                  className={ITEM_CLS}
                 >
                   <span className="text-sm text-muted-foreground">Keyboard shortcuts</span>
                   <kbd className="ml-auto font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
                     ?
                   </kbd>
                 </Command.Item>
-              </Command.Group>
-            )}
+              )}
+            </Command.Group>
           </Command.List>
         </Command>
       </DialogContent>

--- a/frontend/src/contexts/focusedArticle.tsx
+++ b/frontend/src/contexts/focusedArticle.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+import type { WorkflowArticle } from '@/lib/workflowTypes';
+
+interface FocusedArticleCtx {
+  article: WorkflowArticle | null;
+  set: (a: WorkflowArticle | null) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const Ctx = createContext<FocusedArticleCtx>({ article: null, set: (_a) => {} });
+
+export function FocusedArticleProvider({ children }: { children: ReactNode }) {
+  const [article, set] = useState<WorkflowArticle | null>(null);
+  return <Ctx.Provider value={{ article, set }}>{children}</Ctx.Provider>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useFocusedArticle() {
+  return useContext(Ctx);
+}

--- a/frontend/src/hooks/useArticleListNav.ts
+++ b/frontend/src/hooks/useArticleListNav.ts
@@ -37,7 +37,7 @@ export function useArticleListNav(
         mutations.sendLater(cur);
       } else if (e.key === 's' && cur) {
         mutations.toggleStar(cur);
-      } else if (e.key === 'x' && cur) {
+      } else if (e.key === 'x' && cur && !cur.starred) {
         mutations.setState(cur, 'skipped', 'Skipped');
       } else if (e.key === 'e' && cur) {
         mutations.setState(cur, 'archived', 'Archived');

--- a/frontend/src/pages/ArchivePage.tsx
+++ b/frontend/src/pages/ArchivePage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Archive as ArchiveIcon } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
@@ -8,6 +9,7 @@ import { useArticleListNav } from '@/hooks/useArticleListNav';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { fetchTriageArticles } from '@/api/workflowApi';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';
+import { useFocusedArticle } from '@/contexts/focusedArticle';
 
 export function ArchivePage() {
   const navigate = useNavigate();
@@ -25,6 +27,11 @@ export function ArchivePage() {
 
   const mutations = useTriageMutations();
   const { focused } = useArticleListNav(list, (a) => navigate(`/a/${a.id}`), mutations);
+  const { set: setFocused } = useFocusedArticle();
+  useEffect(() => {
+    setFocused(list[focused] ?? null);
+    return () => setFocused(null);
+  }, [focused, list, setFocused]);
 
   return (
     <div>

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Inbox } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
@@ -8,6 +9,7 @@ import { useArticleListNav } from '@/hooks/useArticleListNav';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { fetchTriageArticles } from '@/api/workflowApi';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';
+import { useFocusedArticle } from '@/contexts/focusedArticle';
 
 export function InboxPage() {
   const navigate = useNavigate();
@@ -21,6 +23,11 @@ export function InboxPage() {
 
   const mutations = useTriageMutations();
   const { focused } = useArticleListNav(articles, (a) => navigate(`/a/${a.id}`), mutations);
+  const { set: setFocused } = useFocusedArticle();
+  useEffect(() => {
+    setFocused(articles[focused] ?? null);
+    return () => setFocused(null);
+  }, [focused, articles, setFocused]);
 
   return (
     <div>

--- a/frontend/src/pages/LaterPage.tsx
+++ b/frontend/src/pages/LaterPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Clock } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
@@ -7,6 +8,7 @@ import { useArticleListNav } from '@/hooks/useArticleListNav';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { fetchTriageArticles } from '@/api/workflowApi';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';
+import { useFocusedArticle } from '@/contexts/focusedArticle';
 
 export function LaterPage() {
   const navigate = useNavigate();
@@ -23,6 +25,11 @@ export function LaterPage() {
 
   const mutations = useTriageMutations();
   const { focused } = useArticleListNav(list, (a) => navigate(`/a/${a.id}`), mutations);
+  const { set: setFocused } = useFocusedArticle();
+  useEffect(() => {
+    setFocused(list[focused] ?? null);
+    return () => setFocused(null);
+  }, [focused, list, setFocused]);
 
   return (
     <div>

--- a/frontend/src/pages/StarredPage.tsx
+++ b/frontend/src/pages/StarredPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Star } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
@@ -8,6 +9,7 @@ import { useArticleListNav } from '@/hooks/useArticleListNav';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { fetchTriageArticles } from '@/api/workflowApi';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';
+import { useFocusedArticle } from '@/contexts/focusedArticle';
 
 export function StarredPage() {
   const navigate = useNavigate();
@@ -26,6 +28,11 @@ export function StarredPage() {
 
   const mutations = useTriageMutations();
   const { focused } = useArticleListNav(list, (a) => navigate(`/a/${a.id}`), mutations);
+  const { set: setFocused } = useFocusedArticle();
+  useEffect(() => {
+    setFocused(list[focused] ?? null);
+    return () => setFocused(null);
+  }, [focused, list, setFocused]);
 
   return (
     <div>


### PR DESCRIPTION
Closes #80.

## Summary

- **CommandPalette** fully wired to real data: live article search via `GET /api/search` (250ms debounce, up to 6 results with source · category · reason preview), "Refresh feeds now" action triggering `POST /api/ingest` with a sonner loading→success/error toast, and a focused-article actions section (Done, Later, Star/Unstar, Skip, Archive, Open original) that mirrors the keyboard shortcuts with their kbd hints
- **`FocusedArticleContext`** (`contexts/focusedArticle.tsx`): a minimal React context; triage pages (Inbox, Later, Starred, Archive) publish their currently-focused article via `useEffect` so the palette can act on it without prop-drilling through AppShell
- **`useArticleListNav`**: `x` key is now inert when the focused article is starred (Skip disabled for starred articles)
- **AppRouter**: wraps routes in `FocusedArticleProvider`
- **Tests** (`__tests__/keyboard.test.ts`, `__tests__/palette.test.tsx`): full keyboard triage flow (j/k nav, all action keys, x-inert-when-starred, INPUT focus guard) + palette (open/close/Esc, nav items, live search, ingest trigger) — 57 tests, all pass

## #79 seam

Search result selection calls `window.open(article.url)` with a `TODO(#79)` comment to swap in `navigate('/a/:id')` once the reader route is real.

## Test plan

- [ ] `make check` / `npm run test:frontend` — 57 tests green
- [ ] Open app, press ⌘K — palette opens from any view
- [ ] Type a query — article search results appear with source/category/reason
- [ ] Click "Refresh feeds now" — loading toast then success with article count
- [ ] Focus an article with j/k, open palette — "On: [title]" section visible with all actions
- [ ] Press x on a starred article — no skip fires; press x on unstarred — skip fires
- [ ] Press ? — shortcut overlay shows all bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)