### PR TITLE
feat: per-user article state via user_article_state (#127)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -598,6 +598,20 @@ def ingest_all(db_path: Path | None = None) -> dict[str, int]:
 
 _INTERNAL_ARTICLE_COLUMNS = frozenset({"embedding", "fts_vector"})
 
+# UAS columns that override article-level state when a user_id is provided
+_UAS_STATE_COLUMNS = frozenset(
+    {
+        "state",
+        "starred",
+        "done_at",
+        "starred_at",
+        "skipped_at",
+        "archived_at",
+        "later_until",
+        "restored_at",
+    }
+)
+
 
 def _article_dict(row: Any) -> dict[str, Any]:
     """Convert a DB row to a dict, stripping internal-only columns.
@@ -612,7 +626,105 @@ def _article_dict(row: Any) -> dict[str, Any]:
     return d
 
 
-def list_articles(
+def _merge_uas(article: dict[str, Any], uas: dict[str, Any] | None) -> dict[str, Any]:
+    """Overlay per-user state from a user_article_state row onto an article dict.
+
+    When uas is None the article is implicitly in the 'today' state for the user
+    (the row doesn't exist yet because the user hasn't acted on it).
+    """
+    if uas is None:
+        article["state"] = "today"
+        article["starred"] = False
+        for col in (
+            "done_at",
+            "starred_at",
+            "skipped_at",
+            "archived_at",
+            "later_until",
+            "restored_at",
+        ):
+            article[col] = None
+    else:
+        article["state"] = uas.get("state") or "today"
+        article["starred"] = bool(uas.get("starred", False))
+        article["done_at"] = uas.get("done_at")
+        article["starred_at"] = uas.get("starred_at")
+        article["skipped_at"] = uas.get("skipped_at")
+        article["archived_at"] = uas.get("archived_at")
+        article["later_until"] = uas.get("later_until")
+        article["restored_at"] = uas.get("restored_at")
+    return article
+
+
+def _fetch_uas_map(conn: Any, article_ids: list[int], user_id: int) -> dict[int, dict[str, Any]]:
+    """Return a map of article_id → UAS row dict for the given user and article IDs."""
+    if not article_ids:
+        return {}
+    placeholders = ",".join("?" * len(article_ids))
+    rows = conn.execute(
+        f"SELECT * FROM user_article_state WHERE user_id = ? AND article_id IN ({placeholders})",
+        [user_id, *article_ids],
+    ).fetchall()
+    return {row_to_dict(r)["article_id"]: row_to_dict(r) for r in rows}
+
+
+def _get_uas_row(conn: Any, article_id: int, user_id: int) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT * FROM user_article_state WHERE user_id = ? AND article_id = ?",
+        (user_id, article_id),
+    ).fetchone()
+    return row_to_dict(row) if row else None
+
+
+def _upsert_uas(  # noqa: PLR0913
+    conn: Any,
+    user_id: int,
+    article_id: int,
+    *,
+    state: str,
+    starred: bool,
+    done_at: str | None = None,
+    starred_at: str | None = None,
+    skipped_at: str | None = None,
+    archived_at: str | None = None,
+    later_until: str | None = None,
+    restored_at: str | None = None,
+    updated_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO user_article_state(
+          user_id, article_id, state, starred,
+          done_at, starred_at, skipped_at, archived_at, later_until, restored_at, updated_at
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(user_id, article_id) DO UPDATE SET
+          state = excluded.state,
+          starred = excluded.starred,
+          done_at = COALESCE(excluded.done_at, user_article_state.done_at),
+          starred_at = COALESCE(excluded.starred_at, user_article_state.starred_at),
+          skipped_at = COALESCE(excluded.skipped_at, user_article_state.skipped_at),
+          archived_at = COALESCE(excluded.archived_at, user_article_state.archived_at),
+          later_until = excluded.later_until,
+          restored_at = COALESCE(excluded.restored_at, user_article_state.restored_at),
+          updated_at = excluded.updated_at
+        """,
+        (
+            user_id,
+            article_id,
+            state,
+            1 if starred else 0,
+            done_at,
+            starred_at,
+            skipped_at,
+            archived_at,
+            later_until,
+            restored_at,
+            updated_at,
+        ),
+    )
+
+
+def list_articles(  # noqa: PLR0913
     status: str | None = None,
     state: str | None = None,
     category: str | None = None,
@@ -620,9 +732,25 @@ def list_articles(
     limit: int = 100,
     offset: int = 0,
     db_path: Path | None = None,
+    user_id: int | None = None,
 ) -> list[dict[str, Any]]:
     init_db(db_path)
     now = now_iso()
+
+    if user_id is not None:
+        return _list_articles_for_user(
+            user_id=user_id,
+            status=status,
+            state=state,
+            category=category,
+            starred=starred,
+            limit=limit,
+            offset=offset,
+            db_path=db_path,
+            now=now,
+        )
+
+    # ── Legacy path (no user context) ─────────────────────────────────────────
     # Exclude canonical-archived duplicates from results
     clauses: list[str] = ["(canonical_id IS NULL OR state != 'archived')"]
     params: list[object] = []
@@ -642,7 +770,6 @@ def list_articles(
             clauses.append("starred = 1")
     if state:
         if state == "today":
-            # Today = explicitly today OR later with expired snooze
             clauses.append(
                 "(state = 'today'"
                 " OR (state = 'later' AND later_until IS NOT NULL AND later_until <= ?))"
@@ -665,26 +792,117 @@ def list_articles(
             params,
         ).fetchall()
         articles = [_article_dict(row) for row in rows]
-
-        # Attach duplicate source names to canonical articles
-        article_ids = [a["id"] for a in articles]
-        if article_ids:
-            placeholders = ",".join("?" * len(article_ids))
-            dup_rows = conn.execute(
-                f"""
-                SELECT canonical_id, source_name FROM articles
-                WHERE canonical_id IN ({placeholders}) AND state='archived'
-                """,
-                article_ids,
-            ).fetchall()
-            dupes_by_canonical: dict[int, list[str]] = defaultdict(list)
-            for dr in dup_rows:
-                d = row_to_dict(dr)
-                dupes_by_canonical[d["canonical_id"]].append(d["source_name"])
-            for article in articles:
-                article["also_from"] = dupes_by_canonical.get(article["id"], [])
-
+        _attach_also_from(conn, articles)
         return articles
+
+
+def _list_articles_for_user(  # noqa: PLR0913
+    user_id: int,
+    *,
+    status: str | None,
+    state: str | None,
+    category: str | None,
+    starred: bool | None,
+    limit: int,
+    offset: int,
+    db_path: Path | None,
+    now: str,
+) -> list[dict[str, Any]]:
+    """Article listing scoped to a specific user via user_article_state."""
+    # Map legacy status → state
+    if status:
+        legacy_map = {
+            "new": "today",
+            "read": "done",
+            "saved": "today",
+            "skipped": "skipped",
+            "archived": "archived",
+        }
+        state = legacy_map.get(status, status)
+        if status == "saved":
+            starred = True
+
+    # Build WHERE on articles
+    not_archived = "(a.canonical_id IS NULL OR COALESCE(uas.state, 'today') != 'archived')"
+    art_clauses: list[str] = [not_archived]
+    params: list[object] = [user_id]  # first param is for the LEFT JOIN ON clause
+
+    # State filter on UAS
+    if state:
+        if state == "today":
+            art_clauses.append(
+                "(uas.state IS NULL OR uas.state = 'today'"
+                " OR (uas.state = 'later' AND uas.later_until IS NOT NULL"
+                " AND uas.later_until <= ?))"
+            )
+            params.append(now)
+        else:
+            art_clauses.append("COALESCE(uas.state, 'today') = ?")
+            params.append(state)
+    if starred is not None:
+        art_clauses.append("COALESCE(uas.starred, 0) = ?")
+        params.append(1 if starred else 0)
+    if category:
+        art_clauses.append("a.category = ?")
+        params.append(category)
+
+    where = f"WHERE {' AND '.join(art_clauses)}"
+    params.extend([limit, offset])
+
+    sql = f"""
+        SELECT a.*,
+          COALESCE(uas.state, 'today') AS _uas_state,
+          COALESCE(uas.starred, 0)     AS _uas_starred,
+          uas.done_at     AS _uas_done_at,
+          uas.starred_at  AS _uas_starred_at,
+          uas.skipped_at  AS _uas_skipped_at,
+          uas.archived_at AS _uas_archived_at,
+          uas.later_until AS _uas_later_until,
+          uas.restored_at AS _uas_restored_at
+        FROM articles a
+        LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = ?
+        {where}
+        ORDER BY a.discovered_at DESC, a.id DESC
+        LIMIT ? OFFSET ?
+    """
+    with connect(db_path) as conn:
+        rows = conn.execute(sql, params).fetchall()
+        articles = []
+        for row in rows:
+            d = _article_dict(row)
+            # Apply UAS overrides from the prefixed columns
+            d["state"] = d.pop("_uas_state", "today")
+            d["starred"] = bool(d.pop("_uas_starred", 0))
+            d["done_at"] = d.pop("_uas_done_at", None)
+            d["starred_at"] = d.pop("_uas_starred_at", None)
+            d["skipped_at"] = d.pop("_uas_skipped_at", None)
+            d["archived_at"] = d.pop("_uas_archived_at", None)
+            d["later_until"] = d.pop("_uas_later_until", None)
+            d["restored_at"] = d.pop("_uas_restored_at", None)
+            articles.append(d)
+        _attach_also_from(conn, articles)
+        return articles
+
+
+def _attach_also_from(conn: Any, articles: list[dict[str, Any]]) -> None:
+    """Attach duplicate source names to canonical articles (in-place)."""
+    article_ids = [a["id"] for a in articles]
+    if not article_ids:
+        return
+    placeholders = ",".join("?" * len(article_ids))
+    dup_rows = conn.execute(
+        f"""
+        SELECT canonical_id, source_name FROM articles
+        WHERE canonical_id IN ({placeholders}) AND state='archived'
+        """,
+        article_ids,
+    ).fetchall()
+    dupes_by_canonical: dict[int, list[str]] = defaultdict(list)
+    for dr in dup_rows:
+        d = row_to_dict(dr)
+        dupes_by_canonical[d["canonical_id"]].append(d["source_name"])
+    for article in articles:
+        article["also_from"] = dupes_by_canonical.get(article["id"], [])
 
 
 def search_articles(  # noqa: PLR0913
@@ -697,9 +915,26 @@ def search_articles(  # noqa: PLR0913
     starred_only: bool = False,
     include_archived: bool = False,
     date_range: str = "all",
+    user_id: int | None = None,
 ) -> list[dict[str, Any]]:
     init_db(db_path)
     terms = [t for t in q.split() if len(t) >= 2]
+    now_ts = now_iso()
+
+    if user_id is not None:
+        return _search_articles_for_user(
+            user_id=user_id,
+            q=q,
+            limit=limit,
+            db_path=db_path,
+            states=states,
+            categories=categories,
+            sources=sources,
+            starred_only=starred_only,
+            include_archived=include_archived,
+            date_range=date_range,
+            now_ts=now_ts,
+        )
 
     clauses: list[str] = []
     params: list[Any] = []
@@ -743,7 +978,6 @@ def search_articles(  # noqa: PLR0913
         clauses.append("starred = 1")
 
     # Date range filter
-    now_ts = now_iso()
     if date_range == "today":
         clauses.append("discovered_at >= datetime(?, '-1 day')")
         params.append(now_ts)
@@ -764,6 +998,100 @@ def search_articles(  # noqa: PLR0913
     with connect(db_path) as conn:
         rows = conn.execute(sql, params).fetchall()
         return [_article_dict(row) for row in rows]
+
+
+def _search_articles_for_user(  # noqa: PLR0913
+    *,
+    user_id: int,
+    q: str,
+    limit: int,
+    db_path: Path | None,
+    states: list[str] | None,
+    categories: list[str] | None,
+    sources: list[str] | None,
+    starred_only: bool,
+    include_archived: bool,
+    date_range: str,
+    now_ts: str,
+) -> list[dict[str, Any]]:
+    terms = [t for t in q.split() if len(t) >= 2]
+    clauses: list[str] = []
+    params: list[Any] = [user_id]  # first positional = LEFT JOIN ON uas.user_id = ?
+
+    for term in terms:
+        like = f"%{term}%"
+        clauses.append(
+            "(a.title LIKE ? OR a.summary LIKE ? OR a.reason LIKE ? OR a.tags LIKE ?"
+            " OR a.source_name LIKE ? OR (a.body IS NOT NULL AND a.body LIKE ?))"
+        )
+        params.extend([like, like, like, like, like, like])
+
+    if not include_archived:
+        clauses.append("COALESCE(uas.state, 'today') != 'archived'")
+
+    if states:
+        placeholders = ",".join("?" * len(states))
+        clauses.append(f"COALESCE(uas.state, 'today') IN ({placeholders})")
+        params.extend(states)
+        if include_archived is False and "archived" in states:
+            clauses.remove("COALESCE(uas.state, 'today') != 'archived'")
+
+    if categories:
+        placeholders = ",".join("?" * len(categories))
+        clauses.append(f"a.category IN ({placeholders})")
+        params.extend(categories)
+
+    if sources:
+        placeholders = ",".join("?" * len(sources))
+        clauses.append(f"a.source_slug IN ({placeholders})")
+        params.extend(sources)
+
+    if starred_only:
+        clauses.append("COALESCE(uas.starred, 0) = 1")
+
+    if date_range == "today":
+        clauses.append("a.discovered_at >= datetime(?, '-1 day')")
+        params.append(now_ts)
+    elif date_range == "week":
+        clauses.append("a.discovered_at >= datetime(?, '-7 days')")
+        params.append(now_ts)
+    elif date_range == "month":
+        clauses.append("a.discovered_at >= datetime(?, '-30 days')")
+        params.append(now_ts)
+
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    params.append(limit)
+
+    sql = f"""
+        SELECT a.*,
+          COALESCE(uas.state, 'today') AS _uas_state,
+          COALESCE(uas.starred, 0)     AS _uas_starred,
+          uas.done_at     AS _uas_done_at,
+          uas.starred_at  AS _uas_starred_at,
+          uas.skipped_at  AS _uas_skipped_at,
+          uas.archived_at AS _uas_archived_at,
+          uas.later_until AS _uas_later_until,
+          uas.restored_at AS _uas_restored_at
+        FROM articles a
+        LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = ?
+        {where}
+        ORDER BY a.importance_score DESC, a.discovered_at DESC LIMIT ?
+    """
+    with connect(db_path) as conn:
+        rows = conn.execute(sql, params).fetchall()
+        result = []
+        for row in rows:
+            d = _article_dict(row)
+            d["state"] = d.pop("_uas_state", "today")
+            d["starred"] = bool(d.pop("_uas_starred", 0))
+            d["done_at"] = d.pop("_uas_done_at", None)
+            d["starred_at"] = d.pop("_uas_starred_at", None)
+            d["skipped_at"] = d.pop("_uas_skipped_at", None)
+            d["archived_at"] = d.pop("_uas_archived_at", None)
+            d["later_until"] = d.pop("_uas_later_until", None)
+            d["restored_at"] = d.pop("_uas_restored_at", None)
+            result.append(d)
+        return result
 
 
 def set_article_status(
@@ -810,10 +1138,11 @@ def _get_article_row(conn: Any, article_id: int) -> dict[str, Any] | None:
     return _article_dict(row) if row else None
 
 
-def transition_article_state(
+def transition_article_state(  # noqa: PLR0912, PLR0915
     article_id: int,
     new_state: str,
     db_path: Path | None = None,
+    user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Apply a state transition, enforcing allowed-transition rules.
 
@@ -826,45 +1155,74 @@ def transition_article_state(
 
     init_db(db_path)
     with connect(db_path) as conn:
-        current = _get_article_row(conn, article_id)
-        if current is None:
+        base = _get_article_row(conn, article_id)
+        if base is None:
             return None
 
-        current_state = str(current.get("state") or "today")
+        if user_id is not None:
+            uas = _get_uas_row(conn, article_id, user_id)
+            current_state = str((uas or {}).get("state") or "today")
+            current_starred = bool((uas or {}).get("starred", False))
+        else:
+            current_state = str(base.get("state") or "today")
+            current_starred = bool(base.get("starred", False))
+
         if current_state == new_state:
-            return current
+            if user_id is not None:
+                return _merge_uas(base, uas if "uas" in dir() else None)
+            return base
 
         if (current_state, new_state) not in _ALLOWED_TRANSITIONS:
             message = f"transition {current_state!r} → {new_state!r} is not allowed"
             raise ValueError(message)
 
-        if new_state == "skipped" and current.get("starred"):
+        if new_state == "skipped" and current_starred:
             message = "starred articles cannot be skipped"
             raise ValueError(message)
 
         ts = now_iso()
-        timestamp_sets: list[str] = ["state = ?", "updated_at = ?"]
-        params: list[Any] = [new_state, ts]
 
-        if new_state == "done":
-            timestamp_sets.append("done_at = ?")
-            params.append(ts)
-        elif new_state == "skipped":
-            timestamp_sets.append("skipped_at = ?")
-            params.append(ts)
-        elif new_state == "archived":
-            timestamp_sets.append("archived_at = ?")
-            params.append(ts)
-        elif new_state == "today":
-            timestamp_sets.append("restored_at = ?")
-            timestamp_sets.append("later_until = NULL")
-            params.append(ts)
+        if user_id is not None:
+            existing = _get_uas_row(conn, article_id, user_id)
+            _upsert_uas(
+                conn,
+                user_id,
+                article_id,
+                state=new_state,
+                starred=current_starred,
+                done_at=ts if new_state == "done" else None,
+                skipped_at=ts if new_state == "skipped" else None,
+                archived_at=ts if new_state == "archived" else None,
+                restored_at=ts if new_state == "today" else None,
+                later_until=None if new_state == "today" else (existing or {}).get("later_until"),
+                updated_at=ts,
+            )
+            result: dict[str, Any] | None = _merge_uas(
+                _get_article_row(conn, article_id) or {},
+                _get_uas_row(conn, article_id, user_id),
+            )
+        else:
+            timestamp_sets: list[str] = ["state = ?", "updated_at = ?"]
+            params: list[Any] = [new_state, ts]
 
-        set_clause = ", ".join(timestamp_sets)
-        params.append(article_id)
-        conn.execute(f"UPDATE articles SET {set_clause} WHERE id = ?", params)
+            if new_state == "done":
+                timestamp_sets.append("done_at = ?")
+                params.append(ts)
+            elif new_state == "skipped":
+                timestamp_sets.append("skipped_at = ?")
+                params.append(ts)
+            elif new_state == "archived":
+                timestamp_sets.append("archived_at = ?")
+                params.append(ts)
+            elif new_state == "today":
+                timestamp_sets.append("restored_at = ?")
+                timestamp_sets.append("later_until = NULL")
+                params.append(ts)
 
-        result = _get_article_row(conn, article_id)
+            set_clause = ", ".join(timestamp_sets)
+            params.append(article_id)
+            conn.execute(f"UPDATE articles SET {set_clause} WHERE id = ?", params)
+            result = _get_article_row(conn, article_id)
 
     # Embed done articles lazily
     if result and new_state == "done":
@@ -882,15 +1240,32 @@ def set_article_starred(
     article_id: int,
     starred: bool,
     db_path: Path | None = None,
+    user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Set the starred flag on an article. Raises ValueError if starring a skipped article."""
     init_db(db_path)
     with connect(db_path) as conn:
-        current = _get_article_row(conn, article_id)
-        if current is None:
+        base = _get_article_row(conn, article_id)
+        if base is None:
             return None
 
         ts = now_iso()
+
+        if user_id is not None:
+            existing = _get_uas_row(conn, article_id, user_id)
+            current_state = str((existing or {}).get("state") or "today")
+            _upsert_uas(
+                conn,
+                user_id,
+                article_id,
+                state=current_state,
+                starred=starred,
+                starred_at=ts if starred else (existing or {}).get("starred_at"),
+                updated_at=ts,
+            )
+            base2 = _get_article_row(conn, article_id) or {}
+            return _merge_uas(base2, _get_uas_row(conn, article_id, user_id))
+
         if starred:
             conn.execute(
                 "UPDATE articles SET starred = 1, starred_at = ?, updated_at = ? WHERE id = ?",
@@ -909,6 +1284,7 @@ def send_article_later(
     article_id: int,
     days: int = 1,
     db_path: Path | None = None,
+    user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Snooze an article to Later with an expiry of `days` days from now.
 
@@ -920,11 +1296,16 @@ def send_article_later(
 
     init_db(db_path)
     with connect(db_path) as conn:
-        current = _get_article_row(conn, article_id)
-        if current is None:
+        base = _get_article_row(conn, article_id)
+        if base is None:
             return None
 
-        current_state = str(current.get("state") or "today")
+        if user_id is not None:
+            uas = _get_uas_row(conn, article_id, user_id)
+            current_state = str((uas or {}).get("state") or "today")
+        else:
+            current_state = str(base.get("state") or "today")
+
         if current_state not in {"today", "later"}:
             message = f"cannot snooze article in state {current_state!r}"
             raise ValueError(message)
@@ -933,6 +1314,21 @@ def send_article_later(
             (datetime.now(timezone.utc) + timedelta(days=days)).replace(microsecond=0).isoformat()
         )
         ts = now_iso()
+
+        if user_id is not None:
+            existing = _get_uas_row(conn, article_id, user_id)
+            _upsert_uas(
+                conn,
+                user_id,
+                article_id,
+                state="later",
+                starred=bool((existing or {}).get("starred", False)),
+                later_until=later_until,
+                updated_at=ts,
+            )
+            base3 = _get_article_row(conn, article_id) or {}
+            return _merge_uas(base3, _get_uas_row(conn, article_id, user_id))
+
         conn.execute(
             "UPDATE articles SET state = 'later', later_until = ?, updated_at = ? WHERE id = ?",
             (later_until, ts, article_id),

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -218,6 +218,7 @@ def ingest_stream() -> StreamingResponse:
 
 @api.get("/api/articles")
 def articles(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
     status: Annotated[str | None, Query()] = None,
     state: Annotated[str | None, Query()] = None,
     starred: Annotated[bool | None, Query()] = None,
@@ -233,12 +234,14 @@ def articles(
             category=category,
             limit=limit,
             offset=offset,
+            user_id=current_user["id"],
         )
     }
 
 
 @api.get("/api/search")
 def search(  # noqa: PLR0913
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
     q: Annotated[str, Query(description="Space-separated search terms")] = "",
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     states: Annotated[list[str] | None, Query()] = None,
@@ -258,6 +261,7 @@ def search(  # noqa: PLR0913
             starred_only=starred_only,
             include_archived=include_archived,
             date_range=date_range,
+            user_id=current_user["id"],
         )
     }
 
@@ -290,9 +294,13 @@ def update_status(article_id: int, payload: StatusUpdate) -> dict[str, Any]:
 
 
 @api.patch("/api/articles/{article_id}/state")
-def update_state(article_id: int, payload: StateUpdate) -> dict[str, Any]:
+def update_state(
+    article_id: int,
+    payload: StateUpdate,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
     try:
-        article = transition_article_state(article_id, payload.state)
+        article = transition_article_state(article_id, payload.state, user_id=current_user["id"])
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not article:
@@ -301,17 +309,25 @@ def update_state(article_id: int, payload: StateUpdate) -> dict[str, Any]:
 
 
 @api.patch("/api/articles/{article_id}/star")
-def update_star(article_id: int, payload: StarUpdate) -> dict[str, Any]:
-    article = set_article_starred(article_id, payload.starred)
+def update_star(
+    article_id: int,
+    payload: StarUpdate,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    article = set_article_starred(article_id, payload.starred, user_id=current_user["id"])
     if not article:
         raise HTTPException(status_code=404, detail="article not found")
     return article
 
 
 @api.patch("/api/articles/{article_id}/later")
-def snooze_later(article_id: int, payload: LaterUpdate) -> dict[str, Any]:
+def snooze_later(
+    article_id: int,
+    payload: LaterUpdate,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
     try:
-        article = send_article_later(article_id, payload.days)
+        article = send_article_later(article_id, payload.days, user_id=current_user["id"])
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not article:

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -1,0 +1,344 @@
+"""Tests for #127 per-user article state via user_article_state table."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import news_dashboard.db as db_mod
+from news_dashboard.auth import create_user
+from news_dashboard.db import connect
+from news_dashboard.ingest import (
+    list_articles,
+    search_articles,
+    send_article_later,
+    set_article_starred,
+    sync_sources,
+    transition_article_state,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    db = tmp_path / "test.db"
+    sync_sources(db)
+    return db
+
+
+def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "today") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/art{url_suffix}",
+                f"https://example.com/art{url_suffix}",
+                f"Article {url_suffix}",
+                "python-insider",
+                "Python Insider",
+                "python",
+                "rss_feed",
+                state,
+            ),
+        ).fetchone()
+    return int(row["id"] if isinstance(row, dict) else row[0])
+
+
+def _make_user(db_path: Path, username: str = "alice") -> int:
+    """Create a user and return their id, patching DB_PATH so auth uses our test DB."""
+    orig = db_mod.DB_PATH
+    db_mod.DB_PATH = db_path
+    try:
+        user = create_user(username, "password123")
+    finally:
+        db_mod.DB_PATH = orig
+    return int(user["id"])
+
+
+# ── implicit today (no UAS row yet) ──────────────────────────────────────────
+
+
+def test_no_uas_row_is_implicitly_today(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    _insert_article(db)
+    articles = list_articles(state="today", db_path=db, user_id=uid)
+    assert len(articles) == 1
+    assert articles[0]["state"] == "today"
+    assert articles[0]["starred"] is False
+
+
+def test_no_uas_row_not_returned_for_done_filter(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    _insert_article(db)
+    articles = list_articles(state="done", db_path=db, user_id=uid)
+    assert len(articles) == 0
+
+
+# ── per-user state isolation ──────────────────────────────────────────────────
+
+
+def test_state_is_per_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid_a = _make_user(db, "alice")
+    uid_b = _make_user(db, "bob")
+    aid = _insert_article(db)
+
+    transition_article_state(aid, "done", db_path=db, user_id=uid_a)
+
+    # alice sees it as done
+    a_arts = list_articles(state="done", db_path=db, user_id=uid_a)
+    assert any(a["id"] == aid for a in a_arts)
+
+    # bob still sees it as today
+    b_arts = list_articles(state="today", db_path=db, user_id=uid_b)
+    assert any(a["id"] == aid for a in b_arts)
+
+    # bob doesn't see it in done
+    b_done = list_articles(state="done", db_path=db, user_id=uid_b)
+    assert not any(a["id"] == aid for a in b_done)
+
+
+def test_star_is_per_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid_a = _make_user(db, "alice")
+    uid_b = _make_user(db, "bob")
+    aid = _insert_article(db)
+
+    set_article_starred(aid, True, db_path=db, user_id=uid_a)
+
+    a_starred = list_articles(starred=True, db_path=db, user_id=uid_a)
+    assert any(a["id"] == aid for a in a_starred)
+
+    b_starred = list_articles(starred=True, db_path=db, user_id=uid_b)
+    assert not any(a["id"] == aid for a in b_starred)
+
+
+# ── transition_article_state with user_id ─────────────────────────────────────
+
+
+def test_today_to_done_with_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    result = transition_article_state(aid, "done", db_path=db, user_id=uid)
+    assert result is not None
+    assert result["state"] == "done"
+    assert result["done_at"] is not None
+
+
+def test_today_to_skipped_with_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    result = transition_article_state(aid, "skipped", db_path=db, user_id=uid)
+    assert result is not None
+    assert result["state"] == "skipped"
+    assert result["skipped_at"] is not None
+
+
+def test_skipped_to_today_restores(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    transition_article_state(aid, "skipped", db_path=db, user_id=uid)
+    result = transition_article_state(aid, "today", db_path=db, user_id=uid)
+    assert result is not None
+    assert result["state"] == "today"
+    assert result["restored_at"] is not None
+
+
+def test_invalid_transition_raises(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    transition_article_state(aid, "done", db_path=db, user_id=uid)
+    with pytest.raises(ValueError, match="not allowed"):
+        transition_article_state(aid, "skipped", db_path=db, user_id=uid)
+
+
+def test_starred_cannot_be_skipped(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    set_article_starred(aid, True, db_path=db, user_id=uid)
+    with pytest.raises(ValueError, match="starred"):
+        transition_article_state(aid, "skipped", db_path=db, user_id=uid)
+
+
+# ── set_article_starred with user_id ─────────────────────────────────────────
+
+
+def test_star_then_unstar(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    result = set_article_starred(aid, True, db_path=db, user_id=uid)
+    assert result is not None
+    assert result["starred"] is True
+    assert result["starred_at"] is not None
+
+    result = set_article_starred(aid, False, db_path=db, user_id=uid)
+    assert result is not None
+    assert result["starred"] is False
+
+
+# ── send_article_later with user_id ──────────────────────────────────────────
+
+
+def test_snooze_with_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    result = send_article_later(aid, days=3, db_path=db, user_id=uid)
+    assert result is not None
+    assert result["state"] == "later"
+    assert result["later_until"] is not None
+    until = datetime.fromisoformat(result["later_until"])
+    delta = until - datetime.now(timezone.utc)
+    assert 2 < delta.total_seconds() / 3600 < 75  # ~3 days
+
+
+def test_snooze_cannot_snooze_done(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    transition_article_state(aid, "done", db_path=db, user_id=uid)
+    with pytest.raises(ValueError, match="cannot snooze"):
+        send_article_later(aid, days=1, db_path=db, user_id=uid)
+
+
+def test_snooze_returns_to_today_after_expiry(tmp_path: Path) -> None:
+    """An article snoozed with later_until in the past appears in the today filter."""
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    # Put the article in "later" state for this user
+    send_article_later(aid, days=1, db_path=db, user_id=uid)
+
+    # Manually backdate later_until to simulate expiry
+    expired_ts = "2020-01-01T00:00:00+00:00"
+    with connect(db) as conn:
+        conn.execute(
+            "UPDATE user_article_state SET later_until = ? WHERE article_id = ? AND user_id = ?",
+            (expired_ts, aid, uid),
+        )
+
+    today_arts = list_articles(state="today", db_path=db, user_id=uid)
+    assert any(a["id"] == aid for a in today_arts)
+
+
+# ── search_articles with user_id ──────────────────────────────────────────────
+
+
+def test_search_with_user_id(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db, url_suffix="search1")
+
+    # Mark as done for this user
+    transition_article_state(aid, "done", db_path=db, user_id=uid)
+
+    done_results = search_articles(states=["done"], db_path=db, user_id=uid)
+    assert any(a["id"] == aid for a in done_results)
+    assert all(a["state"] == "done" for a in done_results if a["id"] == aid)
+
+
+def test_search_excludes_archived_by_default(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db, url_suffix="arch1")
+
+    transition_article_state(aid, "archived", db_path=db, user_id=uid)
+
+    results = search_articles(db_path=db, user_id=uid)
+    assert not any(a["id"] == aid for a in results)
+
+
+# ── API layer integration ──────────────────────────────────────────────────────
+
+
+def test_api_articles_uses_user_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /api/articles returns per-user state for the authenticated user."""
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api.db")
+    sync_sources(tmp_path / "api.db")
+
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    # Create a real user in our test DB
+    uid = _make_user(tmp_path / "api.db", "testuser")
+    aid = _insert_article(tmp_path / "api.db", url_suffix="api1")
+
+    fake_user = {"id": uid, "username": "testuser", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            resp = client.get("/api/articles", params={"state": "today"})
+            assert resp.status_code == 200
+            ids = [a["id"] for a in resp.json()["items"]]
+            assert aid in ids
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def test_api_state_transition_writes_uas(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """PATCH /api/articles/{id}/state writes to user_article_state."""
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api2.db")
+    sync_sources(tmp_path / "api2.db")
+
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    uid = _make_user(tmp_path / "api2.db", "testuser2")
+    aid = _insert_article(tmp_path / "api2.db", url_suffix="api2")
+
+    fake_user = {"id": uid, "username": "testuser2", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            resp = client.patch(f"/api/articles/{aid}/state", json={"state": "done"})
+            assert resp.status_code == 200
+            assert resp.json()["state"] == "done"
+
+        # Confirm UAS row was written, article table state unchanged
+        with connect(tmp_path / "api2.db") as conn:
+            uas = conn.execute(
+                "SELECT * FROM user_article_state WHERE article_id = ? AND user_id = ?",
+                (aid, uid),
+            ).fetchone()
+            assert uas is not None
+            from news_dashboard.db import row_to_dict
+
+            uas_d = row_to_dict(uas)
+            assert uas_d["state"] == "done"
+
+            art = conn.execute("SELECT state FROM articles WHERE id = ?", (aid,)).fetchone()
+            art_d = row_to_dict(art)
+            assert art_d["state"] == "today"  # article table untouched
+    finally:
+        app.dependency_overrides.pop(require_auth, None)


### PR DESCRIPTION
## Summary

- All article state operations (`list_articles`, `search_articles`, `transition_article_state`, `set_article_starred`, `send_article_later`) accept an optional `user_id` parameter
- When `user_id` is provided, state reads/writes use the `user_article_state` join table — each user gets fully independent per-article state
- Implicit-today semantics: absence of a UAS row means the article is in the `today` state for that user (no migration needed)
- API endpoints (`GET /api/articles`, `GET /api/search`, `PATCH /api/articles/{id}/state`, `PATCH /api/articles/{id}/star`, `PATCH /api/articles/{id}/later`) now inject the authenticated user's id automatically
- Legacy path (no `user_id`) preserved — all existing tests still pass

## Test plan
- [x] 17 new tests in `backend/tests/test_per_user_article_state.py`
- [x] Per-user isolation: Alice and Bob see different states for the same article
- [x] Implicit today, explicit done/skipped/archived/later transitions
- [x] Snooze with Later expiry
- [x] Search with UAS-based state filter
- [x] API layer writes to UAS, leaves `articles.state` untouched
- [x] Full backend test suite: 203 passed
- [x] mypy, ruff clean

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)