### PR TITLE
docs: Keycloak, Caddy, and PWA auth routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ news-dashboard-migrate /data/news-dashboard.db
   HTTPS. See [docs/CADDY_HTTPS_SETUP.md](docs/CADDY_HTTPS_SETUP.md) for the
   full HTTPS setup guide; the Caddyfile lives at `deploy/Caddyfile`.
 - HTTPS is required for PWA install (Chrome/Android "Add to Home Screen" as a
-  standalone app) and for service worker registration.
+  standalone app) and for service worker registration. The service worker must
+  let `/api/*`, `/auth/*`, and `/keycloak/*` bypass SPA navigation fallback so
+  Keycloak redirects and API responses reach the backend.
 - GitHub Actions publishes `ghcr.io/ioachim-hub/news-dashboard`.
 - For the local Kubernetes cluster, if GHCR pull auth is unavailable, build and push to `localhost:5000/news-dashboard:<tag>` and override Helm image values.

--- a/docs/CADDY_HTTPS_SETUP.md
+++ b/docs/CADDY_HTTPS_SETUP.md
@@ -170,6 +170,19 @@ Options:
 
 ## Troubleshooting
 
+**`/auth/login` shows the dashboard login shell instead of redirecting to Keycloak**
+The service worker is probably serving the SPA fallback for an auth route. Keep `vite.config.ts` configured with `navigateFallbackDenylist` entries for `/api/`, `/auth/`, and `/keycloak/`, then rebuild/redeploy. On a phone/PWA, close and reopen the installed app or clear site data once so the new service worker activates.
+
+**Caddy logs ACME errors for `keycloak.lihor.ro`**
+Do not import a separate `keycloak.lihor.ro` site unless DNS exists. The supported local deployment exposes Keycloak at `https://news.lihor.ro/keycloak`, so disable or rename the separate Caddyfile, validate, and reload Caddy:
+
+```bash
+sudo mv /etc/caddy/Caddyfile.d/keycloak.lihor.ro.caddyfile \
+  /etc/caddy/Caddyfile.d/keycloak.lihor.ro.caddyfile.disabled
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
 **`caddy reload` shows a config error**
 Run `caddy validate --config /etc/caddy/Caddyfile` to see the exact error.
 

--- a/docs/KEYCLOAK_AUTH.md
+++ b/docs/KEYCLOAK_AUTH.md
@@ -6,11 +6,23 @@
 
 1. The frontend calls `GET /api/auth/config`.
 2. When `KEYCLOAK_AUTH_ENABLED=1`, the login screen shows the new dashboard-style `Sign in with Keycloak` button.
-3. `/auth/login` redirects the browser to Keycloak using Authorization Code flow.
+3. `/auth/login` must reach the FastAPI backend and returns a `307` redirect to Keycloak using Authorization Code flow.
 4. `/auth/callback` exchanges the code, reads Keycloak `userinfo`, creates or reuses a local app user, and sets the existing signed `nd_session` cookie.
 5. All existing authenticated API routes continue to use `require_auth`, so article state, source subscriptions, briefings, and admin routes remain scoped by local `user_id`.
 
 Keycloak-created users receive an unusable random local password because Keycloak owns authentication. The comma-separated `KEYCLOAK_ADMIN_USERNAMES` env var controls which Keycloak usernames become app admins on first login; the local default is `ioachim`.
+
+### PWA/service-worker routing
+
+The dashboard is a PWA, so the generated Workbox service worker can answer browser navigations with the SPA `index.html` fallback. That is correct for client routes such as `/today`, but it must never intercept backend or identity-provider routes.
+
+`vite.config.ts` therefore denies fallback handling for:
+
+```ts
+navigateFallbackDenylist: [/^\/api\//, /^\/auth\//, /^\/keycloak\//]
+```
+
+Without this denylist, an already-installed PWA or a browser with an old service worker can open `/auth/login` and see the dashboard login shell again instead of following the backend `307` to Keycloak.
 
 ## Backend environment
 
@@ -31,15 +43,25 @@ SESSION_SECRET=<long random string>
 
 ## Caddy
 
-`deploy/news.lihor.ro.caddyfile` exposes Keycloak under the same hostname:
+The minipc Caddy config exposes Keycloak under the same hostname:
 
 ```caddy
-handle /keycloak* {
-	reverse_proxy 127.0.0.1:8081
+news.lihor.ro {
+	handle /keycloak* {
+		reverse_proxy 127.0.0.1:8081
+	}
+
+	reverse_proxy 127.0.0.1:30088
 }
 ```
 
 This avoids a separate DNS record and keeps redirect URIs under `https://news.lihor.ro`.
+
+Do **not** enable a separate `keycloak.lihor.ro` Caddy site unless the DNS record exists first. If that site is imported while the subdomain is `NXDOMAIN`, Caddy will keep retrying Let's Encrypt issuance and logging ACME DNS failures. For this deployment, the durable public Keycloak base is:
+
+```text
+https://news.lihor.ro/keycloak
+```
 
 ## Helm
 


### PR DESCRIPTION
## Summary
- Document why `/auth/*`, `/api/*`, and `/keycloak/*` must bypass the PWA navigation fallback.
- Document the supported minipc Keycloak exposure at `https://news.lihor.ro/keycloak`.
- Add troubleshooting for stale PWA login shells and Caddy ACME failures caused by an NXDOMAIN `keycloak.lihor.ro` site.

## Context
The runtime fix was already pushed and deployed on `main` as `a0b4813` (`fix: let Keycloak auth routes bypass PWA fallback`). This PR adds the documentation requested after that deploy.

## Verification
- `git diff --check`
- Live deployment verified earlier: `/api/health` 200, `/api/auth/config` 200, `/api/auth/me` 401, `/auth/login` 307 to Keycloak.