### PR TITLE
chore: prepare repo to be public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,14 @@ jobs:
           GHCR_ACTOR: ${{ github.actor }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          # Deployment-specific values kept out of the public repo. Set these as
+          # GitHub Actions repository Variables (Settings → Secrets and variables
+          # → Actions → Variables). Falls back to the generic chart defaults.
+          PUBLIC_BASE_URL: ${{ vars.PUBLIC_BASE_URL }}
+          KEYCLOAK_SERVER_URL: ${{ vars.KEYCLOAK_SERVER_URL }}
+          ADMIN_USERNAMES: ${{ vars.ADMIN_USERNAMES }}
+          DATA_HOSTPATH: ${{ vars.DATA_HOSTPATH }}
+          POSTGRES_HOSTPATH: ${{ vars.POSTGRES_HOSTPATH }}
         run: |
           set -euo pipefail
 
@@ -210,12 +218,25 @@ jobs:
             --set image.pullSecretName=ghcr-pull-secret
             --set service.type=NodePort
             --set service.nodePort=30088
-            --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data
-            --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data
+            --set persistence.hostPath="${DATA_HOSTPATH:-/data/news-dashboard-data}"
+            --set postgresql.persistence.hostPath="${POSTGRES_HOSTPATH:-/data/news-dashboard-postgres-data}"
             --set ingress.enabled=false
             --set-string app.auth.sessionSecret="$SESSION_SECRET"
             "${ai_helm_args[@]}"
           )
+          # Apply deployment-specific overrides only when the matching repo
+          # Variable is set, so the public chart defaults stay generic.
+          if [ -n "$PUBLIC_BASE_URL" ]; then
+            helm_args+=(--set "app.auth.publicBaseUrl=$PUBLIC_BASE_URL")
+            helm_args+=(--set "ingress.host=${PUBLIC_BASE_URL#https://}")
+          fi
+          if [ -n "$KEYCLOAK_SERVER_URL" ]; then
+            helm_args+=(--set "app.auth.keycloakServerUrl=$KEYCLOAK_SERVER_URL")
+            helm_args+=(--set "app.auth.keycloakInternalServerUrl=$KEYCLOAK_SERVER_URL")
+          fi
+          if [ -n "$ADMIN_USERNAMES" ]; then
+            helm_args+=(--set "app.auth.adminUsernames=$ADMIN_USERNAMES")
+          fi
           helm "${helm_args[@]}"
 
           # Wait for the new pods to become ready.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ioachim-hub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # news-dashboard
 
-Private dashboard for `news.lihor.ro`: a news inbox, reading tracker, source registry, and later summary/AI question layer for Ioachim.
+Private dashboard for `news.example.com`: a news inbox, reading tracker, source registry, and later summary/AI question layer for the owner.
 
 ## Product intent
 
@@ -82,7 +82,7 @@ helm upgrade --install news-dashboard ./helm/news-dashboard \
 The Kubernetes deployment uses PostgreSQL by default, backed by durable host storage on the local single-node cluster:
 
 ```text
-/home/ioachim-minipc/news-dashboard-postgres-data
+/home/your-runner/news-dashboard-postgres-data
 ```
 
 SQLite remains only a local/test fallback. Existing SQLite data can be migrated with:
@@ -94,11 +94,11 @@ news-dashboard-migrate /data/news-dashboard.db
 ## Deployment notes
 
 - The app should be private/auth-protected when exposed publicly.
-- `news.lihor.ro` uses app-level authentication. The local minipc deployment can
-  use Keycloak under `https://news.lihor.ro/keycloak`; see
+- `news.example.com` uses app-level authentication. The local minipc deployment can
+  use Keycloak under `https://news.example.com/keycloak`; see
   [docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md) for backend env vars, Helm
   values, Caddy routing, and the matching Keycloak login theme.
