### PR TITLE
feat: migrate-multi-user CLI + remove Caddyfile basicauth (#131)

### DIFF
--- a/backend/news_dashboard/migrate.py
+++ b/backend/news_dashboard/migrate.py
@@ -7,7 +7,8 @@ from typing import Annotated, Any
 
 import typer
 
-from .db import connect, init_db
+from .auth import hash_password
+from .db import connect, init_db, row_to_dict
 
 app = typer.Typer(help="Migration helpers for news-dashboard")
 
@@ -132,6 +133,174 @@ def sqlite_to_postgres(
     typer.echo(
         f"Migrated {len(sources)} source(s) and {len(articles)} article(s) from {sqlite_path}"
     )
+
+
+def _check_prerequisites(conn: Any) -> list[str]:
+    """Return a list of missing prerequisite schema items."""
+    missing: list[str] = []
+    required_tables = ["users", "user_article_state", "user_sources"]
+    try:
+        existing = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        missing.extend(f"table '{t}'" for t in required_tables if t not in existing)
+    except Exception:
+        # PostgreSQL — check via information_schema
+        for tbl in required_tables:
+            row = conn.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = %s",
+                (tbl,),
+            ).fetchone()
+            if row is None:
+                missing.append(f"table '{tbl}'")
+
+    try:
+        conn.execute("SELECT user_id FROM briefings LIMIT 0")
+    except Exception:
+        missing.append("column 'briefings.user_id'")
+
+    return missing
+
+
+@app.command("migrate-multi-user")
+def migrate_multi_user(  # noqa: PLR0912, PLR0915
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Print planned actions only")] = False,
+) -> None:
+    """Promote existing single-tenant data to the first user account."""
+    db_path_env = os.getenv("NEWS_DASHBOARD_DB")
+    from pathlib import Path as _Path
+
+    db_path = _Path(db_path_env) if db_path_env else None
+
+    with connect(db_path) as conn:
+        # ── 1. Check prerequisites ─────────────────────────────────────────────
+        missing = _check_prerequisites(conn)
+        if missing:
+            typer.echo("ERROR: prerequisite schema missing:")
+            for item in missing:
+                typer.echo(f"  - {item}")
+            typer.echo("Run 'news-dashboard init' to apply schema migrations first.")
+            raise typer.Exit(code=1)
+
+        # ── 2. Seed user ───────────────────────────────────────────────────────
+        count_row = conn.execute("SELECT COUNT(*) FROM users").fetchone()
+        try:
+            user_count = int(row_to_dict(count_row).get("COUNT(*)", 0))
+        except Exception:
+            user_count = int(count_row[0]) if count_row else 0
+
+        if user_count > 0:
+            typer.echo(f"Users already exist ({user_count}); skipping seed user creation.")
+            seed_row = conn.execute("SELECT id, username FROM users ORDER BY id LIMIT 1").fetchone()
+            seed_uid = int(row_to_dict(seed_row)["id"])
+            seed_username = str(row_to_dict(seed_row)["username"])
+            typer.echo(f"Using existing first user: {seed_username!r} (id={seed_uid})")
+        else:
+            seed_username = os.getenv("SEED_USER") or typer.prompt("Seed username")
+            seed_password = os.getenv("SEED_PASSWORD") or typer.prompt(
+                "Seed password", hide_input=True, confirmation_prompt=True
+            )
+            if dry_run:
+                typer.echo(f"[dry-run] Would create user {seed_username!r}")
+                seed_uid = -1
+            else:
+                pw_hash = hash_password(seed_password)
+                row = conn.execute(
+                    "INSERT INTO users(username, password_hash, is_admin)"
+                    " VALUES(?, ?, 1) RETURNING id",
+                    (seed_username, pw_hash),
+                ).fetchone()
+                seed_uid = int(row_to_dict(row)["id"])
+                typer.echo(f"Created seed user {seed_username!r} (id={seed_uid}, is_admin=1)")
+
+        if dry_run and seed_uid == -1:
+            typer.echo("[dry-run] Skipping data migration steps (no real user id)")
+            raise typer.Exit(0)
+
+        # ── 3. Migrate article state ───────────────────────────────────────────
+        articles = conn.execute(
+            """
+            SELECT id, state, starred, done_at, starred_at, later_until, restored_at, skipped_at
+            FROM articles
+            WHERE (state != 'today' OR starred = 1 OR done_at IS NOT NULL OR starred_at IS NOT NULL)
+            """
+        ).fetchall()
+
+        uas_inserted = 0
+        for art in articles:
+            d = row_to_dict(art)
+            if dry_run:
+                uas_inserted += 1
+                continue
+            conn.execute(
+                """
+                INSERT INTO user_article_state(
+                  user_id, article_id, state, starred,
+                  done_at, starred_at, skipped_at, later_until, restored_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(user_id, article_id) DO NOTHING
+                """,
+                (
+                    seed_uid,
+                    d["id"],
+                    d.get("state", "today"),
+                    1 if d.get("starred") else 0,
+                    d.get("done_at"),
+                    d.get("starred_at"),
+                    d.get("skipped_at"),
+                    d.get("later_until"),
+                    d.get("restored_at"),
+                ),
+            )
+            uas_inserted += 1
+
+        action = "[dry-run] Would migrate" if dry_run else "Migrated"
+        typer.echo(f"{action} {uas_inserted} article state row(s) → user_article_state")
+
+        # ── 4. Migrate briefings ───────────────────────────────────────────────
+        null_briefings = conn.execute(
+            "SELECT COUNT(*) FROM briefings WHERE user_id IS NULL"
+        ).fetchone()
+        try:
+            briefing_count = int(row_to_dict(null_briefings).get("COUNT(*)", 0))
+        except Exception:
+            briefing_count = int(null_briefings[0]) if null_briefings else 0
+
+        if dry_run:
+            typer.echo(f"[dry-run] Would migrate {briefing_count} briefing(s) → user_id={seed_uid}")
+        else:
+            conn.execute(
+                "UPDATE briefings SET user_id = ? WHERE user_id IS NULL",
+                (seed_uid,),
+            )
+            typer.echo(f"Migrated {briefing_count} briefing(s) → user_id={seed_uid}")
+
+        # ── 5. Seed source subscriptions ──────────────────────────────────────
+        enabled_sources = conn.execute(
+            "SELECT slug FROM sources"
+            " WHERE enabled = 1"
+            " AND (owner_user_id IS NULL OR owner_user_id = ?)",
+            (seed_uid,),
+        ).fetchall()
+
+        us_inserted = 0
+        for src in enabled_sources:
+            slug = src[0] if isinstance(src, tuple) else row_to_dict(src)["slug"]
+            if dry_run:
+                us_inserted += 1
+                continue
+            conn.execute(
+                "INSERT INTO user_sources(user_id, source_slug, enabled)"
+                " VALUES(?, ?, 1) ON CONFLICT(user_id, source_slug) DO NOTHING",
+                (seed_uid, slug),
+            )
+            us_inserted += 1
+
+        action = "[dry-run] Would insert" if dry_run else "Inserted"
+        typer.echo(f"{action} {us_inserted} source subscription(s) → user_sources")
+
+    typer.echo("Done.")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_migrate_multi_user.py
+++ b/backend/tests/test_migrate_multi_user.py
@@ -1,0 +1,189 @@
+"""Tests for #131 — migrate-multi-user CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import news_dashboard.db as db_mod
+from news_dashboard.db import connect, init_db
+from news_dashboard.ingest import sync_sources
+from news_dashboard.migrate import _check_prerequisites, app
+
+runner = CliRunner()
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    db = tmp_path / "test.db"
+    sync_sources(db)
+    return db
+
+
+def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "done") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+              category, kind, state, starred)
+            VALUES (?, ?, ?, ?, ?, 'tech', 'rss_feed', ?, 0)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/art{url_suffix}",
+                f"https://example.com/art{url_suffix}",
+                f"Article {url_suffix}",
+                "python-insider",
+                "Python Insider",
+                state,
+            ),
+        ).fetchone()
+    return int(row[0] if isinstance(row, tuple) else row["id"])
+
+
+# ── _check_prerequisites ──────────────────────────────────────────────────────
+
+
+def test_prerequisites_pass_when_schema_complete(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    with connect(db) as conn:
+        missing = _check_prerequisites(conn)
+    assert missing == []
+
+
+def test_prerequisites_detect_missing_table(tmp_path: Path) -> None:
+    db = tmp_path / "bare.db"
+    init_db(db)
+    with connect(db) as conn:
+        conn.execute("DROP TABLE IF EXISTS user_article_state")
+    with connect(db) as conn:
+        missing = _check_prerequisites(conn)
+    assert any("user_article_state" in m for m in missing)
+
+
+# ── migrate-multi-user command ────────────────────────────────────────────────
+
+
+def test_migration_creates_seed_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _setup_db(tmp_path)
+    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setenv("SEED_USER", "alice")
+    monkeypatch.setenv("SEED_PASSWORD", "password123")
+
+    result = runner.invoke(app, ["migrate-multi-user"])
+    assert result.exit_code == 0, result.output
+
+    with connect(db) as conn:
+        users = conn.execute("SELECT username FROM users").fetchall()
+    assert len(users) == 1
+    assert users[0][0] == "alice"
+
+
+def test_migration_migrates_article_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _setup_db(tmp_path)
+    aid = _insert_article(db, url_suffix="m1", state="done")
+    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setenv("SEED_USER", "alice")
+    monkeypatch.setenv("SEED_PASSWORD", "password123")
+
+    result = runner.invoke(app, ["migrate-multi-user"])
+    assert result.exit_code == 0, result.output
+
+    with connect(db) as conn:
+        uas = conn.execute(
+            "SELECT state FROM user_article_state WHERE article_id = ?", (aid,)
+        ).fetchone()
+    assert uas is not None
+    assert uas[0] == "done"
+
+
+def test_migration_seeds_source_subscriptions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = _setup_db(tmp_path)
+    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setenv("SEED_USER", "alice")
+    monkeypatch.setenv("SEED_PASSWORD", "password123")
+
+    result = runner.invoke(app, ["migrate-multi-user"])
+    assert result.exit_code == 0, result.output
+
+    with connect(db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM user_sources").fetchone()[0]
+    assert count > 0
+
+
+def test_migration_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _setup_db(tmp_path)
+    _insert_article(db, url_suffix="i1", state="done")
+    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setenv("SEED_USER", "alice")
+    monkeypatch.setenv("SEED_PASSWORD", "password123")
+
+    result1 = runner.invoke(app, ["migrate-multi-user"])
+    assert result1.exit_code == 0, result1.output
+
+    result2 = runner.invoke(app, ["migrate-multi-user"])
+    assert result2.exit_code == 0, result2.output
+
+    with connect(db) as conn:
+        user_count = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+        uas_count = conn.execute("SELECT COUNT(*) FROM user_article_state").fetchone()[0]
+    assert user_count == 1
+    assert uas_count == 1
+
+
+def test_migration_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _setup_db(tmp_path)
+    _insert_article(db, url_suffix="d1", state="done")
+    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setenv("SEED_USER", "alice")
+    monkeypatch.setenv("SEED_PASSWORD", "password123")
+
+    result = runner.invoke(app, ["migrate-multi-user", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+
+    with connect(db) as conn:
+        user_count = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+        uas_count = conn.execute("SELECT COUNT(*) FROM user_article_state").fetchone()[0]
+    assert user_count == 0
+    assert uas_count == 0
+
+
+def test_migration_aborts_on_missing_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "bare.db"
+    init_db(db)
+    with connect(db) as conn:
+        conn.execute("DROP TABLE IF EXISTS user_article_state")
+    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setenv("SEED_USER", "alice")
+    monkeypatch.setenv("SEED_PASSWORD", "password123")
+
+    result = runner.invoke(app, ["migrate-multi-user"])
+    assert result.exit_code != 0
+    assert "prerequisite schema missing" in result.output.lower() or "ERROR" in result.output
+
+
+def test_migration_skips_user_creation_if_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = _setup_db(tmp_path)
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    from news_dashboard.auth import create_user
+
+    create_user("existing", "pass")
+    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setenv("SEED_USER", "alice")
+    monkeypatch.setenv("SEED_PASSWORD", "password123")
+
+    result = runner.invoke(app, ["migrate-multi-user"])
+    assert result.exit_code == 0, result.output
+    assert "Users already exist" in result.output
+
+    with connect(db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+    assert count == 1

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,9 +1,3 @@
 news.lihor.ro {
     reverse_proxy localhost:30088
-    basicauth {
-        # Add one or more users with hashed passwords.
-        # Generate a hash:  caddy hash-password
-        # Then paste the output here, e.g.:
-        #   ioachim $2a$14$<hash-output-goes-here>
-    }
 }

--- a/docs/CADDY_HTTPS_SETUP.md
+++ b/docs/CADDY_HTTPS_SETUP.md
@@ -11,6 +11,8 @@ The app already runs as a Kubernetes NodePort service on `localhost:30088`.
 Caddy runs on the host (outside Kubernetes), listens on ports 80/443, obtains a
 free Let's Encrypt certificate automatically, and forwards requests to the app.
 
+Authentication is handled by the application itself (see `POST /api/auth/login`).
+
 ---
 
 ## Prerequisites — things only you can do
@@ -95,40 +97,16 @@ caddy version
 sudo systemctl status caddy    # should show "active (running)"
 ```
 
-### Step 5 — Generate a Basic Auth password hash
+### Step 5 — Deploy the Caddyfile
 
-The Caddyfile in this repo (`deploy/Caddyfile`) includes a `basicauth` block so
-the dashboard stays private.  Generate a bcrypt hash for your password:
-
-```bash
-caddy hash-password
-# Enter your password at the prompt — copy the $2a$... output
-```
-
-### Step 6 — Deploy the Caddyfile
-
-Copy the Caddyfile from the repo to the system Caddy config location and fill in
-your username and password hash:
+Copy the Caddyfile from the repo to the system Caddy config location:
 
 ```bash
 # From the repo root on the mini PC:
 sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
-
-# Open it and replace the placeholder with your real username and hash:
-sudo nano /etc/caddy/Caddyfile
 ```
 
-The relevant section looks like:
-
-```
-basicauth {
-    ioachim $2a$14$<paste-your-hash-here>
-}
-```
-
-Replace `ioachim` with whatever username you want and paste the hash from Step 5.
-
-### Step 7 — Reload Caddy
+### Step 6 — Reload Caddy
 
 ```bash
 sudo systemctl reload caddy
@@ -146,16 +124,17 @@ sudo journalctl -u caddy -f
 You should see a line like `certificate obtained successfully`.  This takes
 10–30 seconds on the first run.
 
-### Step 8 — Verify
+### Step 7 — Verify
 
 ```bash
-curl -u ioachim:<your-password> https://news.lihor.ro/api/health
+curl https://news.lihor.ro/api/health
 # Expected: {"status":"ok","database":"PostgreSQL",...}
 ```
 
 Open `https://news.lihor.ro` in Chrome on your phone — you should see a padlock
-and, after a few seconds of visiting, an install prompt or the option in the
-browser menu to "Add to Home Screen" as a standalone app (no browser chrome).
+and the login page.  After logging in, you should see the dashboard, and after a
+few seconds, an install prompt or the option in the browser menu to "Add to Home
+Screen" as a standalone app (no browser chrome).
 
 ---
 
@@ -168,10 +147,6 @@ After any change, copy it to the mini PC and reload:
 sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
 sudo systemctl reload caddy
 ```
-
-The password hash is **not** stored in the repo (it would be visible to anyone
-with repo access).  Keep a note of your password somewhere safe; regenerate the
-hash with `caddy hash-password` if you lose it.
 
 ---
 
@@ -217,7 +192,3 @@ Common remaining issues:
   then close and reopen it
 - A previous visit cached a non-HTTPS version — clear site data in Chrome
   settings and try again
-
-**Basic Auth prompt doesn't appear / returns 401**
-Re-generate the hash (`caddy hash-password`) and make sure there's no trailing
-whitespace when you paste it into the Caddyfile.  Then `sudo systemctl reload caddy`.


### PR DESCRIPTION
## Summary

- **`news-dashboard-migrate migrate-multi-user`**: CLI command that promotes existing single-tenant data to the first user account:
  1. Checks all prerequisite schema elements are present (tables: `users`, `user_article_state`, `user_sources`; column: `briefings.user_id`); aborts with a clear message if missing
  2. Creates seed user from `SEED_USER`/`SEED_PASSWORD` env vars or interactive prompts; skips if any user already exists
  3. Migrates `articles.(state, starred, done_at, starred_at, later_until, restored_at, skipped_at)` → `user_article_state` with `ON CONFLICT DO NOTHING` (idempotent)
  4. Updates `briefings SET user_id = seed_uid WHERE user_id IS NULL`
  5. Inserts `user_sources` rows for all enabled sources (idempotent)
  6. `--dry-run` flag prints planned actions without writing any rows
- **`deploy/Caddyfile`**: removed `basicauth` block — app-level auth from #126 replaces it
- **`docs/CADDY_HTTPS_SETUP.md`**: removed Steps 5–6 (hash generation + basicauth config); renumbered; updated verify step

Closes #131. Completes the multi-user epic (#125).

## Test plan
- [ ] `python -m pytest backend/ -q` → 223 passed, 38 skipped
- [ ] `ruff check backend/` → all checks passed
- [ ] `mypy backend/ --ignore-missing-imports` → success
- [ ] `npm run typecheck && npm run lint && npm run test:frontend` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)