### PR TITLE
[codex] fix deploy repo sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,12 @@ jobs:
             ai_helm_args+=(--set app.ai.existingSecret=news-dashboard-ai)
           fi
 
-          # Sync Helm chart changes from the repo.
-          cd ~/news-dashboard && git pull --ff-only
+          # Sync Helm chart changes from main. Avoid relying on the deploy
+          # host clone's branch/upstream config, which may point at a deleted
+          # feature branch.
+          cd ~/news-dashboard
+          git fetch --prune origin main
+          git checkout --detach FETCH_HEAD
 
           # Upgrade (or install on first run). Keep the host Caddy route stable
           # by preserving the NodePort and local durable hostPath storage.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tsconfig.tsbuildinfo
 .DS_Store
 data/*.db
 data/*.db-*
+.worktrees/

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -116,7 +116,7 @@ git push origin main
        ├─ docker login ghcr.io
        ├─ docker pull <image>:<sha>
        ├─ kubectl apply imagePullSecret
-       ├─ git pull --ff-only (sync chart changes)
+       ├─ git fetch origin main + checkout FETCH_HEAD (sync chart changes)
        ├─ helm upgrade --set image.tag=<sha>
        ├─ kubectl rollout status --timeout=120s
        └─ curl http://localhost:30088/api/health smoke test


### PR DESCRIPTION
## Summary
- sync the deploy host clone from `origin/main` explicitly instead of relying on its branch upstream config
- document the new deploy sync step
- ignore project-local `.worktrees/` directories for future isolated work

## Root cause
The self-hosted deploy step ran `git pull --ff-only` inside `~/news-dashboard`. That local clone was configured to merge from the deleted branch `docs/keycloak-caddy-pwa-auth`, so deploy failed before Helm could run.

## Validation
- `python` YAML parse of `.github/workflows/ci.yml`
- searched `.github`, `docs`, `scripts`, and `helm` for the stale branch name and old `git pull --ff-only` command
- pre-commit hooks on commit passed for the touched files
