### PR TITLE
feat: per-user source subscriptions + custom private feeds (#128)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -566,13 +566,31 @@ def ingest_all(db_path: Path | None = None) -> dict[str, int]:
         run_id = _create_ingest_run(db_path, run_started_at)
         ingest_events.start_run(run_id, f"Ingest run #{run_id} started at {run_started_at}")
 
+        # Collect sources to ingest: DEFAULT_SOURCES + enabled user-owned private sources
+        sources_to_ingest: list[SourceDefinition] = [s for s in DEFAULT_SOURCES if s.enabled]
+        with connect(db_path) as conn:
+            private_rows = conn.execute(
+                "SELECT slug, name, url, category, kind, priority"
+                " FROM sources WHERE owner_user_id IS NOT NULL AND enabled = 1"
+            ).fetchall()
+        for row in private_rows:
+            r = row_to_dict(row)
+            sources_to_ingest.append(
+                SourceDefinition(
+                    slug=r["slug"],
+                    name=r["name"],
+                    url=r["url"],
+                    category=r["category"],
+                    kind=r["kind"],
+                    priority=int(r["priority"] or 0),
+                )
+            )
+
         results: dict[str, int] = {}
         total_new = 0
         total_errors = 0
         try:
-            for source in DEFAULT_SOURCES:
-                if not source.enabled:
-                    continue
+            for source in sources_to_ingest:
                 outcome = _ingest_source(source, db_path)
                 _record_ingest_source(run_id, outcome, db_path)
                 ingest_events.append_line(_format_source_log(outcome))
@@ -825,7 +843,7 @@ def _list_articles_for_user(  # noqa: PLR0913
     # Build WHERE on articles
     not_archived = "(a.canonical_id IS NULL OR COALESCE(uas.state, 'today') != 'archived')"
     art_clauses: list[str] = [not_archived]
-    params: list[object] = [user_id]  # first param is for the LEFT JOIN ON clause
+    where_params: list[object] = []  # params only for WHERE predicates
 
     # State filter on UAS
     if state:
@@ -835,19 +853,26 @@ def _list_articles_for_user(  # noqa: PLR0913
                 " OR (uas.state = 'later' AND uas.later_until IS NOT NULL"
                 " AND uas.later_until <= ?))"
             )
-            params.append(now)
+            where_params.append(now)
         else:
             art_clauses.append("COALESCE(uas.state, 'today') = ?")
-            params.append(state)
+            where_params.append(state)
     if starred is not None:
         art_clauses.append("COALESCE(uas.starred, 0) = ?")
-        params.append(1 if starred else 0)
+        where_params.append(1 if starred else 0)
     if category:
         art_clauses.append("a.category = ?")
-        params.append(category)
+        where_params.append(category)
 
     where = f"WHERE {' AND '.join(art_clauses)}"
-    params.extend([limit, offset])
+
+    # Final param order matches SQL left-to-right:
+    # 1. us_src JOIN: user_id
+    # 2. uas JOIN:    user_id
+    # 3. WHERE:       where_params
+    # 4. owner check: user_id
+    # 5. LIMIT/OFFSET
+    all_params: list[object] = [user_id, user_id, *where_params, user_id, limit, offset]
 
     sql = f"""
         SELECT a.*,
@@ -860,13 +885,19 @@ def _list_articles_for_user(  # noqa: PLR0913
           uas.later_until AS _uas_later_until,
           uas.restored_at AS _uas_restored_at
         FROM articles a
+        LEFT JOIN sources src ON src.slug = a.source_slug
+        LEFT JOIN user_sources us_src ON us_src.user_id = ? AND us_src.source_slug = a.source_slug
         LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = ?
         {where}
+          AND (
+            (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, 1) = 1)
+            OR src.owner_user_id = ?
+          )
         ORDER BY a.discovered_at DESC, a.id DESC
         LIMIT ? OFFSET ?
     """
     with connect(db_path) as conn:
-        rows = conn.execute(sql, params).fetchall()
+        rows = conn.execute(sql, all_params).fetchall()
         articles = []
         for row in rows:
             d = _article_dict(row)
@@ -1000,7 +1031,7 @@ def search_articles(  # noqa: PLR0913
         return [_article_dict(row) for row in rows]
 
 
-def _search_articles_for_user(  # noqa: PLR0913
+def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     *,
     user_id: int,
     q: str,
@@ -1016,7 +1047,7 @@ def _search_articles_for_user(  # noqa: PLR0913
 ) -> list[dict[str, Any]]:
     terms = [t for t in q.split() if len(t) >= 2]
     clauses: list[str] = []
-    params: list[Any] = [user_id]  # first positional = LEFT JOIN ON uas.user_id = ?
+    where_params: list[Any] = []  # params only for WHERE predicates
 
     for term in terms:
         like = f"%{term}%"
@@ -1024,7 +1055,7 @@ def _search_articles_for_user(  # noqa: PLR0913
             "(a.title LIKE ? OR a.summary LIKE ? OR a.reason LIKE ? OR a.tags LIKE ?"
             " OR a.source_name LIKE ? OR (a.body IS NOT NULL AND a.body LIKE ?))"
         )
-        params.extend([like, like, like, like, like, like])
+        where_params.extend([like, like, like, like, like, like])
 
     if not include_archived:
         clauses.append("COALESCE(uas.state, 'today') != 'archived'")
@@ -1032,35 +1063,46 @@ def _search_articles_for_user(  # noqa: PLR0913
     if states:
         placeholders = ",".join("?" * len(states))
         clauses.append(f"COALESCE(uas.state, 'today') IN ({placeholders})")
-        params.extend(states)
+        where_params.extend(states)
         if include_archived is False and "archived" in states:
             clauses.remove("COALESCE(uas.state, 'today') != 'archived'")
 
     if categories:
         placeholders = ",".join("?" * len(categories))
         clauses.append(f"a.category IN ({placeholders})")
-        params.extend(categories)
+        where_params.extend(categories)
 
     if sources:
         placeholders = ",".join("?" * len(sources))
         clauses.append(f"a.source_slug IN ({placeholders})")
-        params.extend(sources)
+        where_params.extend(sources)
 
     if starred_only:
         clauses.append("COALESCE(uas.starred, 0) = 1")
 
     if date_range == "today":
         clauses.append("a.discovered_at >= datetime(?, '-1 day')")
-        params.append(now_ts)
+        where_params.append(now_ts)
     elif date_range == "week":
         clauses.append("a.discovered_at >= datetime(?, '-7 days')")
-        params.append(now_ts)
+        where_params.append(now_ts)
     elif date_range == "month":
         clauses.append("a.discovered_at >= datetime(?, '-30 days')")
-        params.append(now_ts)
+        where_params.append(now_ts)
+
+    # Source subscription filter appended to WHERE
+    src_filter = (
+        "(src.owner_user_id IS NULL AND COALESCE(us_src.enabled, 1) = 1) OR src.owner_user_id = ?"
+    )
+    if clauses:
+        clauses.append(f"({src_filter})")
+    else:
+        clauses = [f"({src_filter})"]
 
     where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-    params.append(limit)
+
+    # Param order: us_src JOIN, uas JOIN, WHERE params, owner check, limit
+    all_params: list[Any] = [user_id, user_id, *where_params, user_id, limit]
 
     sql = f"""
         SELECT a.*,
@@ -1073,12 +1115,14 @@ def _search_articles_for_user(  # noqa: PLR0913
           uas.later_until AS _uas_later_until,
           uas.restored_at AS _uas_restored_at
         FROM articles a
+        LEFT JOIN sources src ON src.slug = a.source_slug
+        LEFT JOIN user_sources us_src ON us_src.user_id = ? AND us_src.source_slug = a.source_slug
         LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = ?
         {where}
         ORDER BY a.importance_score DESC, a.discovered_at DESC LIMIT ?
     """
     with connect(db_path) as conn:
-        rows = conn.execute(sql, params).fetchall()
+        rows = conn.execute(sql, all_params).fetchall()
         result = []
         for row in rows:
             d = _article_dict(row)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -129,6 +129,13 @@ class EnabledUpdate(BaseModel):
     enabled: bool
 
 
+class CreateSourceRequest(BaseModel):
+    url: str
+    name: str
+    category: str = "tech"
+    slug: str | None = None
+
+
 class IntervalUpdate(BaseModel):
     minutes: int
 
@@ -351,13 +358,75 @@ def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict
 
 
 @api.get("/api/sources")
-def sources() -> dict[str, Any]:
+def sources(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
     init_db()
+    uid = current_user["id"]
     with connect() as conn:
         rows = conn.execute(
-            "SELECT * FROM sources ORDER BY category, priority DESC, name"
+            """
+            SELECT s.*,
+              CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, 1)
+                   ELSE s.enabled END AS user_enabled
+            FROM sources s
+            LEFT JOIN user_sources us ON us.source_slug = s.slug AND us.user_id = ?
+            WHERE s.owner_user_id IS NULL OR s.owner_user_id = ?
+            ORDER BY s.category, s.priority DESC, s.name
+            """,
+            (uid, uid),
         ).fetchall()
-        return {"items": [row_to_dict(row) for row in rows]}
+        items = []
+        for row in rows:
+            d = row_to_dict(row)
+            d["subscribed"] = bool(d.pop("user_enabled", 1))
+            items.append(d)
+        return {"items": items}
+
+
+@api.post("/api/sources")
+def create_source(
+    payload: CreateSourceRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Create a private custom source owned by the current user."""
+    import re
+
+    uid = current_user["id"]
+    slug = payload.slug or re.sub(r"[^a-z0-9-]", "-", payload.name.lower()).strip("-")
+    init_db()
+    with connect() as conn:
+        existing = conn.execute("SELECT 1 FROM sources WHERE slug = ?", (slug,)).fetchone()
+        if existing:
+            raise HTTPException(status_code=409, detail=f"source slug {slug!r} already exists")
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+            VALUES (?, ?, ?, ?, 'rss_feed', 0, 1, ?)
+            """,
+            (slug, payload.name, payload.url, payload.category, uid),
+        )
+        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+    return row_to_dict(row)
+
+
+@api.delete("/api/sources/{slug}")
+def delete_source(
+    slug: str,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Delete a private source. Only the owner can delete their own sources."""
+    uid = current_user["id"]
+    init_db()
+    with connect() as conn:
+        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="source not found")
+        src = row_to_dict(row)
+        if src.get("owner_user_id") != uid:
+            raise HTTPException(status_code=403, detail="cannot delete a source you don't own")
+        conn.execute("DELETE FROM sources WHERE slug = ?", (slug,))
+    return {"status": "deleted"}
 
 
 @api.get("/api/sources/health")
@@ -366,17 +435,39 @@ def sources_health() -> dict[str, Any]:
 
 
 @api.patch("/api/sources/{slug}/enabled")
-def set_source_enabled(slug: str, payload: EnabledUpdate) -> dict[str, Any]:
+def set_source_enabled(
+    slug: str,
+    payload: EnabledUpdate,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """For global sources: set per-user subscription. For private sources: set enabled flag."""
+    uid = current_user["id"]
     init_db()
     with connect() as conn:
-        cursor = conn.execute(
-            "UPDATE sources SET enabled=? WHERE slug=?",
-            (1 if payload.enabled else 0, slug),
-        )
-        if cursor.rowcount == 0:
+        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+        if not row:
             raise HTTPException(status_code=404, detail="source not found")
-        row = conn.execute("SELECT * FROM sources WHERE slug=?", (slug,)).fetchone()
-        return row_to_dict(row)
+        src = row_to_dict(row)
+        if src.get("owner_user_id") is None:
+            # Global source — write to user_sources subscription table
+            conn.execute(
+                """
+                INSERT INTO user_sources(user_id, source_slug, enabled)
+                VALUES (?, ?, ?)
+                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = excluded.enabled
+                """,
+                (uid, slug, 1 if payload.enabled else 0),
+            )
+        else:
+            # Private source — only owner can change
+            if src.get("owner_user_id") != uid:
+                raise HTTPException(status_code=403, detail="cannot modify a source you don't own")
+            conn.execute(
+                "UPDATE sources SET enabled = ? WHERE slug = ?",
+                (1 if payload.enabled else 0, slug),
+            )
+        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+    return {**row_to_dict(row), "subscribed": payload.enabled}
 
 
 @api.get("/api/scheduler/status")

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -1,0 +1,368 @@
+"""Tests for #128 — per-user source subscriptions and custom private sources."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import news_dashboard.db as db_mod
+from news_dashboard.auth import create_user
+from news_dashboard.db import connect, row_to_dict
+from news_dashboard.ingest import list_articles, sync_sources
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    db = tmp_path / "test.db"
+    sync_sources(db)
+    return db
+
+
+def _make_user(db_path: Path, username: str = "alice") -> int:
+    orig = db_mod.DB_PATH
+    db_mod.DB_PATH = db_path
+    try:
+        user = create_user(username, "pw")
+    finally:
+        db_mod.DB_PATH = orig
+    return int(user["id"])
+
+
+def _insert_article(db_path: Path, *, source_slug: str, url_suffix: str = "1") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+              category, kind, state)
+            VALUES (?, ?, ?, ?, ?, 'tech', 'rss_feed', 'today')
+            RETURNING id
+            """,
+            (
+                f"https://example.com/{url_suffix}",
+                f"https://example.com/{url_suffix}",
+                f"Article {url_suffix}",
+                source_slug,
+                source_slug,
+            ),
+        ).fetchone()
+    return int(row["id"] if isinstance(row, dict) else row[0])
+
+
+def _global_slug(db_path: Path) -> str:
+    """Return the slug of an arbitrary global source."""
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT slug FROM sources WHERE owner_user_id IS NULL LIMIT 1"
+        ).fetchone()
+        return str(row_to_dict(row)["slug"])
+
+
+def _add_private_source(db_path: Path, *, slug: str, owner_user_id: int) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+            VALUES (?, ?, 'https://example.com/feed', 'tech', 'rss_feed', 0, 1, ?)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug, owner_user_id),
+        )
+
+
+# ── subscription model ────────────────────────────────────────────────────────
+
+
+def test_global_source_visible_to_all_users_by_default(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+
+    # Use an existing global source slug from sync_sources
+    slug = _global_slug(db)
+
+    aid = _insert_article(db, source_slug=slug)
+    articles = list_articles(state="today", db_path=db, user_id=uid)
+    assert any(a["id"] == aid for a in articles)
+
+
+def test_unsubscribed_source_articles_hidden(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+
+    slug = _global_slug(db)
+
+    aid = _insert_article(db, source_slug=slug)
+
+    # Explicitly unsubscribe
+    with connect(db) as conn:
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (?, ?, 0)",
+            (uid, slug),
+        )
+
+    articles = list_articles(state="today", db_path=db, user_id=uid)
+    assert not any(a["id"] == aid for a in articles)
+
+
+def test_resubscription_shows_articles_again(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+
+    slug = _global_slug(db)
+
+    aid = _insert_article(db, source_slug=slug)
+
+    # Unsubscribe then re-subscribe
+    with connect(db) as conn:
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (?, ?, 0)",
+            (uid, slug),
+        )
+        conn.execute(
+            "UPDATE user_sources SET enabled = 1 WHERE user_id = ? AND source_slug = ?",
+            (uid, slug),
+        )
+
+    articles = list_articles(state="today", db_path=db, user_id=uid)
+    assert any(a["id"] == aid for a in articles)
+
+
+def test_private_source_only_visible_to_owner(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid_a = _make_user(db, "alice")
+    uid_b = _make_user(db, "bob")
+
+    _add_private_source(db, slug="alices-feed", owner_user_id=uid_a)
+    aid = _insert_article(db, source_slug="alices-feed", url_suffix="priv1")
+
+    # Alice sees it
+    alice_arts = list_articles(state="today", db_path=db, user_id=uid_a)
+    assert any(a["id"] == aid for a in alice_arts)
+
+    # Bob does not see it
+    bob_arts = list_articles(state="today", db_path=db, user_id=uid_b)
+    assert not any(a["id"] == aid for a in bob_arts)
+
+
+def test_unsubscription_is_per_user(tmp_path: Path) -> None:
+    """Unsubscribing from a source only affects the user who unsubscribed."""
+    db = _setup_db(tmp_path)
+    uid_a = _make_user(db, "alice")
+    uid_b = _make_user(db, "bob")
+
+    slug = _global_slug(db)
+
+    aid = _insert_article(db, source_slug=slug)
+
+    # Alice unsubscribes
+    with connect(db) as conn:
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (?, ?, 0)",
+            (uid_a, slug),
+        )
+
+    alice_arts = list_articles(state="today", db_path=db, user_id=uid_a)
+    assert not any(a["id"] == aid for a in alice_arts)
+
+    bob_arts = list_articles(state="today", db_path=db, user_id=uid_b)
+    assert any(a["id"] == aid for a in bob_arts)
+
+
+# ── API layer ─────────────────────────────────────────────────────────────────
+
+
+def _api_client(db_path: Path, user_id: int, is_admin: bool = False) -> Any:
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_admin, require_auth
+    from news_dashboard.main import app
+
+    fake = {"id": user_id, "username": "testuser", "email": None, "is_admin": is_admin}
+    app.dependency_overrides[require_auth] = lambda: fake
+    app.dependency_overrides[require_admin] = lambda: fake
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_api_list_sources_returns_subscription_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api.db")
+    sync_sources(tmp_path / "api.db")
+    uid = _make_user(tmp_path / "api.db")
+
+    client = _api_client(tmp_path / "api.db", uid)
+    try:
+        resp = client.get("/api/sources")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) > 0
+        # All global sources are subscribed by default
+        assert all(i["subscribed"] for i in items)
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_api_create_private_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api2.db")
+    sync_sources(tmp_path / "api2.db")
+    uid = _make_user(tmp_path / "api2.db")
+
+    client = _api_client(tmp_path / "api2.db", uid)
+    try:
+        resp = client.post(
+            "/api/sources",
+            json={
+                "url": "https://example.com/my-feed.xml",
+                "name": "My Blog",
+                "category": "tech",
+                "slug": "my-blog",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["slug"] == "my-blog"
+        assert data["owner_user_id"] == uid
+
+        # Verify it appears in the source list for this user
+        resp2 = client.get("/api/sources")
+        slugs = [i["slug"] for i in resp2.json()["items"]]
+        assert "my-blog" in slugs
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_api_private_source_not_visible_to_other_user(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api3.db")
+    sync_sources(tmp_path / "api3.db")
+    uid_a = _make_user(tmp_path / "api3.db", "alice")
+    uid_b = _make_user(tmp_path / "api3.db", "bob")
+
+    # Alice creates a private source
+    client_a = _api_client(tmp_path / "api3.db", uid_a)
+    try:
+        resp = client_a.post(
+            "/api/sources",
+            json={
+                "url": "https://private.example.com/feed",
+                "name": "Alice Blog",
+                "slug": "alice-blog",
+            },
+        )
+        assert resp.status_code == 200
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+    # Bob doesn't see it
+    client_b = _api_client(tmp_path / "api3.db", uid_b)
+    try:
+        resp2 = client_b.get("/api/sources")
+        slugs = [i["slug"] for i in resp2.json()["items"]]
+        assert "alice-blog" not in slugs
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_api_delete_own_private_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api4.db")
+    sync_sources(tmp_path / "api4.db")
+    uid = _make_user(tmp_path / "api4.db")
+
+    client = _api_client(tmp_path / "api4.db", uid)
+    try:
+        client.post(
+            "/api/sources",
+            json={
+                "url": "https://delete.example.com/feed",
+                "name": "To Delete",
+                "slug": "to-delete",
+            },
+        )
+        resp = client.delete("/api/sources/to-delete")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_api_cannot_delete_others_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api5.db")
+    sync_sources(tmp_path / "api5.db")
+    uid_a = _make_user(tmp_path / "api5.db", "alice")
+    uid_b = _make_user(tmp_path / "api5.db", "bob")
+
+    client_a = _api_client(tmp_path / "api5.db", uid_a)
+    try:
+        client_a.post(
+            "/api/sources",
+            json={
+                "url": "https://alices.example.com/feed",
+                "name": "Alice Source",
+                "slug": "alice-src",
+            },
+        )
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+    client_b = _api_client(tmp_path / "api5.db", uid_b)
+    try:
+        resp = client_b.delete("/api/sources/alice-src")
+        assert resp.status_code == 403
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_api_toggle_subscription(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api6.db")
+    sync_sources(tmp_path / "api6.db")
+    uid = _make_user(tmp_path / "api6.db")
+
+    slug = _global_slug(tmp_path / "api6.db")
+    client = _api_client(tmp_path / "api6.db", uid)
+    try:
+        # Unsubscribe
+        resp = client.patch(f"/api/sources/{slug}/enabled", json={"enabled": False})
+        assert resp.status_code == 200
+        assert resp.json()["subscribed"] is False
+
+        # Re-subscribe
+        resp2 = client.patch(f"/api/sources/{slug}/enabled", json={"enabled": True})
+        assert resp2.status_code == 200
+        assert resp2.json()["subscribed"] is True
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)


### PR DESCRIPTION
## Summary

- **Subscription model**: global sources (`owner_user_id IS NULL`) are visible to all users by default; explicit unsubscription writes `user_sources(enabled=0)`
- **Private sources**: `POST /api/sources` creates a user-owned source; only visible to the owner; deletable via `DELETE /api/sources/{slug}`
- **Article filtering**: `list_articles` and `search_articles` with `user_id` now JOIN `sources` and `user_sources` to filter out unsubscribed/non-owned sources
- **Ingest**: `ingest_all()` now also ingests enabled user-owned private sources from the DB alongside DEFAULT_SOURCES
- **GET /api/sources**: returns per-user subscription status as `subscribed` boolean field
- **PATCH /api/sources/{slug}/enabled**: writes to `user_sources` for global sources, or `sources.enabled` for private sources (owner only)

## Test plan
- [x] 11 new tests in `backend/tests/test_source_subscriptions.py`
- [x] Global source visible by default, hidden after unsubscribe, visible again after re-subscribe
- [x] Private source only visible to owner
- [x] Unsubscription is per-user (Alice unsubs, Bob still sees it)
- [x] API: list sources, create private, delete own, cannot delete other's, toggle subscription
- [x] Full backend test suite: 214 passed
- [x] mypy, ruff clean

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)