-- `news.lihor.ro` is served by host-level Caddy with automatic Let's Encrypt
+- `news.example.com` is served by host-level Caddy with automatic Let's Encrypt
   HTTPS. See [docs/CADDY_HTTPS_SETUP.md](docs/CADDY_HTTPS_SETUP.md) for the
   full HTTPS setup guide; the Caddyfile lives at `deploy/Caddyfile`.
 - HTTPS is required for PWA install (Chrome/Android "Add to Home Screen" as a
@@ -107,3 +107,7 @@ news-dashboard-migrate /data/news-dashboard.db
   Keycloak redirects and API responses reach the backend.
 - GitHub Actions publishes `ghcr.io/ioachim-hub/news-dashboard`.
 - For the local Kubernetes cluster, if GHCR pull auth is unavailable, build and push to `localhost:5000/news-dashboard:<tag>` and override Helm image values.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -343,7 +343,9 @@ def sync_sources(db_path: Path | None = None) -> None:
 
 def _fetch_feed_entries(source: SourceDefinition) -> list[dict[str, Any]]:
     """Fetch and normalize feed entries, surfacing fetch failures as FeedFetchError."""
-    parsed = feedparser.parse(source.url, agent="news-dashboard/0.1 (personal; contact@lihor.ro)")
+    parsed = feedparser.parse(
+        source.url, agent="news-dashboard/0.1 (personal; contact@example.com)"
+    )
     # feedparser swallows network errors via bozo; surface them so health tracking works
     if parsed.bozo and not parsed.entries:
         exc = getattr(parsed, "bozo_exception", None)

--- a/backend/news_dashboard/scraper.py
+++ b/backend/news_dashboard/scraper.py
@@ -11,7 +11,7 @@ import urllib.request
 from html.parser import HTMLParser
 from typing import Any
 
-USER_AGENT = "news-dashboard/0.1 (personal RSS reader; contact@lihor.ro)"
+USER_AGENT = "news-dashboard/0.1 (personal RSS reader; contact@example.com)"
 TIMEOUT_SECS = 15
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -193,14 +193,14 @@ def test_keycloak_auth_metadata_disabled(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_keycloak_authorization_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
-    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.lihor.ro")
-    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
+    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.example.com")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.example.com/keycloak")
     url = keycloak_authorization_url("state-123")
     assert url.startswith(
-        "https://news.lihor.ro/keycloak/realms/news-dashboard/protocol/openid-connect/auth?"
+        "https://news.example.com/keycloak/realms/news-dashboard/protocol/openid-connect/auth?"
     )
     assert "client_id=news-dashboard" in url
-    assert "redirect_uri=https%3A%2F%2Fnews.lihor.ro%2Fauth%2Fcallback" in url
+    assert "redirect_uri=https%3A%2F%2Fnews.example.com%2Fauth%2Fcallback" in url
     assert "state=state-123" in url
 
 
@@ -208,7 +208,7 @@ def test_keycloak_token_request_data_includes_optional_client_secret(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
-    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.lihor.ro")
+    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.example.com")
     monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "news-dashboard")
     monkeypatch.setenv("KEYCLOAK_CLIENT_SECRET", "client-secret")
 
@@ -219,7 +219,7 @@ def test_keycloak_token_request_data_includes_optional_client_secret(
         "client_id": "news-dashboard",
         "client_secret": "client-secret",
         "code": "code-123",
-        "redirect_uri": "https://news.lihor.ro/auth/callback",
+        "redirect_uri": "https://news.example.com/auth/callback",
     }
 
 
@@ -237,12 +237,12 @@ def test_keycloak_token_request_data_omits_blank_client_secret(
 def test_ensure_keycloak_user_creates_local_user(
     tmp_db: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("KEYCLOAK_ADMIN_USERNAMES", "ioachim")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_USERNAMES", "admin")
     user = ensure_keycloak_user(
-        {"preferred_username": "ioachim", "email": "ioachim@example.test", "sub": "kc-sub"}
+        {"preferred_username": "admin", "email": "admin@example.test", "sub": "kc-sub"}
     )
-    assert user["username"] == "ioachim"
-    assert user["email"] == "ioachim@example.test"
+    assert user["username"] == "admin"
+    assert user["email"] == "admin@example.test"
     assert user["is_admin"]
 
 
@@ -258,7 +258,7 @@ def test_init_auth_requires_session_secret_for_keycloak(
     tmp_db: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
-    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.example.com/keycloak")
     monkeypatch.delenv("SESSION_SECRET", raising=False)
     monkeypatch.delenv("TEST_SESSION_SECRET", raising=False)
 
@@ -270,7 +270,7 @@ def test_init_auth_accepts_keycloak_when_session_secret_is_set(
     tmp_db: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
-    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.example.com/keycloak")
     monkeypatch.setenv("SESSION_SECRET", "test-secret")
 
     init_auth()

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,3 +1,3 @@
-news.lihor.ro {
+news.example.com {
     reverse_proxy localhost:30088
 }

--- a/deploy/keycloak-theme/news-dashboard/login/resources/css/login.css
+++ b/deploy/keycloak-theme/news-dashboard/login/resources/css/login.css
@@ -99,7 +99,7 @@ body.login-pf {
 }
 
 #kc-page-title::after {
-  content: 'Private radar dashboard for news.lihor.ro';
+  content: 'Private radar dashboard for news.example.com';
   display: block;
   margin-top: 0.25rem;
   color: var(--nd-muted-foreground);

--- a/deploy/news.example.com.caddyfile
+++ b/deploy/news.example.com.caddyfile
@@ -1,4 +1,4 @@
-news.lihor.ro {
+news.example.com {
 	# Authentication is enforced by the app. Keycloak is mounted under the same
 	# hostname so OAuth redirect URIs do not require a separate DNS record.
 	handle /keycloak* {

--- a/deploy/news.example.com.caddyfile.disabled
+++ b/deploy/news.example.com.caddyfile.disabled
@@ -1,7 +1,7 @@
-# Staged only. Do not import/reload until news.lihor.ro DNS resolves.
+# Staged only. Do not import/reload until news.example.com DNS resolves.
 # Add basic_auth before public exposure.
 
-news.lihor.ro {
+news.example.com {
   encode zstd gzip
 
   header {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # News Dashboard Architecture
 
-This project is a private personal news dashboard for `news.lihor.ro`. It collects curated technical news feeds, stores articles, lets the owner triage them as `new`, `read`, `saved`, `skipped`, or `archived`, tracks source health, and can send a daily digest email.
+This project is a private personal news dashboard for `news.example.com`. It collects curated technical news feeds, stores articles, lets the owner triage them as `new`, `read`, `saved`, `skipped`, or `archived`, tracks source health, and can send a daily digest email.
 
 The system is not a large microservice platform. It is best understood as a modular monolith with a small number of runtime units:
 
@@ -35,7 +35,7 @@ flowchart TB
   end
 
   subgraph Kubernetes["Kubernetes via Helm"]
-    Caddy["Host Caddy<br/>news.lihor.ro<br/>Basic Auth"]
+    Caddy["Host Caddy<br/>news.example.com<br/>Basic Auth"]
     Service["K8s Service<br/>NodePort 30088 or ClusterIP"]
     Deployment["news-dashboard Deployment<br/>replicas: 1"]
     CronJob["K8s CronJob<br/>news-dashboard ingest<br/>every 6 hours"]
@@ -150,7 +150,7 @@ sequenceDiagram
 
 ```mermaid
 flowchart TD
-  Open["Open news.lihor.ro"] --> Load["React loads dashboard"]
+  Open["Open news.example.com"] --> Load["React loads dashboard"]
   Load --> Summary["GET /api/summary"]
   Load --> Articles["GET /api/articles?status=new"]
   Load --> Sources["GET /api/sources"]
@@ -239,7 +239,7 @@ During ingestion, each source is fetched through either `feedparser` for RSS/Ato
 
 The React UI reads articles by status and category, displays summary counts, shows source health, and lets the user update article status. Status changes are persisted through `PATCH /api/articles/{article_id}/status`, and the UI reloads articles and counts afterward. Search calls `/api/search` and returns matching articles across statuses.
 
-For production, GitHub Actions tests the Python backend, builds the frontend, builds a Docker image, pushes it to GHCR, and deploys it on a self-hosted runner with Helm. The host-level Caddy route exposes the Kubernetes NodePort at `news.lihor.ro` and applies Basic Auth outside the app.
+For production, GitHub Actions tests the Python backend, builds the frontend, builds a Docker image, pushes it to GHCR, and deploys it on a self-hosted runner with Helm. The host-level Caddy route exposes the Kubernetes NodePort at `news.example.com` and applies Basic Auth outside the app.
 
 ## Operational Notes
 

--- a/docs/CADDY_HTTPS_SETUP.md
+++ b/docs/CADDY_HTTPS_SETUP.md
@@ -1,6 +1,6 @@
-# Caddy HTTPS setup for news.lihor.ro
+# Caddy HTTPS setup for news.example.com
 
-This document covers everything needed to put `news.lihor.ro` behind Caddy on
+This document covers everything needed to put `news.example.com` behind Caddy on
 the mini PC so the app is served over HTTPS.  HTTPS is required for:
 
 - Chrome/Android PWA install prompt ("Add to Home Screen" → standalone app)
@@ -31,24 +31,24 @@ curl -s https://ifconfig.me
 Write this IP down — you will need it for Step 2.  If your ISP changes it
 periodically (dynamic IP), see the DDNS note at the bottom of this document.
 
-### Step 2 — Create a DNS A record for news.lihor.ro
+### Step 2 — Create a DNS A record for news.example.com
 
-Log in to wherever you manage the `lihor.ro` domain (your DNS registrar or
+Log in to wherever you manage the `example.com` domain (your DNS registrar or
 hosting panel) and add:
 
 | Type | Name | Value               | TTL  |
 |------|------|---------------------|------|
 | A    | news | `<your-public-IP>`  | 300  |
 
-`news` is the subdomain; `lihor.ro` is added automatically by the registrar.
+`news` is the subdomain; `example.com` is added automatically by the registrar.
 TTL 300 (5 minutes) lets you update it quickly if the IP changes.
 
 To verify the record has propagated (wait a few minutes, then run):
 
 ```bash
-dig +short news.lihor.ro          # should print your public IP
+dig +short news.example.com          # should print your public IP
 # or on Windows:
-nslookup news.lihor.ro
+nslookup news.example.com
 ```
 
 ### Step 3 — Open port 443 on your router (port forwarding)
@@ -114,7 +114,7 @@ sudo systemctl reload caddy
 sudo caddy reload --config /etc/caddy/Caddyfile
 ```
 
-Caddy will immediately request a Let's Encrypt certificate for `news.lihor.ro`.
+Caddy will immediately request a Let's Encrypt certificate for `news.example.com`.
 Watch the logs to confirm:
 
 ```bash
@@ -127,11 +127,11 @@ You should see a line like `certificate obtained successfully`.  This takes
 ### Step 7 — Verify
 
 ```bash
-curl https://news.lihor.ro/api/health
+curl https://news.example.com/api/health
 # Expected: {"status":"ok","database":"PostgreSQL",...}
 ```
 
-Open `https://news.lihor.ro` in Chrome on your phone — you should see a padlock
+Open `https://news.example.com` in Chrome on your phone — you should see a padlock
 and the login page.  After logging in, you should see the dashboard, and after a
 few seconds, an install prompt or the option in the browser menu to "Add to Home
 Screen" as a standalone app (no browser chrome).
@@ -160,7 +160,7 @@ Options:
 1. **Check periodically**: run `curl -s https://ifconfig.me` and update the DNS
    record if it changed.
 2. **DDNS client**: most routers have a built-in DDNS client that updates a
-   provider (DuckDNS, No-IP, Cloudflare) automatically.  If `lihor.ro` is on
+   provider (DuckDNS, No-IP, Cloudflare) automatically.  If `example.com` is on
    Cloudflare, the Cloudflare DDNS client can keep the A record current with
    zero manual effort.
 3. **Static IP**: ask your ISP for a static residential IP (usually a small
@@ -173,12 +173,12 @@ Options:
 **`/auth/login` shows the dashboard login shell instead of redirecting to Keycloak**
 The service worker is probably serving the SPA fallback for an auth route. Keep `vite.config.ts` configured with `navigateFallbackDenylist` entries for `/api/`, `/auth/`, and `/keycloak/`, then rebuild/redeploy. On a phone/PWA, close and reopen the installed app or clear site data once so the new service worker activates.
 
-**Caddy logs ACME errors for `keycloak.lihor.ro`**
-Do not import a separate `keycloak.lihor.ro` site unless DNS exists. The supported local deployment exposes Keycloak at `https://news.lihor.ro/keycloak`, so disable or rename the separate Caddyfile, validate, and reload Caddy:
+**Caddy logs ACME errors for `keycloak.example.com`**
+Do not import a separate `keycloak.example.com` site unless DNS exists. The supported local deployment exposes Keycloak at `https://news.example.com/keycloak`, so disable or rename the separate Caddyfile, validate, and reload Caddy:
 
 ```bash
-sudo mv /etc/caddy/Caddyfile.d/keycloak.lihor.ro.caddyfile \
-  /etc/caddy/Caddyfile.d/keycloak.lihor.ro.caddyfile.disabled
+sudo mv /etc/caddy/Caddyfile.d/keycloak.example.com.caddyfile \
+  /etc/caddy/Caddyfile.d/keycloak.example.com.caddyfile.disabled
 sudo caddy validate --config /etc/caddy/Caddyfile
 sudo systemctl reload caddy
 ```
@@ -190,12 +190,12 @@ Run `caddy validate --config /etc/caddy/Caddyfile` to see the exact error.
 Caddy uses HTTP-01 challenge by default, which requires port 80 to be reachable
 from the internet.  Check:
 - Port 80 is forwarded on the router (Step 3)
-- Your ISP doesn't block inbound port 80 (try `curl http://news.lihor.ro` from
+- Your ISP doesn't block inbound port 80 (try `curl http://news.example.com` from
   a mobile data connection, not Wi-Fi)
-- The DNS A record has propagated (`dig +short news.lihor.ro` returns your IP)
+- The DNS A record has propagated (`dig +short news.example.com` returns your IP)
 
 If port 80 is blocked, switch to DNS-01 challenge — this requires a Cloudflare
-API token if `lihor.ro` is on Cloudflare.  See
+API token if `example.com` is on Cloudflare.  See
 https://caddyserver.com/docs/automatic-https#dns-challenge.
 
 **Chrome still shows "Add to Bookmark" instead of "Install"**

--- a/docs/KEYCLOAK_AUTH.md
+++ b/docs/KEYCLOAK_AUTH.md
@@ -30,9 +30,9 @@ Required when Keycloak auth is enabled:
 
 ```bash
 KEYCLOAK_AUTH_ENABLED=1
-NEWS_DASHBOARD_BASE_URL=https://news.lihor.ro
-KEYCLOAK_SERVER_URL=https://news.lihor.ro/keycloak
-KEYCLOAK_INTERNAL_SERVER_URL=https://news.lihor.ro/keycloak
+NEWS_DASHBOARD_BASE_URL=https://news.example.com
+KEYCLOAK_SERVER_URL=https://news.example.com/keycloak
+KEYCLOAK_INTERNAL_SERVER_URL=https://news.example.com/keycloak
 KEYCLOAK_REALM=news-dashboard
 KEYCLOAK_CLIENT_ID=news-dashboard
 KEYCLOAK_ADMIN_USERNAMES=alice,bob   # comma-separated; omit to grant no admins via Keycloak
@@ -46,7 +46,7 @@ SESSION_SECRET=<long random string>
 The minipc Caddy config exposes Keycloak under the same hostname:
 
 ```caddy
-news.lihor.ro {
+news.example.com {
 	handle /keycloak* {
 		reverse_proxy 127.0.0.1:8081
 	}
@@ -55,12 +55,12 @@ news.lihor.ro {
 }
 ```
 
-This avoids a separate DNS record and keeps redirect URIs under `https://news.lihor.ro`.
+This avoids a separate DNS record and keeps redirect URIs under `https://news.example.com`.
 
-Do **not** enable a separate `keycloak.lihor.ro` Caddy site unless the DNS record exists first. If that site is imported while the subdomain is `NXDOMAIN`, Caddy will keep retrying Let's Encrypt issuance and logging ACME DNS failures. For this deployment, the durable public Keycloak base is:
+Do **not** enable a separate `keycloak.example.com` Caddy site unless the DNS record exists first. If that site is imported while the subdomain is `NXDOMAIN`, Caddy will keep retrying Let's Encrypt issuance and logging ACME DNS failures. For this deployment, the durable public Keycloak base is:
 
 ```text
-https://news.lihor.ro/keycloak
+https://news.example.com/keycloak
 ```
 
 ## Helm
@@ -81,9 +81,9 @@ Recommended realm/client values:
 - Realm: `news-dashboard`
 - Client ID: `news-dashboard`
 - Client type: public OpenID Connect client
-- Valid redirect URI: `https://news.lihor.ro/auth/callback`
-- Valid post-logout redirect URI: `https://news.lihor.ro`
-- Web origin: `https://news.lihor.ro`
+- Valid redirect URI: `https://news.example.com/auth/callback`
+- Valid post-logout redirect URI: `https://news.example.com`
+- Web origin: `https://news.example.com`
 
 ## Google sign-in
 
@@ -101,7 +101,7 @@ dashboard user record as any other Keycloak login.
 4. Add this authorized redirect URI:
 
    ```text
-   https://news.lihor.ro/keycloak/realms/news-dashboard/broker/google/endpoint
+   https://news.example.com/keycloak/realms/news-dashboard/broker/google/endpoint
    ```
 
 5. Copy the generated client ID and client secret.
@@ -123,12 +123,12 @@ dashboard user record as any other Keycloak login.
 6. Save the provider, then open a private browser window and visit:
 
    ```text
-   https://news.lihor.ro/auth/login
+   https://news.example.com/auth/login
    ```
 
    The Keycloak login page should show the Google provider as an alternate
    sign-in action. After Google redirects back to Keycloak, Keycloak redirects
-   to `https://news.lihor.ro/auth/callback`, and the dashboard session cookie is
+   to `https://news.example.com/auth/callback`, and the dashboard session cookie is
    issued by the app.
 
 No frontend or backend environment variable is required specifically for Google

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -1,8 +1,8 @@
-# Product specification: news.lihor.ro
+# Product specification: news.example.com
 
 ## Purpose
 
-A private personal news dashboard for Ioachim. It combines:
+A private personal news dashboard for the owner. It combines:
 
 1. **News inbox** — Clau/cron collects useful sources automatically via RSS, GitHub release feeds, trending feeds, and scraped pages.
 2. **Reading tracker** — records what was read, saved, skipped, and archived with timestamps.

--- a/docs/RUNNER_SETUP.md
+++ b/docs/RUNNER_SETUP.md
@@ -1,16 +1,16 @@
-# Self-hosted runner setup on ioachim-minipc
+# Self-hosted runner setup on your-runner
 
 The CD workflow (deploy job) runs on a self-hosted GitHub Actions runner installed
 directly on the production machine.  This avoids managing SSH keys and gives the
 runner direct access to `kubectl` / `helm` / the local Kubernetes cluster.
 
-## One-time setup (run on ioachim-minipc)
+## One-time setup (run on your-runner)
 
 ### 1. Install the runner
 
 Go to **https://github.com/ioachim-hub/news-dashboard/settings/actions/runners**,
 click **New self-hosted runner**, select Linux/x64, and follow the steps shown.
-When asked for labels, add `ioachim-minipc` (the workflow uses `[self-hosted, ioachim-minipc]`).
+When asked for labels, add `your-runner` (the workflow uses `[self-hosted, your-runner]`).
 
 Install as a systemd service so the runner starts on boot:
 
@@ -82,7 +82,7 @@ docker pull ghcr.io/ioachim-hub/news-dashboard:latest
 git push origin main
   └─ test job      (ubuntu-latest)   pytest + tsc/vite build
   └─ publish job   (ubuntu-latest)   docker build + push to GHCR with :<sha>
-  └─ deploy job    (ioachim-minipc)
+  └─ deploy job    (your-runner)
        ├─ kubectl apply imagePullSecret (refreshes GHCR_READ_TOKEN in cluster)
        ├─ helm upgrade --set image.tag=<sha>  (exact SHA, never "latest")
        ├─ kubectl rollout status --timeout=120s
@@ -111,7 +111,7 @@ produces the pod/deployment name `news-dashboard-news-dashboard`.  This is expec
 ## HTTPS / Caddy setup
 
 The app runs as a NodePort service on `localhost:30088`.  To serve it over HTTPS
-at `news.lihor.ro` (required for PWA install, service worker, and Basic Auth),
+at `news.example.com` (required for PWA install, service worker, and Basic Auth),
 a host-level Caddy reverse proxy is needed.
 
 See **[docs/CADDY_HTTPS_SETUP.md](CADDY_HTTPS_SETUP.md)** for the full walkthrough,

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -45,7 +45,7 @@ tar xzf actions-runner-linux-x64.tar.gz
 # Register — use the token shown on the GitHub UI; it expires in 1 hour
 ./config.sh --url https://github.com/ioachim-hub/news-dashboard \
             --token <REGISTRATION_TOKEN_FROM_GITHUB_UI> \
-            --name ioachim-minipc \
+            --name your-runner \
             --labels self-hosted
 ```
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -56,7 +56,7 @@ export function LoginPage() {
           <div>
             <h1 className="text-xl font-semibold text-foreground">Sign in</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Private radar dashboard for news.lihor.ro
+              Private radar dashboard for news.example.com
             </p>
           </div>
         </div>

--- a/helm/news-dashboard/Chart.yaml
+++ b/helm/news-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: news-dashboard
-description: Private news inbox and reading tracker for news.lihor.ro
+description: Private news inbox and reading tracker for news.example.com
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -32,15 +32,16 @@ app:
   databasePath: /data/news-dashboard.db
   auth:
     enabled: true
-    publicBaseUrl: https://news.lihor.ro
-    keycloakServerUrl: https://news.lihor.ro/keycloak
-    keycloakInternalServerUrl: https://news.lihor.ro/keycloak
+    # Override per deployment (CI sets these from repo Variables).
+    publicBaseUrl: https://news.example.com
+    keycloakServerUrl: https://news.example.com/keycloak
+    keycloakInternalServerUrl: https://news.example.com/keycloak
     realm: news-dashboard
     clientId: news-dashboard
     # Optional. Set this when the Keycloak client uses "confidential" access type.
     clientSecret: ""
     # Comma-separated usernames that become app admins when first seen from Keycloak.
-    adminUsernames: ioachim
+    adminUsernames: admin
     # Override in CI/local deploy with a long random string.
     sessionSecret: ""
   ai:
@@ -60,13 +61,13 @@ postgresql:
     enabled: true
     size: 2Gi
     storageClassName: ""
-    # Local single-node durable storage. This survives pod restarts/upgrades.
-    hostPath: /home/ioachim-minipc/news-dashboard-postgres-data
+    # Local single-node durable storage path on the node (override per deploy).
+    hostPath: /data/news-dashboard-postgres-data
 
 ingress:
   enabled: false
   className: ""
-  host: news.lihor.ro
+  host: news.example.com
   annotations: {}
   tls: []
 

--- a/scripts/deploy-local-k8s.sh
+++ b/scripts/deploy-local-k8s.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Manual deploy to the local Kubernetes cluster on ioachim-minipc.
+# Manual deploy to a local single-node Kubernetes cluster.
 # CI runs the equivalent steps automatically on push to main.
 #
 # Usage:
@@ -41,8 +41,8 @@ helm upgrade --install news-dashboard ./helm/news-dashboard \
   --set-string image.pullSecretName="${PULL_SECRET_NAME:-}" \
   --set service.type=NodePort \
   --set service.nodePort=30088 \
-  --set persistence.hostPath=/home/ioachim-minipc/news-dashboard-data \
-  --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data \
+  --set persistence.hostPath="${DATA_HOSTPATH:-/data/news-dashboard-data}" \
+  --set postgresql.persistence.hostPath="${POSTGRES_HOSTPATH:-/data/news-dashboard-postgres-data}" \
   "${AI_HELM_ARGS[@]}" \
   --set ingress.enabled=false
 


### PR DESCRIPTION
## Summary
Prepares the repo to be made public. A security audit found **no secrets** in any tracked file or in git history — all credentials come from env vars / GitHub Actions secrets. This PR removes personal infrastructure details and adds a license.

## Changes
- **Add MIT `LICENSE`** + a License section in the README.
- **Genericize personal info** across docs, deploy configs, Helm values, frontend, and backend User-Agent strings:
  - `news.lihor.ro` / `lihor.ro` → `example.com`
  - contact email, owner name, runner hostname (`ioachim-minipc`), admin username, and host data paths → generic placeholders
  - Renamed `deploy/news.lihor.ro.caddyfile*` → `news.example.com.caddyfile*`
- **Kept `ioachim-hub`** (the GitHub account / GHCR image path — unavoidably public and load-bearing).
- **Moved deployment-specific values out of the public repo.** CI and `scripts/deploy-local-k8s.sh` now read these from **GitHub Actions repo Variables**, with generic chart defaults as fallback:
  - `PUBLIC_BASE_URL`, `KEYCLOAK_SERVER_URL`, `ADMIN_USERNAMES`, `DATA_HOSTPATH`, `POSTGRES_HOSTPATH`

## ⚠️ Action required before next deploy
Set the repo Variables above (**Settings → Secrets and variables → Actions → Variables**) or the deploy will use generic `example.com` defaults and break auth. The `*_HOSTPATH` values especially must match the existing node paths, or Kubernetes will bind new empty volumes.

## Testing
- Backend `test_auth.py` + `test_database_config.py` pass.
- Full personal-info sweep is clean (only `ioachim-hub` remains).
- All pre-commit hooks pass (ruff, mypy, eslint, prettier, tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)