### PR TITLE
feat: scheduled daily briefing at 09:00 UTC, configurable via BRIEFING_CRON (#119)

### DIFF
--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -1,4 +1,4 @@
-"""Scheduler module: periodic ingest + daily digest email."""
+"""Scheduler module: periodic ingest, daily digest email, and daily briefing."""
 
 from __future__ import annotations
 
@@ -31,6 +31,28 @@ def _run_ingest() -> None:
         logger.info("Scheduled ingest complete: %d new articles", total)
     except Exception:
         logger.exception("Scheduled ingest failed")
+
+
+def _run_briefing() -> None:
+    from .briefings import (
+        BriefingAINotConfiguredError,
+        BriefingGenerationError,
+        generate_briefing,
+    )
+
+    logger.info("Scheduled briefing generation starting…")
+    try:
+        result = generate_briefing()
+        if result.get("status") == "no_candidates":
+            logger.info("Scheduled briefing skipped: no candidate articles found.")
+        else:
+            logger.info("Scheduled briefing complete: id=%s", result.get("id"))
+    except BriefingAINotConfiguredError:
+        logger.warning("Scheduled briefing skipped: OPENAI_API_KEY not configured.")
+    except BriefingGenerationError:
+        logger.exception("Scheduled briefing failed (generation error)")
+    except Exception:
+        logger.exception("Scheduled briefing failed (unexpected error)")
 
 
 def _run_digest() -> None:
@@ -68,6 +90,7 @@ def start_scheduler() -> None:
     start_paused = db_paused == "true" if db_paused is not None else False
 
     digest_cron = os.getenv("DIGEST_CRON", "0 8 * * *")
+    briefing_cron = os.getenv("BRIEFING_CRON", "0 9 * * *")
 
     scheduler = BackgroundScheduler(timezone="UTC")
 
@@ -98,6 +121,25 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
+    try:
+        b_parts = briefing_cron.strip().split()
+        if len(b_parts) >= 2:
+            b_minute = b_parts[0]
+            b_hour = b_parts[1]
+        else:
+            b_minute, b_hour = "0", "9"
+    except Exception:
+        b_minute, b_hour = "0", "9"
+
+    scheduler.add_job(
+        _run_briefing,
+        trigger="cron",
+        hour=b_hour,
+        minute=b_minute,
+        id="briefing",
+        replace_existing=True,
+    )
+
     scheduler.start()
     _state.scheduler = scheduler
 
@@ -109,10 +151,12 @@ def start_scheduler() -> None:
             logger.exception("Failed to pause ingest job on startup")
     else:
         logger.info(
-            "Scheduler started: ingest every %d min, digest at %s:%s UTC",
+            "Scheduler started: ingest every %d min, digest at %s:%s UTC, briefing at %s:%s UTC",
             interval_minutes,
             cron_hour.zfill(2),
             cron_minute.zfill(2),
+            b_hour.zfill(2),
+            b_minute.zfill(2),
         )
 
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,171 @@
+"""Unit tests for scheduler.py — briefing job and cron wiring.
+
+No APScheduler or database is required; all external dependencies are patched.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.briefings import BriefingAINotConfiguredError, BriefingGenerationError
+from news_dashboard.scheduler import _run_briefing
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# _run_briefing does `from .briefings import generate_briefing` lazily,
+# so the correct patch target is the briefings module itself.
+_GEN_PATH = "news_dashboard.briefings.generate_briefing"
+
+
+# ── _run_briefing — happy path ────────────────────────────────────────────────
+
+
+def test_run_briefing_calls_generate_briefing() -> None:
+    with patch(_GEN_PATH) as mock_gen:
+        mock_gen.return_value = {"id": 1, "status": "complete", "title": "Daily Brief"}
+        _run_briefing()
+    mock_gen.assert_called_once_with()
+
+
+def test_run_briefing_logs_completion(caplog: pytest.LogCaptureFixture) -> None:
+    with (
+        caplog.at_level(logging.INFO, logger="news_dashboard.scheduler"),
+        patch(_GEN_PATH) as mock_gen,
+    ):
+        mock_gen.return_value = {"id": 42, "status": "complete", "title": "T"}
+        _run_briefing()
+    assert any("42" in r.message for r in caplog.records)
+
+
+def test_run_briefing_logs_no_candidates(caplog: pytest.LogCaptureFixture) -> None:
+    with (
+        caplog.at_level(logging.INFO, logger="news_dashboard.scheduler"),
+        patch(_GEN_PATH) as mock_gen,
+    ):
+        mock_gen.return_value = {"status": "no_candidates"}
+        _run_briefing()
+    assert any("no candidate" in r.message.lower() for r in caplog.records)
+
+
+# ── _run_briefing — error handling ────────────────────────────────────────────
+
+
+def test_run_briefing_suppresses_ai_not_configured() -> None:
+    with patch(_GEN_PATH) as mock_gen:
+        mock_gen.side_effect = BriefingAINotConfiguredError("no key")
+        _run_briefing()  # must not raise
+
+
+def test_run_briefing_logs_warning_when_ai_not_configured(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        caplog.at_level(logging.WARNING, logger="news_dashboard.scheduler"),
+        patch(_GEN_PATH) as mock_gen,
+    ):
+        mock_gen.side_effect = BriefingAINotConfiguredError("no key")
+        _run_briefing()
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_run_briefing_suppresses_generation_error() -> None:
+    with patch(_GEN_PATH) as mock_gen:
+        mock_gen.side_effect = BriefingGenerationError("bad json")
+        _run_briefing()  # must not raise
+
+
+def test_run_briefing_suppresses_unexpected_exception() -> None:
+    with patch(_GEN_PATH) as mock_gen:
+        mock_gen.side_effect = RuntimeError("totally unexpected")
+        _run_briefing()  # must not raise
+
+
+def test_run_briefing_logs_generation_error(caplog: pytest.LogCaptureFixture) -> None:
+    with (
+        caplog.at_level(logging.ERROR, logger="news_dashboard.scheduler"),
+        patch(_GEN_PATH) as mock_gen,
+    ):
+        mock_gen.side_effect = BriefingGenerationError("bad json")
+        _run_briefing()
+    assert any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+# ── start_scheduler — BRIEFING_CRON wiring ───────────────────────────────────
+
+# All three lazy imports in start_scheduler() must be patched at their source:
+#   from apscheduler.schedulers.background import BackgroundScheduler
+#   from .db import get_setting, init_db
+_BGSCHED_PATH = "apscheduler.schedulers.background.BackgroundScheduler"
+_INIT_DB_PATH = "news_dashboard.db.init_db"
+_GET_SETTING_PATH = "news_dashboard.db.get_setting"
+
+
+def _start_with_env(monkeypatch: pytest.MonkeyPatch, briefing_cron: str | None = None) -> MagicMock:
+    """Run start_scheduler() with APScheduler mocked; return the mock scheduler."""
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = None
+
+    if briefing_cron is not None:
+        monkeypatch.setenv("BRIEFING_CRON", briefing_cron)
+    else:
+        monkeypatch.delenv("BRIEFING_CRON", raising=False)
+
+    with (
+        patch(_BGSCHED_PATH, return_value=mock_sched),
+        patch(_INIT_DB_PATH),
+        patch(_GET_SETTING_PATH, return_value=None),
+    ):
+        from news_dashboard import scheduler
+
+        # Reset module-level state between tests
+        scheduler._state.scheduler = None
+        scheduler.start_scheduler()
+
+    return mock_sched
+
+
+def test_start_scheduler_registers_briefing_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_sched = _start_with_env(monkeypatch)
+    ids = [c.kwargs.get("id") for c in mock_sched.add_job.call_args_list]
+    assert "briefing" in ids
+
+
+def test_start_scheduler_briefing_default_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default BRIEFING_CRON = '0 9 * * *' → hour='9', minute='0'."""
+    mock_sched = _start_with_env(monkeypatch, briefing_cron=None)
+    briefing_call = next(
+        c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "briefing"
+    )
+    assert briefing_call.kwargs["hour"] == "9"
+    assert briefing_call.kwargs["minute"] == "0"
+
+
+def test_start_scheduler_briefing_custom_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BRIEFING_CRON='30 7 * * *' → hour='7', minute='30'."""
+    mock_sched = _start_with_env(monkeypatch, briefing_cron="30 7 * * *")
+    briefing_call = next(
+        c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "briefing"
+    )
+    assert briefing_call.kwargs["hour"] == "7"
+    assert briefing_call.kwargs["minute"] == "30"
+
+
+def test_start_scheduler_briefing_uses_cron_trigger(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_sched = _start_with_env(monkeypatch)
+    briefing_call = next(
+        c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "briefing"
+    )
+    assert briefing_call.kwargs["trigger"] == "cron"
+
+
+def test_start_scheduler_briefing_fn_is_run_briefing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.scheduler import _run_briefing as expected_fn
+
+    mock_sched = _start_with_env(monkeypatch)
+    briefing_call = next(
+        c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "briefing"
+    )
+    assert briefing_call.args[0] is expected_fn

--- a/e2e/briefs.spec.ts
+++ b/e2e/briefs.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * E2E tests for the Briefing History pages (/briefs and /briefs/:id).
+ */
+import { test, expect } from '@playwright/test';
+import { mockApi, SAMPLE_BRIEFING } from './fixtures';
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test.describe('Briefing History list — /briefs', () => {
+  test('shows Briefs heading', async ({ page }) => {
+    await page.goto('/briefs');
+    await expect(page.locator('h1').filter({ hasText: 'Briefs' })).toBeVisible();
+  });
+
+  test('shows page sub-heading', async ({ page }) => {
+    await page.goto('/briefs');
+    await expect(page.getByText('Briefing History')).toBeVisible();
+  });
+
+  test('renders briefing title in the list', async ({ page }) => {
+    await page.goto('/briefs');
+    await expect(page.getByText(SAMPLE_BRIEFING.title)).toBeVisible();
+  });
+
+  test('briefing row links to detail page', async ({ page }) => {
+    await page.goto('/briefs');
+    const row = page.getByRole('link', { name: new RegExp(SAMPLE_BRIEFING.title) });
+    await expect(row).toBeVisible();
+    await expect(row).toHaveAttribute('href', `/briefs/${SAMPLE_BRIEFING.id}`);
+  });
+
+  test('briefing summary snippet is shown', async ({ page }) => {
+    await page.goto('/briefs');
+    await expect(page.locator('main')).toContainText(
+      SAMPLE_BRIEFING.summary.slice(0, 30)
+    );
+  });
+
+  test('clicking a row navigates to the detail page', async ({ page }) => {
+    await page.goto('/briefs');
+    const row = page.getByRole('link', { name: new RegExp(SAMPLE_BRIEFING.title) });
+    await row.click();
+    await expect(page).toHaveURL(`/briefs/${SAMPLE_BRIEFING.id}`);
+  });
+});
+
+test.describe('Briefing History detail — /briefs/:id', () => {
+  test('shows Briefs heading', async ({ page }) => {
+    await page.goto(`/briefs/${SAMPLE_BRIEFING.id}`);
+    await expect(page.locator('h1').filter({ hasText: 'Briefs' })).toBeVisible();
+  });
+
+  test('shows back link to history', async ({ page }) => {
+    await page.goto(`/briefs/${SAMPLE_BRIEFING.id}`);
+    const back = page.getByRole('link', { name: /briefing history/i });
+    await expect(back).toBeVisible();
+    await expect(back).toHaveAttribute('href', '/briefs');
+  });
+
+  test('renders briefing title', async ({ page }) => {
+    await page.goto(`/briefs/${SAMPLE_BRIEFING.id}`);
+    await expect(page.getByText(SAMPLE_BRIEFING.title)).toBeVisible();
+  });
+
+  test('renders briefing summary', async ({ page }) => {
+    await page.goto(`/briefs/${SAMPLE_BRIEFING.id}`);
+    await expect(page.getByText(SAMPLE_BRIEFING.summary)).toBeVisible();
+  });
+
+  test('renders section heading', async ({ page }) => {
+    await page.goto(`/briefs/${SAMPLE_BRIEFING.id}`);
+    const sectionTitle = SAMPLE_BRIEFING.content.sections[0].title;
+    await expect(page.getByText(sectionTitle, { exact: true })).toBeVisible();
+  });
+
+  test('back link navigates to /briefs', async ({ page }) => {
+    await page.goto(`/briefs/${SAMPLE_BRIEFING.id}`);
+    const back = page.getByRole('link', { name: /briefing history/i });
+    await back.click();
+    await expect(page).toHaveURL('/briefs');
+  });
+
+  test('no Refresh button on detail page', async ({ page }) => {
+    await page.goto(`/briefs/${SAMPLE_BRIEFING.id}`);
+    await expect(page.getByText(SAMPLE_BRIEFING.title)).toBeVisible();
+    await expect(page.getByRole('button', { name: /refresh/i })).toHaveCount(0);
+  });
+});
+
+test.describe('Brief page — View history link', () => {
+  test('BriefPage shows "View history" link to /briefs', async ({ page }) => {
+    await page.goto('/');
+    const link = page.getByRole('link', { name: /view history/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', '/briefs');
+  });
+
+  test('"View history" link navigates to /briefs', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: /view history/i }).click();
+    await expect(page).toHaveURL('/briefs');
+  });
+});
+
+test.describe('Navigation — Brief History entries', () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test('desktop rail secondary nav shows Brief History', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('aside a[href="/briefs"]').first()).toBeVisible();
+  });
+
+  test('Brief History is active at /briefs', async ({ page }) => {
+    await page.goto('/briefs');
+    await expect(page.locator('aside a[href="/briefs"]').first()).toHaveClass(/bg-surface-2/);
+  });
+
+  test('clicking Brief History in nav navigates to /briefs', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('aside a[href="/briefs"]').first().click();
+    await expect(page).toHaveURL('/briefs');
+  });
+});
+
+test.describe('Command palette — Briefing History', () => {
+  test('command palette includes Briefing History item', async ({ page }) => {
+    await page.goto('/');
+    await page.keyboard.press('Meta+k');
+    const option = page.getByRole('option', { name: 'Briefing History', exact: true });
+    await expect(option).toBeVisible();
+    await page.keyboard.press('Escape');
+  });
+});

--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -41,7 +41,7 @@ test.describe('Command palette — navigation items', () => {
   });
 
   test('shows Brief nav item', async ({ page }) => {
-    await expect(page.getByRole('option', { name: /brief/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Brief', exact: true })).toBeVisible();
   });
 
   test('shows Today nav item', async ({ page }) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -161,15 +161,21 @@ export async function mockApi(page: Page) {
   // Summary / counts
   await page.route('/api/summary', (r) => r.fulfill(json(SUMMARY_DATA)));
 
-  // Briefings
-  await page.route('/api/briefings/latest', (r) => r.fulfill(json(SAMPLE_BRIEFING)));
-  await page.route('/api/briefings', async (r: Route) => {
-    if (r.request().method() === 'POST') {
+  // Briefings — single handler dispatches by path/method to avoid glob ambiguity
+  await page.route('/api/briefings**', async (r: Route) => {
+    const url = new URL(r.request().url());
+    const method = r.request().method();
+    const path = url.pathname;
+
+    if (method === 'GET' && path === '/api/briefings') {
+      return r.fulfill(json({ items: [SAMPLE_BRIEFING] }));
+    }
+    if (method === 'POST' && path === '/api/briefings') {
       return r.fulfill(json(SAMPLE_BRIEFING));
     }
-    return r.fulfill(json({ items: [SAMPLE_BRIEFING] }));
+    // /api/briefings/latest, /api/briefings/:id, etc.
+    return r.fulfill(json(SAMPLE_BRIEFING));
   });
-  await page.route('/api/briefings/**', (r) => r.fulfill(json(SAMPLE_BRIEFING)));
 
   // Articles
   await page.route('/api/articles**', async (r: Route) => {

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -16,6 +16,8 @@ import { StatsPage } from './pages/StatsPage';
 import { ArchivePage } from './pages/ArchivePage';
 import { SettingsPage } from './pages/SettingsPage';
 import { ArticlePage } from './pages/ArticlePage';
+import { BriefingsHistoryPage } from './pages/BriefingsHistoryPage';
+import { BriefingDetailPage } from './pages/BriefingDetailPage';
 
 function NotFound() {
   return (
@@ -64,6 +66,8 @@ const router = createBrowserRouter([
           { path: 'logs', element: <FeedsLogsPage /> },
         ],
       },
+      { path: 'briefs', element: <BriefingsHistoryPage /> },
+      { path: 'briefs/:id', element: <BriefingDetailPage /> },
       { path: 'stats', element: <StatsPage /> },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'settings', element: <SettingsPage /> },

--- a/frontend/src/__tests__/briefingsHistory.test.tsx
+++ b/frontend/src/__tests__/briefingsHistory.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BriefingsHistoryPage } from '../pages/BriefingsHistoryPage';
+import { BriefingDetailPage } from '../pages/BriefingDetailPage';
+import * as api from '../api';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const COMPLETE_BRIEFING = {
+  id: 7,
+  created_at: '2026-06-13T12:00:00+00:00',
+  scope: 'since_last_briefing',
+  since_at: '2026-06-12T12:00:00+00:00',
+  until_at: '2026-06-13T12:00:00+00:00',
+  status: 'complete' as const,
+  title: 'AI Safety Takes Center Stage',
+  summary: 'Anthropic and OpenAI both made waves today.',
+  content: {
+    sections: [
+      {
+        title: 'Safety Research',
+        body: 'New frameworks published.',
+        citations: [1],
+      },
+    ],
+    worth_opening: [],
+  },
+  model: 'gpt-4o-mini',
+  error: null,
+  articles: [
+    {
+      id: 1,
+      title: 'Anthropic Safety Paper',
+      url: 'https://example.com/1',
+      source_name: 'Anthropic Blog',
+      category: 'ai',
+      section_index: 0,
+      citation_index: 0,
+    },
+  ],
+};
+
+const FAILED_BRIEFING = {
+  ...COMPLETE_BRIEFING,
+  id: 8,
+  status: 'failed' as const,
+  title: '',
+  summary: '',
+  content: null,
+  error: 'AI returned invalid JSON',
+  articles: [],
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeQc() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderHistory() {
+  return render(
+    <QueryClientProvider client={makeQc()}>
+      <MemoryRouter initialEntries={['/briefs']}>
+        <BriefingsHistoryPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderDetail(id: string) {
+  return render(
+    <QueryClientProvider client={makeQc()}>
+      <MemoryRouter initialEntries={[`/briefs/${id}`]}>
+        <Routes>
+          <Route path="/briefs/:id" element={<BriefingDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ── BriefingsHistoryPage ──────────────────────────────────────────────────────
+
+describe('BriefingsHistoryPage — loading state', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchBriefings').mockReturnValue(new Promise((_r) => undefined));
+  });
+
+  it('renders without crashing while loading', () => {
+    const { container } = renderHistory();
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('shows the page heading', () => {
+    renderHistory();
+    expect(screen.getByText('Briefing History')).toBeTruthy();
+  });
+});
+
+describe('BriefingsHistoryPage — empty state', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchBriefings').mockResolvedValue({ items: [] });
+  });
+
+  it('shows empty message when no briefings', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText('No briefings yet')).toBeTruthy());
+  });
+
+  it('links to Brief page from empty state', async () => {
+    renderHistory();
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'Brief' });
+      expect(link).toBeTruthy();
+      expect(link.getAttribute('href')).toBe('/');
+    });
+  });
+});
+
+describe('BriefingsHistoryPage — list state', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchBriefings').mockResolvedValue({
+      items: [COMPLETE_BRIEFING, FAILED_BRIEFING],
+    });
+  });
+
+  it('renders briefing title', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText('AI Safety Takes Center Stage')).toBeTruthy());
+  });
+
+  it('renders a link to the briefing detail', async () => {
+    renderHistory();
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /AI Safety Takes Center Stage/i });
+      expect(link.getAttribute('href')).toBe('/briefs/7');
+    });
+  });
+
+  it('shows failed badge for failed briefing', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText('Failed')).toBeTruthy());
+  });
+
+  it('shows failed briefing error message', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/AI returned invalid JSON/i)).toBeTruthy());
+  });
+
+  it('renders multiple rows', async () => {
+    renderHistory();
+    await waitFor(() => {
+      const links = screen.getAllByRole('link');
+      // Each briefing row is a link; at least 2 briefing rows
+      const briefingLinks = links.filter((l) => l.getAttribute('href')?.startsWith('/briefs/'));
+      expect(briefingLinks.length).toBe(2);
+    });
+  });
+});
+
+// ── BriefingDetailPage ────────────────────────────────────────────────────────
+
+describe('BriefingDetailPage — loading state', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchBriefing').mockReturnValue(new Promise((_r) => undefined));
+  });
+
+  it('shows skeleton while loading', () => {
+    const { container } = renderDetail('7');
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('shows back link while loading', () => {
+    renderDetail('7');
+    const link = screen.getByRole('link', { name: /briefing history/i });
+    expect(link.getAttribute('href')).toBe('/briefs');
+  });
+});
+
+describe('BriefingDetailPage — complete briefing', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchBriefing').mockResolvedValue(COMPLETE_BRIEFING);
+  });
+
+  it('renders briefing title', async () => {
+    renderDetail('7');
+    await waitFor(() => expect(screen.getByText('AI Safety Takes Center Stage')).toBeTruthy());
+  });
+
+  it('renders briefing summary', async () => {
+    renderDetail('7');
+    await waitFor(() =>
+      expect(screen.getByText('Anthropic and OpenAI both made waves today.')).toBeTruthy()
+    );
+  });
+
+  it('renders section heading', async () => {
+    renderDetail('7');
+    await waitFor(() => expect(screen.getByText('Safety Research')).toBeTruthy());
+  });
+
+  it('renders back link to /briefs', () => {
+    renderDetail('7');
+    const link = screen.getByRole('link', { name: /briefing history/i });
+    expect(link.getAttribute('href')).toBe('/briefs');
+  });
+
+  it('does not show a Refresh button (read-only view)', async () => {
+    renderDetail('7');
+    await waitFor(() => expect(screen.getByText('AI Safety Takes Center Stage')).toBeTruthy());
+    expect(screen.queryByRole('button', { name: /refresh|generate/i })).toBeNull();
+  });
+});
+
+describe('BriefingDetailPage — failed briefing', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchBriefing').mockResolvedValue(FAILED_BRIEFING);
+  });
+
+  it('shows failed state message', async () => {
+    renderDetail('8');
+    await waitFor(() => expect(screen.getByText('This briefing failed')).toBeTruthy());
+  });
+
+  it('shows the error message', async () => {
+    renderDetail('8');
+    await waitFor(() => expect(screen.getByText(/AI returned invalid JSON/i)).toBeTruthy());
+  });
+});
+
+describe('BriefingDetailPage — error / not found', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchBriefing').mockRejectedValue(new Error('404 Not Found'));
+  });
+
+  it('shows not found message', async () => {
+    renderDetail('999');
+    await waitFor(() => expect(screen.getByText('Briefing not found')).toBeTruthy());
+  });
+
+  it('shows back link even in error state', async () => {
+    renderDetail('999');
+    await waitFor(() => {
+      const links = screen.getAllByRole('link', { name: /briefing history/i });
+      expect(links.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('BriefingDetailPage — invalid ID', () => {
+  it('shows invalid ID message for non-numeric ID', () => {
+    renderDetail('not-a-number');
+    expect(screen.getByText('Invalid briefing ID.')).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -31,12 +31,14 @@ vi.mock('../hooks/useTriageMutations', () => ({
   ARTICLES_KEY: 'articles',
 }));
 
-// Silence BriefPage's briefing fetch during AppShell render tests
+// Silence page fetches during AppShell render tests
 vi.mock('../api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api')>();
   return {
     ...actual,
     fetchLatestBriefing: vi.fn().mockReturnValue(new Promise((_r) => undefined)),
+    fetchBriefings: vi.fn().mockReturnValue(new Promise((_r) => undefined)),
+    fetchBriefing: vi.fn().mockReturnValue(new Promise((_r) => undefined)),
     fetchSummary: vi.fn().mockResolvedValue({ byStatus: {}, byCategory: {} }),
     searchArticles: vi.fn().mockResolvedValue([]),
   };
@@ -189,12 +191,53 @@ describe('#105 — shortcut overlay', () => {
 
   it('has Brief in shortcut descriptions', () => {
     render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
-    expect(screen.getByText(/brief/i)).toBeTruthy();
+    expect(screen.getAllByText(/brief/i).length).toBeGreaterThan(0);
   });
 
   it('has Today in shortcut descriptions', () => {
     render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
     expect(screen.getAllByText(/today/i).length).toBeGreaterThan(0);
+  });
+});
+
+// ── #118: Briefing History nav + shortcuts ────────────────────────────────────
+
+describe('#118 — Brief History in moreItems nav', () => {
+  it('shows Brief History link in shell nav', async () => {
+    renderShell('/');
+    await waitFor(() => {
+      const links = screen.getAllByRole('link', { name: /brief history/i });
+      expect(links.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('Brief History link points to /briefs', async () => {
+    renderShell('/');
+    await waitFor(() => {
+      const link = screen
+        .getAllByRole('link', { name: /brief history/i })
+        .find((l) => l.getAttribute('href') === '/briefs');
+      expect(link).toBeTruthy();
+    });
+  });
+
+  it('header shows "Briefs" title at /briefs', async () => {
+    renderShell('/briefs');
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Briefs' })).toBeTruthy());
+  });
+});
+
+describe('#118 — Briefing History in command palette', () => {
+  it('shows Briefing History as a nav item', () => {
+    renderPalette();
+    expect(screen.getByText('Briefing History')).toBeTruthy();
+  });
+});
+
+describe('#118 — shortcut overlay shows g h', () => {
+  it('mentions g h for Briefing History', () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText('g h')).toBeTruthy();
   });
 });
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -13,6 +13,7 @@ import {
   BarChart3,
   Archive,
   Settings,
+  History,
 } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { CommandPalette } from './CommandPalette';
@@ -52,6 +53,7 @@ const navItems: NavItem[] = [
 const mobileNavItems = navItems.slice(0, 5);
 
 const moreItems = [
+  { to: '/briefs', label: 'Brief History', icon: History },
   { to: '/feeds', label: 'Feeds', icon: Radio },
   { to: '/stats', label: 'Stats', icon: BarChart3 },
   { to: '/archive', label: 'Archive', icon: Archive },
@@ -70,6 +72,7 @@ function currentTitle(p: string) {
   if (p.startsWith('/starred')) return 'Starred';
   if (p.startsWith('/search')) return 'Search';
   if (p.startsWith('/ask')) return 'Ask AI';
+  if (p.startsWith('/briefs')) return 'Briefs';
   if (p.startsWith('/feeds')) return 'Feeds';
   if (p.startsWith('/stats')) return 'Stats';
   if (p.startsWith('/archive')) return 'Archive';
@@ -170,6 +173,7 @@ export function AppShell() {
           else if (k === 's') navigate('/starred');
           else if (k === 'a') navigate('/ask');
           else if (k === 'f') navigate('/feeds');
+          else if (k === 'h') navigate('/briefs');
           window.removeEventListener('keydown', handler2);
         };
         window.addEventListener('keydown', handler2, { once: true });

--- a/frontend/src/components/BriefingView.tsx
+++ b/frontend/src/components/BriefingView.tsx
@@ -1,0 +1,154 @@
+import { Link } from 'react-router-dom';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatDate, formatWindow } from '@/lib/briefingUtils';
+import type { Briefing, BriefingArticle, BriefingSection } from '@/types';
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+export function CitationChip({ article }: { article: BriefingArticle }) {
+  return (
+    <Link
+      to={`/a/${article.id}`}
+      className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/50 px-2.5 py-0.5 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors max-w-[200px] shrink-0"
+    >
+      <span className="truncate">{article.title}</span>
+      <span className="text-muted-foreground shrink-0">·</span>
+      <span className="text-muted-foreground shrink-0 truncate max-w-[60px]">
+        {article.source_name}
+      </span>
+    </Link>
+  );
+}
+
+export function BriefSection({
+  section,
+  articleMap,
+  index,
+}: {
+  section: BriefingSection;
+  articleMap: Map<number, BriefingArticle>;
+  index: number;
+}) {
+  return (
+    <div className={index > 0 ? 'mt-5 pt-5 border-t border-border' : ''}>
+      <h3 className="text-sm font-semibold text-foreground mb-1.5">{section.title}</h3>
+      <p className="text-sm text-muted-foreground leading-relaxed">{section.body}</p>
+      {section.citations.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {section.citations.map((id) => {
+            const article = articleMap.get(id);
+            if (!article) return null;
+            return <CitationChip key={id} article={article} />;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WorthOpening({ articles }: { articles: BriefingArticle[] }) {
+  if (articles.length === 0) return null;
+  return (
+    <div className="mt-6 pt-5 border-t border-border">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+        Also worth a look
+      </h3>
+      <div className="flex flex-col gap-2">
+        {articles.map((article) => (
+          <Link
+            key={article.id}
+            to={`/a/${article.id}`}
+            className="flex items-start gap-3 rounded-md p-2 hover:bg-accent transition-colors group"
+          >
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-foreground group-hover:text-accent-foreground leading-snug">
+                {article.title}
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5">{article.source_name}</div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function BriefSkeleton() {
+  return (
+    <div className="px-4 md:px-5 pt-4">
+      <Skeleton className="h-6 w-3/4 mb-2" />
+      <Skeleton className="h-3 w-1/2 mb-6" />
+      <Skeleton className="h-4 w-full mb-2" />
+      <Skeleton className="h-4 w-5/6 mb-2" />
+      <Skeleton className="h-4 w-4/6 mb-6" />
+      <Skeleton className="h-4 w-3/4 mb-2" />
+      <Skeleton className="h-4 w-full mb-2" />
+      <Skeleton className="h-4 w-2/3" />
+    </div>
+  );
+}
+
+// ── Main view ─────────────────────────────────────────────────────────────────
+
+export function BriefingView({
+  briefing,
+  onGenerate,
+  isGenerating,
+  afterMeta,
+}: {
+  briefing: Briefing;
+  onGenerate?: () => void;
+  isGenerating?: boolean;
+  afterMeta?: React.ReactNode;
+}) {
+  const articleMap = new Map(briefing.articles.map((a) => [a.id, a]));
+  const worthOpening = briefing.articles.filter((a) => a.section_index === null);
+  const sections = briefing.content?.sections ?? [];
+  const articleCount = briefing.articles.length;
+
+  return (
+    <div>
+      <div className="px-4 md:px-5 pt-4 pb-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-[22px] font-semibold tracking-tight leading-tight">
+            {briefing.title}
+          </h2>
+          <p className="text-xs text-muted-foreground mt-1">
+            {formatDate(briefing.created_at)} · {formatWindow(briefing.since_at, briefing.until_at)}{' '}
+            · {articleCount} {articleCount === 1 ? 'article' : 'articles'}
+          </p>
+          {afterMeta}
+        </div>
+        {onGenerate && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onGenerate}
+            disabled={isGenerating}
+            className="shrink-0 mt-1"
+            aria-label="Generate new briefing"
+          >
+            <RefreshCw className={isGenerating ? 'animate-spin' : ''} />
+            {isGenerating ? 'Generating…' : 'Refresh'}
+          </Button>
+        )}
+      </div>
+
+      <div className="px-4 md:px-5 pb-6">
+        {briefing.summary && (
+          <p className="text-sm text-muted-foreground leading-relaxed mb-5 pb-5 border-b border-border">
+            {briefing.summary}
+          </p>
+        )}
+        <div>
+          {sections.map((section, i) => (
+            <BriefSection key={i} section={section} articleMap={articleMap} index={i} />
+          ))}
+        </div>
+        <WorthOpening articles={worthOpening} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -21,6 +21,7 @@ import {
   CheckCheck,
   SkipForward,
   ExternalLink,
+  History,
 } from 'lucide-react';
 import { searchArticles, ingestNow } from '@/api';
 import { adaptArticle } from '@/api/workflowApi';
@@ -36,6 +37,7 @@ interface Props {
 
 const NAV_ITEMS = [
   { icon: Newspaper, label: 'Brief', to: '/' },
+  { icon: History, label: 'Briefing History', to: '/briefs' },
   { icon: Inbox, label: 'Today', to: '/today' },
   { icon: Clock, label: 'Later', to: '/later' },
   { icon: Star, label: 'Starred', to: '/starred' },

--- a/frontend/src/components/ShortcutOverlay.tsx
+++ b/frontend/src/components/ShortcutOverlay.tsx
@@ -14,6 +14,7 @@ const SECTIONS: { title: string; items: [string, string][] }[] = [
       ['g b / g t', 'Go to Brief / Today'],
       ['g l / g s', 'Go to Later / Starred'],
       ['g a / g f', 'Go to Ask / Feeds'],
+      ['g h', 'Go to Briefing History'],
     ],
   },
   {

--- a/frontend/src/lib/briefingUtils.ts
+++ b/frontend/src/lib/briefingUtils.ts
@@ -1,0 +1,16 @@
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+export function formatWindow(sinceAt: string, untilAt: string): string {
+  const since = new Date(sinceAt);
+  const until = new Date(untilAt);
+  const sameDay = since.toDateString() === until.toDateString();
+  if (sameDay) {
+    return since.toLocaleDateString(undefined, { dateStyle: 'medium' });
+  }
+  return `${since.toLocaleDateString(undefined, { dateStyle: 'medium' })} – ${until.toLocaleDateString(undefined, { dateStyle: 'medium' })}`;
+}

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -1,171 +1,10 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Newspaper, RefreshCw, AlertCircle, Inbox } from 'lucide-react';
+import { Newspaper, RefreshCw, AlertCircle, Inbox, History } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
 import { fetchLatestBriefing, createBriefing } from '@/api';
-import type { Briefing, BriefingArticle, BriefingSection } from '@/types';
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  });
-}
-
-function formatWindow(sinceAt: string, untilAt: string): string {
-  const since = new Date(sinceAt);
-  const until = new Date(untilAt);
-  const sameDay = since.toDateString() === until.toDateString();
-  if (sameDay) {
-    return since.toLocaleDateString(undefined, { dateStyle: 'medium' });
-  }
-  return `${since.toLocaleDateString(undefined, { dateStyle: 'medium' })} – ${until.toLocaleDateString(undefined, { dateStyle: 'medium' })}`;
-}
-
-// ── Sub-components ────────────────────────────────────────────────────────────
-
-function CitationChip({ article }: { article: BriefingArticle }) {
-  return (
-    <Link
-      to={`/a/${article.id}`}
-      className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/50 px-2.5 py-0.5 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors max-w-[200px] shrink-0"
-    >
-      <span className="truncate">{article.title}</span>
-      <span className="text-muted-foreground shrink-0">·</span>
-      <span className="text-muted-foreground shrink-0 truncate max-w-[60px]">
-        {article.source_name}
-      </span>
-    </Link>
-  );
-}
-
-function BriefSection({
-  section,
-  articleMap,
-  index,
-}: {
-  section: BriefingSection;
-  articleMap: Map<number, BriefingArticle>;
-  index: number;
-}) {
-  return (
-    <div className={index > 0 ? 'mt-5 pt-5 border-t border-border' : ''}>
-      <h3 className="text-sm font-semibold text-foreground mb-1.5">{section.title}</h3>
-      <p className="text-sm text-muted-foreground leading-relaxed">{section.body}</p>
-      {section.citations.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1.5">
-          {section.citations.map((id) => {
-            const article = articleMap.get(id);
-            if (!article) return null;
-            return <CitationChip key={id} article={article} />;
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function WorthOpening({ articles }: { articles: BriefingArticle[] }) {
-  if (articles.length === 0) return null;
-  return (
-    <div className="mt-6 pt-5 border-t border-border">
-      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-        Also worth a look
-      </h3>
-      <div className="flex flex-col gap-2">
-        {articles.map((article) => (
-          <Link
-            key={article.id}
-            to={`/a/${article.id}`}
-            className="flex items-start gap-3 rounded-md p-2 hover:bg-accent transition-colors group"
-          >
-            <div className="min-w-0">
-              <div className="text-sm font-medium text-foreground group-hover:text-accent-foreground leading-snug">
-                {article.title}
-              </div>
-              <div className="text-xs text-muted-foreground mt-0.5">{article.source_name}</div>
-            </div>
-          </Link>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function BriefingView({
-  briefing,
-  onGenerate,
-  isGenerating,
-}: {
-  briefing: Briefing;
-  onGenerate: () => void;
-  isGenerating: boolean;
-}) {
-  const articleMap = new Map(briefing.articles.map((a) => [a.id, a]));
-  const worthOpening = briefing.articles.filter((a) => a.section_index === null);
-  const sections = briefing.content?.sections ?? [];
-  const articleCount = briefing.articles.length;
-
-  return (
-    <div>
-      <div className="px-4 md:px-5 pt-4 pb-3 flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h2 className="text-[22px] font-semibold tracking-tight leading-tight">
-            {briefing.title}
-          </h2>
-          <p className="text-xs text-muted-foreground mt-1">
-            {formatDate(briefing.created_at)} · {formatWindow(briefing.since_at, briefing.until_at)}{' '}
-            · {articleCount} {articleCount === 1 ? 'article' : 'articles'}
-          </p>
-        </div>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={onGenerate}
-          disabled={isGenerating}
-          className="shrink-0 mt-1"
-          aria-label="Generate new briefing"
-        >
-          <RefreshCw className={isGenerating ? 'animate-spin' : ''} />
-          {isGenerating ? 'Generating…' : 'Refresh'}
-        </Button>
-      </div>
-
-      <div className="px-4 md:px-5 pb-6">
-        {briefing.summary && (
-          <p className="text-sm text-muted-foreground leading-relaxed mb-5 pb-5 border-b border-border">
-            {briefing.summary}
-          </p>
-        )}
-        <div>
-          {sections.map((section, i) => (
-            <BriefSection key={i} section={section} articleMap={articleMap} index={i} />
-          ))}
-        </div>
-        <WorthOpening articles={worthOpening} />
-      </div>
-    </div>
-  );
-}
-
-function BriefSkeleton() {
-  return (
-    <div className="px-4 md:px-5 pt-4">
-      <Skeleton className="h-6 w-3/4 mb-2" />
-      <Skeleton className="h-3 w-1/2 mb-6" />
-      <Skeleton className="h-4 w-full mb-2" />
-      <Skeleton className="h-4 w-5/6 mb-2" />
-      <Skeleton className="h-4 w-4/6 mb-6" />
-      <Skeleton className="h-4 w-3/4 mb-2" />
-      <Skeleton className="h-4 w-full mb-2" />
-      <Skeleton className="h-4 w-2/3" />
-    </div>
-  );
-}
+import { BriefingView, BriefSkeleton } from '@/components/BriefingView';
 
 // ── Main page ─────────────────────────────────────────────────────────────────
 
@@ -328,5 +167,20 @@ export function BriefPage() {
     );
   }
 
-  return <BriefingView briefing={data} onGenerate={generate} isGenerating={isGenerating} />;
+  return (
+    <BriefingView
+      briefing={data}
+      onGenerate={generate}
+      isGenerating={isGenerating}
+      afterMeta={
+        <Link
+          to="/briefs"
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mt-1 transition-colors"
+        >
+          <History className="size-3" />
+          View history
+        </Link>
+      }
+    />
+  );
 }

--- a/frontend/src/pages/BriefingDetailPage.tsx
+++ b/frontend/src/pages/BriefingDetailPage.tsx
@@ -1,0 +1,98 @@
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowLeft, AlertCircle, Newspaper } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { fetchBriefing } from '@/api';
+import { BriefingView, BriefSkeleton } from '@/components/BriefingView';
+
+function BackLink() {
+  return (
+    <Link
+      to="/briefs"
+      className="inline-flex items-center gap-1.5 px-4 md:px-5 pt-3 pb-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <ArrowLeft className="size-3.5" />
+      Briefing history
+    </Link>
+  );
+}
+
+export function BriefingDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const briefingId = id ? parseInt(id, 10) : NaN;
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['briefings', briefingId],
+    queryFn: () => fetchBriefing(briefingId),
+    enabled: !isNaN(briefingId),
+    retry: false,
+  });
+
+  if (isNaN(briefingId)) {
+    return (
+      <div className="px-4 md:px-5 pt-4 pb-6">
+        <BackLink />
+        <div className="text-sm text-muted-foreground mt-4">Invalid briefing ID.</div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        <BackLink />
+        <BriefSkeleton />
+      </>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="px-4 md:px-5 pt-4 pb-6">
+        <BackLink />
+        <div className="flex items-start gap-3 p-4 rounded-lg border border-destructive/30 bg-destructive/5 mt-4 mb-4">
+          <AlertCircle className="size-4 text-destructive mt-0.5 shrink-0" />
+          <div>
+            <div className="text-sm font-medium text-foreground">Briefing not found</div>
+            <div className="text-xs text-muted-foreground mt-1">
+              This briefing may have been deleted or the ID is invalid.
+            </div>
+          </div>
+        </div>
+        <Button size="sm" variant="outline" onClick={() => navigate('/briefs')}>
+          <Newspaper />
+          View all briefings
+        </Button>
+      </div>
+    );
+  }
+
+  if (data.status === 'failed') {
+    return (
+      <div className="px-4 md:px-5 pt-4 pb-6">
+        <BackLink />
+        <div className="flex items-start gap-3 p-4 rounded-lg border border-destructive/30 bg-destructive/5 mt-4 mb-4">
+          <AlertCircle className="size-4 text-destructive mt-0.5 shrink-0" />
+          <div>
+            <div className="text-sm font-medium text-foreground">This briefing failed</div>
+            {data.error && (
+              <div className="text-xs text-muted-foreground mt-1 font-mono">{data.error}</div>
+            )}
+          </div>
+        </div>
+        <Button size="sm" variant="outline" onClick={() => navigate('/briefs')}>
+          <Newspaper />
+          View all briefings
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <BackLink />
+      <BriefingView briefing={data} />
+    </>
+  );
+}

--- a/frontend/src/pages/BriefingsHistoryPage.tsx
+++ b/frontend/src/pages/BriefingsHistoryPage.tsx
@@ -1,0 +1,112 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Newspaper, AlertCircle, ChevronRight } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { fetchBriefings } from '@/api';
+import { formatDate, formatWindow } from '@/lib/briefingUtils';
+import type { Briefing } from '@/types';
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function BriefingRow({ briefing }: { briefing: Briefing }) {
+  const isFailed = briefing.status === 'failed';
+  return (
+    <Link
+      to={`/briefs/${briefing.id}`}
+      className="flex items-center gap-3 px-4 md:px-5 py-3.5 border-b border-border hover:bg-surface transition-colors group"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          {isFailed ? (
+            <span className="flex items-center gap-1 text-[10px] font-medium text-destructive bg-destructive/10 border border-destructive/20 px-1.5 py-0.5 rounded-full">
+              <AlertCircle className="size-2.5" />
+              Failed
+            </span>
+          ) : null}
+          <span className="text-[11px] text-muted-foreground tabular-nums">
+            {formatDate(briefing.created_at)}
+          </span>
+          {briefing.since_at && briefing.until_at && (
+            <span className="text-[11px] text-subtle">
+              · {formatWindow(briefing.since_at, briefing.until_at)}
+            </span>
+          )}
+        </div>
+        <div className="text-sm font-medium text-foreground leading-snug mt-0.5 group-hover:text-foreground line-clamp-1">
+          {isFailed ? (
+            <span className="text-muted-foreground italic">Generation failed</span>
+          ) : (
+            briefing.title || 'Untitled briefing'
+          )}
+        </div>
+        {briefing.summary && !isFailed && (
+          <div className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+            {briefing.summary}
+          </div>
+        )}
+        {briefing.error && isFailed && (
+          <div className="text-xs text-destructive/70 mt-0.5 font-mono line-clamp-1">
+            {briefing.error}
+          </div>
+        )}
+      </div>
+      <ChevronRight className="size-4 text-subtle shrink-0 group-hover:text-muted-foreground transition-colors" />
+    </Link>
+  );
+}
+
+function HistorySkeleton() {
+  return (
+    <div className="divide-y divide-border">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <div key={i} className="px-4 md:px-5 py-3.5">
+          <Skeleton className="h-3 w-32 mb-2" />
+          <Skeleton className="h-4 w-3/4 mb-1.5" />
+          <Skeleton className="h-3 w-2/3" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export function BriefingsHistoryPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['briefings', 'list'],
+    queryFn: () => fetchBriefings(50, 0),
+  });
+
+  const briefings = data?.items ?? [];
+
+  return (
+    <div>
+      <div className="px-4 md:px-5 pt-4 pb-3">
+        <h2 className="text-[22px] font-semibold tracking-tight">Briefing History</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">All generated daily briefs</p>
+      </div>
+
+      {isLoading ? (
+        <HistorySkeleton />
+      ) : briefings.length === 0 ? (
+        <div className="flex flex-col items-center justify-center text-center py-20 text-muted-foreground px-4">
+          <Newspaper className="size-10 text-subtle mb-3" strokeWidth={1.25} />
+          <div className="text-sm font-medium text-foreground">No briefings yet</div>
+          <div className="text-xs mt-1 max-w-xs">
+            Go to{' '}
+            <Link to="/" className="text-accent hover:underline">
+              Brief
+            </Link>{' '}
+            to generate your first daily briefing.
+          </div>
+        </div>
+      ) : (
+        <div>
+          {briefings.map((b) => (
+            <BriefingRow key={b.id} briefing={b} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `_run_briefing()` to `scheduler.py`: a thin wrapper around `generate_briefing()` that logs completion/skip/error and swallows all exceptions so the APScheduler thread never dies on a missing key or bad AI response
- Registers a `cron` job with `id="briefing"` in `start_scheduler()`, defaulting to `"0 9 * * *"` (09:00 UTC daily); override with `BRIEFING_CRON` env var using standard 5-field cron syntax (`minute hour * * *`)
- The existing `IDEMPOTENCY_WINDOW_MINUTES` guard inside `generate_briefing()` prevents duplicate rows if the job fires twice in quick succession (e.g. restart during the same minute)
- No schema changes, no API changes, no new env vars beyond `BRIEFING_CRON`

## Test plan

- [x] 13 new unit tests in `test_scheduler.py` (no DB or APScheduler needed — all patched):
  - `_run_briefing()` calls `generate_briefing()` once
  - Logs briefing ID on completion
  - Logs skip message on `no_candidates`
  - Suppresses `BriefingAINotConfiguredError` with a `WARNING` log
  - Suppresses `BriefingGenerationError` with an `ERROR` log
  - Suppresses unexpected `RuntimeError` without raising
  - `start_scheduler()` registers a job with `id="briefing"`
  - Default cron parses to `hour="9"`, `minute="0"`
  - Custom `BRIEFING_CRON="30 7 * * *"` parses to `hour="7"`, `minute="30"`
  - Job uses `trigger="cron"`
  - Registered function is `_run_briefing`
- [x] Full backend suite: 160 passed, 38 skipped (testcontainers — expected)
- [x] Frontend vitest: 157 passed; typecheck and lint clean

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)