### PR TITLE
fix: Keycloak Google auth, PWA polish, and PostgreSQL boolean type fixes

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -29,6 +29,7 @@ class KeycloakConfig:
     internal_server_url: str
     realm: str
     client_id: str
+    client_secret: str | None
     base_url: str
 
     @property
@@ -66,6 +67,7 @@ def keycloak_config() -> KeycloakConfig:
         internal_server_url=internal_server,
         realm=(os.getenv("KEYCLOAK_REALM") or "news-dashboard").strip(),
         client_id=(os.getenv("KEYCLOAK_CLIENT_ID") or "news-dashboard").strip(),
+        client_secret=(os.getenv("KEYCLOAK_CLIENT_SECRET") or "").strip() or None,
         base_url=_strip_url(os.getenv("NEWS_DASHBOARD_BASE_URL")) or "http://localhost:8080",
     )
 
@@ -322,6 +324,19 @@ def keycloak_authorization_url(state: str) -> str:
     return f"{config.public_realm_url}/protocol/openid-connect/auth?{params}"
 
 
+def keycloak_token_request_data(code: str) -> dict[str, str]:
+    config = keycloak_config()
+    data = {
+        "grant_type": "authorization_code",
+        "client_id": config.client_id,
+        "code": code,
+        "redirect_uri": config.redirect_uri,
+    }
+    if config.client_secret:
+        data["client_secret"] = config.client_secret
+    return data
+
+
 def ensure_keycloak_user(info: dict[str, Any]) -> dict[str, Any]:
     username = str(
         info.get("preferred_username") or info.get("email") or info.get("sub") or ""
@@ -358,12 +373,7 @@ async def exchange_keycloak_code(code: str) -> dict[str, Any]:
     async with httpx.AsyncClient(timeout=10.0) as client:
         token_response = await client.post(
             token_url,
-            data={
-                "grant_type": "authorization_code",
-                "client_id": config.client_id,
-                "code": code,
-                "redirect_uri": config.redirect_uri,
-            },
+            data=keycloak_token_request_data(code),
             headers={"Accept": "application/json"},
         )
         if token_response.status_code >= 400:

--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -192,7 +192,7 @@ def create_user(
         row = conn.execute(
             "INSERT INTO users(username, password_hash, email, is_admin)"
             " VALUES(?, ?, ?, ?) RETURNING id, username, email, is_admin, created_at",
-            (username, password_hash, email, 1 if is_admin else 0),
+            (username, password_hash, email, bool(is_admin)),
         ).fetchone()
         if row is None:
             msg = "User insert returned no row"

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -858,8 +858,8 @@ def _list_articles_for_user(  # noqa: PLR0913
             art_clauses.append("COALESCE(uas.state, 'today') = ?")
             where_params.append(state)
     if starred is not None:
-        art_clauses.append("COALESCE(uas.starred, 0) = ?")
-        where_params.append(1 if starred else 0)
+        art_clauses.append("COALESCE(uas.starred, false) = ?")
+        where_params.append(bool(starred))
     if category:
         art_clauses.append("a.category = ?")
         where_params.append(category)
@@ -877,7 +877,7 @@ def _list_articles_for_user(  # noqa: PLR0913
     sql = f"""
         SELECT a.*,
           COALESCE(uas.state, 'today') AS _uas_state,
-          COALESCE(uas.starred, 0)     AS _uas_starred,
+          COALESCE(uas.starred, false)  AS _uas_starred,
           uas.done_at     AS _uas_done_at,
           uas.starred_at  AS _uas_starred_at,
           uas.skipped_at  AS _uas_skipped_at,
@@ -1078,7 +1078,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
         where_params.extend(sources)
 
     if starred_only:
-        clauses.append("COALESCE(uas.starred, 0) = 1")
+        clauses.append("COALESCE(uas.starred, false) = true")
 
     if date_range == "today":
         clauses.append("a.discovered_at >= datetime(?, '-1 day')")
@@ -1107,7 +1107,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     sql = f"""
         SELECT a.*,
           COALESCE(uas.state, 'today') AS _uas_state,
-          COALESCE(uas.starred, 0)     AS _uas_starred,
+          COALESCE(uas.starred, false)  AS _uas_starred,
           uas.done_at     AS _uas_done_at,
           uas.starred_at  AS _uas_starred_at,
           uas.skipped_at  AS _uas_skipped_at,

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -890,7 +890,7 @@ def _list_articles_for_user(  # noqa: PLR0913
         LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = ?
         {where}
           AND (
-            (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, 1) = 1)
+            (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true))
             OR src.owner_user_id = ?
           )
         ORDER BY a.discovered_at DESC, a.id DESC
@@ -1092,7 +1092,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
 
     # Source subscription filter appended to WHERE
     src_filter = (
-        "(src.owner_user_id IS NULL AND COALESCE(us_src.enabled, 1) = 1) OR src.owner_user_id = ?"
+        "(src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true)) OR src.owner_user_id = ?"
     )
     if clauses:
         clauses.append(f"({src_filter})")

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -730,7 +730,7 @@ def _upsert_uas(  # noqa: PLR0913
             user_id,
             article_id,
             state,
-            1 if starred else 0,
+            bool(starred),
             done_at,
             starred_at,
             skipped_at,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -439,8 +439,8 @@ def sources(
         rows = conn.execute(
             """
             SELECT s.*,
-              CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, 1)
-                   ELSE s.enabled END AS user_enabled
+              CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, true)
+                   ELSE (s.enabled = 1) END AS user_enabled
             FROM sources s
             LEFT JOIN user_sources us ON us.source_slug = s.slug AND us.user_id = ?
             WHERE s.owner_user_id IS NULL OR s.owner_user_id = ?
@@ -528,7 +528,7 @@ def set_source_enabled(
                 VALUES (?, ?, ?)
                 ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = excluded.enabled
                 """,
-                (uid, slug, 1 if payload.enabled else 0),
+                (uid, slug, bool(payload.enabled)),
             )
         else:
             # Private source — only owner can change

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -106,6 +106,42 @@ def test_create_and_get_user(tmp_db: Path) -> None:
     assert fetched["username"] == "alice"
 
 
+def test_create_user_passes_boolean_admin_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeCursor:
+        def fetchone(self) -> dict[str, Any]:
+            return {
+                "id": 1,
+                "username": "admin",
+                "email": None,
+                "is_admin": True,
+                "created_at": "now",
+            }
+
+    class FakeConnection:
+        params: tuple[Any, ...] | None = None
+
+        def execute(self, _sql: str, params: tuple[Any, ...]) -> FakeCursor:
+            self.params = params
+            return FakeCursor()
+
+    class FakeConnect:
+        conn = FakeConnection()
+
+        def __enter__(self) -> FakeConnection:
+            return self.conn
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    fake_connect = FakeConnect()
+    monkeypatch.setattr("news_dashboard.auth.connect", lambda: fake_connect)
+
+    create_user("admin", "secret", is_admin=True)
+
+    assert fake_connect.conn.params is not None
+    assert fake_connect.conn.params[3] is True
+
+
 def test_list_users(tmp_db: Path) -> None:
     create_user("u1", "p1")
     create_user("u2", "p2")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -21,6 +21,7 @@ from news_dashboard.auth import (
     init_auth,
     keycloak_auth_metadata,
     keycloak_authorization_url,
+    keycloak_token_request_data,
     list_users,
     update_password,
     user_count_from_row,
@@ -165,6 +166,36 @@ def test_keycloak_authorization_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "client_id=news-dashboard" in url
     assert "redirect_uri=https%3A%2F%2Fnews.lihor.ro%2Fauth%2Fcallback" in url
     assert "state=state-123" in url
+
+
+def test_keycloak_token_request_data_includes_optional_client_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.lihor.ro")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "news-dashboard")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_SECRET", "client-secret")
+
+    data = keycloak_token_request_data("code-123")
+
+    assert data == {
+        "grant_type": "authorization_code",
+        "client_id": "news-dashboard",
+        "client_secret": "client-secret",
+        "code": "code-123",
+        "redirect_uri": "https://news.lihor.ro/auth/callback",
+    }
+
+
+def test_keycloak_token_request_data_omits_blank_client_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_SECRET", " ")
+
+    data = keycloak_token_request_data("code-123")
+
+    assert "client_secret" not in data
 
 
 def test_ensure_keycloak_user_creates_local_user(

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -1,0 +1,456 @@
+"""PostgreSQL-specific type-compatibility tests.
+
+These tests run against a real PostgreSQL instance (via testcontainers) and
+guard against the class of bug where SQLite happily accepts integer 0/1 for
+boolean columns but PostgreSQL raises DatatypeMismatch.
+
+Covered scenarios
+-----------------
+- COALESCE(uas.starred, false)     — list_articles starred filter
+- COALESCE(us_src.enabled, true)   — source subscription filter in list_articles
+- COALESCE(us.enabled, true)       — sources listing CASE expression in main.py
+- Writing user_sources.enabled as a Python bool (not 0/1) via PATCH API
+- State isolation between users on PostgreSQL
+- Private source visibility on PostgreSQL
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.postgres
+
+
+# ── fixture: set DATABASE_URL for the duration of each test ──────────────────
+
+
+@pytest.fixture
+def pg_env(pg_clean: str) -> Generator[str]:
+    """Set DATABASE_URL in the environment and restore it after the test."""
+    orig = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = pg_clean
+    try:
+        yield pg_clean
+    finally:
+        if orig is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = orig
+
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_user(pg_url: str, username: str) -> int:
+    import psycopg
+
+    with psycopg.connect(pg_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "x"),
+        ).fetchone()
+        conn.commit()
+    return int(row[0])  # type: ignore[index]
+
+
+def _add_global_source(pg_url: str, slug: str) -> None:
+    import psycopg
+
+    with psycopg.connect(pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, 'https://example.com/feed', 'tech', 'rss_feed', 50, 1)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug),
+        )
+        conn.commit()
+
+
+def _add_private_source(pg_url: str, slug: str, *, owner_user_id: int) -> None:
+    import psycopg
+
+    with psycopg.connect(pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+            VALUES (%s, %s, 'https://example.com/feed', 'tech', 'rss_feed', 50, 1, %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug, owner_user_id),
+        )
+        conn.commit()
+
+
+def _add_article(pg_url: str, *, source_slug: str, url_suffix: str = "1") -> int:
+    import psycopg
+
+    with psycopg.connect(pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+              category, kind, state)
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', 'today')
+            RETURNING id
+            """,
+            (
+                f"https://example.com/{url_suffix}",
+                f"https://example.com/{url_suffix}",
+                f"Article {url_suffix}",
+                source_slug,
+                source_slug,
+            ),
+        ).fetchone()
+        conn.commit()
+    return int(row[0])  # type: ignore[index]
+
+
+def _api_client(uid: int, username: str = "user") -> Any:
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_admin, require_auth
+    from news_dashboard.main import app
+
+    fake = {"id": uid, "username": username, "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake
+    app.dependency_overrides[require_admin] = lambda: fake
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _clear_auth_overrides() -> None:
+    from news_dashboard.auth import require_admin, require_auth
+    from news_dashboard.main import app
+
+    app.dependency_overrides.pop(require_auth, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+# ── starred BOOLEAN column ────────────────────────────────────────────────────
+
+
+def test_pg_list_articles_starred_filter(pg_env: str) -> None:
+    """COALESCE(uas.starred, false) must not raise DatatypeMismatch on PostgreSQL."""
+    from news_dashboard.ingest import list_articles, set_article_starred
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-star")
+    uid = _make_user(pg_url, "star-user")
+    aid = _add_article(pg_url, source_slug="pg-src-star", url_suffix="star1")
+
+    # No UAS row yet — starred filter should return empty without crashing.
+    results = list_articles(starred=True, user_id=uid)
+    assert not any(a["id"] == aid for a in results)
+
+    # Star the article and verify it appears.
+    set_article_starred(aid, True, user_id=uid)
+    results = list_articles(starred=True, user_id=uid)
+    assert any(a["id"] == aid for a in results)
+    assert all(a["starred"] is True for a in results if a["id"] == aid)
+
+
+def test_pg_list_articles_unstarred_filter(pg_env: str) -> None:
+    """Starred=False filter must correctly exclude starred articles on PostgreSQL."""
+    from news_dashboard.ingest import list_articles, set_article_starred
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-unstar")
+    uid = _make_user(pg_url, "unstar-user")
+    aid_a = _add_article(pg_url, source_slug="pg-src-unstar", url_suffix="unstar1")
+    aid_b = _add_article(pg_url, source_slug="pg-src-unstar", url_suffix="unstar2")
+
+    set_article_starred(aid_a, True, user_id=uid)
+
+    starred = list_articles(starred=True, user_id=uid)
+    unstarred = list_articles(starred=False, user_id=uid)
+
+    assert any(a["id"] == aid_a for a in starred)
+    assert not any(a["id"] == aid_a for a in unstarred)
+    assert not any(a["id"] == aid_b for a in starred)
+    assert any(a["id"] == aid_b for a in unstarred)
+
+
+def test_pg_list_articles_today_without_uas(pg_env: str) -> None:
+    """list_articles state=today must work when no UAS row exists (NULL coalesces to false)."""
+    from news_dashboard.ingest import list_articles
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-today")
+    uid = _make_user(pg_url, "today-user")
+    aid = _add_article(pg_url, source_slug="pg-src-today", url_suffix="today1")
+
+    results = list_articles(state="today", user_id=uid)
+    assert any(a["id"] == aid for a in results)
+    match = next(a for a in results if a["id"] == aid)
+    assert match["starred"] is False
+    assert match["state"] == "today"
+
+
+def test_pg_star_then_unstar(pg_env: str) -> None:
+    """set_article_starred round-trip on PostgreSQL boolean column."""
+    from news_dashboard.ingest import list_articles, set_article_starred
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-roundtrip")
+    uid = _make_user(pg_url, "roundtrip-user")
+    aid = _add_article(pg_url, source_slug="pg-src-roundtrip", url_suffix="rt1")
+
+    result = set_article_starred(aid, True, user_id=uid)
+    assert result is not None
+    assert result["starred"] is True
+
+    result = set_article_starred(aid, False, user_id=uid)
+    assert result is not None
+    assert result["starred"] is False
+
+    # Confirm list also shows correct value.
+    today = list_articles(state="today", user_id=uid)
+    match = next((a for a in today if a["id"] == aid), None)
+    assert match is not None
+    assert match["starred"] is False
+
+
+# ── user_sources.enabled BOOLEAN column ──────────────────────────────────────
+
+
+def test_pg_list_articles_respects_source_subscription(pg_env: str) -> None:
+    """COALESCE(us_src.enabled, true) must not raise DatatypeMismatch on PostgreSQL."""
+    import psycopg
+
+    from news_dashboard.ingest import list_articles
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-sub")
+    uid = _make_user(pg_url, "sub-user")
+    aid = _add_article(pg_url, source_slug="pg-src-sub", url_suffix="sub1")
+
+    # Default: no user_sources row → source is visible.
+    results = list_articles(state="today", user_id=uid)
+    assert any(a["id"] == aid for a in results)
+
+    # Unsubscribe using a Python bool (not 0/1).
+    with psycopg.connect(pg_url) as conn:
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (%s, %s, %s)",
+            (uid, "pg-src-sub", False),
+        )
+        conn.commit()
+
+    results = list_articles(state="today", user_id=uid)
+    assert not any(a["id"] == aid for a in results)
+
+
+def test_pg_list_articles_resubscription(pg_env: str) -> None:
+    """Flipping user_sources.enabled back to true restores article visibility."""
+    import psycopg
+
+    from news_dashboard.ingest import list_articles
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-resub")
+    uid = _make_user(pg_url, "resub-user")
+    aid = _add_article(pg_url, source_slug="pg-src-resub", url_suffix="resub1")
+
+    with psycopg.connect(pg_url) as conn:
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (%s, %s, %s)",
+            (uid, "pg-src-resub", False),
+        )
+        conn.commit()
+
+    assert not any(a["id"] == aid for a in list_articles(state="today", user_id=uid))
+
+    with psycopg.connect(pg_url) as conn:
+        conn.execute(
+            "UPDATE user_sources SET enabled = %s WHERE user_id = %s AND source_slug = %s",
+            (True, uid, "pg-src-resub"),
+        )
+        conn.commit()
+
+    results = list_articles(state="today", user_id=uid)
+    assert any(a["id"] == aid for a in results)
+
+
+# ── GET /api/sources CASE WHEN COALESCE expression ───────────────────────────
+
+
+def test_pg_sources_listing_subscribed_by_default(pg_env: str) -> None:
+    """GET /api/sources COALESCE(us.enabled, true) must not raise DatatypeMismatch."""
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-list")
+    uid = _make_user(pg_url, "list-user")
+
+    client = _api_client(uid, "list-user")
+    try:
+        resp = client.get("/api/sources")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        match = next((i for i in items if i["slug"] == "pg-src-list"), None)
+        assert match is not None
+        assert match["subscribed"] is True
+    finally:
+        _clear_auth_overrides()
+
+
+def test_pg_sources_listing_after_unsubscribe(pg_env: str) -> None:
+    """After unsubscribing, GET /api/sources must show subscribed=false."""
+    import psycopg
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-unsub-list")
+    uid = _make_user(pg_url, "unsub-list-user")
+
+    with psycopg.connect(pg_url) as conn:
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (%s, %s, %s)",
+            (uid, "pg-src-unsub-list", False),
+        )
+        conn.commit()
+
+    client = _api_client(uid, "unsub-list-user")
+    try:
+        resp = client.get("/api/sources")
+        assert resp.status_code == 200
+        match = next((i for i in resp.json()["items"] if i["slug"] == "pg-src-unsub-list"), None)
+        assert match is not None
+        assert match["subscribed"] is False
+    finally:
+        _clear_auth_overrides()
+
+
+# ── PATCH /api/sources/{slug}/enabled writes boolean ─────────────────────────
+
+
+def test_pg_api_toggle_subscription_writes_boolean(pg_env: str) -> None:
+    """PATCH /api/sources/{slug}/enabled must write a Python bool to user_sources.enabled."""
+    import psycopg
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-toggle")
+    uid = _make_user(pg_url, "toggle-user")
+
+    client = _api_client(uid, "toggle-user")
+    try:
+        resp = client.patch("/api/sources/pg-src-toggle/enabled", json={"enabled": False})
+        assert resp.status_code == 200
+        assert resp.json()["subscribed"] is False
+
+        resp2 = client.patch("/api/sources/pg-src-toggle/enabled", json={"enabled": True})
+        assert resp2.status_code == 200
+        assert resp2.json()["subscribed"] is True
+    finally:
+        _clear_auth_overrides()
+
+    # Confirm the DB column holds a proper boolean, not an integer.
+    with psycopg.connect(pg_url) as conn:
+        row = conn.execute(
+            "SELECT enabled FROM user_sources WHERE user_id = %s AND source_slug = %s",
+            (uid, "pg-src-toggle"),
+        ).fetchone()
+    assert row is not None
+    assert row[0] is True
+
+
+# ── per-user state isolation ──────────────────────────────────────────────────
+
+
+def test_pg_state_isolation_between_users(pg_env: str) -> None:
+    """State transitions on PostgreSQL must be isolated per user."""
+    from news_dashboard.ingest import list_articles, transition_article_state
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-iso")
+    uid_a = _make_user(pg_url, "iso-alice")
+    uid_b = _make_user(pg_url, "iso-bob")
+    aid = _add_article(pg_url, source_slug="pg-src-iso", url_suffix="iso1")
+
+    transition_article_state(aid, "done", user_id=uid_a)
+
+    assert any(a["id"] == aid for a in list_articles(state="done", user_id=uid_a))
+    assert any(a["id"] == aid for a in list_articles(state="today", user_id=uid_b))
+    assert not any(a["id"] == aid for a in list_articles(state="done", user_id=uid_b))
+
+
+def test_pg_star_isolation_between_users(pg_env: str) -> None:
+    """Starring an article for one user must not affect another user's view."""
+    from news_dashboard.ingest import list_articles, set_article_starred
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-star-iso")
+    uid_a = _make_user(pg_url, "stariso-alice")
+    uid_b = _make_user(pg_url, "stariso-bob")
+    aid = _add_article(pg_url, source_slug="pg-src-star-iso", url_suffix="stariso1")
+
+    set_article_starred(aid, True, user_id=uid_a)
+
+    assert any(a["id"] == aid for a in list_articles(starred=True, user_id=uid_a))
+    assert not any(a["id"] == aid for a in list_articles(starred=True, user_id=uid_b))
+
+
+# ── private source visibility ─────────────────────────────────────────────────
+
+
+def test_pg_private_source_visibility(pg_env: str) -> None:
+    """Private source articles must only be visible to the owner on PostgreSQL."""
+    from news_dashboard.ingest import list_articles
+
+    pg_url = pg_env
+    uid_a = _make_user(pg_url, "priv-alice")
+    uid_b = _make_user(pg_url, "priv-bob")
+    _add_private_source(pg_url, "pg-priv-src", owner_user_id=uid_a)
+    aid = _add_article(pg_url, source_slug="pg-priv-src", url_suffix="priv1")
+
+    assert any(a["id"] == aid for a in list_articles(state="today", user_id=uid_a))
+    assert not any(a["id"] == aid for a in list_articles(state="today", user_id=uid_b))
+
+
+# ── schema correctness ────────────────────────────────────────────────────────
+
+
+def test_pg_user_article_state_starred_is_boolean(pg_clean: str) -> None:
+    """user_article_state.starred must be a boolean column in PostgreSQL."""
+    import psycopg
+
+    with psycopg.connect(pg_clean) as conn:
+        row = conn.execute(
+            """
+            SELECT data_type FROM information_schema.columns
+            WHERE table_name = 'user_article_state' AND column_name = 'starred'
+            """,
+        ).fetchone()
+    assert row is not None
+    assert row[0] == "boolean"
+
+
+def test_pg_user_sources_enabled_is_boolean(pg_clean: str) -> None:
+    """user_sources.enabled must be a boolean column in PostgreSQL."""
+    import psycopg
+
+    with psycopg.connect(pg_clean) as conn:
+        row = conn.execute(
+            """
+            SELECT data_type FROM information_schema.columns
+            WHERE table_name = 'user_sources' AND column_name = 'enabled'
+            """,
+        ).fetchone()
+    assert row is not None
+    assert row[0] == "boolean"
+
+
+def test_pg_articles_starred_is_integer(pg_clean: str) -> None:
+    """articles.starred is added via ALTER TABLE as INTEGER — verify no regression."""
+    import psycopg
+
+    with psycopg.connect(pg_clean) as conn:
+        row = conn.execute(
+            """
+            SELECT data_type FROM information_schema.columns
+            WHERE table_name = 'articles' AND column_name = 'starred'
+            """,
+        ).fetchone()
+    assert row is not None
+    assert row[0] == "integer"

--- a/deploy/keycloak-theme/news-dashboard/login/resources/css/login.css
+++ b/deploy/keycloak-theme/news-dashboard/login/resources/css/login.css
@@ -1,16 +1,23 @@
-/* Keycloak login theme for the new Radar Dashboard application. */
+/* Keycloak login theme for the Radar Dashboard application. */
 :root {
   --nd-radius: 0.5rem;
   --nd-background: oklch(0.985 0.003 80);
   --nd-foreground: oklch(0.2 0.012 70);
   --nd-surface: oklch(0.97 0.005 80);
+  --nd-surface-2: oklch(0.945 0.006 80);
   --nd-card: oklch(1 0 0);
   --nd-muted-foreground: oklch(0.5 0.012 70);
   --nd-subtle: oklch(0.62 0.012 70);
   --nd-border: oklch(0.9 0.008 80);
+  --nd-border-strong: oklch(0.82 0.01 80);
+  --nd-primary: oklch(0.32 0.04 60);
+  --nd-primary-foreground: oklch(0.98 0.005 80);
+  --nd-accent: oklch(0.55 0.13 45);
   --nd-ring: oklch(0.55 0.13 45);
   --nd-err: oklch(0.55 0.18 28);
-  --nd-font: 'Inter Variable', 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --nd-font:
+    'Inter Variable', 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
 }
 
 html,
@@ -25,6 +32,7 @@ body.login-pf {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-feature-settings: 'cv11', 'ss01', 'ss03';
+  letter-spacing: 0;
 }
 
 .login-pf-page,
@@ -54,7 +62,7 @@ body.login-pf {
   width: min(24rem, 100%);
   padding: 1.5rem;
   border: 1px solid var(--nd-border);
-  border-radius: 0.75rem;
+  border-radius: calc(var(--nd-radius) + 0.25rem);
   background: var(--nd-card);
   box-shadow: 0 1px 2px rgba(20, 23, 31, 0.05);
 }
@@ -62,7 +70,7 @@ body.login-pf {
 .pf-v5-c-login__main-header,
 .pf-v5-c-login__main-body,
 .pf-v5-c-login__main-footer {
-  padding: 0;
+  padding-inline: 0;
 }
 
 #kc-page-title,
@@ -82,12 +90,12 @@ body.login-pf {
   width: 2.5rem;
   height: 2.5rem;
   margin: 0 auto 0.5rem;
-  border-radius: 0.75rem;
+  border-radius: calc(var(--nd-radius) + 0.25rem);
   background: color-mix(in oklch, var(--nd-foreground) 90%, transparent);
   color: var(--nd-background);
   font-size: 0.875rem;
   font-weight: 700;
-  letter-spacing: -0.025em;
+  letter-spacing: 0;
 }
 
 #kc-page-title::after {
@@ -106,6 +114,10 @@ body.login-pf {
   gap: 1rem;
 }
 
+.pf-v5-c-form__group {
+  margin-bottom: 0;
+}
+
 .pf-v5-c-form__label-text,
 label {
   color: var(--nd-muted-foreground);
@@ -117,7 +129,8 @@ label {
 .pf-v5-c-form-control > input,
 input[type='text'],
 input[type='password'],
-input[type='email'] {
+input[type='email'],
+select {
   min-height: 2.5rem;
   padding: 0.5rem 0.75rem !important;
   border: 1px solid var(--nd-border) !important;
@@ -132,12 +145,14 @@ input[type='email'] {
 .pf-v5-c-form-control > input:focus,
 input[type='text']:focus,
 input[type='password']:focus,
-input[type='email']:focus {
+input[type='email']:focus,
+select:focus {
   outline: none !important;
   box-shadow: 0 0 0 2px var(--nd-ring) !important;
 }
 
-.pf-v5-c-button.pf-m-control {
+.pf-v5-c-button.pf-m-control,
+.pf-v5-c-input-group .pf-v5-c-button {
   min-height: 2.5rem;
   border-color: var(--nd-border) !important;
   border-radius: var(--nd-radius) !important;
@@ -154,8 +169,8 @@ input[type='email']:focus {
   min-height: 2.5rem;
   border: 0 !important;
   border-radius: var(--nd-radius) !important;
-  background: var(--nd-foreground) !important;
-  color: var(--nd-background) !important;
+  background: var(--nd-primary) !important;
+  color: var(--nd-primary-foreground) !important;
   font-size: 0.875rem;
   font-weight: 500;
   box-shadow: none !important;
@@ -165,6 +180,15 @@ input[type='email']:focus {
 .pf-v5-c-button.pf-m-primary:hover,
 #kc-login:hover {
   opacity: 0.9;
+}
+
+.pf-v5-c-button.pf-m-secondary,
+.pf-v5-c-button.pf-m-link {
+  min-height: 2.5rem;
+  border-radius: var(--nd-radius) !important;
+  color: var(--nd-foreground) !important;
+  font-size: 0.875rem;
+  font-weight: 500;
 }
 
 a {
@@ -190,15 +214,113 @@ a {
   text-align: center;
 }
 
+#kc-social-providers {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--nd-border);
+}
+
+#kc-social-providers h2,
+#kc-social-providers .pf-v5-c-title {
+  margin: 0 0 0.75rem !important;
+  color: var(--nd-muted-foreground) !important;
+  font-size: 0.75rem !important;
+  font-weight: 500 !important;
+  text-align: center;
+}
+
+#kc-social-providers ul,
+#kc-social-providers .pf-v5-c-login__main-footer-links {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+#kc-social-providers li {
+  margin: 0;
+}
+
+#kc-social-providers a,
+#kc-social-providers .pf-v5-c-button,
+.kc-social-provider-name {
+  text-decoration: none !important;
+}
+
+#kc-social-providers a,
+#kc-social-providers .pf-v5-c-button {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: 2.5rem;
+  border: 1px solid var(--nd-border) !important;
+  border-radius: var(--nd-radius) !important;
+  background: var(--nd-surface) !important;
+  color: var(--nd-foreground) !important;
+  font-size: 0.875rem;
+  font-weight: 500;
+  box-shadow: none !important;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease;
+}
+
+#kc-social-providers a:hover,
+#kc-social-providers .pf-v5-c-button:hover {
+  border-color: var(--nd-border-strong) !important;
+  background: var(--nd-surface-2) !important;
+}
+
+#kc-social-providers a:focus-visible,
+#kc-social-providers .pf-v5-c-button:focus-visible {
+  outline: none !important;
+  box-shadow: 0 0 0 2px var(--nd-ring) !important;
+}
+
+.kc-social-provider-name {
+  color: inherit;
+}
+
+.kc-social-provider-logo,
+#kc-social-providers i {
+  color: var(--nd-foreground);
+  font-size: 1rem;
+}
+
+.kc-social-google .kc-social-provider-logo,
+#kc-social-google i {
+  color: #4285f4;
+}
+
+.pf-v5-c-divider {
+  --pf-v5-c-divider--BackgroundColor: var(--nd-border);
+  margin-block: 1rem;
+}
+
+.pf-v5-c-check__label,
+.pf-v5-c-helper-text__item,
+.pf-v5-c-form__helper-text {
+  color: var(--nd-muted-foreground) !important;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --nd-background: oklch(0.155 0.008 80);
     --nd-foreground: oklch(0.94 0.005 80);
     --nd-surface: oklch(0.185 0.008 80);
+    --nd-surface-2: oklch(0.215 0.008 80);
     --nd-card: oklch(0.2 0.008 80);
     --nd-muted-foreground: oklch(0.65 0.01 80);
     --nd-subtle: oklch(0.55 0.01 80);
     --nd-border: oklch(0.28 0.008 80);
+    --nd-border-strong: oklch(0.36 0.01 80);
+    --nd-primary: oklch(0.92 0.005 80);
+    --nd-primary-foreground: oklch(0.18 0.008 80);
+    --nd-accent: oklch(0.68 0.13 45);
     --nd-ring: oklch(0.68 0.13 45);
     --nd-err: oklch(0.68 0.18 28);
   }

--- a/docs/KEYCLOAK_AUTH.md
+++ b/docs/KEYCLOAK_AUTH.md
@@ -19,7 +19,7 @@ The dashboard is a PWA, so the generated Workbox service worker can answer brows
 `vite.config.ts` therefore denies fallback handling for:
 
 ```ts
-navigateFallbackDenylist: [/^\/api\//, /^\/auth\//, /^\/keycloak\//]
+navigateFallbackDenylist: [/^\/api\//, /^\/auth\//, /^\/keycloak\//];
 ```
 
 Without this denylist, an already-installed PWA or a browser with an old service worker can open `/auth/login` and see the dashboard login shell again instead of following the backend `307` to Keycloak.
@@ -85,6 +85,56 @@ Recommended realm/client values:
 - Valid post-logout redirect URI: `https://news.lihor.ro`
 - Web origin: `https://news.lihor.ro`
 
+## Google sign-in
+
+Enable Google through Keycloak, not as a second auth implementation inside the
+dashboard. The app should keep talking only to Keycloak; Keycloak brokers the
+Google identity, then `/auth/callback` creates or reuses the same local
+dashboard user record as any other Keycloak login.
+
+### Google Cloud
+
+1. Open Google Cloud Console and create or select the project that should own
+   the OAuth client.
+2. Configure the OAuth consent screen for the app.
+3. Create an OAuth 2.0 Client ID with application type `Web application`.
+4. Add this authorized redirect URI:
+
+   ```text
+   https://news.lihor.ro/keycloak/realms/news-dashboard/broker/google/endpoint
+   ```
+
+5. Copy the generated client ID and client secret.
+
+### Keycloak
+
+1. Open the `news-dashboard` realm.
+2. Go to **Identity providers** and add **Google**.
+3. Use alias `google` so the broker callback path stays:
+
+   ```text
+   /realms/news-dashboard/broker/google/endpoint
+   ```
+
+4. Paste the Google client ID and client secret.
+5. Keep the default scopes unless the dashboard needs more profile data. The
+   app currently needs only standard OIDC identity fields such as username,
+   email, and display name.
+6. Save the provider, then open a private browser window and visit:
+
+   ```text
+   https://news.lihor.ro/auth/login
+   ```
+
+   The Keycloak login page should show the Google provider as an alternate
+   sign-in action. After Google redirects back to Keycloak, Keycloak redirects
+   to `https://news.lihor.ro/auth/callback`, and the dashboard session cookie is
+   issued by the app.
+
+No frontend or backend environment variable is required specifically for Google
+as long as `KEYCLOAK_AUTH_ENABLED=1` and the existing Keycloak settings point at
+the `news-dashboard` realm.
+
 ## Login theme
 
 The custom Keycloak theme lives in:
@@ -93,7 +143,10 @@ The custom Keycloak theme lives in:
 deploy/keycloak-theme/news-dashboard/login/
 ```
 
-It extends `keycloak.v2` and overrides only CSS. The CSS mirrors the new Radar Dashboard app shell: `RD` mark, compact centered card, warm OKLCH background/card colors, rounded inputs, dark foreground button, and dark-mode support.
+It extends `keycloak.v2` and overrides only CSS. The CSS mirrors the Radar
+Dashboard app shell: `RD` mark, compact centered card, warm OKLCH
+background/card colors, rounded inputs, app-style primary actions, social
+provider buttons, and dark-mode support.
 
 Mount it into the Keycloak container at:
 
@@ -106,7 +159,7 @@ Then set the realm login theme to `news-dashboard`.
 For local development/self-hosting, disable Keycloak theme caching while iterating:
 
 ```yaml
-KC_SPI_THEME_CACHE_THEMES: "false"
-KC_SPI_THEME_CACHE_TEMPLATES: "false"
-KC_SPI_THEME_STATIC_MAX_AGE: "-1"
+KC_SPI_THEME_CACHE_THEMES: 'false'
+KC_SPI_THEME_CACHE_TEMPLATES: 'false'
+KC_SPI_THEME_STATIC_MAX_AGE: '-1'
 ```

--- a/helm/news-dashboard/templates/auth-secret.yaml
+++ b/helm/news-dashboard/templates/auth-secret.yaml
@@ -9,4 +9,5 @@ metadata:
 type: Opaque
 stringData:
   SESSION_SECRET: {{ required "app.auth.sessionSecret is required when app.auth.enabled=true" .Values.app.auth.sessionSecret | quote }}
+  KEYCLOAK_CLIENT_SECRET: {{ .Values.app.auth.clientSecret | quote }}
 {{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
               value: {{ .Values.app.auth.realm | quote }}
             - name: KEYCLOAK_CLIENT_ID
               value: {{ .Values.app.auth.clientId | quote }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "news-dashboard.fullname" . }}-auth
+                  key: KEYCLOAK_CLIENT_SECRET
             - name: KEYCLOAK_ADMIN_USERNAMES
               value: {{ .Values.app.auth.adminUsernames | quote }}
             - name: SESSION_SECRET

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -37,6 +37,8 @@ app:
     keycloakInternalServerUrl: https://news.lihor.ro/keycloak
     realm: news-dashboard
     clientId: news-dashboard
+    # Optional. Set this when the Keycloak client uses "confidential" access type.
+    clientSecret: ""
     # Comma-separated usernames that become app admins when first seen from Keycloak.
     adminUsernames: ioachim
     # Override in CI/local deploy with a long random string.


### PR DESCRIPTION
## Summary

- **Keycloak auth integration**: Wire Google auth through Keycloak, fix client secret exchange, align login theme with dashboard, redirect unauthenticated users, validate session secret at startup
- **PWA / frontend**: Add favicon, web manifest, fix Keycloak auth routes bypassing PWA fallback, update Vite config
- **PostgreSQL boolean fixes**: Replace all `COALESCE(col, 0/1)` and integer writes with proper boolean literals for `user_article_state.starred` (BOOLEAN) and `user_sources.enabled` (BOOLEAN) — was causing `DatatypeMismatch` 500 errors on every `/api/articles` request
- **Tests**: 15 new PostgreSQL integration tests in `test_postgres_types.py` covering COALESCE expressions, schema column types, API toggle, and per-user isolation; skip gracefully without Docker

## PostgreSQL boolean fixes detail

| Location | Bug | Fix |
|---|---|---|
| `ingest.py` `_list_articles_for_user` | `COALESCE(uas.starred, 0)` | `COALESCE(uas.starred, false)` |
| `ingest.py` source subscription filter (×2) | `COALESCE(us_src.enabled, 1) = 1` | `COALESCE(us_src.enabled, true)` |
| `main.py` GET /api/sources CASE | `COALESCE(us.enabled, 1)` mixed with INTEGER branch | `COALESCE(us.enabled, true)` + `(s.enabled = 1)` |
| `main.py` PATCH /api/sources enabled | `1 if payload.enabled else 0` | `bool(payload.enabled)` |

## Test plan

- [ ] Verify `/api/articles?state=today` returns 200 (was 500 before the boolean fixes)
- [ ] Verify starring/unstarring articles works
- [ ] Verify source subscription toggle works
- [ ] Verify Keycloak login flow end-to-end
- [ ] `pytest backend/tests/test_postgres_types.py` — skips without Docker, passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)