### PR TITLE
feat(#88): Search view with filter chips, URL state, real backend

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import feedparser
 
-from .db import connect, init_db, insert_article_sql, is_postgres, row_to_dict, search_articles_sql
+from .db import connect, init_db, insert_article_sql, is_postgres, row_to_dict
 from .ingest_events import ingest_events
 from .sources import DEFAULT_SOURCES, SourceDefinition
 
@@ -687,10 +687,81 @@ def list_articles(
         return articles
 
 
-def search_articles(q: str, limit: int = 50, db_path: Path | None = None) -> list[dict[str, Any]]:
+def search_articles(  # noqa: PLR0913
+    q: str = "",
+    limit: int = 50,
+    db_path: Path | None = None,
+    states: list[str] | None = None,
+    categories: list[str] | None = None,
+    sources: list[str] | None = None,
+    starred_only: bool = False,
+    include_archived: bool = False,
+    date_range: str = "all",
+) -> list[dict[str, Any]]:
     init_db(db_path)
     terms = [t for t in q.split() if len(t) >= 2]
-    sql, params = search_articles_sql(terms, limit)
+
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    # Full-text search across title, summary, reason, tags, source_name, body
+    for term in terms:
+        like = f"%{term}%"
+        clauses.append(
+            "(title LIKE ? OR summary LIKE ? OR reason LIKE ? OR tags LIKE ?"
+            " OR source_name LIKE ? OR (body IS NOT NULL AND body LIKE ?))"
+        )
+        params.extend([like, like, like, like, like, like])
+
+    # Archived exclusion — must come before state filter to avoid conflict
+    if not include_archived:
+        clauses.append("state != 'archived'")
+
+    # State filter (multi-select; overrides archived exclusion for explicit archived selection)
+    if states:
+        placeholders = ",".join("?" * len(states))
+        clauses.append(f"state IN ({placeholders})")
+        params.extend(states)
+        if include_archived is False and "archived" in states:
+            # User explicitly wants archived — remove the exclusion clause we just added
+            clauses.remove("state != 'archived'")
+
+    # Category filter
+    if categories:
+        placeholders = ",".join("?" * len(categories))
+        clauses.append(f"category IN ({placeholders})")
+        params.extend(categories)
+
+    # Source filter
+    if sources:
+        placeholders = ",".join("?" * len(sources))
+        clauses.append(f"source_slug IN ({placeholders})")
+        params.extend(sources)
+
+    # Starred filter
+    if starred_only:
+        clauses.append("starred = 1")
+
+    # Date range filter
+    now_ts = now_iso()
+    if date_range == "today":
+        clauses.append("discovered_at >= datetime(?, '-1 day')")
+        params.append(now_ts)
+    elif date_range == "week":
+        clauses.append("discovered_at >= datetime(?, '-7 days')")
+        params.append(now_ts)
+    elif date_range == "month":
+        clauses.append("discovered_at >= datetime(?, '-30 days')")
+        params.append(now_ts)
+
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    params.append(limit)
+
+    sql = (
+        f"SELECT * FROM articles {where}"
+        " ORDER BY importance_score DESC, discovered_at DESC LIMIT ?"
+    )
+
     with connect(db_path) as conn:
         rows = conn.execute(sql, params).fetchall()
         return [_article_dict(row) for row in rows]

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -147,11 +147,28 @@ def articles(
 
 
 @app.get("/api/search")
-def search(
-    q: Annotated[str, Query(min_length=1, description="Space-separated search terms")] = "",
+def search(  # noqa: PLR0913
+    q: Annotated[str, Query(description="Space-separated search terms")] = "",
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    states: Annotated[list[str] | None, Query()] = None,
+    categories: Annotated[list[str] | None, Query()] = None,
+    sources: Annotated[list[str] | None, Query()] = None,
+    starred_only: Annotated[bool, Query()] = False,
+    include_archived: Annotated[bool, Query()] = False,
+    date_range: Annotated[str, Query()] = "all",
 ) -> dict[str, Any]:
-    return {"items": search_articles(q=q.strip(), limit=limit)}
+    return {
+        "items": search_articles(
+            q=q.strip(),
+            limit=limit,
+            states=states,
+            categories=categories,
+            sources=sources,
+            starred_only=starred_only,
+            include_archived=include_archived,
+            date_range=date_range,
+        )
+    }
 
 
 @app.get("/api/articles/{article_id}")

--- a/backend/tests/test_search_filters.py
+++ b/backend/tests/test_search_filters.py
@@ -1,0 +1,333 @@
+"""Tests for #88 search filter combinations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.ingest import search_articles, sync_sources
+from news_dashboard.main import app
+
+
+def _db(tmp: Path) -> Path:
+    return tmp / "news.db"
+
+
+def _insert(  # noqa: PLR0913
+    db_path: Path,
+    *,
+    title: str = "Article",
+    summary: str = "",
+    reason: str = "",
+    body: str | None = None,
+    category: str = "python",
+    source_slug: str = "python-insider",
+    source_name: str = "Python Insider",
+    state: str = "today",
+    starred: int = 0,
+    url_suffix: str = "",
+) -> int:
+    url = f"https://example.com/{title.lower().replace(' ', '-')}{url_suffix}"
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, starred, summary, reason, tags, body
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            RETURNING id
+            """,
+            (
+                url,
+                url,
+                title,
+                source_slug,
+                source_name,
+                category,
+                "rss_feed",
+                state,
+                starred,
+                summary,
+                reason,
+                "[]",
+                body,
+            ),
+        ).fetchone()
+    return int(row["id"] if isinstance(row, dict) else row[0])
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    path = _db(tmp_path)
+    sync_sources(path)
+    init_db(path)
+    return path
+
+
+# ─── Text search ─────────────────────────────────────────────────────────────
+
+
+def test_search_by_title(db: Path) -> None:
+    _insert(db, title="FastAPI Guide")
+    _insert(db, title="Django Tutorial")
+    results = search_articles("FastAPI", db_path=db)
+    titles = [r["title"] for r in results]
+    assert "FastAPI Guide" in titles
+    assert "Django Tutorial" not in titles
+
+
+def test_search_by_summary(db: Path) -> None:
+    _insert(db, title="Article A", summary="Covers asyncio patterns")
+    _insert(db, title="Article B", summary="CSS grid layout tricks")
+    results = search_articles("asyncio", db_path=db)
+    assert any(r["title"] == "Article A" for r in results)
+    assert all(r["title"] != "Article B" for r in results)
+
+
+def test_search_by_reason(db: Path) -> None:
+    _insert(db, title="Article A", reason="Relevant because of Python 3.13 release")
+    _insert(db, title="Article B", reason="Unrelated content")
+    results = search_articles("Python 3.13", db_path=db)
+    assert any(r["title"] == "Article A" for r in results)
+
+
+def test_search_by_body(db: Path) -> None:
+    _insert(db, title="Deep Dive", body="The full text discusses pydantic validation in detail")
+    _insert(db, title="Other Article", body="Nothing relevant here")
+    results = search_articles("pydantic", db_path=db)
+    assert any(r["title"] == "Deep Dive" for r in results)
+    assert all(r["title"] != "Other Article" for r in results)
+
+
+def test_no_query_returns_empty_without_filters(db: Path) -> None:
+    _insert(db, title="Some Article")
+    # Empty q with no filters returns nothing (SELECT * LIMIT n)
+    # but with include_archived=False the default archived exclusion applies
+    results = search_articles("", db_path=db)
+    # Should not error; may return articles since no WHERE clauses restrict much
+    assert isinstance(results, list)
+
+
+# ─── State filter ─────────────────────────────────────────────────────────────
+
+
+def test_filter_by_state(db: Path) -> None:
+    _insert(db, title="Today Art", state="today", url_suffix="-1")
+    _insert(db, title="Done Art", state="done", url_suffix="-2")
+    _insert(db, title="Archived Art", state="archived", url_suffix="-3")
+
+    results = search_articles(db_path=db, states=["today"])
+    titles = [r["title"] for r in results]
+    assert "Today Art" in titles
+    assert "Done Art" not in titles
+    assert "Archived Art" not in titles
+
+
+def test_filter_multiple_states(db: Path) -> None:
+    _insert(db, title="Today Art", state="today", url_suffix="-1")
+    _insert(db, title="Done Art", state="done", url_suffix="-2")
+    _insert(db, title="Skipped Art", state="skipped", url_suffix="-3")
+
+    results = search_articles(db_path=db, states=["today", "done"])
+    titles = [r["title"] for r in results]
+    assert "Today Art" in titles
+    assert "Done Art" in titles
+    assert "Skipped Art" not in titles
+
+
+# ─── Archived exclusion ───────────────────────────────────────────────────────
+
+
+def test_archived_excluded_by_default(db: Path) -> None:
+    _insert(db, title="Active", state="today", url_suffix="-1")
+    _insert(db, title="Archived", state="archived", url_suffix="-2")
+
+    results = search_articles(db_path=db)
+    titles = [r["title"] for r in results]
+    assert "Active" in titles
+    assert "Archived" not in titles
+
+
+def test_include_archived(db: Path) -> None:
+    _insert(db, title="Active", state="today", url_suffix="-1")
+    _insert(db, title="Archived", state="archived", url_suffix="-2")
+
+    results = search_articles(db_path=db, include_archived=True)
+    titles = [r["title"] for r in results]
+    assert "Active" in titles
+    assert "Archived" in titles
+
+
+# ─── Starred filter ───────────────────────────────────────────────────────────
+
+
+def test_starred_only(db: Path) -> None:
+    _insert(db, title="Starred Art", starred=1, url_suffix="-1")
+    _insert(db, title="Normal Art", starred=0, url_suffix="-2")
+
+    results = search_articles(db_path=db, starred_only=True)
+    titles = [r["title"] for r in results]
+    assert "Starred Art" in titles
+    assert "Normal Art" not in titles
+
+
+# ─── Category filter ──────────────────────────────────────────────────────────
+
+
+def test_filter_by_category(db: Path) -> None:
+    _insert(db, title="Python Art", category="python", url_suffix="-1")
+    _insert(db, title="AI Art", category="ai-llm", url_suffix="-2")
+
+    results = search_articles(db_path=db, categories=["python"])
+    titles = [r["title"] for r in results]
+    assert "Python Art" in titles
+    assert "AI Art" not in titles
+
+
+def test_filter_multiple_categories(db: Path) -> None:
+    _insert(db, title="Python Art", category="python", url_suffix="-1")
+    _insert(db, title="AI Art", category="ai-llm", url_suffix="-2")
+    _insert(db, title="Infra Art", category="cloud-infra", url_suffix="-3")
+
+    results = search_articles(db_path=db, categories=["python", "ai-llm"])
+    titles = [r["title"] for r in results]
+    assert "Python Art" in titles
+    assert "AI Art" in titles
+    assert "Infra Art" not in titles
+
+
+# ─── Source filter ────────────────────────────────────────────────────────────
+
+
+def test_filter_by_source(db: Path) -> None:
+    _insert(db, title="Insider Art", source_slug="python-insider", url_suffix="-1")
+    _insert(
+        db,
+        title="Weekly Art",
+        source_slug="python-weekly",
+        source_name="Python Weekly",
+        url_suffix="-2",
+    )
+
+    results = search_articles(db_path=db, sources=["python-insider"])
+    titles = [r["title"] for r in results]
+    assert "Insider Art" in titles
+    assert "Weekly Art" not in titles
+
+
+# ─── Combined filters ─────────────────────────────────────────────────────────
+
+
+def test_q_plus_state_filter(db: Path) -> None:
+    _insert(db, title="FastAPI Guide", state="today", url_suffix="-1")
+    _insert(db, title="FastAPI Tutorial", state="done", url_suffix="-2")
+    _insert(db, title="Django Guide", state="today", url_suffix="-3")
+
+    results = search_articles("FastAPI", db_path=db, states=["today"])
+    titles = [r["title"] for r in results]
+    assert "FastAPI Guide" in titles
+    assert "FastAPI Tutorial" not in titles
+    assert "Django Guide" not in titles
+
+
+def test_starred_plus_category_filter(db: Path) -> None:
+    _insert(db, title="Starred Python", category="python", starred=1, url_suffix="-1")
+    _insert(db, title="Unstarred Python", category="python", starred=0, url_suffix="-2")
+    _insert(db, title="Starred AI", category="ai-llm", starred=1, url_suffix="-3")
+
+    results = search_articles(db_path=db, starred_only=True, categories=["python"])
+    titles = [r["title"] for r in results]
+    assert "Starred Python" in titles
+    assert "Unstarred Python" not in titles
+    assert "Starred AI" not in titles
+
+
+# ─── API endpoint tests ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def api_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Spin up a throwaway SQLite DB and patch the app to use it."""
+    import news_dashboard.db as db_mod
+    import news_dashboard.ingest as ingest_mod
+
+    path = tmp_path / "search_api.db"
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    monkeypatch.setattr(ingest_mod, "DB_PATH", path, raising=False)
+    init_db(path)
+    sync_sources(path)
+    return path
+
+
+@pytest.fixture
+def client(api_db: Path) -> TestClient:
+    return TestClient(app)
+
+
+def test_search_endpoint_defaults(client: TestClient) -> None:
+    resp = client.get("/api/search")
+    assert resp.status_code == 200
+    assert "items" in resp.json()
+
+
+def test_search_endpoint_with_q(client: TestClient) -> None:
+    resp = client.get("/api/search?q=python")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+
+
+def test_search_endpoint_state_filter(client: TestClient) -> None:
+    resp = client.get("/api/search?states=today&states=done")
+    assert resp.status_code == 200
+    assert "items" in resp.json()
+
+
+def test_search_endpoint_category_filter(client: TestClient) -> None:
+    resp = client.get("/api/search?categories=python&categories=ai-llm")
+    assert resp.status_code == 200
+    assert "items" in resp.json()
+
+
+def test_search_endpoint_starred_only(client: TestClient) -> None:
+    resp = client.get("/api/search?starred_only=true")
+    assert resp.status_code == 200
+    assert "items" in resp.json()
+
+
+def test_search_endpoint_include_archived(client: TestClient) -> None:
+    resp = client.get("/api/search?include_archived=true")
+    assert resp.status_code == 200
+    assert "items" in resp.json()
+
+
+def test_search_endpoint_date_range(client: TestClient, api_db: Path) -> None:
+    _insert(api_db, title="Recent", url_suffix="-recent")
+    for dr in ["today", "week", "month"]:
+        resp = client.get(f"/api/search?date_range={dr}")
+        assert resp.status_code == 200, f"Failed for date_range={dr}"
+
+
+def test_search_endpoint_all_filters(client: TestClient) -> None:
+    resp = client.get(
+        "/api/search?q=python&states=today&categories=python"
+        "&starred_only=false&include_archived=false&date_range=week"
+    )
+    assert resp.status_code == 200
+    assert "items" in resp.json()
+
+
+def test_search_endpoint_returns_matching_articles(client: TestClient, api_db: Path) -> None:
+    _insert(api_db, title="Pytest Tips", category="python", state="today", url_suffix="-1")
+    _insert(api_db, title="Rust Intro", category="engineering", state="today", url_suffix="-2")
+
+    resp = client.get("/api/search?q=Pytest&categories=python")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    titles = [it["title"] for it in items]
+    assert "Pytest Tips" in titles
+    assert "Rust Intro" not in titles

--- a/frontend/src/__tests__/search.test.tsx
+++ b/frontend/src/__tests__/search.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SearchPage } from '../pages/SearchPage';
+import * as workflowApi from '../api/workflowApi';
+import type { WorkflowArticle } from '../lib/workflowTypes';
+import { FocusedArticleProvider } from '../contexts/focusedArticle';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
+  return {
+    id: '1',
+    title: 'Python Tips Article',
+    sourceId: 'python-insider',
+    sourceName: 'Python Insider',
+    category: 'python',
+    url: 'https://example.com/python-tips',
+    publishedAt: '2024-01-15T10:00:00Z',
+    ingestedAt: '2024-01-15T11:00:00Z',
+    reason: 'Relevant to your interests',
+    summary: 'Summary of the article.',
+    signal: 'high',
+    tags: ['python', 'tips'],
+    bodyStatus: 'missing',
+    state: 'today',
+    starred: false,
+    ...overrides,
+  };
+}
+
+function renderSearch(initialSearch = '') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FocusedArticleProvider>
+        <MemoryRouter initialEntries={[`/search${initialSearch}`]}>
+          <Routes>
+            <Route path="/search" element={<SearchPage />} />
+            <Route path="/a/:id" element={<div data-testid="reader-page">Reader</div>} />
+          </Routes>
+        </MemoryRouter>
+      </FocusedArticleProvider>
+    </QueryClientProvider>
+  );
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+describe('SearchPage — rendering', () => {
+  it('renders the heading and search input', () => {
+    renderSearch();
+    expect(screen.getByText('Search')).toBeTruthy();
+    expect(screen.getByPlaceholderText(/Search titles/)).toBeTruthy();
+  });
+
+  it('renders all filter chip groups', () => {
+    renderSearch();
+    expect(screen.getByText('Starred')).toBeTruthy();
+    expect(screen.getByText('Include archived')).toBeTruthy();
+    expect(screen.getByText('State')).toBeTruthy();
+    expect(screen.getByText('Category')).toBeTruthy();
+    expect(screen.getByText('Date')).toBeTruthy();
+  });
+
+  it('shows empty state prompt when no query or filters', () => {
+    renderSearch();
+    expect(screen.getByText('Start searching')).toBeTruthy();
+  });
+});
+
+// ─── Search flow ─────────────────────────────────────────────────────────────
+
+describe('SearchPage — search flow', () => {
+  it('calls searchArticlesFiltered when user types a query', async () => {
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    renderSearch();
+
+    const input = screen.getByPlaceholderText(/Search titles/);
+    await userEvent.type(input, 'python');
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'python' })
+      );
+    }, { timeout: 1000 });
+  });
+
+  it('displays results when API returns articles', async () => {
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([
+      makeArticle({ id: '1', title: 'Python Tips Article' }),
+      makeArticle({ id: '2', title: 'Async Patterns' }),
+    ]);
+
+    renderSearch('?q=python');
+
+    await waitFor(() => {
+      expect(screen.getByText('Python Tips Article')).toBeTruthy();
+      expect(screen.getByText('Async Patterns')).toBeTruthy();
+    });
+  });
+
+  it('shows result count', async () => {
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([
+      makeArticle({ id: '1' }),
+      makeArticle({ id: '2', url: 'https://example.com/2' }),
+    ]);
+
+    renderSearch('?q=python');
+
+    await waitFor(() => {
+      expect(screen.getByText('2 results')).toBeTruthy();
+    });
+  });
+
+  it('shows "No results" when API returns empty array', async () => {
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    renderSearch('?q=nonexistent');
+
+    await waitFor(() => {
+      expect(screen.getByText('No results')).toBeTruthy();
+    });
+  });
+});
+
+// ─── Filter chips ─────────────────────────────────────────────────────────────
+
+describe('SearchPage — filter chips', () => {
+  it('Starred chip toggles starred_only in API call', async () => {
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    renderSearch('?q=test');
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    spy.mockClear();
+
+    const starredChip = screen.getByRole('button', { name: 'Starred' });
+    await userEvent.click(starredChip);
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ starredOnly: true })
+      );
+    });
+  });
+
+  it('Include archived chip toggles includeArchived in API call', async () => {
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    renderSearch('?q=test');
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    spy.mockClear();
+
+    const archivedChip = screen.getByRole('button', { name: 'Include archived' });
+    await userEvent.click(archivedChip);
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ includeArchived: true })
+      );
+    });
+  });
+});
+
+// ─── Navigation to reader ────────────────────────────────────────────────────
+
+describe('SearchPage — reader navigation', () => {
+  it('navigates to reader when article row is clicked', async () => {
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([
+      makeArticle({ id: '42', title: 'Clickable Article' }),
+    ]);
+
+    renderSearch('?q=python');
+
+    await waitFor(() => {
+      expect(screen.getByText('Clickable Article')).toBeTruthy();
+    });
+
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toContain('/a/42');
+  });
+});

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -131,3 +131,31 @@ export async function patchArticleStar(id: string, starred: boolean): Promise<vo
 export function snapshot(article: WorkflowArticle): UndoSnapshot {
   return { article: { ...article } };
 }
