### PR TITLE
[codex] Redirect unauthenticated Keycloak users

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -158,7 +158,9 @@ def test_keycloak_authorization_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.lihor.ro")
     monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
     url = keycloak_authorization_url("state-123")
-    assert url.startswith("https://news.lihor.ro/keycloak/realms/news-dashboard/protocol/openid-connect/auth?")
+    assert url.startswith(
+        "https://news.lihor.ro/keycloak/realms/news-dashboard/protocol/openid-connect/auth?"
+    )
     assert "client_id=news-dashboard" in url
     assert "redirect_uri=https%3A%2F%2Fnews.lihor.ro%2Fauth%2Fcallback" in url
     assert "state=state-123" in url

--- a/design/radar-source/tsconfig.json
+++ b/design/radar-source/tsconfig.json
@@ -6,14 +6,10 @@
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["vite/client"],
-
-    /* Bundler mode */
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": false,
     "noEmit": true,
-
-    /* Linting */
     "skipLibCheck": true,
     "strict": true,
     "noUnusedLocals": false,

--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -66,6 +66,12 @@ describe('RequireAuth', () => {
 
   it('redirects to /login when /api/auth/me returns 401', async () => {
     vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401 Unauthorized'));
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'password',
+      keycloak_enabled: false,
+      login_url: null,
+      logout_url: '/api/auth/logout',
+    });
 
     renderWithRouter(
       <Routes>
@@ -87,8 +93,57 @@ describe('RequireAuth', () => {
     expect(screen.queryByText('Protected content')).toBeNull();
   });
 
+  it('redirects straight to Keycloak when /api/auth/me returns 401 and Keycloak is enabled', async () => {
+    vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401 Unauthorized'));
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'keycloak',
+      keycloak_enabled: true,
+      login_url: '/auth/login',
+      logout_url: '/auth/logout',
+    });
+    const assign = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, assign },
+    });
+
+    try {
+      renderWithRouter(
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <RequireAuth>
+                <div>Protected content</div>
+              </RequireAuth>
+            }
+          />
+          <Route path="/login" element={<div>Login page</div>} />
+        </Routes>
+      );
+
+      await waitFor(() => {
+        expect(assign).toHaveBeenCalledWith('/auth/login');
+      });
+      expect(screen.queryByText('Protected content')).toBeNull();
+      expect(screen.queryByText('Login page')).toBeNull();
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it('passes the original path via location state when redirecting', async () => {
     vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401 Unauthorized'));
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'password',
+      keycloak_enabled: false,
+      login_url: null,
+      logout_url: '/api/auth/logout',
+    });
 
     let capturedState: unknown = undefined;
 

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { fetchMe } from '@/api';
+import { fetchAuthConfig, fetchMe } from '@/api';
 import { useAuth } from '@/contexts/auth';
 
 interface Props {
@@ -19,7 +19,12 @@ export function RequireAuth({ children }: Props) {
         setUser(user);
         setChecked(true);
       })
-      .catch(() => {
+      .catch(async () => {
+        const config = await fetchAuthConfig().catch(() => null);
+        if (config?.provider === 'keycloak') {
+          window.location.assign(config.login_url ?? '/auth/login');
+          return;
+        }
         navigate('/login', { state: { from: location.pathname }, replace: true });
       });
     // Run once on mount only

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -18,7 +18,14 @@ export function LoginPage() {
   useEffect(() => {
     void fetchAuthConfig()
       .then(setAuthConfig)
-      .catch(() => setAuthConfig({ provider: 'password', keycloak_enabled: false, login_url: null, logout_url: '/api/auth/logout' }));
+      .catch(() =>
+        setAuthConfig({
+          provider: 'password',
+          keycloak_enabled: false,
+          login_url: null,
+          logout_url: '/api/auth/logout',
+        })
+      );
   }, []);
 
   async function handleSubmit(e: FormEvent) {
@@ -36,7 +43,8 @@ export function LoginPage() {
     }
   }
 
-  const keycloakLoginUrl = authConfig?.provider === 'keycloak' ? (authConfig.login_url ?? '/auth/login') : null;
+  const keycloakLoginUrl =
+    authConfig?.provider === 'keycloak' ? (authConfig.login_url ?? '/auth/login') : null;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
@@ -47,7 +55,9 @@ export function LoginPage() {
           </div>
           <div>
             <h1 className="text-xl font-semibold text-foreground">Sign in</h1>
-            <p className="mt-1 text-sm text-muted-foreground">Private radar dashboard for news.lihor.ro</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Private radar dashboard for news.lihor.ro
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- redirect unauthenticated users directly to the configured Keycloak login URL when Keycloak auth is enabled
- keep the existing local `/login` fallback for password auth or auth config failures
- add frontend coverage for the Keycloak redirect behavior
- clean up formatting/JSON validity issues surfaced by pre-commit

## Validation

- `pre-commit run --all-files`
- `npm run test:frontend --silent -- frontend/src/__tests__/auth.test.tsx`
- `pytest backend/tests/test_auth.py -q`
- `make test`
- `make build`
