### PR TITLE
fix: production hardening — remove hardcoded admin default, make CORS configurable

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -81,7 +81,7 @@ def keycloak_auth_metadata() -> dict[str, Any]:
 
 
 def _keycloak_admin_usernames() -> set[str]:
-    raw = os.getenv("KEYCLOAK_ADMIN_USERNAMES", "ioachim")
+    raw = os.getenv("KEYCLOAK_ADMIN_USERNAMES", "")
     return {u.strip().lower() for u in raw.split(",") if u.strip()}
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import secrets
 from collections.abc import AsyncIterator, MutableMapping
 from contextlib import asynccontextmanager
@@ -105,9 +106,15 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="News Dashboard", version="0.4.0", lifespan=lifespan)
+_cors_origins_env = os.getenv("CORS_ORIGINS", "")
+_cors_origins = (
+    [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
+    if _cors_origins_env.strip()
+    else ["http://localhost:5173", "http://127.0.0.1:5173"]
+)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origins=_cors_origins,
     allow_methods=["*"],
     allow_headers=["*"],
     allow_credentials=True,

--- a/docs/KEYCLOAK_AUTH.md
+++ b/docs/KEYCLOAK_AUTH.md
@@ -10,7 +10,7 @@
 4. `/auth/callback` exchanges the code, reads Keycloak `userinfo`, creates or reuses a local app user, and sets the existing signed `nd_session` cookie.
 5. All existing authenticated API routes continue to use `require_auth`, so article state, source subscriptions, briefings, and admin routes remain scoped by local `user_id`.
 
-Keycloak-created users receive an unusable random local password because Keycloak owns authentication. The comma-separated `KEYCLOAK_ADMIN_USERNAMES` env var controls which Keycloak usernames become app admins on first login; the local default is `ioachim`.
+Keycloak-created users receive an unusable random local password because Keycloak owns authentication. The comma-separated `KEYCLOAK_ADMIN_USERNAMES` env var controls which Keycloak usernames become app admins on first login. If unset, no Keycloak user is granted admin on first login.
 
 ### PWA/service-worker routing
 
@@ -35,7 +35,7 @@ KEYCLOAK_SERVER_URL=https://news.lihor.ro/keycloak
 KEYCLOAK_INTERNAL_SERVER_URL=https://news.lihor.ro/keycloak
 KEYCLOAK_REALM=news-dashboard
 KEYCLOAK_CLIENT_ID=news-dashboard
-KEYCLOAK_ADMIN_USERNAMES=ioachim
+KEYCLOAK_ADMIN_USERNAMES=alice,bob   # comma-separated; omit to grant no admins via Keycloak
 SESSION_SECRET=<long random string>
 ```
 


### PR DESCRIPTION
## Summary

- **Remove hardcoded admin username**: `KEYCLOAK_ADMIN_USERNAMES` defaulted to `"ioachim"`, silently granting admin to that Keycloak username in any fresh deployment. The default is now an empty string — no Keycloak user becomes admin unless the env var is explicitly configured.
- **Configurable CORS origins**: `allow_origins` was hardcoded to `localhost:5173`. Now reads from a `CORS_ORIGINS` env var (comma-separated); falls back to the localhost dev origins when unset so local development needs no config change.
- **Docs updated**: `KEYCLOAK_AUTH.md` documents the no-default admin behaviour and shows the correct placeholder format for `KEYCLOAK_ADMIN_USERNAMES`.

## Test plan

- [ ] 236 backend tests pass (`pytest backend/tests/ -q`)
- [ ] Verify `KEYCLOAK_ADMIN_USERNAMES` unset → no Keycloak user gets admin on first login
- [ ] Verify `CORS_ORIGINS=https://news.lihor.ro` in production env → CORS restricted to that origin
- [ ] Verify local dev with no `CORS_ORIGINS` set → falls back to `localhost:5173` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)