### PR TITLE
[codex] Validate Keycloak session secret at startup

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -394,5 +394,11 @@ def keycloak_logout_url() -> str:
 def init_auth() -> None:
     """Initialise DB and bootstrap first admin on startup."""
     init_db()
-    if not keycloak_config().enabled:
-        bootstrap_admin()
+    config = keycloak_config()
+    if config.enabled:
+        _get_secret()
+        if not config.public_server_url or not config.internal_server_url:
+            message = "Keycloak authentication is enabled but KEYCLOAK_SERVER_URL is not set"
+            raise RuntimeError(message)
+        return
+    bootstrap_admin()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -18,6 +18,7 @@ from news_dashboard.auth import (
     ensure_keycloak_user,
     get_user_by_id,
     hash_password,
+    init_auth,
     keycloak_auth_metadata,
     keycloak_authorization_url,
     list_users,
@@ -184,6 +185,28 @@ def test_password_login_disabled_when_keycloak_enabled(
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
     create_user("local", "pw")
     assert authenticate("local", "pw") is None
+
+
+def test_init_auth_requires_session_secret_for_keycloak(
+    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
+    monkeypatch.delenv("SESSION_SECRET", raising=False)
+    monkeypatch.delenv("TEST_SESSION_SECRET", raising=False)
+
+    with pytest.raises(RuntimeError, match="SESSION_SECRET env var is not set"):
+        init_auth()
+
+
+def test_init_auth_accepts_keycloak_when_session_secret_is_set(
+    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
+    monkeypatch.setenv("SESSION_SECRET", "test-secret")
+
+    init_auth()
 
 
 # ── Bootstrap ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- validate Keycloak auth startup configuration before serving login traffic
- require the session-signing secret when Keycloak SSO is enabled
- add tests for missing and present Keycloak session secret configuration

## Root Cause
`/auth/login` can redirect to Keycloak without `SESSION_SECRET`, but `/auth/callback` needs that secret after a successful token exchange to sign the local `nd_session` cookie. A missing secret can therefore appear as an opaque callback 500 after login.

## Validation
- `python3 -m pytest backend/tests/test_auth.py`
- pre-commit hooks during commit: ruff, ruff format, mypy
