### PR TITLE
docs: Caddy HTTPS setup guide + Caddyfile for news.lihor.ro (PWA fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ news-dashboard-migrate /data/news-dashboard.db
 ## Deployment notes
 
 - The app should be private/auth-protected when exposed publicly.
-- `news.lihor.ro` is served by host-level Caddy with Basic Auth.
+- `news.lihor.ro` is served by host-level Caddy with Basic Auth and automatic
+  Let's Encrypt HTTPS. See [docs/CADDY_HTTPS_SETUP.md](docs/CADDY_HTTPS_SETUP.md)
+  for the full setup guide; the Caddyfile lives at `deploy/Caddyfile`.
+- HTTPS is required for PWA install (Chrome/Android "Add to Home Screen" as a
+  standalone app) and for service worker registration.
 - GitHub Actions publishes `ghcr.io/ioachim-hub/news-dashboard`.
 - For the local Kubernetes cluster, if GHCR pull auth is unavailable, build and push to `localhost:5000/news-dashboard:<tag>` and override Helm image values.

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,9 @@
+news.lihor.ro {
+    reverse_proxy localhost:30088
+    basicauth {
+        # Add one or more users with hashed passwords.
+        # Generate a hash:  caddy hash-password
+        # Then paste the output here, e.g.:
+        #   ioachim $2a$14$<hash-output-goes-here>
+    }
+}

--- a/docs/CADDY_HTTPS_SETUP.md
+++ b/docs/CADDY_HTTPS_SETUP.md
@@ -1,0 +1,223 @@
+# Caddy HTTPS setup for news.lihor.ro
+
+This document covers everything needed to put `news.lihor.ro` behind Caddy on
+the mini PC so the app is served over HTTPS.  HTTPS is required for:
+
+- Chrome/Android PWA install prompt ("Add to Home Screen" → standalone app)
+- iOS Safari "Add to Home Screen" fullscreen mode
+- Service worker registration (browsers enforce secure context)
+
+The app already runs as a Kubernetes NodePort service on `localhost:30088`.
+Caddy runs on the host (outside Kubernetes), listens on ports 80/443, obtains a
+free Let's Encrypt certificate automatically, and forwards requests to the app.
+
+---
+
+## Prerequisites — things only you can do
+
+Before running any commands on the mini PC you need to complete these steps
+through your router and domain registrar.  They cannot be scripted.
+
+### Step 1 — Find your home's public IP address
+
+On the mini PC (or any device on the same network):
+
+```bash
+curl -s https://ifconfig.me
+```
+
+Write this IP down — you will need it for Step 2.  If your ISP changes it
+periodically (dynamic IP), see the DDNS note at the bottom of this document.
+
+### Step 2 — Create a DNS A record for news.lihor.ro
+
+Log in to wherever you manage the `lihor.ro` domain (your DNS registrar or
+hosting panel) and add:
+
+| Type | Name | Value               | TTL  |
+|------|------|---------------------|------|
+| A    | news | `<your-public-IP>`  | 300  |
+
+`news` is the subdomain; `lihor.ro` is added automatically by the registrar.
+TTL 300 (5 minutes) lets you update it quickly if the IP changes.
+
+To verify the record has propagated (wait a few minutes, then run):
+
+```bash
+dig +short news.lihor.ro          # should print your public IP
+# or on Windows:
+nslookup news.lihor.ro
+```
+
+### Step 3 — Open port 443 on your router (port forwarding)
+
+Log in to your home router admin panel (usually `http://192.168.1.1` or
+`http://192.168.0.1`) and add a port-forwarding rule:
+
+| Setting          | Value                              |
+|------------------|------------------------------------|
+| External port    | 443 (HTTPS)                        |
+| Internal IP      | the mini PC's LAN IP               |
+| Internal port    | 443                                |
+| Protocol         | TCP                                |
+
+You can find the mini PC's LAN IP with `hostname -I` on the mini PC.
+
+Also forward port **80** (HTTP → 80) — Caddy needs it to complete the Let's
+Encrypt HTTP-01 challenge on the first run, then redirects all traffic to HTTPS
+automatically.
+
+> **Note:** Some ISPs block inbound port 80/443 on residential connections.
+> If Let's Encrypt fails with a timeout, see the "Troubleshooting" section.
+
+---
+
+## Installing and configuring Caddy on the mini PC
+
+Run all commands below **on the mini PC** (not in the cluster or a container).
+
+### Step 4 — Install Caddy
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+    | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+    | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update
+sudo apt install caddy
+```
+
+Verify the install:
+
+```bash
+caddy version
+sudo systemctl status caddy    # should show "active (running)"
+```
+
+### Step 5 — Generate a Basic Auth password hash
+
+The Caddyfile in this repo (`deploy/Caddyfile`) includes a `basicauth` block so
+the dashboard stays private.  Generate a bcrypt hash for your password:
+
+```bash
+caddy hash-password
+# Enter your password at the prompt — copy the $2a$... output
+```
+
+### Step 6 — Deploy the Caddyfile
+
+Copy the Caddyfile from the repo to the system Caddy config location and fill in
+your username and password hash:
+
+```bash
+# From the repo root on the mini PC:
+sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
+
+# Open it and replace the placeholder with your real username and hash:
+sudo nano /etc/caddy/Caddyfile
+```
+
+The relevant section looks like:
+
+```
+basicauth {
+    ioachim $2a$14$<paste-your-hash-here>
+}
+```
+
+Replace `ioachim` with whatever username you want and paste the hash from Step 5.
+
+### Step 7 — Reload Caddy
+
+```bash
+sudo systemctl reload caddy
+# or, to apply config changes and watch for errors:
+sudo caddy reload --config /etc/caddy/Caddyfile
+```
+
+Caddy will immediately request a Let's Encrypt certificate for `news.lihor.ro`.
+Watch the logs to confirm:
+
+```bash
+sudo journalctl -u caddy -f
+```
+
+You should see a line like `certificate obtained successfully`.  This takes
+10–30 seconds on the first run.
+
+### Step 8 — Verify
+
+```bash
+curl -u ioachim:<your-password> https://news.lihor.ro/api/health
+# Expected: {"status":"ok","database":"PostgreSQL",...}
+```
+
+Open `https://news.lihor.ro` in Chrome on your phone — you should see a padlock
+and, after a few seconds of visiting, an install prompt or the option in the
+browser menu to "Add to Home Screen" as a standalone app (no browser chrome).
+
+---
+
+## Keeping the Caddyfile in sync with the repo
+
+The `deploy/Caddyfile` in this repo is the source of truth for the Caddy config.
+After any change, copy it to the mini PC and reload:
+
+```bash
+sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+The password hash is **not** stored in the repo (it would be visible to anyone
+with repo access).  Keep a note of your password somewhere safe; regenerate the
+hash with `caddy hash-password` if you lose it.
+
+---
+
+## Dynamic IP / DDNS (if your public IP changes)
+
+Residential ISPs often assign a new public IP when the router reboots.  If the
+DNS A record goes stale, the certificate renewal and site access both break.
+
+Options:
+
+1. **Check periodically**: run `curl -s https://ifconfig.me` and update the DNS
+   record if it changed.
+2. **DDNS client**: most routers have a built-in DDNS client that updates a
+   provider (DuckDNS, No-IP, Cloudflare) automatically.  If `lihor.ro` is on
+   Cloudflare, the Cloudflare DDNS client can keep the A record current with
+   zero manual effort.
+3. **Static IP**: ask your ISP for a static residential IP (usually a small
+   monthly fee).
+
+---
+
+## Troubleshooting
+
+**`caddy reload` shows a config error**
+Run `caddy validate --config /etc/caddy/Caddyfile` to see the exact error.
+
+**Let's Encrypt certificate request times out**
+Caddy uses HTTP-01 challenge by default, which requires port 80 to be reachable
+from the internet.  Check:
+- Port 80 is forwarded on the router (Step 3)
+- Your ISP doesn't block inbound port 80 (try `curl http://news.lihor.ro` from
+  a mobile data connection, not Wi-Fi)
+- The DNS A record has propagated (`dig +short news.lihor.ro` returns your IP)
+
+If port 80 is blocked, switch to DNS-01 challenge — this requires a Cloudflare
+API token if `lihor.ro` is on Cloudflare.  See
+https://caddyserver.com/docs/automatic-https#dns-challenge.
+
+**Chrome still shows "Add to Bookmark" instead of "Install"**
+Open DevTools → Application → Manifest and check the "Installability" section.
+Common remaining issues:
+- The service worker hasn't activated yet — visit the page, wait 10 seconds,
+  then close and reopen it
+- A previous visit cached a non-HTTPS version — clear site data in Chrome
+  settings and try again
+
+**Basic Auth prompt doesn't appear / returns 401**
+Re-generate the hash (`caddy hash-password`) and make sure there's no trailing
+whitespace when you paste it into the Caddyfile.  Then `sudo systemctl reload caddy`.

