### PR TITLE
fix: prevent swipe from firing after long-press in the same gesture

### DIFF
--- a/frontend/src/__tests__/SwipeableRow.test.tsx
+++ b/frontend/src/__tests__/SwipeableRow.test.tsx
@@ -146,4 +146,45 @@ describe('SwipeableRow — long-press gesture', () => {
     inner.dispatchEvent(evt);
     expect(evt.defaultPrevented).toBe(false);
   });
+
+  it('does not fire swipe action when long-press already fired during the same gesture', () => {
+    const onLongPress = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { getByTestId } = render(
+      <SwipeableRow onLongPress={onLongPress} onSwipeRight={onSwipeRight}>
+        <div data-testid="inner">content</div>
+      </SwipeableRow>
+    );
+    const inner = getByTestId('inner');
+    // Start touch and hold for 500 ms → long-press fires
+    fireEvent.touchStart(inner, { touches: [{ clientX: 0, clientY: 0 }] });
+    void act(() => vi.advanceTimersByTime(500));
+    expect(onLongPress).toHaveBeenCalledOnce();
+    // Finger slides right past the swipe threshold while still holding
+    fireEvent.touchMove(inner, { touches: [{ clientX: 100, clientY: 0 }] });
+    // Lift finger — swipe must NOT fire because long-press already handled the gesture
+    fireEvent.touchEnd(inner);
+    void act(() => vi.advanceTimersByTime(200));
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('resets gesture state on touchcancel so the next gesture works correctly', () => {
+    const onSwipeRight = vi.fn();
+    const { getByTestId } = render(
+      <SwipeableRow onSwipeRight={onSwipeRight}>
+        <div data-testid="inner">content</div>
+      </SwipeableRow>
+    );
+    const inner = getByTestId('inner');
+    // First touch is cancelled by the browser (e.g. notification arrives)
+    fireEvent.touchStart(inner, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchMove(inner, { touches: [{ clientX: 50, clientY: 0 }] });
+    fireEvent(inner, new TouchEvent('touchcancel', { bubbles: true }));
+    // Second touch should behave normally — swipe right works
+    fireEvent.touchStart(inner, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchMove(inner, { touches: [{ clientX: 100, clientY: 0 }] });
+    fireEvent.touchEnd(inner);
+    void act(() => vi.advanceTimersByTime(200));
+    expect(onSwipeRight).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/src/components/article/SwipeableRow.tsx
+++ b/frontend/src/components/article/SwipeableRow.tsx
@@ -63,8 +63,12 @@ export function SwipeableRow({
     longPressOrigin.current = null;
     if (!isDragging) return;
     setIsDragging(false);
+    // Suppress swipe if a long-press already fired — the two actions must be mutually exclusive.
+    // Before PR #162, Chrome's contextmenu dialog consumed touchend so this was never reached;
+    // preventing the default unblocked touchend and exposed the race.
     const willFire =
-      (dx > THRESHOLD && !!onSwipeRight) || (dx < -THRESHOLD && !disableLeft && !!onSwipeLeft);
+      !longPressFired.current &&
+      ((dx > THRESHOLD && !!onSwipeRight) || (dx < -THRESHOLD && !disableLeft && !!onSwipeLeft));
     if (willFire) {
       setCommitting(true);
       const action = dx > THRESHOLD ? onSwipeRight : onSwipeLeft;
@@ -152,6 +156,7 @@ export function SwipeableRow({
           onMove(touch.clientX, touch.clientY);
         }}
         onTouchEnd={onEnd}
+        onTouchCancel={onEnd}
       >
         {children}
       </div>


### PR DESCRIPTION
## Root cause

PR #162 fixed Chrome's native context menu appearing during a long-press-to-star gesture by calling `e.preventDefault()` on the `contextmenu` event. Before that PR, Chrome's context menu dialog consumed the `touchend` event, which accidentally prevented a latent bug from surfacing: if the user's finger drifted > 80 px rightward **while still holding** after the 500 ms long-press threshold, `onEnd` would see `dx > THRESHOLD` and fire the swipe action (mark-as-done or skip) **in addition to** the star mutation that had already fired. With PR #162 preventing the default, `touchend` now fires reliably in all cases — exposing the race.

Result: the star optimistic update appears briefly, then the concurrent done/skip mutation moves the article out of the today list, making it look as though the star "reverted".

## Fix

Gate the `willFire` swipe check on `!longPressFired.current` so the two actions are mutually exclusive within one touch gesture. Once a long-press fires, lifting the finger can never also trigger a swipe — even if the finger moved past the threshold while the user was holding.

Also adds `onTouchCancel={onEnd}` so a browser-cancelled touch sequence (e.g. incoming notification, pointer-capture loss) resets `isDragging` and `dx` instead of leaving the row in a stuck visual state.

## Tests

Two new tests cover the fix:
- Long-press fires → finger slides past threshold → swipe must not fire
- Touch-cancel during drag → next gesture works correctly

## Test plan

- [ ] Long-press an article to star; verify only the star fires and the article stays in today list
- [ ] Swipe-right to mark done; verify only done fires (long-press not triggered)
- [ ] Long-press and hold, then slowly slide right past threshold, then lift; verify only star fires, no done
- [ ] Incoming notification during swipe; verify next swipe behaves normally

🤖 Generated with [Claude Code](https://claude.ai/claude-code)