+
+// ─── Search ─────────────────────────────────────────────────────────────────
+
+export interface SearchFilters {
+  q?: string;
+  states?: WorkflowState[];
+  categories?: string[];
+  sources?: string[];
+  starredOnly?: boolean;
+  includeArchived?: boolean;
+  dateRange?: 'all' | 'today' | 'week' | 'month';
+  limit?: number;
+}
+
+export async function searchArticlesFiltered(filters: SearchFilters): Promise<WorkflowArticle[]> {
+  const params = new URLSearchParams();
+  if (filters.q) params.set('q', filters.q);
+  if (filters.limit) params.set('limit', String(filters.limit));
+  if (filters.starredOnly) params.set('starred_only', 'true');
+  if (filters.includeArchived) params.set('include_archived', 'true');
+  if (filters.dateRange && filters.dateRange !== 'all') params.set('date_range', filters.dateRange);
+  filters.states?.forEach((s) => params.append('states', s));
+  filters.categories?.forEach((c) => params.append('categories', c));
+  filters.sources?.forEach((s) => params.append('sources', s));
+
+  const data = await requestJson<{ items: LegacyArticle[] }>(`/api/search?${params}`);
+  return data.items.map(adaptArticle);
+}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,8 +1,388 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Search as SearchIcon } from 'lucide-react';
+import { ArticleRow } from '@/components/article/ArticleRow';
+import { EmptyState } from '@/components/EmptyState';
+import { useArticleListNav } from '@/hooks/useArticleListNav';
+import { useTriageMutations } from '@/hooks/useTriageMutations';
+import { useFocusedArticle } from '@/contexts/focusedArticle';
+import { setReaderList } from '@/lib/readerList';
+import { searchArticlesFiltered } from '@/api/workflowApi';
+import type { WorkflowState } from '@/lib/workflowTypes';
+import { cn } from '@/lib/utils';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const WORKFLOW_STATES: { value: WorkflowState; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'later', label: 'Later' },
+  { value: 'done', label: 'Done' },
+  { value: 'skipped', label: 'Skipped' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const CATEGORIES = [
+  'python',
+  'ai-llm',
+  'agents',
+  'cloud-infra',
+  'engineering',
+  'trending',
+  'repositories',
+];
+
+const DATE_OPTIONS: { value: string; label: string }[] = [
+  { value: 'all', label: 'Any time' },
+  { value: 'today', label: 'Today' },
+  { value: 'week', label: 'Past week' },
+  { value: 'month', label: 'Past month' },
+];
+
+// ─── URL state helpers ────────────────────────────────────────────────────────
+
+function parseList(params: URLSearchParams, key: string): string[] {
+  return params.getAll(key).filter(Boolean);
+}
+
+function encodedFilters(
+  q: string,
+  states: string[],
+  categories: string[],
+  sources: string[],
+  starredOnly: boolean,
+  includeArchived: boolean,
+  dateRange: string
+): URLSearchParams {
+  const p = new URLSearchParams();
+  if (q) p.set('q', q);
+  states.forEach((s) => p.append('states', s));
+  categories.forEach((c) => p.append('categories', c));
+  sources.forEach((s) => p.append('sources', s));
+  if (starredOnly) p.set('starred_only', '1');
+  if (includeArchived) p.set('include_archived', '1');
+  if (dateRange !== 'all') p.set('date_range', dateRange);
+  return p;
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
 export function SearchPage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const q = searchParams.get('q') ?? '';
+  const states = parseList(searchParams, 'states') as WorkflowState[];
+  const categories = parseList(searchParams, 'categories');
+  const sources = parseList(searchParams, 'sources');
+  const starredOnly = searchParams.get('starred_only') === '1';
+  const includeArchived = searchParams.get('include_archived') === '1';
+  const dateRange = searchParams.get('date_range') ?? 'all';
+
+  const [inputValue, setInputValue] = useState(q);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Sync input when URL changes externally (e.g., back navigation)
+  useEffect(() => {
+    setInputValue(q);
+  }, [q]);
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function updateParams(overrides: {
+    q?: string;
+    states?: string[];
+    categories?: string[];
+    sources?: string[];
+    starredOnly?: boolean;
+    includeArchived?: boolean;
+    dateRange?: string;
+  }) {
+    setSearchParams(
+      encodedFilters(
+        overrides.q ?? q,
+        overrides.states ?? states,
+        overrides.categories ?? categories,
+        overrides.sources ?? sources,
+        overrides.starredOnly ?? starredOnly,
+        overrides.includeArchived ?? includeArchived,
+        overrides.dateRange ?? dateRange
+      ),
+      { replace: true }
+    );
+  }
+
+  const hasFilters = q || states.length || categories.length || sources.length || starredOnly || includeArchived || dateRange !== 'all';
+
+  const { data: results = [], isLoading } = useQuery({
+    queryKey: ['search', q, states, categories, sources, starredOnly, includeArchived, dateRange],
+    queryFn: () =>
+      searchArticlesFiltered({
+        q,
+        states: states.length ? states : undefined,
+        categories: categories.length ? categories : undefined,
+        sources: sources.length ? sources : undefined,
+        starredOnly,
+        includeArchived,
+        dateRange: (dateRange || 'all') as 'all' | 'today' | 'week' | 'month',
+        limit: 100,
+      }),
+    enabled: !!hasFilters,
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    setReaderList(results.map((a) => a.id));
+  }, [results]);
+
+  const mutations = useTriageMutations();
+  const { focused } = useArticleListNav(results, (a) => navigate(`/a/${a.id}`), mutations);
+  const { set: setFocused } = useFocusedArticle();
+  useEffect(() => {
+    setFocused(results[focused] ?? null);
+    return () => setFocused(null);
+  }, [focused, results, setFocused]);
+
+  // Debounced query update when typing
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function handleInputChange(value: string) {
+    setInputValue(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      updateParams({ q: value });
+    }, 300);
+  }
+
   return (
-    <div className="p-4 md:p-5">
-      <h2 className="text-[22px] font-semibold tracking-tight mb-1">Search</h2>
-      <p className="text-sm text-muted-foreground">Full-text search — coming in a future slice.</p>
+    <div>
+      <div className="px-4 md:px-5 pt-4 pb-2">
+        <h2 className="text-[22px] font-semibold tracking-tight mb-3">Search</h2>
+
+        {/* Search input */}
+        <div className="relative">
+          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            value={inputValue}
+            onChange={(e) => handleInputChange(e.target.value)}
+            placeholder="Search titles, summaries, tags, full text…"
+            className="w-full h-10 pl-9 pr-3 rounded-md border border-border bg-surface text-sm outline-none focus:border-border-strong focus:bg-background"
+          />
+        </div>
+
+        {/* Filter chips */}
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {/* Starred */}
+          <Chip
+            active={starredOnly}
+            onClick={() => updateParams({ starredOnly: !starredOnly })}
+          >
+            Starred
+          </Chip>
+
+          {/* Include archived */}
+          <Chip
+            active={includeArchived}
+            onClick={() => updateParams({ includeArchived: !includeArchived })}
+          >
+            Include archived
+          </Chip>
+
+          {/* State group */}
+          <FilterGroup
+            label="State"
+            all={WORKFLOW_STATES.map((s) => s.value)}
+            selected={states}
+            onChange={(next) => updateParams({ states: next })}
+            render={(v) => WORKFLOW_STATES.find((s) => s.value === v)?.label ?? v}
+          />
+
+          {/* Category group */}
+          <FilterGroup
+            label="Category"
+            all={CATEGORIES}
+            selected={categories}
+            onChange={(next) => updateParams({ categories: next })}
+            render={(v) => v}
+          />
+
+          {/* Date group */}
+          <FilterGroup
+            label="Date"
+            all={DATE_OPTIONS.map((d) => d.value)}
+            selected={dateRange !== 'all' ? [dateRange] : []}
+            onChange={(next) => updateParams({ dateRange: next[next.length - 1] ?? 'all' })}
+            render={(v) => DATE_OPTIONS.find((d) => d.value === v)?.label ?? v}
+            single
+          />
+        </div>
+      </div>
+
+      {/* Result count */}
+      {hasFilters && (
+        <div className="px-4 md:px-5 py-2 text-[11px] text-muted-foreground border-b border-border">
+          {isLoading
+            ? '…'
+            : `${results.length} ${results.length === 1 ? 'result' : 'results'}`}
+        </div>
+      )}
+
+      {/* Results */}
+      {!hasFilters ? (
+        <EmptyState
+          icon={SearchIcon}
+          title="Start searching"
+          subtitle="Type a query or apply filters to find articles."
+        />
+      ) : isLoading ? (
+        <SearchSkeleton />
+      ) : results.length === 0 ? (
+        <EmptyState icon={SearchIcon} title="No results" subtitle="Try different search terms or filters." />
+      ) : (
+        <div>
+          {results.map((a, i) => (
+            <ArticleRow key={a.id} article={a} focused={i === focused} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Chip ────────────────────────────────────────────────────────────────────
+
+function Chip({
+  active,
+  onClick,
+  children,
+}: {
+  active?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'h-7 px-2.5 rounded-full border text-[11px] font-medium transition-colors',
+        active
+          ? 'bg-foreground text-background border-foreground'
+          : 'bg-surface border-border text-muted-foreground hover:text-foreground hover:border-border-strong'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ─── FilterGroup ─────────────────────────────────────────────────────────────
+
+function FilterGroup({
+  label,
+  all,
+  selected,
+  onChange,
+  render,
+  single,
+}: {
+  label: string;
+  all: string[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+  render: (v: string) => string;
+  single?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const isActive = selected.length > 0;
+  const badge = single && selected[0]
+    ? ` · ${render(selected[0])}`
+    : !single && selected.length > 0
+      ? ` · ${selected.length}`
+      : '';
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'h-7 px-2.5 rounded-full border text-[11px] font-medium transition-colors',
+          isActive
+            ? 'bg-foreground text-background border-foreground'
+            : 'bg-surface border-border text-muted-foreground hover:text-foreground hover:border-border-strong'
+        )}
+      >
+        {label}{badge}
+      </button>
+      {open && (
+        <div className="absolute z-20 mt-1 min-w-[160px] max-h-64 overflow-y-auto rounded-md border border-border bg-popover shadow-md p-1">
+          {all.map((v) => {
+            const on = selected.includes(v);
+            return (
+              <button
+                key={v}
+                onClick={() => {
+                  if (single) {
+                    onChange(on ? [] : [v]);
+                    setOpen(false);
+                  } else {
+                    onChange(on ? selected.filter((x) => x !== v) : [...selected, v]);
+                  }
+                }}
+                className={cn(
+                  'flex w-full items-center justify-between gap-2 px-2.5 py-1.5 rounded text-xs hover:bg-surface',
+                  on && 'font-medium text-foreground'
+                )}
+              >
+                <span className="truncate text-left">{render(v)}</span>
+                {on && <span className="text-accent shrink-0">✓</span>}
+              </button>
+            );
+          })}
+          {!single && (
+            <div className="border-t border-border mt-1 pt-1 flex justify-end gap-1">
+              <button
+                onClick={() => onChange([])}
+                className="px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+              >
+                Clear
+              </button>
+              <button onClick={() => setOpen(false)} className="px-2 py-1 text-[11px] text-foreground">
+                Done
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Skeleton ────────────────────────────────────────────────────────────────
+
+function SearchSkeleton() {
+  return (
+    <div className="divide-y divide-border">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="px-4 md:px-5 py-3">
+          <div className="h-3 w-32 bg-surface-2 rounded animate-pulse mb-2" />
+          <div className="h-4 w-3/4 bg-surface-2 rounded animate-pulse mb-2" />
+          <div className="h-3 w-1/2 bg-surface-2 rounded animate-pulse" />
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **SearchPage** fully replaced with the design-mockup port: persistent search input, six chip groups (State, Starred, Include archived, Category, Date), result count, skeleton loader, and empty states
- All filters are **encoded in the URL** (`?q=&states=&categories=&starred_only=&include_archived=&date_range=`) so searches are shareable/addressable; back navigation restores search state via browser history
- Selecting a result calls `setReaderList` then navigates to `/a/:id` (reader), preserving list context for swipe navigation
- **Backend** `search_articles()` extended with `states`, `categories`, `sources`, `starred_only`, `include_archived`, `date_range` params; searches cover title, summary, reason, tags, source_name, and body; archived excluded by default
- **`GET /api/search`** accepts all filter params as query strings (multi-value `states[]`, `categories[]`, `sources[]`)

## Test plan

- [x] 24 backend tests covering text-search fields (title/summary/reason/body), each filter type individually, combined filters, and all API endpoint shapes
- [x] 10 frontend tests: page render, chips present, empty state, results display, result count, no-results state, Starred chip toggles `starredOnly`, Include archived chip toggles `includeArchived`, reader link href correct
- [x] `ruff check` — clean
- [x] `eslint --max-warnings 0` — clean
- [x] `tsc --noEmit` — clean
- [x] 119 backend tests pass, 88 frontend tests pass

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)