### PR TITLE
fix: self-host fonts via Fontsource, eliminate Google Fonts CDN (#113)

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -158,12 +158,6 @@ function json(data: unknown, status = 200) {
  * matching handler.
  */
 export async function mockApi(page: Page) {
-  // Stub external font CDN so tests don't depend on network access
-  await page.route('https://fonts.googleapis.com/**', (r) => r.fulfill({ status: 200, body: '' }));
-  await page.route('https://fonts.gstatic.com/**', (r) =>
-    r.fulfill({ status: 200, contentType: 'font/woff2', body: Buffer.alloc(0) })
-  );
-
   // Summary / counts
   await page.route('/api/summary', (r) => r.fulfill(json(SUMMARY_DATA)));
 

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -1,5 +1,8 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
+@import '@fontsource-variable/inter/wght.css';
+@import '@fontsource-variable/jetbrains-mono/wght.css';
+@import '@fontsource-variable/source-serif-4/wght.css';
 
 /* Map Tailwind's dark: variant to [data-theme=dark] */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
@@ -44,9 +47,9 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  --font-serif: 'Source Serif 4', 'Iowan Old Style', Georgia, serif;
+  --font-sans: 'Inter Variable', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono Variable', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-serif: 'Source Serif 4 Variable', 'Iowan Old Style', Georgia, serif;
 }
 
 :root {
@@ -209,31 +212,6 @@
     box-shadow: inset 2px 0 0 var(--color-accent);
     background: color-mix(in oklch, var(--color-accent) 6%, transparent);
   }
-}
-
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZhrib2Bg-4.woff2')
-    format('woff2');
-}
-@font-face {
-  font-family: 'JetBrains Mono';
-  font-style: normal;
-  font-weight: 100 800;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/jetbrainsmono/v24/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxjPVmUsaaDhw.woff2')
-    format('woff2');
-}
-@font-face {
-  font-family: 'Source Serif 4';
-  font-style: normal;
-  font-weight: 200 900;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjihdqrhxXD-wGvjU.woff2')
-    format('woff2');
 }
 
 /* Neutralise global a { color: ... } from legacy styles.css inside new shell */

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/source-serif-4": "^5.2.9",
         "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -767,6 +770,36 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/source-serif-4": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-serif-4/-/source-serif-4-5.2.9.tgz",
+      "integrity": "sha512-PPcxjLFk/fS0WHg79pDM2YNvz61kC+oYZ5cWZZyCS0DHpJncmuYOuiZAsvj4tDxlWPBEvxxcRLQQNmSaRbPkqw==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/source-serif-4": "^5.2.9",
     "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## Summary

Eliminates the Google Fonts CDN dependency by self-hosting all three fonts via Fontsource npm packages. Vite bundles the woff2 files at build time so fonts load in any environment — offline, CI, network-restricted deploys — without any external request.

## What changed

**`globals.css`**
- Replaced three stale `fonts.gstatic.com` `@font-face` URLs (which were returning 404) with Fontsource imports
- Updated CSS variable font-family names to match Fontsource's variable-font convention

**`package.json`** — three new devDependencies:
- `@fontsource-variable/inter` → `'Inter Variable'` (was `'Inter'`)
- `@fontsource-variable/jetbrains-mono` → `'JetBrains Mono Variable'`
- `@fontsource-variable/source-serif-4` → `'Source Serif 4 Variable'`

**`e2e/fixtures.ts`** — removed the `fonts.gstatic.com` route stubs added in PR #114; fonts are bundled now so they never hit the network.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:frontend` — 125/125 pass
- [x] `python -m pytest backend/ -q` — 147 pass, 38 skip
- [x] `npx playwright test --project=chromium-desktop` — 130/130 pass (no font 404 errors)

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)