### PR TITLE
feat: persist failed briefings + idempotency guard on POST /api/briefings

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -6,6 +6,7 @@ Runtime SQL uses psycopg %s parameter style. No SQLite fallback.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
@@ -16,6 +17,9 @@ from .db import connect, row_to_dict
 
 CANDIDATE_LIMIT = 40
 DEFAULT_BRIEFING_MODEL = "gpt-4o-mini"
+IDEMPOTENCY_WINDOW_MINUTES = 10
+
+logger = logging.getLogger(__name__)
 
 # ── Error types ───────────────────────────────────────────────────────────────
 
@@ -264,6 +268,48 @@ def _save_briefing(
     return result
 
 
+def _find_recent_briefing(
+    window_minutes: int,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the most recent complete briefing if created within window_minutes, else None."""
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            SELECT id FROM briefings
+            WHERE status = 'complete' AND created_at >= %s
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (cutoff,),
+        ).fetchone()
+    if row is None:
+        return None
+    return get_briefing(int(row_to_dict(row)["id"]), database_url=database_url)
+
+
+def _save_failed_briefing(
+    since_at: datetime,
+    until_at: datetime,
+    exc: Exception,
+    model: str,
+    database_url: str | None = None,
+) -> None:
+    """Persist a failed-status row for observability; DB errors are swallowed."""
+    try:
+        with connect(database_url=database_url) as conn:
+            conn.execute(
+                """
+                INSERT INTO briefings(scope, since_at, until_at, status, model, error)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                ("since_last_briefing", since_at, until_at, "failed", model, str(exc)),
+            )
+    except Exception:
+        logger.exception("Failed to persist failed-briefing row — original error follows")
+
+
 # ── Public API ────────────────────────────────────────────────────────────────
 
 
@@ -282,8 +328,12 @@ def generate_briefing(
     *,
     model: str | None = None,
     ai_fn: AiFn | None = None,
+    idempotency_window_minutes: int = IDEMPOTENCY_WINDOW_MINUTES,
 ) -> dict[str, Any]:
     """Generate and persist a briefing from eligible Today articles.
+
+    If a complete briefing already exists within ``idempotency_window_minutes``,
+    return it immediately without calling the AI again.
 
     Returns the saved briefing dict on success, or ``{"status": "no_candidates"}``
     when no eligible articles are found.
@@ -292,6 +342,10 @@ def generate_briefing(
         BriefingAINotConfiguredError: OPENAI_API_KEY is not set.
         BriefingGenerationError: AI returned an invalid or unparseable response.
     """
+    recent = _find_recent_briefing(idempotency_window_minutes, database_url)
+    if recent is not None:
+        return recent
+
     _env_model = os.getenv("OPENAI_BRIEFING_MODEL", DEFAULT_BRIEFING_MODEL)
     resolved_model = model if model is not None else _env_model
     since_at = _get_since_at(database_url)
@@ -303,9 +357,12 @@ def generate_briefing(
 
     candidate_ids = {int(a["id"]) for a in candidates}
     call_ai: AiFn = ai_fn if ai_fn is not None else _call_openai
-    raw_content = call_ai(candidates, resolved_model)
-
-    content = _validate_content(raw_content, candidate_ids)
+    try:
+        raw_content = call_ai(candidates, resolved_model)
+        content = _validate_content(raw_content, candidate_ids)
+    except (BriefingAINotConfiguredError, BriefingGenerationError) as exc:
+        _save_failed_briefing(since_at, until_at, exc, resolved_model, database_url)
+        raise
     return _save_briefing(since_at, until_at, content, candidate_ids, resolved_model, database_url)
 
 

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -308,3 +308,11 @@ def test_create_returns_content_and_articles_on_success(monkeypatch: Any) -> Non
     assert "sections" in data["content"]
     assert "articles" in data
     assert len(data["articles"]) > 0
+
+
+def test_create_returns_existing_briefing_inside_idempotency_window(monkeypatch: Any) -> None:
+    existing = dict(_SAMPLE_BRIEFING)
+    monkeypatch.setattr(main_mod, "generate_briefing", lambda: existing)
+    resp = client.post("/api/briefings")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == existing["id"]

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -17,6 +17,7 @@ import pytest
 
 from news_dashboard.briefings import (
     CANDIDATE_LIMIT,
+    IDEMPOTENCY_WINDOW_MINUTES,
     BriefingGenerationError,
     _get_since_at,
     _validate_content,
@@ -639,3 +640,109 @@ def test_generate_briefing_persisted_to_db(pg_clean: str) -> None:
     briefings = list_briefings(database_url=pg_clean)
     assert len(briefings) == 1
     assert briefings[0]["title"] == "Fake Briefing"
+
+
+# ── Failed-status persistence ─────────────────────────────────────────────────
+
+
+def test_generate_briefing_persists_failed_row_on_generation_error(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/e1", title="E1", state="today")
+
+    def _bad_ai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        msg = "simulated AI failure"
+        raise BriefingGenerationError(msg)
+
+    with pytest.raises(BriefingGenerationError):
+        generate_briefing(database_url=pg_clean, ai_fn=_bad_ai)
+
+    briefings = list_briefings(database_url=pg_clean)
+    assert len(briefings) == 1
+    assert briefings[0]["status"] == "failed"
+    assert "simulated AI failure" in (briefings[0]["error"] or "")
+
+
+def test_generate_briefing_failed_row_has_no_content(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/f1", title="F1", state="today")
+
+    def _bad_ai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        msg = "boom"
+        raise BriefingGenerationError(msg)
+
+    with pytest.raises(BriefingGenerationError):
+        generate_briefing(database_url=pg_clean, ai_fn=_bad_ai)
+
+    result = get_latest_briefing(database_url=pg_clean)
+    assert result is not None
+    assert result["status"] == "failed"
+    assert result["content"] is None
+    assert result["articles"] == []
+
+
+# ── Idempotency guard ─────────────────────────────────────────────────────────
+
+
+def test_generate_briefing_returns_recent_briefing_without_calling_ai(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_briefing(pg_clean, title="Existing Brief")  # created_at = NOW()
+
+    def _should_not_run(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        msg = "AI was called inside idempotency window"
+        raise AssertionError(msg)
+
+    result = generate_briefing(
+        database_url=pg_clean,
+        ai_fn=_should_not_run,
+        idempotency_window_minutes=IDEMPOTENCY_WINDOW_MINUTES,
+    )
+    assert result["title"] == "Existing Brief"
+
+
+def test_generate_briefing_skips_idempotency_when_window_is_zero(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_briefing(pg_clean, title="Old Brief")
+    _seed_article(pg_clean, url="https://example.com/g1", title="G1", state="today")
+
+    result = generate_briefing(
+        database_url=pg_clean,
+        ai_fn=_fake_ai,
+        idempotency_window_minutes=0,
+    )
+    # A window of 0 minutes means no guard — a new briefing should be generated
+    assert result["title"] == "Fake Briefing"
+    assert len(list_briefings(database_url=pg_clean)) == 2  # old + new
+
+
+def test_generate_briefing_ignores_failed_rows_in_idempotency_check(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    a1 = _seed_article(pg_clean, url="https://example.com/h1", title="H1", state="today")
+
+    def _bad_then_good_ai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        # First call: fail; second call (outside the guard): succeed
+        return {
+            "title": "Recovery Brief",
+            "summary": "S",
+            "sections": [{"title": "S", "body": "B", "citations": [a1]}],
+            "worth_opening": [],
+        }
+
+    def _always_fail(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        msg = "fail"
+        raise BriefingGenerationError(msg)
+
+    with pytest.raises(BriefingGenerationError):
+        generate_briefing(
+            database_url=pg_clean,
+            ai_fn=_always_fail,
+            idempotency_window_minutes=IDEMPOTENCY_WINDOW_MINUTES,
+        )
+
+    # Failed row exists — but it should NOT block a retry
+    result = generate_briefing(
+        database_url=pg_clean,
+        ai_fn=_bad_then_good_ai,
+        idempotency_window_minutes=IDEMPOTENCY_WINDOW_MINUTES,
+    )
+    assert result["status"] == "complete"
+    assert result["title"] == "Recovery Brief"


### PR DESCRIPTION
Follow-up to #108 (merged). Applies two behaviours requested after review.

## Changes

**Failed-status persistence:** when the AI call or validation raises `BriefingAINotConfiguredError` or `BriefingGenerationError`, a `briefings` row with `status='failed'` and the error message is inserted before re-raising. DB errors during that insert are swallowed and logged so they can't obscure the original failure.

**Idempotency guard:** if a `status='complete'` briefing already exists with `created_at` within the last `IDEMPOTENCY_WINDOW_MINUTES` (10 min, injectable per-call), `generate_briefing` returns it immediately without touching the AI. Failed rows are intentionally excluded from the guard so a user can always retry after a failure.

## Tests added

- `test_generate_briefing_persists_failed_row_on_generation_error` — error row written, correct message
- `test_generate_briefing_failed_row_has_no_content` — failed row has `content=NULL`, empty articles list
- `test_generate_briefing_returns_recent_briefing_without_calling_ai` — AI stub that raises if called; proves no call happens inside window
- `test_generate_briefing_skips_idempotency_when_window_is_zero` — window=0 disables guard
- `test_generate_briefing_ignores_failed_rows_in_idempotency_check` — failed row does not block retry
- `test_create_returns_existing_briefing_inside_idempotency_window` — API-layer smoke test

## Test plan
- [x] `pytest` — 147 passed, 38 skipped (postgres skipped locally; tested in CI with Docker)
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [x] pre-commit hooks — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)