--- a/docs/RUNNER_SETUP.md
+++ b/docs/RUNNER_SETUP.md
@@ -107,3 +107,13 @@ If missing, re-run the workflow or create it manually with the PAT.
 **Deployment name**: The Helm release name `news-dashboard` + chart name `news-dashboard`
 produces the pod/deployment name `news-dashboard-news-dashboard`.  This is expected
 (Helm double-name pattern); don't rename without a `helm rename` migration.
+
+## HTTPS / Caddy setup
+
+The app runs as a NodePort service on `localhost:30088`.  To serve it over HTTPS
+at `news.lihor.ro` (required for PWA install, service worker, and Basic Auth),
+a host-level Caddy reverse proxy is needed.
+
+See **[docs/CADDY_HTTPS_SETUP.md](CADDY_HTTPS_SETUP.md)** for the full walkthrough,
+including the Caddyfile (at `deploy/Caddyfile` in this repo), DNS configuration,
+router port forwarding, and Let's Encrypt certificate setup.


### PR DESCRIPTION
## Summary

Adds everything needed to get `news.lihor.ro` behind Caddy with HTTPS — which is the prerequisite for Chrome to show the PWA install prompt and for the service worker to register.

**What's in the repo now:**

- `deploy/Caddyfile` — the Caddy config: `news.lihor.ro` → reverse proxy `localhost:30088` with Basic Auth. Caddy handles Let's Encrypt cert acquisition and renewal automatically.
- `docs/CADDY_HTTPS_SETUP.md` — full step-by-step setup guide (install Caddy, generate password hash, deploy Caddyfile, DNS, router port forwarding, verification, DDNS note, troubleshooting).
- `docs/RUNNER_SETUP.md` — added a cross-reference section pointing to the new HTTPS guide.
- `README.md` — deployment notes updated to mention the Caddyfile location and HTTPS requirement for PWA.

## No code changes

The app bundle, service worker, and manifest are unchanged and already correct. The only missing piece was HTTPS at the network layer.

## Test plan

- [x] All existing tests pass (167 vitest, 160 pytest, typecheck, lint)
- [x] No app code changed — docs/config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)