### PR TITLE
[codex] fix Keycloak client secret exchange

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -29,6 +29,7 @@ class KeycloakConfig:
     internal_server_url: str
     realm: str
     client_id: str
+    client_secret: str | None
     base_url: str
 
     @property
@@ -66,6 +67,7 @@ def keycloak_config() -> KeycloakConfig:
         internal_server_url=internal_server,
         realm=(os.getenv("KEYCLOAK_REALM") or "news-dashboard").strip(),
         client_id=(os.getenv("KEYCLOAK_CLIENT_ID") or "news-dashboard").strip(),
+        client_secret=(os.getenv("KEYCLOAK_CLIENT_SECRET") or "").strip() or None,
         base_url=_strip_url(os.getenv("NEWS_DASHBOARD_BASE_URL")) or "http://localhost:8080",
     )
 
@@ -322,6 +324,19 @@ def keycloak_authorization_url(state: str) -> str:
     return f"{config.public_realm_url}/protocol/openid-connect/auth?{params}"
 
 
+def keycloak_token_request_data(code: str) -> dict[str, str]:
+    config = keycloak_config()
+    data = {
+        "grant_type": "authorization_code",
+        "client_id": config.client_id,
+        "code": code,
+        "redirect_uri": config.redirect_uri,
+    }
+    if config.client_secret:
+        data["client_secret"] = config.client_secret
+    return data
+
+
 def ensure_keycloak_user(info: dict[str, Any]) -> dict[str, Any]:
     username = str(
         info.get("preferred_username") or info.get("email") or info.get("sub") or ""
@@ -358,12 +373,7 @@ async def exchange_keycloak_code(code: str) -> dict[str, Any]:
     async with httpx.AsyncClient(timeout=10.0) as client:
         token_response = await client.post(
             token_url,
-            data={
-                "grant_type": "authorization_code",
-                "client_id": config.client_id,
-                "code": code,
-                "redirect_uri": config.redirect_uri,
-            },
+            data=keycloak_token_request_data(code),
             headers={"Accept": "application/json"},
         )
         if token_response.status_code >= 400:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -21,6 +21,7 @@ from news_dashboard.auth import (
     init_auth,
     keycloak_auth_metadata,
     keycloak_authorization_url,
+    keycloak_token_request_data,
     list_users,
     update_password,
     user_count_from_row,
@@ -165,6 +166,36 @@ def test_keycloak_authorization_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "client_id=news-dashboard" in url
     assert "redirect_uri=https%3A%2F%2Fnews.lihor.ro%2Fauth%2Fcallback" in url
     assert "state=state-123" in url
+
+
+def test_keycloak_token_request_data_includes_optional_client_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.lihor.ro")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "news-dashboard")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_SECRET", "client-secret")
+
+    data = keycloak_token_request_data("code-123")
+
+    assert data == {
+        "grant_type": "authorization_code",
+        "client_id": "news-dashboard",
+        "client_secret": "client-secret",
+        "code": "code-123",
+        "redirect_uri": "https://news.lihor.ro/auth/callback",
+    }
+
+
+def test_keycloak_token_request_data_omits_blank_client_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_SECRET", " ")
+
+    data = keycloak_token_request_data("code-123")
+
+    assert "client_secret" not in data
 
 
 def test_ensure_keycloak_user_creates_local_user(

--- a/helm/news-dashboard/templates/auth-secret.yaml
+++ b/helm/news-dashboard/templates/auth-secret.yaml
@@ -9,4 +9,5 @@ metadata:
 type: Opaque
 stringData:
   SESSION_SECRET: {{ required "app.auth.sessionSecret is required when app.auth.enabled=true" .Values.app.auth.sessionSecret | quote }}
+  KEYCLOAK_CLIENT_SECRET: {{ .Values.app.auth.clientSecret | quote }}
 {{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
               value: {{ .Values.app.auth.realm | quote }}
             - name: KEYCLOAK_CLIENT_ID
               value: {{ .Values.app.auth.clientId | quote }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "news-dashboard.fullname" . }}-auth
+                  key: KEYCLOAK_CLIENT_SECRET
             - name: KEYCLOAK_ADMIN_USERNAMES
               value: {{ .Values.app.auth.adminUsernames | quote }}
             - name: SESSION_SECRET

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -37,6 +37,8 @@ app:
     keycloakInternalServerUrl: https://news.lihor.ro/keycloak
     realm: news-dashboard
     clientId: news-dashboard
+    # Optional. Set this when the Keycloak client uses "confidential" access type.
+    clientSecret: ""
     # Comma-separated usernames that become app admins when first seen from Keycloak.
     adminUsernames: ioachim
     # Override in CI/local deploy with a long random string.


### PR DESCRIPTION
## Summary
- Include optional `KEYCLOAK_CLIENT_SECRET` in the Keycloak authorization-code token exchange.
- Wire `app.auth.clientSecret` through the Helm auth secret and deployment environment.
- Add auth tests for token request payloads with and without a client secret.

## Root cause
When the Keycloak client is configured as confidential, Keycloak requires the client secret during code exchange. The app redirected back from Keycloak with a `code`, but then exchanged that code without a secret, which can leave the browser stuck on `/auth/callback` after token exchange fails.

## Validation
- `pytest backend/tests/test_auth.py -q` passed: 35 tests.
- Commit hooks passed: ruff, ruff format, mypy, and repository pre-commit checks.

## Notes
- Public-client setups are unchanged because blank `KEYCLOAK_CLIENT_SECRET` is ignored.
- I could not run `helm template` locally because `helm` is not installed in this environment.
