### PR TITLE
feat: Brief as default route, Today at /today, nav + shortcuts (#104 #105)

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
 import { FocusedArticleProvider } from './contexts/focusedArticle';
 import { AppShell } from './components/AppShell';
+import { BriefPage } from './pages/BriefPage';
 import { InboxPage } from './pages/InboxPage';
 import { LaterPage } from './pages/LaterPage';
 import { StarredPage } from './pages/StarredPage';
@@ -15,7 +16,6 @@ import { StatsPage } from './pages/StatsPage';
 import { ArchivePage } from './pages/ArchivePage';
 import { SettingsPage } from './pages/SettingsPage';
 import { ArticlePage } from './pages/ArticlePage';
-import { BriefPage } from './pages/BriefPage';
 
 function NotFound() {
   return (
@@ -48,12 +48,12 @@ const router = createBrowserRouter([
     path: '/',
     element: <AppShell />,
     children: [
-      { index: true, element: <InboxPage /> },
+      { index: true, element: <BriefPage /> },
+      { path: 'today', element: <InboxPage /> },
       { path: 'later', element: <LaterPage /> },
       { path: 'starred', element: <StarredPage /> },
       { path: 'search', element: <SearchPage /> },
       { path: 'ask', element: <AskPage /> },
-      { path: 'brief', element: <BriefPage /> },
       {
         path: 'feeds',
         element: <FeedsPage />,
@@ -69,7 +69,7 @@ const router = createBrowserRouter([
       { path: 'settings', element: <SettingsPage /> },
 
       /* Legacy route redirects — remove when each migration slice lands */
-      { path: 'inbox', element: <Navigate to="/" replace /> },
+      { path: 'inbox', element: <Navigate to="/today" replace /> },
       { path: 'saved', element: <Navigate to="/starred" replace /> },
       { path: 'read', element: <Navigate to="/archive" replace /> },
       { path: 'skipped', element: <Navigate to="/archive" replace /> },

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment happy-dom
+/**
+ * Routing and navigation tests for #104 (Brief default route, Today at /today)
+ * and #105 (command palette + keyboard shortcuts for Brief/Today).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AppShell } from '../components/AppShell';
+import { CommandPalette } from '../components/CommandPalette';
+import { ShortcutOverlay } from '../components/ShortcutOverlay';
+import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import * as api from '../api';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+// ── Silence deps that don't affect these tests ────────────────────────────────
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    loading: vi.fn(() => 'toast-id'),
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useTriageMutations', () => ({
+  useTriageMutations: () => ({ setState: vi.fn(), toggleStar: vi.fn(), sendLater: vi.fn() }),
+  ARTICLES_KEY: 'articles',
+}));
+
+// Silence BriefPage's briefing fetch during AppShell render tests
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api')>();
+  return {
+    ...actual,
+    fetchLatestBriefing: vi.fn().mockReturnValue(new Promise((_r) => undefined)),
+    fetchSummary: vi.fn().mockResolvedValue({ byStatus: {}, byCategory: {} }),
+    searchArticles: vi.fn().mockResolvedValue([]),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeQc() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderShell(initialPath = '/') {
+  const qc = makeQc();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <FocusedArticleProvider>
+          <AppShell />
+        </FocusedArticleProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderPalette(open = true) {
+  const qc = makeQc();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <FocusedArticleProvider>
+          <CommandPalette open={open} onOpenChange={vi.fn()} />
+        </FocusedArticleProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ── #104: Desktop navigation items ───────────────────────────────────────────
+
+describe('#104 — desktop rail navigation', () => {
+  it('shows Brief in desktop nav', async () => {
+    renderShell('/');
+    await waitFor(() => {
+      const links = screen.getAllByRole('link', { name: /brief/i });
+      expect(links.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shows Today in desktop nav', async () => {
+    renderShell('/today');
+    await waitFor(() => {
+      const links = screen.getAllByRole('link', { name: /today/i });
+      expect(links.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('Brief link points to /', async () => {
+    renderShell('/');
+    await waitFor(() => {
+      const briefLinks = screen
+        .getAllByRole('link', { name: /brief/i })
+        .filter((l) => l.getAttribute('href') === '/');
+      expect(briefLinks.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('Today link points to /today', async () => {
+    renderShell('/today');
+    await waitFor(() => {
+      const todayLinks = screen
+        .getAllByRole('link', { name: /today/i })
+        .filter((l) => l.getAttribute('href') === '/today');
+      expect(todayLinks.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ── #104: Mobile bottom nav items ────────────────────────────────────────────
+
+describe('#104 — mobile bottom navigation', () => {
+  it('Brief appears in mobile nav', async () => {
+    renderShell('/');
+    await waitFor(() => {
+      const briefLinks = screen
+        .getAllByRole('link', { name: /brief/i })
+        .filter((l) => l.getAttribute('href') === '/');
+      expect(briefLinks.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('Today appears in mobile nav', async () => {
+    renderShell('/today');
+    await waitFor(() => {
+      const todayLinks = screen
+        .getAllByRole('link', { name: /today/i })
+        .filter((l) => l.getAttribute('href') === '/today');
+      expect(todayLinks.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ── #104: Page title reflects route ──────────────────────────────────────────
+
+describe('#104 — header title', () => {
+  it('shows "Brief" as title at /', async () => {
+    renderShell('/');
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Brief' })).toBeTruthy());
+  });
+
+  it('shows "Today" as title at /today', async () => {
+    renderShell('/today');
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Today' })).toBeTruthy());
+  });
+});
+
+// ── #105: Command palette navigation entries ──────────────────────────────────
+
+describe('#105 — command palette navigation', () => {
+  it('shows Brief as a nav item in the palette', () => {
+    renderPalette();
+    expect(screen.getByText('Brief')).toBeTruthy();
+  });
+
+  it('shows Today as a nav item in the palette', () => {
+    renderPalette();
+    expect(screen.getByText('Today')).toBeTruthy();
+  });
+
+  it('shows both Brief and Today in the palette', () => {
+    renderPalette();
+    const items = screen.getAllByRole('option');
+    const labels = items.map((i) => i.textContent ?? '');
+    expect(labels.some((l) => l.includes('Brief'))).toBe(true);
+    expect(labels.some((l) => l.includes('Today'))).toBe(true);
+  });
+});
+
+// ── #105: Shortcut overlay text ───────────────────────────────────────────────
+
+describe('#105 — shortcut overlay', () => {
+  it('mentions g b for Brief', () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText(/g b/i)).toBeTruthy();
+  });
+
+  it('mentions g t for Today', () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText(/g t/i)).toBeTruthy();
+  });
+
+  it('has Brief in shortcut descriptions', () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText(/brief/i)).toBeTruthy();
+  });
+
+  it('has Today in shortcut descriptions', () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getAllByText(/today/i).length).toBeGreaterThan(0);
+  });
+});
+
+// ── #105: Keyboard shortcut navigation ───────────────────────────────────────
+
+describe('#105 — g-key shortcuts via AppShell', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchSummary').mockResolvedValue({ byStatus: {}, byCategory: {} });
+  });
+
+  it('g then b navigates to / (Brief)', async () => {
+    const qc = makeQc();
+    // We can't easily spy on react-router navigate in unit tests,
+    // so we verify the shortcut wiring via the keyboard test for AppShell.
+    // This test checks the key handler registers 'b' for Brief.
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/today']}>
+          <FocusedArticleProvider>
+            <AppShell />
+          </FocusedArticleProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    // Fire g then b — if wired, the URL would change; we verify no error is thrown.
+    await userEvent.keyboard('gb');
+    // Verify the component renders without error after the keypress.
+    expect(screen.getAllByText('Brief').length).toBeGreaterThan(0);
+  });
+
+  it('g then t navigates to /today (Today)', async () => {
+    const qc = makeQc();
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/']}>
+          <FocusedArticleProvider>
+            <AppShell />
+          </FocusedArticleProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    await userEvent.keyboard('gt');
+    expect(screen.getAllByText('Brief').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import { useLocation, useNavigate, Outlet, Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
+  Newspaper,
   Inbox,
   Clock,
   Star,
@@ -32,14 +33,23 @@ function useNavCounts() {
   };
 }
 
-const navItems: { to: string; label: string; icon: React.ComponentType<{ className?: string }> }[] =
-  [
-    { to: '/', label: 'Today', icon: Inbox },
-    { to: '/later', label: 'Later', icon: Clock },
-    { to: '/starred', label: 'Starred', icon: Star },
-    { to: '/search', label: 'Search', icon: Search },
-    { to: '/ask', label: 'Ask', icon: Sparkles },
-  ];
+interface NavItem {
+  to: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+// Desktop rail shows all primary + ask; mobile nav shows only the first 5.
+const navItems: NavItem[] = [
+  { to: '/', label: 'Brief', icon: Newspaper },
+  { to: '/today', label: 'Today', icon: Inbox },
+  { to: '/later', label: 'Later', icon: Clock },
+  { to: '/starred', label: 'Starred', icon: Star },
+  { to: '/search', label: 'Search', icon: Search },
+  { to: '/ask', label: 'Ask', icon: Sparkles },
+];
+
+const mobileNavItems = navItems.slice(0, 5);
 
 const moreItems = [
   { to: '/feeds', label: 'Feeds', icon: Radio },
@@ -48,8 +58,14 @@ const moreItems = [
   { to: '/settings', label: 'Settings', icon: Settings },
 ];
 
+function isNavActive(to: string, pathname: string): boolean {
+  if (to === '/' || to === '/today') return pathname === to;
+  return pathname.startsWith(to);
+}
+
 function currentTitle(p: string) {
-  if (p === '/') return 'Today';
+  if (p === '/') return 'Brief';
+  if (p === '/today') return 'Today';
   if (p.startsWith('/later')) return 'Later';
   if (p.startsWith('/starred')) return 'Starred';
   if (p.startsWith('/search')) return 'Search';
@@ -64,14 +80,14 @@ function currentTitle(p: string) {
 function DesktopRail({ pathname }: { pathname: string }) {
   const counts = useNavCounts();
   const countFor = (to: string): number | null =>
-    to === '/' ? counts.today : to === '/starred' ? counts.starred : null;
+    to === '/today' ? counts.today : to === '/starred' ? counts.starred : null;
 
   return (
     <aside className="hidden md:flex md:flex-col md:w-[200px] md:shrink-0 md:border-r md:border-border md:min-h-[calc(100vh-3rem)] md:sticky md:top-12 md:self-start">
       <nav className="flex flex-col p-2 gap-0.5">
         {navItems.map((n) => {
           const Icon = n.icon;
-          const active = n.to === '/' ? pathname === '/' : pathname.startsWith(n.to);
+          const active = isNavActive(n.to, pathname);
           const count = countFor(n.to);
           return (
             <Link
@@ -145,7 +161,8 @@ export function AppShell() {
       } else if (e.key === 'g') {
         const handler2 = (e2: KeyboardEvent) => {
           const k = e2.key.toLowerCase();
-          if (k === 't') navigate('/');
+          if (k === 'b') navigate('/');
+          else if (k === 't') navigate('/today');
           else if (k === 'l') navigate('/later');
           else if (k === 's') navigate('/starred');
           else if (k === 'a') navigate('/ask');
@@ -253,9 +270,9 @@ export function AppShell() {
       {/* Mobile bottom nav */}
       <nav className="md:hidden fixed bottom-0 inset-x-0 z-30 border-t border-border bg-background/95 backdrop-blur pb-[env(safe-area-inset-bottom)]">
         <div className="grid grid-cols-5">
-          {navItems.map((n) => {
+          {mobileNavItems.map((n) => {
             const Icon = n.icon;
-            const active = n.to === '/' ? pathname === '/' : pathname.startsWith(n.to);
+            const active = isNavActive(n.to, pathname);
             return (
               <Link
                 key={n.to}

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -6,6 +6,7 @@ import { Command } from 'cmdk';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { toast } from 'sonner';
 import {
+  Newspaper,
   Inbox,
   Clock,
   Star,
@@ -34,7 +35,8 @@ interface Props {
 }
 
 const NAV_ITEMS = [
-  { icon: Inbox, label: 'Today', to: '/' },
+  { icon: Newspaper, label: 'Brief', to: '/' },
+  { icon: Inbox, label: 'Today', to: '/today' },
   { icon: Clock, label: 'Later', to: '/later' },
   { icon: Star, label: 'Starred', to: '/starred' },
   { icon: Search, label: 'Search', to: '/search' },

--- a/frontend/src/components/ShortcutOverlay.tsx
+++ b/frontend/src/components/ShortcutOverlay.tsx
@@ -11,7 +11,8 @@ const SECTIONS: { title: string; items: [string, string][] }[] = [
     items: [
       ['j / k', 'Move down / up in list'],
       ['Enter', 'Open selected article'],
-      ['g t / g l / g s', 'Go to Today / Later / Starred'],
+      ['g b / g t', 'Go to Brief / Today'],
+      ['g l / g s', 'Go to Later / Starred'],
       ['g a / g f', 'Go to Ask / Feeds'],
     ],
   },

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -246,7 +246,7 @@ export function BriefPage() {
               {isGenerating ? 'Retrying…' : 'Retry'}
             </Button>
           )}
-          <Button size="sm" variant="outline" onClick={() => navigate('/')}>
+          <Button size="sm" variant="outline" onClick={() => navigate('/today')}>
             <Inbox />
             Review Today feed
           </Button>
@@ -267,7 +267,7 @@ export function BriefPage() {
           </div>
         </div>
         <div className="flex justify-center">
-          <Button size="sm" variant="outline" onClick={() => navigate('/')}>
+          <Button size="sm" variant="outline" onClick={() => navigate('/today')}>
             <Inbox />
             Review Today feed
           </Button>
@@ -292,7 +292,7 @@ export function BriefPage() {
             <RefreshCw className={isGenerating ? 'animate-spin' : ''} />
             {isGenerating ? 'Generating…' : 'Generate briefing'}
           </Button>
-          <Button size="sm" variant="outline" onClick={() => navigate('/')}>
+          <Button size="sm" variant="outline" onClick={() => navigate('/today')}>
             <Inbox />
             Review Today feed
           </Button>
@@ -319,7 +319,7 @@ export function BriefPage() {
             <RefreshCw className={isGenerating ? 'animate-spin' : ''} />
             {isGenerating ? 'Retrying…' : 'Retry'}
           </Button>
-          <Button size="sm" variant="outline" onClick={() => navigate('/')}>
+          <Button size="sm" variant="outline" onClick={() => navigate('/today')}>
             <Inbox />
             Review Today feed
           </Button>


### PR DESCRIPTION
## Summary

- **Routing (#104):** `/` now renders `BriefPage`; `/today` renders the existing feed (`InboxPage`); `/inbox` redirects to `/today`
- **Navigation (#104):** Desktop rail shows Brief + Today + Later + Starred + Search + Ask (6 items); mobile bottom nav shows first 5 (Brief, Today, Later, Starred, Search); active states use exact match for `/` and `/today` to avoid false positives; article count badge moves from `/` to `/today`
- **Keyboard shortcuts (#104 + #105):** `g b` → Brief (`/`), `g t` → Today (`/today`); other shortcuts unchanged
- **Command palette (#105):** Brief and Today are separate nav entries
- **Shortcut overlay (#105):** Documents `g b / g t` for Brief / Today
- **BriefPage fix:** "Review Today feed" buttons now navigate to `/today` (was `/`)

## Routing notes

- Old bookmarks to `/` now land on Brief (the new home) — intentional per spec
- `/inbox` → `/today` legacy redirect preserves old links
- The design spec's "More" as 5th mobile nav item is deferred; Search fills slot 5 for now

## Test plan

- [ ] 17 new tests in `routing.test.tsx`: desktop nav links, mobile nav links, header title at `/` and `/today`, command palette entries for Brief + Today, shortcut overlay text, g-key smoke tests
- [ ] `npm run test:frontend` → 125 tests pass (9 files)
- [ ] `pytest backend/tests/` → 147 pass, 38 skipped
- [ ] `npm run typecheck` + `npm run lint` → clean

Closes #104, Closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)