### PR TITLE
fix: copy public/ into Docker build so manifest.webmanifest is served

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install
 COPY index.html tsconfig.json vite.config.ts ./
+COPY public ./public
 COPY frontend ./frontend
 RUN npm run build
 


### PR DESCRIPTION
## Summary

- The `public/` directory was never `COPY`'d in the frontend Docker build stage
- Vite copies `public/` assets (manifest.webmanifest, icons, favicon.svg) into `frontend/dist` during build
- Without it, these files were missing from the Docker image → 404 on `/manifest.webmanifest` in production

## Test plan

- [ ] Build the Docker image locally and confirm `frontend/dist/manifest.webmanifest` exists inside the container
- [ ] Verify `/manifest.webmanifest` returns 200 after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)