### PR TITLE
feat: users table + bcrypt auth + signed session cookies + admin API (#126)

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -1,0 +1,230 @@
+"""Authentication: users, sessions, and FastAPI dependencies."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Annotated, Any
+
+import bcrypt
+from fastapi import Depends, HTTPException, Request
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from .db import connect, init_db, row_to_dict
+
+logger = logging.getLogger(__name__)
+
+_SESSION_COOKIE = "nd_session"
+_SESSION_SALT = "nd-session-v1"
+
+# --------------------------------------------------------------------------- #
+# Session secret — required in production; tests may set TEST_SESSION_SECRET.  #
+# --------------------------------------------------------------------------- #
+
+
+def _get_secret() -> str:
+    secret = os.getenv("SESSION_SECRET") or os.getenv("TEST_SESSION_SECRET")
+    if not secret:
+        msg = (
+            "SESSION_SECRET env var is not set. "
+            'Generate one with: python -c "import secrets; print(secrets.token_hex(32))"'
+        )
+        raise RuntimeError(msg)
+    return secret
+
+
+def _session_days() -> int:
+    try:
+        return int(os.getenv("SESSION_DAYS", "30"))
+    except ValueError:
+        return 30
+
+
+# --------------------------------------------------------------------------- #
+# Password helpers                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    try:
+        return bcrypt.checkpw(password.encode(), password_hash.encode())
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Session cookie helpers                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def create_session_token(user_id: int, is_admin: bool) -> str:
+    s = URLSafeTimedSerializer(_get_secret(), salt=_SESSION_SALT)
+    return s.dumps({"u": user_id, "a": int(is_admin)})
+
+
+def verify_session_token(token: str) -> dict[str, Any] | None:
+    s = URLSafeTimedSerializer(_get_secret(), salt=_SESSION_SALT)
+    max_age = _session_days() * 86400
+    try:
+        payload = s.loads(token, max_age=max_age)
+        return {"user_id": payload["u"], "is_admin": bool(payload["a"])}
+    except (BadSignature, SignatureExpired, KeyError):
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# User DB helpers                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def get_user_by_id(user_id: int) -> dict[str, Any] | None:
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT id, username, email, is_admin, created_at, last_login_at FROM users WHERE id=?",
+            (user_id,),
+        ).fetchone()
+        return row_to_dict(row) if row else None
+
+
+def get_user_by_username(username: str) -> dict[str, Any] | None:
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT id, username, email, is_admin, created_at, last_login_at, password_hash"
+            " FROM users WHERE username=?",
+            (username,),
+        ).fetchone()
+        return row_to_dict(row) if row else None
+
+
+def create_user(
+    username: str,
+    password: str,
+    *,
+    email: str | None = None,
+    is_admin: bool = False,
+) -> dict[str, Any]:
+    password_hash = hash_password(password)
+    with connect() as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash, email, is_admin)"
+            " VALUES(?, ?, ?, ?) RETURNING id, username, email, is_admin, created_at",
+            (username, password_hash, email, 1 if is_admin else 0),
+        ).fetchone()
+        if row is None:
+            msg = "User insert returned no row"
+            raise RuntimeError(msg)
+        return row_to_dict(row)
+
+
+def list_users() -> list[dict[str, Any]]:
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT id, username, email, is_admin, created_at, last_login_at FROM users ORDER BY id"
+        ).fetchall()
+        return [row_to_dict(r) for r in rows]
+
+
+def update_password(user_id: int, new_password: str) -> bool:
+    new_hash = hash_password(new_password)
+    with connect() as conn:
+        cursor = conn.execute("UPDATE users SET password_hash=? WHERE id=?", (new_hash, user_id))
+        return bool(cursor.rowcount > 0)
+
+
+def delete_user(user_id: int) -> bool:
+    with connect() as conn:
+        cursor = conn.execute("DELETE FROM users WHERE id=?", (user_id,))
+        return bool(cursor.rowcount > 0)
+
+
+def _touch_last_login(user_id: int) -> None:
+    with connect() as conn:
+        conn.execute("UPDATE users SET last_login_at=CURRENT_TIMESTAMP WHERE id=?", (user_id,))
+
+
+# --------------------------------------------------------------------------- #
+# Bootstrap: create first admin from env vars on startup                       #
+# --------------------------------------------------------------------------- #
+
+
+def bootstrap_admin() -> None:
+    username = os.getenv("BOOTSTRAP_ADMIN_USERNAME")
+    password = os.getenv("BOOTSTRAP_ADMIN_PASSWORD")
+    if not username or not password:
+        with connect() as conn:
+            count = conn.execute("SELECT COUNT(*) FROM users").fetchone()
+            n = count[0] if not isinstance(count, dict) else count["count(*)"]
+            if int(n) == 0:
+                logger.warning(
+                    "No users exist and BOOTSTRAP_ADMIN_USERNAME/BOOTSTRAP_ADMIN_PASSWORD "
+                    "are not set. The app will start but login is impossible. "
+                    "Set these env vars to create the first admin account."
+                )
+        return
+
+    with connect() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM users").fetchone()
+        n = count[0] if not isinstance(count, dict) else count["count(*)"]
+        if int(n) > 0:
+            return  # users already exist; bootstrap is a no-op
+
+    user = create_user(username, password, is_admin=True)
+    logger.info("Bootstrap admin created: username=%s id=%s", user["username"], user["id"])
+
+
+# --------------------------------------------------------------------------- #
+# FastAPI dependencies                                                          #
+# --------------------------------------------------------------------------- #
+
+
+async def get_current_user(request: Request) -> dict[str, Any]:
+    token = request.cookies.get(_SESSION_COOKIE)
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    payload = verify_session_token(token)
+    if not payload:
+        raise HTTPException(status_code=401, detail="Session expired or invalid")
+    user = get_user_by_id(payload["user_id"])
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user
+
+
+async def require_auth(
+    user: Annotated[dict[str, Any], Depends(get_current_user)],
+) -> dict[str, Any]:
+    return user
+
+
+async def require_admin(
+    user: Annotated[dict[str, Any], Depends(get_current_user)],
+) -> dict[str, Any]:
+    if not user.get("is_admin"):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return user
+
+
+# --------------------------------------------------------------------------- #
+# Login / logout helpers (called from main.py)                                 #
+# --------------------------------------------------------------------------- #
+
+
+def authenticate(username: str, password: str) -> dict[str, Any] | None:
+    """Return user dict if credentials are valid, None otherwise."""
+    user = get_user_by_username(username)
+    if not user:
+        return None
+    if not verify_password(password, user["password_hash"]):
+        return None
+    _touch_last_login(user["id"])
+    return {k: v for k, v in user.items() if k != "password_hash"}
+
+
+def init_auth() -> None:
+    """Initialise DB and bootstrap first admin on startup."""
+    init_db()
+    bootstrap_admin()

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -25,6 +25,16 @@ SQLITE_SCHEMA = """
 PRAGMA journal_mode=WAL;
 PRAGMA foreign_keys=ON;
 
+CREATE TABLE IF NOT EXISTS users (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  username      TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  email         TEXT,
+  is_admin      INTEGER NOT NULL DEFAULT 0,
+  created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_login_at TEXT
+);
+
 CREATE TABLE IF NOT EXISTS sources (
   slug TEXT PRIMARY KEY,
   name TEXT NOT NULL,
@@ -132,6 +142,10 @@ SQLITE_COLUMN_MIGRATIONS = [
     ("articles", "starred_at", "TEXT"),
     ("articles", "later_until", "TEXT"),
     ("articles", "restored_at", "TEXT"),
+    # #126 auth — owner column on sources
+    ("sources", "owner_user_id", "INTEGER REFERENCES users(id)"),
+    # #129 per-user briefings
+    ("briefings", "user_id", "INTEGER REFERENCES users(id)"),
 ]
 
 # Data-only migrations run after column additions (idempotent via WHERE guard)
@@ -154,6 +168,17 @@ SQLITE_DATA_MIGRATIONS = [
 ]
 
 POSTGRES_SCHEMA = [
+    """
+    CREATE TABLE IF NOT EXISTS users (
+      id            SERIAL PRIMARY KEY,
+      username      TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      email         TEXT,
+      is_admin      BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_login_at TIMESTAMPTZ
+    )
+    """,
     """
     CREATE TABLE IF NOT EXISTS sources (
       slug TEXT PRIMARY KEY,
@@ -310,6 +335,14 @@ POSTGRES_SCHEMA = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_briefing_articles_briefing ON briefing_articles(briefing_id)",
+    # #126 Auth — owner column on sources (NULL = global catalog)
+    (
+        "ALTER TABLE sources ADD COLUMN IF NOT EXISTS"
+        " owner_user_id INTEGER REFERENCES users(id) ON DELETE CASCADE"
+    ),
+    # #129 Per-user briefings
+    "ALTER TABLE briefings ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
+    "CREATE INDEX IF NOT EXISTS idx_briefings_user ON briefings(user_id, created_at DESC)",
 ]
 
 # SQLite-compatible briefing tables (TEXT instead of JSONB/TIMESTAMPTZ, for tests only)
@@ -325,7 +358,8 @@ CREATE TABLE IF NOT EXISTS briefings (
   summary    TEXT,
   content    TEXT,
   model      TEXT,
-  error      TEXT
+  error      TEXT,
+  user_id    INTEGER REFERENCES users(id)
 );
 
 CREATE TABLE IF NOT EXISTS briefing_articles (
@@ -339,6 +373,74 @@ CREATE TABLE IF NOT EXISTS briefing_articles (
 CREATE INDEX IF NOT EXISTS idx_briefings_created ON briefings(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_briefing_articles_briefing ON briefing_articles(briefing_id);
 """
+
+# SQLite-compatible multi-user tables (for tests)
+SQLITE_MULTIUSER_SCHEMA = """
+CREATE TABLE IF NOT EXISTS user_sources (
+  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source_slug TEXT    NOT NULL REFERENCES sources(slug) ON DELETE CASCADE,
+  enabled     INTEGER NOT NULL DEFAULT 1,
+  added_at    TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, source_slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_sources_user ON user_sources(user_id, enabled);
+
+CREATE TABLE IF NOT EXISTS user_article_state (
+  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  article_id  INTEGER NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+  state       TEXT NOT NULL DEFAULT 'today'
+                CHECK(state IN ('today','done','skipped','archived','later')),
+  starred     INTEGER NOT NULL DEFAULT 0,
+  done_at     TEXT,
+  starred_at  TEXT,
+  skipped_at  TEXT,
+  archived_at TEXT,
+  later_until TEXT,
+  restored_at TEXT,
+  updated_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, article_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_uas_user_state ON user_article_state(user_id, state);
+CREATE INDEX IF NOT EXISTS idx_uas_user_starred ON user_article_state(user_id, starred);
+"""
+
+# PostgreSQL multi-user tables
+POSTGRES_MULTIUSER_SCHEMA = [
+    """
+    CREATE TABLE IF NOT EXISTS user_sources (
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      source_slug TEXT    NOT NULL REFERENCES sources(slug) ON DELETE CASCADE,
+      enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+      added_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (user_id, source_slug)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_sources_user ON user_sources(user_id, enabled)",
+    """
+    CREATE TABLE IF NOT EXISTS user_article_state (
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      article_id  BIGINT  NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+      state       TEXT NOT NULL DEFAULT 'today'
+                    CHECK(state IN ('today','done','skipped','archived','later')),
+      starred     BOOLEAN NOT NULL DEFAULT FALSE,
+      done_at     TIMESTAMPTZ,
+      starred_at  TIMESTAMPTZ,
+      skipped_at  TIMESTAMPTZ,
+      archived_at TIMESTAMPTZ,
+      later_until TIMESTAMPTZ,
+      restored_at TIMESTAMPTZ,
+      updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (user_id, article_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_uas_user_state ON user_article_state(user_id, state)",
+    (
+        "CREATE INDEX IF NOT EXISTS idx_uas_user_starred"
+        " ON user_article_state(user_id, starred) WHERE starred = TRUE"
+    ),
+]
 
 
 def _validate_postgres_url(url: str) -> str:
@@ -375,7 +477,10 @@ def is_postgres(database_url: str | None = None) -> bool:
 
 
 def describe_database(db_path: Path | None = None, database_url: str | None = None) -> str:
-    url = active_database_url(database_url)
+    try:
+        url = active_database_url(database_url)
+    except RuntimeError:
+        return str(db_path or DB_PATH)
     if url:
         parts = urlsplit(url)
         if parts.password:
@@ -464,7 +569,7 @@ def _apply_sqlite_data_migrations(conn: Any) -> None:
 def init_db(db_path: Path | None = None, database_url: str | None = None) -> None:
     if is_postgres(database_url):
         with connect(db_path, database_url) as conn:
-            for statement in POSTGRES_SCHEMA:
+            for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
                 try:
                     conn.execute(statement)
                 except Exception:  # idempotent best-effort schema statements
@@ -473,6 +578,7 @@ def init_db(db_path: Path | None = None, database_url: str | None = None) -> Non
     with connect(db_path, database_url) as conn:
         conn.executescript(SQLITE_SCHEMA)
         conn.executescript(SQLITE_BRIEFINGS_SCHEMA)
+        conn.executescript(SQLITE_MULTIUSER_SCHEMA)
         _apply_sqlite_column_migrations(conn)
         _apply_sqlite_data_migrations(conn)
         _build_fts_index(conn)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -6,14 +6,26 @@ from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.responses import Response
+from starlette.responses import Response as StarletteResponse
 
+from .auth import (
+    authenticate,
+    create_session_token,
+    create_user,
+    delete_user,
+    get_user_by_id,
+    init_auth,
+    list_users,
+    require_admin,
+    require_auth,
+    update_password,
+)
 from .body_fetch import fetch_and_cache_body, get_article
 from .briefings import (
     BriefingAINotConfiguredError,
@@ -58,11 +70,14 @@ from .stats import (
     triage_metrics,
 )
 
+_SESSION_COOKIE = "nd_session"
+_SESSION_DAYS = 30
+
 
 class SPAStaticFiles(StaticFiles):
     """Serve index.html for client-side routes while preserving API/static 404s."""
 
-    async def get_response(self, path: str, scope: MutableMapping[str, Any]) -> Response:
+    async def get_response(self, path: str, scope: MutableMapping[str, Any]) -> StarletteResponse:
         try:
             return await super().get_response(path, scope)
         except StarletteHTTPException as exc:
@@ -75,19 +90,23 @@ class SPAStaticFiles(StaticFiles):
 
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    init_auth()
     sync_sources()
     start_scheduler()
     yield
     stop_scheduler()
 
 
-app = FastAPI(title="News Dashboard", version="0.3.0", lifespan=lifespan)
+app = FastAPI(title="News Dashboard", version="0.4.0", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
     allow_methods=["*"],
     allow_headers=["*"],
+    allow_credentials=True,
 )
+
+# ── Pydantic models ──────────────────────────────────────────────────────────
 
 
 class StatusUpdate(BaseModel):
@@ -110,7 +129,32 @@ class EnabledUpdate(BaseModel):
     enabled: bool
 
 
-@app.get("/api/health")
+class IntervalUpdate(BaseModel):
+    minutes: int
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class CreateUserRequest(BaseModel):
+    username: str
+    password: str
+    email: str | None = None
+    is_admin: bool = False
+
+
+class UpdatePasswordRequest(BaseModel):
+    password: str
+
+
+# ── Public auth routes (no session required) ──────────────────────────────────
+
+public_router = APIRouter()
+
+
+@public_router.get("/api/health")
 def health() -> dict[str, Any]:
     init_db()
     return {
@@ -120,36 +164,59 @@ def health() -> dict[str, Any]:
     }
 
 
-@app.post("/api/ingest")
+@public_router.post("/api/auth/login")
+def login(payload: LoginRequest, response: Response) -> dict[str, Any]:
+    user = authenticate(payload.username, payload.password)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_session_token(user["id"], bool(user["is_admin"]))
+    response.set_cookie(
+        key=_SESSION_COOKIE,
+        value=token,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=_SESSION_DAYS * 86400,
+        path="/",
+    )
+    return {"id": user["id"], "username": user["username"], "is_admin": bool(user["is_admin"])}
+
+
+@public_router.get("/api/auth/logout")
+def logout(response: Response) -> dict[str, str]:
+    response.delete_cookie(key=_SESSION_COOKIE, path="/")
+    return {"status": "logged_out"}
+
+
+app.include_router(public_router)
+
+# ── Authenticated API router ─────────────────────────────────────────────────
+
+api = APIRouter(dependencies=[Depends(require_auth)])
+
+
+@api.get("/api/auth/me")
+def auth_me(current_user: Annotated[dict[str, Any], Depends(require_auth)]) -> dict[str, Any]:
+    return {
+        "id": current_user["id"],
+        "username": current_user["username"],
+        "email": current_user.get("email"),
+        "is_admin": bool(current_user["is_admin"]),
+    }
+
+
+@api.post("/api/ingest")
 def ingest() -> dict[str, Any]:
     results = ingest_all()
     return {"results": results, "inserted": sum(v for v in results.values() if v > 0)}
 
 
-@app.get("/api/ingest/stream")
+@api.get("/api/ingest/stream")
 def ingest_stream() -> StreamingResponse:
     return StreamingResponse(stream_ingest_events(), media_type="text/event-stream")
 
 
-@app.get("/api/ingest/runs")
-def ingest_runs(
-    from_: Annotated[datetime | None, Query(alias="from")] = None,
-    to: Annotated[datetime | None, Query()] = None,
-    page: Annotated[int, Query(ge=1)] = 1,
-    per_page: Annotated[int, Query(ge=1, le=100)] = 20,
-) -> dict[str, Any]:
-    return list_ingest_runs(from_=from_, to=to, page=page, per_page=per_page)
-
-
-@app.get("/api/ingest/runs/{run_id}")
-def ingest_run_sources(run_id: int) -> dict[str, Any]:
-    sources = get_ingest_run_sources(run_id)
-    if sources is None:
-        raise HTTPException(status_code=404, detail="ingest run not found")
-    return {"items": sources}
-
-
-@app.get("/api/articles")
+@api.get("/api/articles")
 def articles(
     status: Annotated[str | None, Query()] = None,
     state: Annotated[str | None, Query()] = None,
@@ -170,7 +237,7 @@ def articles(
     }
 
 
-@app.get("/api/search")
+@api.get("/api/search")
 def search(  # noqa: PLR0913
     q: Annotated[str, Query(description="Space-separated search terms")] = "",
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
@@ -195,7 +262,7 @@ def search(  # noqa: PLR0913
     }
 
 
-@app.get("/api/articles/{article_id}")
+@api.get("/api/articles/{article_id}")
 def get_article_by_id(article_id: int) -> dict[str, Any]:
     article = get_article(article_id)
     if not article:
@@ -203,16 +270,15 @@ def get_article_by_id(article_id: int) -> dict[str, Any]:
     return article
 
 
-@app.post("/api/articles/{article_id}/body")
+@api.post("/api/articles/{article_id}/body")
 def fetch_article_body(article_id: int) -> dict[str, Any]:
-    """Fetch and cache full body text for an article. Idempotent (cache hit returns fast)."""
     article = fetch_and_cache_body(article_id)
     if not article:
         raise HTTPException(status_code=404, detail="article not found")
     return article
 
 
-@app.patch("/api/articles/{article_id}/status")
+@api.patch("/api/articles/{article_id}/status")
 def update_status(article_id: int, payload: StatusUpdate) -> dict[str, Any]:
     try:
         article = set_article_status(article_id, payload.status)
@@ -223,7 +289,7 @@ def update_status(article_id: int, payload: StatusUpdate) -> dict[str, Any]:
     return article
 
 
-@app.patch("/api/articles/{article_id}/state")
+@api.patch("/api/articles/{article_id}/state")
 def update_state(article_id: int, payload: StateUpdate) -> dict[str, Any]:
     try:
         article = transition_article_state(article_id, payload.state)
@@ -234,7 +300,7 @@ def update_state(article_id: int, payload: StateUpdate) -> dict[str, Any]:
     return article
 
 
-@app.patch("/api/articles/{article_id}/star")
+@api.patch("/api/articles/{article_id}/star")
 def update_star(article_id: int, payload: StarUpdate) -> dict[str, Any]:
     article = set_article_starred(article_id, payload.starred)
     if not article:
@@ -242,7 +308,7 @@ def update_star(article_id: int, payload: StarUpdate) -> dict[str, Any]:
     return article
 
 
-@app.patch("/api/articles/{article_id}/later")
+@api.patch("/api/articles/{article_id}/later")
 def snooze_later(article_id: int, payload: LaterUpdate) -> dict[str, Any]:
     try:
         article = send_article_later(article_id, payload.days)
@@ -253,9 +319,8 @@ def snooze_later(article_id: int, payload: LaterUpdate) -> dict[str, Any]:
     return article
 
 
-@app.get("/api/articles/{article_id}/read")
+@api.get("/api/articles/{article_id}/read")
 def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict[str, Any]:
-    """One-click mark-read endpoint for digest emails. Validates a signed token."""
     from .digest import verify_read_token
 
     if not verify_read_token(article_id, token):
@@ -269,7 +334,7 @@ def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict
     return {"status": "marked_read", "article": article}
 
 
-@app.get("/api/sources")
+@api.get("/api/sources")
 def sources() -> dict[str, Any]:
     init_db()
     with connect() as conn:
@@ -279,12 +344,12 @@ def sources() -> dict[str, Any]:
         return {"items": [row_to_dict(row) for row in rows]}
 
 
-@app.get("/api/sources/health")
+@api.get("/api/sources/health")
 def sources_health() -> dict[str, Any]:
     return {"items": list_source_health()}
 
 
-@app.patch("/api/sources/{slug}/enabled")
+@api.patch("/api/sources/{slug}/enabled")
 def set_source_enabled(slug: str, payload: EnabledUpdate) -> dict[str, Any]:
     init_db()
     with connect() as conn:
@@ -298,11 +363,7 @@ def set_source_enabled(slug: str, payload: EnabledUpdate) -> dict[str, Any]:
         return row_to_dict(row)
 
 
-class IntervalUpdate(BaseModel):
-    minutes: int
-
-
-@app.get("/api/scheduler/status")
+@api.get("/api/scheduler/status")
 def scheduler_status() -> dict[str, Any]:
     next_run = get_next_ingest_at()
     paused = is_paused()
@@ -313,7 +374,10 @@ def scheduler_status() -> dict[str, Any]:
     }
 
 
-@app.post("/api/scheduler/interval")
+_admin_dep = [Depends(require_admin)]
+
+
+@api.post("/api/scheduler/interval", dependencies=_admin_dep)
 def scheduler_set_interval(payload: IntervalUpdate) -> dict[str, Any]:
     if payload.minutes < 1:
         raise HTTPException(status_code=400, detail="minutes must be >= 1")
@@ -321,19 +385,37 @@ def scheduler_set_interval(payload: IntervalUpdate) -> dict[str, Any]:
     return {"interval_minutes": payload.minutes, "next_run_at": get_next_ingest_at()}
 
 
-@app.post("/api/scheduler/pause")
+@api.post("/api/scheduler/pause", dependencies=_admin_dep)
 def scheduler_pause() -> dict[str, Any]:
     pause_scheduler()
     return {"paused": True}
 
 
-@app.post("/api/scheduler/resume")
+@api.post("/api/scheduler/resume", dependencies=_admin_dep)
 def scheduler_resume() -> dict[str, Any]:
     resume_scheduler()
     return {"paused": False, "next_run_at": get_next_ingest_at()}
 
 
-@app.get("/api/stats/overview")
+@api.get("/api/ingest/runs", dependencies=_admin_dep)
+def ingest_runs(
+    from_: Annotated[datetime | None, Query(alias="from")] = None,
+    to: Annotated[datetime | None, Query()] = None,
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> dict[str, Any]:
+    return list_ingest_runs(from_=from_, to=to, page=page, per_page=per_page)
+
+
+@api.get("/api/ingest/runs/{run_id}", dependencies=_admin_dep)
+def ingest_run_sources(run_id: int) -> dict[str, Any]:
+    run_sources = get_ingest_run_sources(run_id)
+    if run_sources is None:
+        raise HTTPException(status_code=404, detail="ingest run not found")
+    return {"items": run_sources}
+
+
+@api.get("/api/stats/overview", dependencies=_admin_dep)
 def stats_overview_endpoint(
     from_: Annotated[str, Query(alias="from")],
     to: Annotated[str, Query()],
@@ -344,7 +426,7 @@ def stats_overview_endpoint(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@app.get("/api/stats/articles-over-time")
+@api.get("/api/stats/articles-over-time", dependencies=_admin_dep)
 def stats_articles_over_time_endpoint(
     from_: Annotated[str, Query(alias="from")],
     to: Annotated[str, Query()],
@@ -355,7 +437,7 @@ def stats_articles_over_time_endpoint(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@app.get("/api/stats/sources-volume")
+@api.get("/api/stats/sources-volume", dependencies=_admin_dep)
 def stats_sources_volume_endpoint(
     from_: Annotated[str, Query(alias="from")],
     to: Annotated[str, Query()],
@@ -366,32 +448,32 @@ def stats_sources_volume_endpoint(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@app.get("/api/stats/article-counts")
+@api.get("/api/stats/article-counts", dependencies=_admin_dep)
 def stats_article_counts_endpoint() -> dict[str, Any]:
     return article_counts()
 
 
-@app.get("/api/stats/triage-metrics")
+@api.get("/api/stats/triage-metrics", dependencies=_admin_dep)
 def stats_triage_metrics_endpoint() -> dict[str, Any]:
     return triage_metrics()
 
 
-@app.get("/api/stats/source-quality")
+@api.get("/api/stats/source-quality", dependencies=_admin_dep)
 def stats_source_quality_endpoint() -> dict[str, Any]:
     return {"items": source_quality()}
 
 
-@app.get("/api/stats/category-mix")
+@api.get("/api/stats/category-mix", dependencies=_admin_dep)
 def stats_category_mix_endpoint() -> dict[str, Any]:
     return {"items": category_mix()}
 
 
-@app.get("/api/stats/ingested-vs-handled")
+@api.get("/api/stats/ingested-vs-handled", dependencies=_admin_dep)
 def stats_ingested_vs_handled_endpoint() -> dict[str, Any]:
     return {"items": ingested_vs_handled()}
 
 
-@app.get("/api/briefings/latest")
+@api.get("/api/briefings/latest")
 def briefings_latest() -> dict[str, Any]:
     briefing = get_latest_briefing()
     if briefing is None:
@@ -399,7 +481,7 @@ def briefings_latest() -> dict[str, Any]:
     return briefing
 
 
-@app.get("/api/briefings")
+@api.get("/api/briefings")
 def briefings_list(
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     offset: Annotated[int, Query(ge=0)] = 0,
@@ -407,7 +489,7 @@ def briefings_list(
     return {"items": list_briefings(limit=limit, offset=offset)}
 
 
-@app.get("/api/briefings/{briefing_id}")
+@api.get("/api/briefings/{briefing_id}")
 def briefings_detail(briefing_id: int) -> dict[str, Any]:
     briefing = get_briefing(briefing_id)
     if briefing is None:
@@ -415,9 +497,8 @@ def briefings_detail(briefing_id: int) -> dict[str, Any]:
     return briefing
 
 
-@app.post("/api/briefings")
+@api.post("/api/briefings")
 def briefings_create() -> dict[str, Any]:
-    """Generate a briefing from eligible Today articles and persist it."""
     try:
         return generate_briefing()
     except BriefingAINotConfiguredError as exc:
@@ -431,9 +512,8 @@ class AskRequest(BaseModel):
     include_all: bool = False
 
 
-@app.post("/api/ask")
+@api.post("/api/ask")
 def ask_ai(payload: AskRequest) -> dict[str, Any]:
-    """Answer a natural-language question using saved/read articles as context."""
     from .embeddings import ask
 
     q = payload.query.strip()
@@ -442,11 +522,10 @@ def ask_ai(payload: AskRequest) -> dict[str, Any]:
     try:
         return ask(q, include_all=payload.include_all)
     except Exception as exc:
-        # Surface errors clearly (missing API keys, etc.)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
-@app.get("/api/summary")
+@api.get("/api/summary")
 def summary() -> dict[str, Any]:
     init_db()
     with connect() as conn:
@@ -461,6 +540,62 @@ def summary() -> dict[str, Any]:
         "byCategory": {row["category"]: row["count"] for row in category_rows},
     }
 
+
+# ── Admin user-management routes ─────────────────────────────────────────────
+
+admin = APIRouter(prefix="/api/admin", dependencies=[Depends(require_admin)])
+
+
+@admin.get("/users")
+def admin_list_users() -> dict[str, Any]:
+    return {"items": list_users()}
+
+
+@admin.post("/users")
+def admin_create_user(payload: CreateUserRequest) -> dict[str, Any]:
+    try:
+        return create_user(
+            payload.username,
+            payload.password,
+            email=payload.email,
+            is_admin=payload.is_admin,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@admin.get("/users/{user_id}")
+def admin_get_user(user_id: int) -> dict[str, Any]:
+    user = get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="user not found")
+    return user
+
+
+@admin.patch("/users/{user_id}/password")
+def admin_update_password(user_id: int, payload: UpdatePasswordRequest) -> dict[str, Any]:
+    if not update_password(user_id, payload.password):
+        raise HTTPException(status_code=404, detail="user not found")
+    return {"status": "updated"}
+
+
+@admin.delete("/users/{user_id}")
+def admin_delete_user(
+    user_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    if user_id == current_user["id"]:
+        raise HTTPException(status_code=400, detail="cannot delete your own account")
+    if not delete_user(user_id):
+        raise HTTPException(status_code=404, detail="user not found")
+    return {"status": "deleted"}
+
+
+app.include_router(api)
+app.include_router(admin)
+
+
+# ── SPA static files ─────────────────────────────────────────────────────────
 
 static_dir = Path(__file__).resolve().parents[2] / "frontend" / "dist"
 if static_dir.exists():

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,15 +7,24 @@ is not reachable (e.g. on a dev machine without Docker Desktop).
 
 The ``pg_clean`` fixture truncates briefing/article/source rows before each
 test so every integration test starts from a known empty state.
+
+Auth: ``override_auth`` is an autouse fixture that patches ``require_auth``
+and ``require_admin`` to return a fake admin user so existing API tests keep
+working without needing real sessions.  Auth-specific tests that need real
+session behaviour should clear ``app.dependency_overrides`` themselves.
 """
 
 from __future__ import annotations
 
+import os
 from collections.abc import Generator
 
 import pytest
 
 from news_dashboard.db import init_db
+
+# Ensure SESSION_SECRET is set for all tests so auth module can load.
+os.environ.setdefault("TEST_SESSION_SECRET", "test-secret-key-not-for-production")
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -23,6 +32,33 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "postgres: marks tests that require a live PostgreSQL instance",
     )
+
+
+_FAKE_ADMIN = {
+    "id": 1,
+    "username": "testadmin",
+    "email": None,
+    "is_admin": True,
+    "created_at": "2026-01-01T00:00:00",
+    "last_login_at": None,
+}
+
+
+@pytest.fixture(autouse=True)
+def override_auth() -> Generator[None]:
+    """Inject a fake admin user into all tests that use the FastAPI app.
+
+    Auth-specific tests that need real session behaviour should call
+    ``app.dependency_overrides.clear()`` at the start of the test.
+    """
+    from news_dashboard.auth import require_admin, require_auth
+    from news_dashboard.main import app
+
+    app.dependency_overrides[require_auth] = lambda: _FAKE_ADMIN
+    app.dependency_overrides[require_admin] = lambda: _FAKE_ADMIN
+    yield
+    app.dependency_overrides.pop(require_auth, None)
+    app.dependency_overrides.pop(require_admin, None)
 
 
 @pytest.fixture(scope="session")
@@ -70,7 +106,8 @@ def pg_clean(pg_url: str) -> str:
 
     with psycopg.connect(pg_url) as conn:
         conn.execute(
-            "TRUNCATE briefing_articles, briefings, articles, sources RESTART IDENTITY CASCADE"
+            "TRUNCATE user_article_state, user_sources, briefing_articles, briefings,"
+            " articles, sources, users RESTART IDENTITY CASCADE"
         )
         conn.commit()
     return pg_url

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,290 @@
+"""Tests for #126: users table, login/logout, session cookies, and auth middleware."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import news_dashboard.db as db_mod
+from news_dashboard.auth import (
+    authenticate,
+    bootstrap_admin,
+    create_session_token,
+    create_user,
+    delete_user,
+    get_user_by_id,
+    hash_password,
+    list_users,
+    update_password,
+    verify_password,
+    verify_session_token,
+)
+from news_dashboard.db import init_db
+from news_dashboard.main import app
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _fresh_client() -> TestClient:
+    """Return a TestClient with NO dependency overrides — tests real auth flow."""
+    app.dependency_overrides.clear()
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fresh SQLite DB with DB_PATH patched so auth helpers use it."""
+    db = tmp_path / "test.db"
+    init_db(db)
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    return db
+
+
+# ── Password hashing ──────────────────────────────────────────────────────────
+
+
+def test_hash_and_verify_password() -> None:
+    h = hash_password("hunter2")
+    assert verify_password("hunter2", h)
+    assert not verify_password("wrong", h)
+
+
+def test_verify_bad_hash() -> None:
+    assert not verify_password("x", "not-a-valid-hash")
+
+
+# ── Session tokens ────────────────────────────────────────────────────────────
+
+
+def test_create_and_verify_token() -> None:
+    token = create_session_token(42, is_admin=True)
+    payload = verify_session_token(token)
+    assert payload is not None
+    assert payload["user_id"] == 42
+    assert payload["is_admin"] is True
+
+
+def test_tampered_token_rejected() -> None:
+    token = create_session_token(1, is_admin=False)
+    bad = token[:-4] + "xxxx"
+    assert verify_session_token(bad) is None
+
+
+def test_expired_token_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    import itsdangerous
+
+    token = create_session_token(1, is_admin=False)
+
+    def reject_all(self: Any, *a: Any, **kw: Any) -> Any:
+        msg = "forced"
+        raise itsdangerous.SignatureExpired(msg)
+
+    monkeypatch.setattr(itsdangerous.URLSafeTimedSerializer, "loads", reject_all)
+    assert verify_session_token(token) is None
+
+
+# ── User CRUD ─────────────────────────────────────────────────────────────────
+
+
+def test_create_and_get_user(tmp_db: Path) -> None:
+    user = create_user("alice", "secret", email="a@b.com", is_admin=False)
+    assert user["username"] == "alice"
+    assert user["email"] == "a@b.com"
+    assert not user["is_admin"]
+
+    fetched = get_user_by_id(user["id"])
+    assert fetched is not None
+    assert fetched["username"] == "alice"
+
+
+def test_list_users(tmp_db: Path) -> None:
+    create_user("u1", "p1")
+    create_user("u2", "p2")
+    usernames = [u["username"] for u in list_users()]
+    assert "u1" in usernames
+    assert "u2" in usernames
+
+
+def test_update_password(tmp_db: Path) -> None:
+    user = create_user("bob", "old")
+    assert update_password(user["id"], "new-pass")
+    assert authenticate("bob", "new-pass") is not None
+    assert authenticate("bob", "old") is None
+
+
+def test_delete_user(tmp_db: Path) -> None:
+    user = create_user("carol", "pw")
+    assert delete_user(user["id"])
+    assert get_user_by_id(user["id"]) is None
+
+
+# ── authenticate() ────────────────────────────────────────────────────────────
+
+
+def test_authenticate_correct(tmp_db: Path) -> None:
+    create_user("dave", "correct")
+    result = authenticate("dave", "correct")
+    assert result is not None
+    assert result["username"] == "dave"
+    assert "password_hash" not in result
+
+
+def test_authenticate_wrong_password(tmp_db: Path) -> None:
+    create_user("eve", "right")
+    assert authenticate("eve", "wrong") is None
+
+
+def test_authenticate_unknown_user(tmp_db: Path) -> None:
+    assert authenticate("nobody", "pw") is None
+
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+
+
+def test_bootstrap_creates_first_admin(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BOOTSTRAP_ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_ADMIN_PASSWORD", "adminpass")
+    bootstrap_admin()
+    users = list_users()
+    assert len(users) == 1
+    assert users[0]["username"] == "admin"
+    assert users[0]["is_admin"]
+
+
+def test_bootstrap_noop_if_users_exist(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BOOTSTRAP_ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("BOOTSTRAP_ADMIN_PASSWORD", "pw")
+    create_user("existing", "pw2")
+    bootstrap_admin()
+    users = list_users()
+    assert len(users) == 1
+    assert users[0]["username"] == "existing"
+
+
+# ── Login / logout API ────────────────────────────────────────────────────────
+
+
+def test_login_sets_cookie(tmp_db: Path) -> None:
+    create_user("frank", "frankpass", is_admin=False)
+    client = _fresh_client()
+    resp = client.post("/api/auth/login", json={"username": "frank", "password": "frankpass"})
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "frank"
+    assert "nd_session" in resp.cookies
+
+
+def test_login_wrong_password_returns_401(tmp_db: Path) -> None:
+    create_user("grace", "right")
+    client = _fresh_client()
+    resp = client.post("/api/auth/login", json={"username": "grace", "password": "wrong"})
+    assert resp.status_code == 401
+    assert "nd_session" not in resp.cookies
+
+
+def test_logout_clears_cookie(tmp_db: Path) -> None:
+    create_user("henry", "pw")
+    client = _fresh_client()
+    client.post("/api/auth/login", json={"username": "henry", "password": "pw"})
+    resp = client.get("/api/auth/logout")
+    assert resp.status_code == 200
+    assert resp.cookies.get("nd_session", "") == ""
+
+
+# ── Auth middleware: protected routes require session ─────────────────────────
+
+
+def test_protected_route_without_session_returns_401(tmp_db: Path) -> None:
+    client = _fresh_client()
+    resp = client.get("/api/articles", cookies={})
+    assert resp.status_code == 401
+
+
+def test_protected_route_with_valid_session(tmp_db: Path) -> None:
+    user = create_user("irene", "pw")
+    token = create_session_token(user["id"], is_admin=False)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.get("/api/articles")
+    assert resp.status_code == 200
+
+
+def test_auth_me_returns_current_user(tmp_db: Path) -> None:
+    user = create_user("jane", "pw", is_admin=True)
+    token = create_session_token(user["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.get("/api/auth/me")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["username"] == "jane"
+    assert data["is_admin"] is True
+
+
+# ── Admin-only routes ─────────────────────────────────────────────────────────
+
+
+def test_admin_route_blocked_for_non_admin(tmp_db: Path) -> None:
+    user = create_user("regular", "pw", is_admin=False)
+    token = create_session_token(user["id"], is_admin=False)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.get("/api/admin/users")
+    assert resp.status_code == 403
+
+
+def test_admin_list_users(tmp_db: Path) -> None:
+    admin = create_user("superadmin", "pw", is_admin=True)
+    create_user("other", "pw2")
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.get("/api/admin/users")
+    assert resp.status_code == 200
+    usernames = [u["username"] for u in resp.json()["items"]]
+    assert "superadmin" in usernames
+    assert "other" in usernames
+
+
+def test_admin_create_user(tmp_db: Path) -> None:
+    admin = create_user("superadmin", "pw", is_admin=True)
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.post(
+        "/api/admin/users",
+        json={"username": "newuser", "password": "newpass", "is_admin": False},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "newuser"
+
+
+def test_admin_delete_user(tmp_db: Path) -> None:
+    admin = create_user("theadmin", "pw", is_admin=True)
+    target = create_user("victim", "pw2", is_admin=False)
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.delete(f"/api/admin/users/{target['id']}")
+    assert resp.status_code == 200
+    assert get_user_by_id(target["id"]) is None
+
+
+def test_admin_cannot_delete_self(tmp_db: Path) -> None:
+    admin = create_user("self", "pw", is_admin=True)
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.delete(f"/api/admin/users/{admin['id']}")
+    assert resp.status_code == 400
+
+
+# ── Health endpoint is public ─────────────────────────────────────────────────
+
+
+def test_health_is_public(tmp_db: Path) -> None:
+    client = _fresh_client()
+    resp = client.get("/api/health")
+    assert resp.status_code == 200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
   "openai>=1.50.0",
   "numpy>=1.26.0",
   "rapidfuzz>=3.0.0",
+  "bcrypt>=4.0.0",
+  "itsdangerous>=2.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Adds `users` table (PostgreSQL + SQLite) with bcrypt-hashed passwords
- New `auth.py` module: password hashing, itsdangerous session tokens, `require_auth` / `require_admin` FastAPI dependencies, bootstrap admin from env vars
- Rewrites `main.py`: public auth routes (`POST /api/auth/login`, `GET /api/auth/logout`, `GET /api/auth/me`), authenticated `APIRouter`, admin router at `/api/admin/users` (list / create / get / update-password / delete)
- Stats, ingest-runs, and scheduler-mutate endpoints are now admin-only (via route-level `dependencies=[Depends(require_admin)]`)
- Also adds multi-user schema tables (`user_sources`, `user_article_state`) and columns (`sources.owner_user_id`, `briefings.user_id`) used by follow-on sub-issues #127–#129
- `conftest.py` autouse fixture injects fake admin user so all 186 existing tests stay green without modification

## Design decisions applied

- First admin account bootstrapped from `BOOTSTRAP_ADMIN_USERNAME` + `BOOTSTRAP_ADMIN_PASSWORD` env vars on startup when `users` table is empty (decision #1)
- Stateless signed cookie (`itsdangerous.URLSafeTimedSerializer`), 30-day default, `SESSION_SECRET` env var required (decisions #5)
- `TEST_SESSION_SECRET` env var allows tests to run without a real `SESSION_SECRET`

## Test plan

- [ ] 26 new tests in `backend/tests/test_auth.py` covering: password hashing, session tokens, user CRUD, bootstrap, login/logout, protected/public routes, admin-only enforcement
- [ ] All 186 existing tests still pass (autouse `override_auth` fixture in conftest)
- [ ] ruff, mypy, eslint, tsc all pass

Closes #126
Part of epic #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)