### PR TITLE
[codex] Wire favicon into PWA metadata

### DIFF
--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -4,9 +4,8 @@
  * Split by what's available in dev vs build:
  *
  *  - iOS meta tags + theme-color: always present in index.html — tested here.
- *  - manifest link <link rel="manifest">: injected by vite-plugin-pwa at
- *    BUILD time only (devOptions.enabled = false). Covered by the vitest
- *    pwa.test.ts unit tests and by `npm run build` in CI.
+ *  - manifest link <link rel="manifest">: always present in index.html so the
+ *    dev server and production build both expose install metadata.
  *  - /manifest.webmanifest file: served from public/ in both dev and prod,
  *    so we verify its content here via fetch.
  */
@@ -19,6 +18,16 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('PWA — iOS meta tags', () => {
+  test('has app favicon and manifest links', async ({ page }) => {
+    const favicon = page.locator('link[rel="icon"]');
+    await expect(favicon).toHaveCount(1);
+    expect(await favicon.getAttribute('href')).toBe('/favicon.svg');
+
+    const manifest = page.locator('link[rel="manifest"]');
+    await expect(manifest).toHaveCount(1);
+    expect(await manifest.getAttribute('href')).toBe('/manifest.webmanifest');
+  });
+
   test('has apple-mobile-web-app-capable meta tag', async ({ page }) => {
     const meta = page.locator('meta[name="apple-mobile-web-app-capable"]');
     await expect(meta).toHaveCount(1);
@@ -78,6 +87,16 @@ test.describe('PWA — manifest file', () => {
     expect(icon192?.type).toBe('image/png');
   });
 
+  test('manifest includes app favicon', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    const manifest = await response.json();
+    const icons: Array<{ src: string; sizes: string; type: string }> = manifest.icons ?? [];
+    const favicon = icons.find((i) => i.src === '/favicon.svg');
+    expect(favicon).toBeDefined();
+    expect(favicon?.sizes).toBe('any');
+    expect(favicon?.type).toBe('image/svg+xml');
+  });
+
   test('manifest includes maskable icon', async ({ page }) => {
     const response = await page.request.get('/manifest.webmanifest');
     const manifest = await response.json();
@@ -87,6 +106,12 @@ test.describe('PWA — manifest file', () => {
 });
 
 test.describe('PWA — icon files', () => {
+  test('GET /favicon.svg returns 200', async ({ page }) => {
+    const response = await page.request.get('/favicon.svg');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('image/svg+xml');
+  });
+
   test('GET /icons/icon-192.png returns 200', async ({ page }) => {
     const response = await page.request.get('/icons/icon-192.png');
     expect(response.status()).toBe(200);

--- a/frontend/src/__tests__/pwa.test.ts
+++ b/frontend/src/__tests__/pwa.test.ts
@@ -5,32 +5,24 @@
  * These tests verify that the PWA configuration values match the app's
  * branding and that icons are declared at the required sizes.
  *
- * We import directly from vite.config.ts so any change to the manifest
- * is automatically caught here.
+ * We read public/manifest.webmanifest directly so CI catches drift in the
+ * install metadata served by both dev and production builds.
  */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
 
-// vite-plugin-pwa manifest config (imported statically so CI catches drift)
-const MANIFEST = {
-  name: 'News Dashboard',
-  short_name: 'News',
-  description: 'Personal AI-curated news dashboard',
-  start_url: '/',
-  display: 'standalone',
-  background_color: '#faf8f5',
-  theme_color: '#221f1a',
-  lang: 'en',
-  icons: [
-    { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },
-    { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
-    {
-      src: '/icons/icon-512-maskable.png',
-      sizes: '512x512',
-      type: 'image/png',
-      purpose: 'maskable',
-    },
-  ],
-} as const;
+const MANIFEST = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'public/manifest.webmanifest'), 'utf-8')
+) as {
+  name: string;
+  short_name: string;
+  start_url: string;
+  display: string;
+  background_color: string;
+  theme_color: string;
+  icons: { src: string; sizes: string; type: string; purpose: string }[];
+};
 
 describe('PWA manifest — identity', () => {
   it('has a human-readable name', () => {
@@ -51,6 +43,13 @@ describe('PWA manifest — identity', () => {
 });
 
 describe('PWA manifest — icons', () => {
+  it('declares the app favicon for browser and PWA metadata', () => {
+    const icon = MANIFEST.icons.find((i) => i.src === '/favicon.svg');
+    expect(icon).toBeDefined();
+    expect(icon?.sizes).toBe('any');
+    expect(icon?.type).toBe('image/svg+xml');
+  });
+
   it('declares a 192×192 icon (required for Android install)', () => {
     const icon = MANIFEST.icons.find((i) => i.sizes === '192x192');
     expect(icon).toBeDefined();

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <meta name="theme-color" content="#221f1a" />
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
 
     <title>Ioachim News Dashboard</title>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -9,6 +9,12 @@
   "lang": "en",
   "icons": [
     {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
       "src": "/icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,36 +15,15 @@ export default defineConfig({
       injectRegister: 'auto',
       // Only apply PWA in production builds — dev mode uses Vite HMR.
       devOptions: { enabled: false },
-      manifest: {
-        name: 'News Dashboard',
-        short_name: 'News',
-        description: 'Personal AI-curated news dashboard',
-        start_url: '/',
-        display: 'standalone',
-        background_color: '#faf8f5',
-        theme_color: '#221f1a',
-        lang: 'en',
-        icons: [
-          {
-            src: '/icons/icon-192.png',
-            sizes: '192x192',
-            type: 'image/png',
-            purpose: 'any',
-          },
-          {
-            src: '/icons/icon-512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any',
-          },
-          {
-            src: '/icons/icon-512-maskable.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'maskable',
-          },
-        ],
-      },
+      includeAssets: [
+        'favicon.svg',
+        'manifest.webmanifest',
+        'icons/apple-touch-icon.png',
+        'icons/icon-192.png',
+        'icons/icon-512.png',
+        'icons/icon-512-maskable.png',
+      ],
+      manifest: false,
       workbox: {
         // Cache the app shell (JS/CSS/HTML) with a StaleWhileRevalidate strategy
         // so the app loads instantly and updates in the background.


### PR DESCRIPTION
## Summary
- expose the web manifest directly from the app shell so dev and production both advertise PWA install metadata
- add the app favicon to the served manifest icons
- keep the public manifest as the single source of truth for PWA metadata and precache the manifest/favicon/icon assets
- expand PWA tests for favicon, manifest, icon files, and install metadata

## Validation
- npm run test:frontend -- pwa.test.ts
- npx playwright test e2e/pwa.spec.ts --project=chromium-desktop
- npm run build
