### PR TITLE
fix: suppress Chrome native context menu during long-press-to-star

### DIFF
--- a/frontend/src/__tests__/SwipeableRow.test.tsx
+++ b/frontend/src/__tests__/SwipeableRow.test.tsx
@@ -121,4 +121,29 @@ describe('SwipeableRow — long-press gesture', () => {
     void act(() => vi.advanceTimersByTime(500));
     expect(onLongPress).toHaveBeenCalledOnce();
   });
+
+  it('prevents contextmenu event when onLongPress is set', () => {
+    const onLongPress = vi.fn();
+    const { getByTestId } = render(
+      <SwipeableRow onLongPress={onLongPress}>
+        <div data-testid="inner">content</div>
+      </SwipeableRow>
+    );
+    const inner = getByTestId('inner');
+    const evt = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    inner.dispatchEvent(evt);
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it('does not prevent contextmenu event when onLongPress is not set', () => {
+    const { getByTestId } = render(
+      <SwipeableRow>
+        <div data-testid="inner">content</div>
+      </SwipeableRow>
+    );
+    const inner = getByTestId('inner');
+    const evt = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    inner.dispatchEvent(evt);
+    expect(evt.defaultPrevented).toBe(false);
+  });
 });

--- a/frontend/src/components/article/SwipeableRow.tsx
+++ b/frontend/src/components/article/SwipeableRow.tsx
@@ -130,6 +130,10 @@ export function SwipeableRow({
             longPressFired.current = false;
           }
         }}
+        onContextMenu={(e) => {
+          // Suppress Chrome's native link context menu during long-press
+          if (onLongPress) e.preventDefault();
+        }}
         onTouchStart={(e) => {
           const touch = e.touches[0];
           onStart(touch.clientX);


### PR DESCRIPTION
## Summary

- Added `onContextMenu` handler to the translating `<div>` in `SwipeableRow` that calls `e.preventDefault()` when an `onLongPress` prop is set
- This blocks Chrome mobile's native "Open in new tab / Copy link" popup that fires on long-press of `<a>` elements, which was appearing alongside our star gesture
- Normal tap-to-navigate and swipe-right/left gestures are unaffected — `contextmenu` is only suppressed when we're handling long-press ourselves

## Test plan

- [x] New unit test: `contextmenu` event's `defaultPrevented` is `true` when `onLongPress` is set
- [x] New unit test: `defaultPrevented` remains `false` when `onLongPress` is absent
- [x] Existing long-press, swipe, and cancel tests all still pass (186 total, 0 failures)
- [x] `tsc`, `eslint`, `prettier` all clean
- [x] `pytest backend/ -q` — 262 passed, 53 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)