### PR TITLE
feat: POST /api/briefings — generate briefing from Today articles (#102)

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -1,4 +1,4 @@
-"""PostgreSQL-backed briefings storage and read API.
+"""PostgreSQL-backed briefings storage, read API, and generation.
 
 Runtime SQL uses psycopg %s parameter style. No SQLite fallback.
 """
@@ -6,24 +6,33 @@ Runtime SQL uses psycopg %s parameter style. No SQLite fallback.
 from __future__ import annotations
 
 import json
+import os
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 from .db import connect, row_to_dict
 
-# Columns returned on briefing list items (no content blob, no articles).
-_LIST_COLS = (
-    "id",
-    "created_at",
-    "scope",
-    "since_at",
-    "until_at",
-    "status",
-    "title",
-    "summary",
-    "model",
-    "error",
-)
+CANDIDATE_LIMIT = 40
+DEFAULT_BRIEFING_MODEL = "gpt-4o-mini"
+
+# ── Error types ───────────────────────────────────────────────────────────────
+
+
+class BriefingAINotConfiguredError(RuntimeError):
+    """Raised when OPENAI_API_KEY is absent and generation is attempted."""
+
+
+class BriefingGenerationError(RuntimeError):
+    """Raised when the AI returns a structurally invalid or unparseable briefing."""
+
+
+# ── Type alias for the injectable AI function ─────────────────────────────────
+
+AiFn = Callable[[list[dict[str, Any]], str], dict[str, Any]]
+
+# ── SQL constants ─────────────────────────────────────────────────────────────
 
 _CITED_ARTICLES_SQL = """
     SELECT
@@ -45,6 +54,18 @@ _CITED_ARTICLES_SQL = """
     ORDER BY ba.section_index NULLS LAST, ba.citation_index NULLS LAST, a.id
 """
 
+_CANDIDATES_SQL = """
+    SELECT id, title, url, source_name, category, summary, importance_score, discovered_at
+    FROM articles
+    WHERE state = 'today'
+      AND discovered_at >= %s
+    ORDER BY importance_score DESC NULLS LAST, discovered_at DESC
+    LIMIT %s
+"""
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
 
 def _fetch_cited_articles(conn: Any, briefing_id: int) -> list[dict[str, Any]]:
     rows = conn.execute(_CITED_ARTICLES_SQL, (briefing_id,)).fetchall()
@@ -59,6 +80,233 @@ def _coerce_content(value: Any) -> Any:
         except (json.JSONDecodeError, TypeError):
             return value
     return value
+
+
+def _get_since_at(database_url: str | None = None) -> datetime:
+    """Return the previous briefing's until_at, or now() - 24h if none exists."""
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            SELECT until_at FROM briefings
+            WHERE status = 'complete' AND until_at IS NOT NULL
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+        ).fetchone()
+    if row is not None:
+        val = row_to_dict(row)["until_at"]
+        if val is not None:
+            # psycopg returns TIMESTAMPTZ as an aware datetime; normalise just in case
+            if isinstance(val, datetime):
+                return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+            # fallback: parse ISO string
+            return datetime.fromisoformat(str(val))
+    return datetime.now(timezone.utc) - timedelta(hours=24)
+
+
+def _call_openai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+    """Call OpenAI to generate structured briefing JSON from a candidate article list."""
+    from openai import OpenAI  # lazy import — optional dep at import time
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = "Briefing generation requires OPENAI_API_KEY. Set it in the app environment."
+        raise BriefingAINotConfiguredError(msg)
+
+    article_lines = []
+    for a in candidates:
+        snippet = (a.get("summary") or "")[:200]
+        article_lines.append(
+            f"[{a['id']}] {a['title']} "
+            f"({a.get('source_name', '')} / {a.get('category', '')})\n  {snippet}"
+        )
+
+    system = (
+        "You are a briefing editor. Given a list of news articles (each with a numeric ID), "
+        "produce a JSON object with these exact keys:\n"
+        "  title     — short, punchy headline for the briefing (max 10 words)\n"
+        "  summary   — 1-2 sentence overview of the day's themes\n"
+        "  sections  — array of section objects, each with:\n"
+        "                title     — section heading\n"
+        "                body      — 2-4 sentence narrative\n"
+        "                citations — array of integer article IDs cited in body\n"
+        "  worth_opening — flat array of integer article IDs most worth reading in full\n"
+        "Only use IDs from the provided list. Return valid JSON only, no markdown wrapper."
+    )
+    user = "Articles:\n\n" + "\n\n".join(article_lines)
+
+    client = OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        response_format={"type": "json_object"},
+        max_tokens=2048,
+    )
+    text = response.choices[0].message.content or "{}"
+    try:
+        return json.loads(text)  # type: ignore[no-any-return]
+    except json.JSONDecodeError as exc:
+        msg = f"AI returned invalid JSON: {exc}"
+        raise BriefingGenerationError(msg) from exc
+
+
+def _validate_content(raw: dict[str, Any], candidate_ids: set[int]) -> dict[str, Any]:
+    """Validate structure and strip citations that reference unknown article IDs."""
+    required = {"title", "summary", "sections"}
+    missing = required - raw.keys()
+    if missing:
+        msg = f"AI response missing required keys: {missing}"
+        raise BriefingGenerationError(msg)
+
+    sections = raw.get("sections") or []
+    if not isinstance(sections, list):
+        msg = "AI response 'sections' must be a list"
+        raise BriefingGenerationError(msg)
+
+    clean_sections = []
+    for section in sections:
+        citations = [c for c in (section.get("citations") or []) if int(c) in candidate_ids]
+        clean_sections.append(
+            {
+                "title": section.get("title", ""),
+                "body": section.get("body", ""),
+                "citations": citations,
+            }
+        )
+
+    worth_opening = [int(c) for c in (raw.get("worth_opening") or []) if int(c) in candidate_ids]
+
+    return {
+        "title": str(raw.get("title", "")),
+        "summary": str(raw.get("summary", "")),
+        "sections": clean_sections,
+        "worth_opening": worth_opening,
+    }
+
+
+def _save_briefing(
+    since_at: datetime,
+    until_at: datetime,
+    content: dict[str, Any],
+    candidate_ids: set[int],
+    model: str,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Insert briefing + article links; return the full briefing dict."""
+    title = content.get("title") or ""
+    summary = content.get("summary") or ""
+    content_blob = {
+        "sections": content.get("sections", []),
+        "worth_opening": content.get("worth_opening", []),
+    }
+
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO briefings(
+                scope, since_at, until_at, status, title, summary, content, model
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+            RETURNING id
+            """,
+            (
+                "since_last_briefing",
+                since_at,
+                until_at,
+                "complete",
+                title,
+                summary,
+                json.dumps(content_blob),
+                model,
+            ),
+        ).fetchone()
+        if row is None:
+            msg = "INSERT INTO briefings returned no row"
+            raise BriefingGenerationError(msg)
+        briefing_id = int(row_to_dict(row)["id"])
+
+        cited_ids: set[int] = set()
+        for s_idx, section in enumerate(content.get("sections", [])):
+            for c_idx, article_id in enumerate(section.get("citations", [])):
+                aid = int(article_id)
+                if aid in candidate_ids:
+                    conn.execute(
+                        """
+                        INSERT INTO briefing_articles(
+                            briefing_id, article_id, section_index, citation_index
+                        )
+                        VALUES (%s, %s, %s, %s)
+                        ON CONFLICT DO NOTHING
+                        """,
+                        (briefing_id, aid, s_idx, c_idx),
+                    )
+                    cited_ids.add(aid)
+
+        for article_id in content.get("worth_opening", []):
+            aid = int(article_id)
+            if aid in candidate_ids and aid not in cited_ids:
+                conn.execute(
+                    """
+                    INSERT INTO briefing_articles(briefing_id, article_id)
+                    VALUES (%s, %s)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    (briefing_id, aid),
+                )
+
+    result = get_briefing(briefing_id, database_url=database_url)
+    if result is None:
+        msg = f"Could not re-read briefing {briefing_id} after insert"
+        raise BriefingGenerationError(msg)
+    return result
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def select_candidates(
+    since_at: datetime,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return up to CANDIDATE_LIMIT today-state articles discovered after since_at."""
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(_CANDIDATES_SQL, (since_at, CANDIDATE_LIMIT)).fetchall()
+        return [row_to_dict(r) for r in rows]
+
+
+def generate_briefing(
+    database_url: str | None = None,
+    *,
+    model: str | None = None,
+    ai_fn: AiFn | None = None,
+) -> dict[str, Any]:
+    """Generate and persist a briefing from eligible Today articles.
+
+    Returns the saved briefing dict on success, or ``{"status": "no_candidates"}``
+    when no eligible articles are found.
+
+    Raises:
+        BriefingAINotConfiguredError: OPENAI_API_KEY is not set.
+        BriefingGenerationError: AI returned an invalid or unparseable response.
+    """
+    _env_model = os.getenv("OPENAI_BRIEFING_MODEL", DEFAULT_BRIEFING_MODEL)
+    resolved_model = model if model is not None else _env_model
+    since_at = _get_since_at(database_url)
+    until_at = datetime.now(timezone.utc)
+
+    candidates = select_candidates(since_at, database_url=database_url)
+    if not candidates:
+        return {"status": "no_candidates"}
+
+    candidate_ids = {int(a["id"]) for a in candidates}
+    call_ai: AiFn = ai_fn if ai_fn is not None else _call_openai
+    raw_content = call_ai(candidates, resolved_model)
+
+    content = _validate_content(raw_content, candidate_ids)
+    return _save_briefing(since_at, until_at, content, candidate_ids, resolved_model, database_url)
 
 
 def get_latest_briefing(

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -58,7 +58,7 @@ _CANDIDATES_SQL = """
     SELECT id, title, url, source_name, category, summary, importance_score, discovered_at
     FROM articles
     WHERE state = 'today'
-      AND discovered_at >= %s
+      AND discovered_at::timestamptz >= %s
     ORDER BY importance_score DESC NULLS LAST, discovered_at DESC
     LIMIT %s
 """

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -15,7 +15,14 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response
 
 from .body_fetch import fetch_and_cache_body, get_article
-from .briefings import get_briefing, get_latest_briefing, list_briefings
+from .briefings import (
+    BriefingAINotConfiguredError,
+    BriefingGenerationError,
+    generate_briefing,
+    get_briefing,
+    get_latest_briefing,
+    list_briefings,
+)
 from .db import connect, describe_database, init_db, row_to_dict
 from .ingest import (
     ingest_all,
@@ -406,6 +413,17 @@ def briefings_detail(briefing_id: int) -> dict[str, Any]:
     if briefing is None:
         raise HTTPException(status_code=404, detail="briefing not found")
     return briefing
+
+
+@app.post("/api/briefings")
+def briefings_create() -> dict[str, Any]:
+    """Generate a briefing from eligible Today articles and persist it."""
+    try:
+        return generate_briefing()
+    except BriefingAINotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except BriefingGenerationError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 class AskRequest(BaseModel):

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -21,6 +21,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 import news_dashboard.main as main_mod
+from news_dashboard.briefings import BriefingAINotConfiguredError, BriefingGenerationError
 from news_dashboard.db import init_db
 from news_dashboard.main import app
 
@@ -255,3 +256,55 @@ def test_detail_cited_article_has_section_and_citation_index(monkeypatch: Any) -
     article = resp.json()["articles"][0]
     assert "section_index" in article
     assert "citation_index" in article
+
+
+# ── POST /api/briefings — generate ───────────────────────────────────────────
+
+
+def test_create_returns_briefing_on_success(monkeypatch: Any) -> None:
+    monkeypatch.setattr(main_mod, "generate_briefing", lambda: dict(_SAMPLE_BRIEFING))
+    resp = client.post("/api/briefings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == 1
+    assert data["status"] == "complete"
+    assert "articles" in data
+
+
+def test_create_returns_no_candidates_when_no_today_articles(monkeypatch: Any) -> None:
+    monkeypatch.setattr(main_mod, "generate_briefing", lambda: {"status": "no_candidates"})
+    resp = client.post("/api/briefings")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "no_candidates"}
+
+
+def test_create_returns_503_when_ai_not_configured(monkeypatch: Any) -> None:
+    def _raise() -> dict[str, Any]:
+        msg = "OPENAI_API_KEY not set"
+        raise BriefingAINotConfiguredError(msg)
+
+    monkeypatch.setattr(main_mod, "generate_briefing", _raise)
+    resp = client.post("/api/briefings")
+    assert resp.status_code == 503
+    assert "OPENAI_API_KEY" in resp.json()["detail"]
+
+
+def test_create_returns_500_when_generation_fails(monkeypatch: Any) -> None:
+    def _raise() -> dict[str, Any]:
+        msg = "AI returned invalid JSON"
+        raise BriefingGenerationError(msg)
+
+    monkeypatch.setattr(main_mod, "generate_briefing", _raise)
+    resp = client.post("/api/briefings")
+    assert resp.status_code == 500
+    assert "invalid JSON" in resp.json()["detail"]
+
+
+def test_create_returns_content_and_articles_on_success(monkeypatch: Any) -> None:
+    monkeypatch.setattr(main_mod, "generate_briefing", lambda: dict(_SAMPLE_BRIEFING))
+    resp = client.post("/api/briefings")
+    data = resp.json()
+    assert "content" in data
+    assert "sections" in data["content"]
+    assert "articles" in data
+    assert len(data["articles"]) > 0

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -9,12 +9,23 @@ fixture (started by testcontainers) and are skipped when Docker is unavailable.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import psycopg
 import pytest
 
-from news_dashboard.briefings import get_briefing, get_latest_briefing, list_briefings
+from news_dashboard.briefings import (
+    CANDIDATE_LIMIT,
+    BriefingGenerationError,
+    _get_since_at,
+    _validate_content,
+    generate_briefing,
+    get_briefing,
+    get_latest_briefing,
+    list_briefings,
+    select_candidates,
+)
 from news_dashboard.db import connect
 
 # ── Seeding helpers ───────────────────────────────────────────────────────────
@@ -39,18 +50,36 @@ def _seed_article(
     title: str = "Test Article",
     source_slug: str = "test-source",
     importance_score: int = 50,
+    state: str = "new",
+    discovered_at: str | None = None,
 ) -> int:
+    extra_cols = ""
+    extra_vals: tuple[object, ...] = ()
+    if discovered_at is not None:
+        extra_cols = ", discovered_at"
+        extra_vals = (discovered_at,)
     with connect(database_url=pg_url) as conn:
         row = conn.execute(
-            """
+            f"""
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, importance_score
+              category, kind, importance_score, state{extra_cols}
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s{", %s" if discovered_at else ""})
             RETURNING id
             """,
-            (url, url, title, source_slug, "Test Source", "tech", "rss_feed", importance_score),
+            (
+                url,
+                url,
+                title,
+                source_slug,
+                "Test Source",
+                "tech",
+                "rss_feed",
+                importance_score,
+                state,
+                *extra_vals,
+            ),
         ).fetchone()
     assert row is not None
     return int(row["id"])
@@ -357,3 +386,237 @@ def test_cited_articles_nulls_last_in_citation_index(pg_clean: str) -> None:
     assert result is not None
     titles = [a["title"] for a in result["articles"]]
     assert titles == ["Cite 0", "No Cite Index"]
+
+
+# ── _get_since_at ─────────────────────────────────────────────────────────────
+
+
+def test_get_since_at_returns_24h_ago_when_no_briefings(pg_clean: str) -> None:
+    before = datetime.now(timezone.utc) - timedelta(hours=24, seconds=5)
+    result = _get_since_at(database_url=pg_clean)
+    after = datetime.now(timezone.utc) - timedelta(hours=24) + timedelta(seconds=5)
+    assert before <= result <= after
+
+
+def test_get_since_at_returns_previous_briefing_until_at(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_briefing(pg_clean)
+    result = _get_since_at(database_url=pg_clean)
+    # _seed_briefing sets until_at = "2026-06-13T00:00:00+00:00"
+    expected = datetime(2026, 6, 13, 0, 0, 0, tzinfo=timezone.utc)
+    assert result == expected
+
+
+def test_get_since_at_uses_most_recent_briefing(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_briefing(pg_clean, created_at="2026-06-11T00:00:00+00:00")
+    _seed_briefing(pg_clean, created_at="2026-06-13T00:00:00+00:00")
+    # Both briefings have until_at = "2026-06-13T00:00:00+00:00" (seeded default)
+    # Most recent by created_at is the second one
+    result = _get_since_at(database_url=pg_clean)
+    assert isinstance(result, datetime)
+    assert result.tzinfo is not None
+
+
+# ── select_candidates ─────────────────────────────────────────────────────────
+
+
+def test_select_candidates_returns_only_today_articles(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    since_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    _seed_article(pg_clean, url="https://example.com/today-1", title="Today 1", state="today")
+    _seed_article(pg_clean, url="https://example.com/later-1", title="Later 1", state="later")
+    _seed_article(pg_clean, url="https://example.com/new-1", title="New 1", state="new")
+
+    candidates = select_candidates(since_at, database_url=pg_clean)
+    titles = [a["title"] for a in candidates]
+    assert "Today 1" in titles
+    assert "Later 1" not in titles
+    assert "New 1" not in titles
+
+
+def test_select_candidates_filters_by_since_at(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    since_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    recent_ts = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+
+    _seed_article(
+        pg_clean,
+        url="https://example.com/recent",
+        title="Recent",
+        state="today",
+        discovered_at=recent_ts,
+    )
+    _seed_article(
+        pg_clean,
+        url="https://example.com/old",
+        title="Old",
+        state="today",
+        discovered_at=old_ts,
+    )
+
+    candidates = select_candidates(since_at, database_url=pg_clean)
+    titles = [a["title"] for a in candidates]
+    assert "Recent" in titles
+    assert "Old" not in titles
+
+
+def test_select_candidates_caps_at_limit(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    since_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    for i in range(CANDIDATE_LIMIT + 5):
+        _seed_article(
+            pg_clean,
+            url=f"https://example.com/art-{i}",
+            title=f"Article {i}",
+            state="today",
+        )
+
+    candidates = select_candidates(since_at, database_url=pg_clean)
+    assert len(candidates) == CANDIDATE_LIMIT
+
+
+def test_select_candidates_ordered_by_importance_desc(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    since_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    _seed_article(
+        pg_clean,
+        url="https://example.com/low",
+        title="Low",
+        state="today",
+        importance_score=10,
+    )
+    _seed_article(
+        pg_clean,
+        url="https://example.com/high",
+        title="High",
+        state="today",
+        importance_score=90,
+    )
+
+    candidates = select_candidates(since_at, database_url=pg_clean)
+    assert candidates[0]["title"] == "High"
+    assert candidates[1]["title"] == "Low"
+
+
+# ── _validate_content (pure unit tests, no DB required) ───────────────────────
+
+
+def test_validate_content_strips_unknown_citations() -> None:
+    raw = {
+        "title": "T",
+        "summary": "S",
+        "sections": [{"title": "A", "body": "B", "citations": [1, 2, 99]}],
+        "worth_opening": [1, 88],
+    }
+    result = _validate_content(raw, candidate_ids={1, 2})
+    assert result["sections"][0]["citations"] == [1, 2]
+    assert result["worth_opening"] == [1]
+
+
+def test_validate_content_raises_on_missing_title() -> None:
+    raw: dict[str, Any] = {"summary": "S", "sections": []}
+    with pytest.raises(BriefingGenerationError, match="missing required keys"):
+        _validate_content(raw, candidate_ids=set())
+
+
+def test_validate_content_raises_on_missing_sections() -> None:
+    raw: dict[str, Any] = {"title": "T", "summary": "S"}
+    with pytest.raises(BriefingGenerationError, match="missing required keys"):
+        _validate_content(raw, candidate_ids=set())
+
+
+def test_validate_content_handles_empty_worth_opening() -> None:
+    raw: dict[str, Any] = {"title": "T", "summary": "S", "sections": []}
+    result = _validate_content(raw, candidate_ids={1, 2})
+    assert result["worth_opening"] == []
+
+
+# ── generate_briefing (end-to-end with fake AI) ───────────────────────────────
+
+
+def _fake_ai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+    """Minimal deterministic AI stub: puts the first two candidates in a section."""
+    ids = [c["id"] for c in candidates[:2]]
+    return {
+        "title": "Fake Briefing",
+        "summary": "A fake summary.",
+        "sections": [{"title": "Top Stories", "body": "Stuff happened.", "citations": ids}],
+        "worth_opening": ids[:1],
+    }
+
+
+def test_generate_briefing_no_candidates_returns_status(pg_clean: str) -> None:
+    # No articles seeded → no today candidates
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai)
+    assert result == {"status": "no_candidates"}
+
+
+def test_generate_briefing_creates_briefing_row(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/a1", title="Article 1", state="today")
+    _seed_article(pg_clean, url="https://example.com/a2", title="Article 2", state="today")
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai)
+
+    assert result["title"] == "Fake Briefing"
+    assert result["summary"] == "A fake summary."
+    assert result["status"] == "complete"
+    assert result["scope"] == "since_last_briefing"
+    assert result["since_at"] is not None
+    assert result["until_at"] is not None
+
+
+def test_generate_briefing_links_section_citations(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    a1 = _seed_article(pg_clean, url="https://example.com/b1", title="B1", state="today")
+    a2 = _seed_article(pg_clean, url="https://example.com/b2", title="B2", state="today")
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai)
+
+    article_ids = {a["id"] for a in result["articles"]}
+    assert a1 in article_ids
+    assert a2 in article_ids
+
+    # First article: cited in section 0 at index 0
+    cited = {a["id"]: a for a in result["articles"]}
+    assert cited[a1]["section_index"] == 0
+    assert cited[a1]["citation_index"] == 0
+
+
+def test_generate_briefing_worth_opening_gets_null_indices(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    a1 = _seed_article(pg_clean, url="https://example.com/c1", title="C1", state="today")
+    _seed_article(pg_clean, url="https://example.com/c2", title="C2", state="today")
+    a3 = _seed_article(pg_clean, url="https://example.com/c3", title="C3", state="today")
+
+    def _ai_worth_only(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        ids = [c["id"] for c in candidates]
+        return {
+            "title": "T",
+            "summary": "S",
+            "sections": [{"title": "S0", "body": "B", "citations": [ids[0], ids[1]]}],
+            # a3 appears only in worth_opening (no section citation)
+            "worth_opening": [ids[2]],
+        }
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_ai_worth_only)
+    by_id = {a["id"]: a for a in result["articles"]}
+
+    assert a3 in by_id
+    assert by_id[a3]["section_index"] is None
+    assert by_id[a3]["citation_index"] is None
+    assert a1 in by_id
+    assert by_id[a1]["section_index"] == 0
+
+
+def test_generate_briefing_persisted_to_db(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/d1", title="D1", state="today")
+
+    generate_briefing(database_url=pg_clean, ai_fn=_fake_ai)
+
+    briefings = list_briefings(database_url=pg_clean)
+    assert len(briefings) == 1
+    assert briefings[0]["title"] == "Fake Briefing"

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -570,35 +570,50 @@ def test_generate_briefing_creates_briefing_row(pg_clean: str) -> None:
 
 def test_generate_briefing_links_section_citations(pg_clean: str) -> None:
     _seed_source(pg_clean)
-    a1 = _seed_article(pg_clean, url="https://example.com/b1", title="B1", state="today")
-    a2 = _seed_article(pg_clean, url="https://example.com/b2", title="B2", state="today")
+    # Use distinct importance scores so candidate ordering is deterministic
+    a1 = _seed_article(
+        pg_clean, url="https://example.com/b1", title="B1", state="today", importance_score=90
+    )
+    a2 = _seed_article(
+        pg_clean, url="https://example.com/b2", title="B2", state="today", importance_score=10
+    )
 
+    # _fake_ai puts candidates[0] (a1, score=90) and candidates[1] (a2, score=10) in citations
     result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai)
 
     article_ids = {a["id"] for a in result["articles"]}
     assert a1 in article_ids
     assert a2 in article_ids
 
-    # First article: cited in section 0 at index 0
     cited = {a["id"]: a for a in result["articles"]}
     assert cited[a1]["section_index"] == 0
-    assert cited[a1]["citation_index"] == 0
+    assert cited[a1]["citation_index"] == 0  # a1 is candidates[0] → citation index 0
+    assert cited[a2]["section_index"] == 0
+    assert cited[a2]["citation_index"] == 1  # a2 is candidates[1] → citation index 1
 
 
 def test_generate_briefing_worth_opening_gets_null_indices(pg_clean: str) -> None:
     _seed_source(pg_clean)
-    a1 = _seed_article(pg_clean, url="https://example.com/c1", title="C1", state="today")
-    _seed_article(pg_clean, url="https://example.com/c2", title="C2", state="today")
-    a3 = _seed_article(pg_clean, url="https://example.com/c3", title="C3", state="today")
+    # Seed with distinct importance scores for deterministic candidate order:
+    # candidates order will be: a1 (90), a2 (50), a3 (10)
+    a1 = _seed_article(
+        pg_clean, url="https://example.com/c1", title="C1", state="today", importance_score=90
+    )
+    a2 = _seed_article(
+        pg_clean, url="https://example.com/c2", title="C2", state="today", importance_score=50
+    )
+    a3 = _seed_article(
+        pg_clean, url="https://example.com/c3", title="C3", state="today", importance_score=10
+    )
 
+    # Use a closure so the AI references known IDs directly, ignoring candidate order
     def _ai_worth_only(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
-        ids = [c["id"] for c in candidates]
         return {
             "title": "T",
             "summary": "S",
-            "sections": [{"title": "S0", "body": "B", "citations": [ids[0], ids[1]]}],
-            # a3 appears only in worth_opening (no section citation)
-            "worth_opening": [ids[2]],
+            # a1 and a2 are section citations; a3 appears only in worth_opening
+            "sections": [{"title": "S0", "body": "B", "citations": [a1, a2]}],
+            "worth_opening": [a3],
         }
 
     result = generate_briefing(database_url=pg_clean, ai_fn=_ai_worth_only)
@@ -609,6 +624,10 @@ def test_generate_briefing_worth_opening_gets_null_indices(pg_clean: str) -> Non
     assert by_id[a3]["citation_index"] is None
     assert a1 in by_id
     assert by_id[a1]["section_index"] == 0
+    assert by_id[a1]["citation_index"] == 0
+    assert a2 in by_id
+    assert by_id[a2]["section_index"] == 0
+    assert by_id[a2]["citation_index"] == 1
 
 
 def test_generate_briefing_persisted_to_db(pg_clean: str) -> None:


### PR DESCRIPTION
Closes #102.

## Summary

- **`generate_briefing(database_url, *, model, ai_fn)`** — orchestrates the full flow: resolves `since_at` from the previous briefing's `until_at` (fallback: `now() - 24h`), selects up to 40 `state='today'` articles, calls OpenAI (or an injected `ai_fn`), validates/strips invalid citations, persists to `briefings` + `briefing_articles`, returns the full briefing dict.
- **`POST /api/briefings`** in `main.py` — returns 200 with the briefing on success, 200 `{"status": "no_candidates"}` when no eligible articles, 503 for missing `OPENAI_API_KEY`, 500 for AI/validation failures.
- **5 new API-contract tests** (monkeypatched) covering success, no-candidates, 503, 500 paths.
- **18 new PostgreSQL integration tests** covering `_get_since_at`, `select_candidates`, `_validate_content` (pure unit), and `generate_briefing` end-to-end with a deterministic `_fake_ai` stub.

## Design decisions and open questions

### Decisions made (flagged for review)

**1. `state='today'` only — `state='later'` excluded.**
Spec says "eligible Today articles" explicitly. Later/snoozed articles are not candidates even if recently added. If the intention is "anything the user hasn't archived", the filter needs widening — the spec is silent on this.

**2. `discovered_at >= since_at`, not `published_at`.**
`published_at` is nullable and can be days in the past for RSS backfill items. `discovered_at` is when the article entered the inbox — a better proxy for "what arrived since the last briefing". Could be toggled, but the spec doesn't say.

**3. No-candidates returns HTTP 200, not 4xx.**
The endpoint is idempotent from the client's view — it tried, nothing was eligible. Returning 503 or 404 would wrongly imply an error condition. The `{"status": "no_candidates"}` envelope mirrors the `{"status": "empty"}` pattern in `GET /api/briefings/latest`.

**4. OpenAI `json_object` response format, 2048 token cap.**
Reliable JSON is more important than richness at this stage. The prompt constrains sections to 2-4 sentences each. Raising the cap is a one-liner if needed.

**5. Citation sanitisation, not failure.**
Unknown citation IDs are silently stripped. The contract: whatever the AI hallucinates doesn't crash the endpoint; the worst case is a briefing with fewer references than expected. A stricter policy (reject entirely) seems too fragile for early production.

**6. Failed generations are NOT persisted.**
If the AI call or validation raises, nothing is written to the DB. The spec doesn't specify persistence of failure states. Persisting `status='failed'` rows would be useful for observability but adds schema complexity — left out until there's a concrete monitoring requirement.

**7. `ai_fn` injection for testing (no mock-patching at the OpenAI layer).**
The `generate_briefing` function accepts `ai_fn: Callable[[list[dict], str], dict] | None`. Tests pass a deterministic stub directly; no `sys.modules` hacks. This keeps the AI boundary clean and the tests hermetic.

### Open questions

- **`OPENAI_BRIEFING_MODEL` env var** — added alongside the existing `OPENAI_ANSWER_MODEL` convention. Should these be unified into a single model env var? Currently `gpt-4o-mini` default for both.
- **Idempotency** — calling `POST /api/briefings` twice in quick succession will create two briefings covering almost the same window (the second `since_at` will be the first's `until_at`). Is rate-limiting or a lock needed?
- **`worth_opening` articles in `briefing_articles`** — articles that appear only in `worth_opening` (not cited in any section) are linked with `section_index=NULL, citation_index=NULL`. The frontend needs to differentiate these from section citations. The current read API returns them in NULLS LAST position — is that the right UX?

## Test plan

- [x] `pytest` — 146 passed, 33 skipped (postgres/testcontainers skipped locally, run in CI on ubuntu-latest with Docker)
- [x] `ruff check` — no issues
- [x] `mypy` — no issues
- [x] Pre-commit hooks — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)