### PR TITLE
fix: PostgreSQL init_db transaction safety + SESSION_DAYS env-var

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -570,12 +570,17 @@ def _apply_sqlite_data_migrations(conn: Any) -> None:
 
 def init_db(db_path: Path | None = None, database_url: str | None = None) -> None:
     if is_postgres(database_url):
-        with connect(db_path, database_url) as conn:
-            for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
-                try:
+        # Each statement runs in its own transaction so that a failed statement
+        # (e.g. column already exists without IF NOT EXISTS, data migration with
+        # no matching rows) does not leave the psycopg3 connection in ABORTED
+        # state and cause every subsequent statement — and the final commit() —
+        # to raise InFailedSqlTransaction.
+        for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
+            try:
+                with connect(db_path, database_url) as conn:
                     conn.execute(statement)
-                except Exception:  # idempotent best-effort schema statements
-                    logger.debug("Schema statement skipped (already applied): %.80s", statement)
+            except Exception:  # idempotent best-effort schema statements
+                logger.debug("Schema statement skipped (already applied): %.80s", statement)
         return
     with connect(db_path, database_url) as conn:
         conn.executescript(SQLITE_SCHEMA)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -27,6 +27,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response as StarletteResponse
 
 from .auth import (
+    _session_days,
     authenticate,
     create_session_token,
     create_user,
@@ -92,7 +93,6 @@ logger = logging.getLogger(__name__)
 
 _SESSION_COOKIE = "nd_session"
 _OAUTH_STATE_COOKIE = "nd_oauth_state"
-_SESSION_DAYS = 30
 
 
 class SPAStaticFiles(StaticFiles):
@@ -240,7 +240,7 @@ async def keycloak_callback(request: Request) -> RedirectResponse:
         httponly=True,
         secure=True,
         samesite="strict",
-        max_age=_SESSION_DAYS * 86400,
+        max_age=_session_days() * 86400,
         path="/",
     )
     redirect.delete_cookie(key=_OAUTH_STATE_COOKIE, path="/auth/callback")
@@ -268,7 +268,7 @@ def login(payload: LoginRequest, response: Response) -> dict[str, Any]:
         httponly=True,
         secure=True,
         samesite="strict",
-        max_age=_SESSION_DAYS * 86400,
+        max_age=_session_days() * 86400,
         path="/",
     )
     return {"id": user["id"], "username": user["username"], "is_admin": bool(user["is_admin"])}

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -1,0 +1,112 @@
+"""Unit tests for init_db PostgreSQL transaction-safety behaviour.
+
+These tests mock the connect() context manager so they run without Docker.
+The key invariant: each schema statement must execute in its own transaction
+so that a failing statement does not put psycopg3 into ABORTED state and
+prevent every subsequent statement — and the final commit() — from running.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+_SIMULATED_FAILURE = "simulated: column already exists"
+
+
+def test_init_db_postgres_applies_all_statements(tmp_path: Any) -> None:
+    """Every statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA is executed."""
+    applied: list[str] = []
+
+    @contextmanager
+    def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
+        class _Conn:
+            def execute(self, sql: str, params: Any = None) -> None:  # noqa: ARG002
+                applied.append(sql.strip())
+
+        yield _Conn()
+
+    fake_schema = ["CREATE TABLE a", "CREATE TABLE b", "CREATE TABLE c"]
+
+    with (
+        patch("news_dashboard.db.is_postgres", return_value=True),
+        patch("news_dashboard.db.connect", fake_connect),
+        patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
+        patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+    ):
+        from news_dashboard.db import init_db
+
+        init_db()
+
+    assert applied == fake_schema
+
+
+def test_init_db_postgres_continues_after_statement_failure(tmp_path: Any) -> None:
+    """A failing schema statement must not prevent subsequent ones from running.
+
+    Before the fix, all 47 statements shared one psycopg3 transaction: a single
+    failure left the transaction in ABORTED state, causing every later execute()
+    and the final commit() to raise InFailedSqlTransaction.
+    """
+    applied: list[str] = []
+
+    @contextmanager
+    def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
+        class _Conn:
+            def execute(self, sql: str, params: Any = None) -> None:  # noqa: ARG002
+                if sql.strip() == "WILL_FAIL":
+                    raise RuntimeError(_SIMULATED_FAILURE)
+                applied.append(sql.strip())
+
+        yield _Conn()
+
+    fake_schema = ["stmt_ok_1", "WILL_FAIL", "stmt_ok_2"]
+
+    with (
+        patch("news_dashboard.db.is_postgres", return_value=True),
+        patch("news_dashboard.db.connect", fake_connect),
+        patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
+        patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+    ):
+        from news_dashboard.db import init_db
+
+        init_db()  # must not raise
+
+    assert "stmt_ok_1" in applied
+    assert "stmt_ok_2" in applied
+    assert "WILL_FAIL" not in applied
+
+
+def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> None:
+    """connect() must be called once per statement, not once for all statements."""
+    connect_calls: list[str] = []
+    statements_per_call: list[list[str]] = []
+
+    @contextmanager
+    def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
+        this_call: list[str] = []
+        statements_per_call.append(this_call)
+        connect_calls.append("open")
+
+        class _Conn:
+            def execute(self, sql: str, params: Any = None) -> None:  # noqa: ARG002
+                this_call.append(sql.strip())
+
+        yield _Conn()
+
+    fake_schema = ["stmt_a", "stmt_b", "stmt_c"]
+
+    with (
+        patch("news_dashboard.db.is_postgres", return_value=True),
+        patch("news_dashboard.db.connect", fake_connect),
+        patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
+        patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+    ):
+        from news_dashboard.db import init_db
+
+        init_db()
+
+    assert len(connect_calls) == 3, "expected one connect() call per statement"
+    for per_call in statements_per_call:
+        assert len(per_call) == 1, "each connection must execute exactly one statement"

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from news_dashboard.db import connect, init_db
@@ -226,7 +227,8 @@ def test_article_counts_returns_status_counts(tmp_path: Path) -> None:
 def test_triage_metrics_computes_handled_and_save_rates(tmp_path: Path) -> None:
     db_path = tmp_path / "triage.db"
     init_db(db_path)
-    recent = "2026-06-09T10:00:00+00:00"
+    now = datetime.now(timezone.utc)
+    recent = (now - timedelta(days=2)).isoformat()
     _insert_article(db_path, url="u1", source_name="S", status="new", discovered_at=recent)
     _insert_article(
         db_path,
@@ -234,7 +236,7 @@ def test_triage_metrics_computes_handled_and_save_rates(tmp_path: Path) -> None:
         source_name="S",
         status="skipped",
         discovered_at=recent,
-        skipped_at="2026-06-09T11:00:00+00:00",
+        skipped_at=(now - timedelta(days=2, hours=-1)).isoformat(),
     )
     _insert_article(
         db_path,
@@ -242,7 +244,7 @@ def test_triage_metrics_computes_handled_and_save_rates(tmp_path: Path) -> None:
         source_name="S",
         status="saved",
         discovered_at=recent,
-        saved_at="2026-06-09T12:00:00+00:00",
+        saved_at=(now - timedelta(days=2, hours=-2)).isoformat(),
     )
 
     result = triage_metrics(db_path)

--- a/frontend/src/__tests__/SwipeableRow.test.tsx
+++ b/frontend/src/__tests__/SwipeableRow.test.tsx
@@ -187,4 +187,21 @@ describe('SwipeableRow — long-press gesture', () => {
     void act(() => vi.advanceTimersByTime(200));
     expect(onSwipeRight).toHaveBeenCalledOnce();
   });
+
+  it('does not fire swipe action when touchcancel arrives even if dx exceeds threshold', () => {
+    // Regression: onTouchCancel={onEnd} would invoke onEnd which fires the swipe if dx > 80.
+    // A browser cancel (e.g. scroll taking over) must never trigger an article action.
+    const onSwipeRight = vi.fn();
+    const { getByTestId } = render(
+      <SwipeableRow onSwipeRight={onSwipeRight}>
+        <div data-testid="inner">content</div>
+      </SwipeableRow>
+    );
+    const inner = getByTestId('inner');
+    fireEvent.touchStart(inner, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchMove(inner, { touches: [{ clientX: 100, clientY: 0 }] }); // dx=100 > THRESHOLD
+    fireEvent(inner, new TouchEvent('touchcancel', { bubbles: true }));
+    void act(() => vi.advanceTimersByTime(200));
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/article/SwipeableRow.tsx
+++ b/frontend/src/components/article/SwipeableRow.tsx
@@ -81,6 +81,17 @@ export function SwipeableRow({
     startX.current = null;
   };
 
+  // Browser-cancelled touch (scroll takeover, notification, etc.) — reset state only, no action.
+  const onCancel = () => {
+    clearLongPress();
+    longPressOrigin.current = null;
+    longPressFired.current = false;
+    if (!isDragging) return;
+    setIsDragging(false);
+    setDx(0);
+    startX.current = null;
+  };
+
   const showRight = dx > 10;
   const showLeft = dx < -10 && !disableLeft;
 
@@ -156,7 +167,7 @@ export function SwipeableRow({
           onMove(touch.clientX, touch.clientY);
         }}
         onTouchEnd={onEnd}
-        onTouchCancel={onEnd}
+        onTouchCancel={onCancel}
       >
         {children}
       </div>


### PR DESCRIPTION
## Summary

- **Root cause of production auth failure**: `init_db()` ran all 47 PostgreSQL schema statements inside a single `connect()` call (one transaction). psycopg3 puts the transaction in **ABORTED** state on any statement failure; all subsequent `execute()` calls raise `InFailedSqlTransaction` (silently caught by the loop's `try/except`), but the final `commit()` is **not** caught and propagates through `init_db → lifespan → startup failure**, making the application unreachable.
- **Fix**: each statement now runs in its own `with connect()` block (own transaction), so a single failure is fully isolated and the remaining statements proceed normally.
- **Secondary fix**: replaced the hardcoded `_SESSION_DAYS = 30` constant in `main.py` with `_session_days()` from `auth.py` so both login paths (password and Keycloak callback) honour the `SESSION_DAYS` environment variable consistently.

## Test plan

- [ ] `test_init_db_postgres_applies_all_statements` — every statement is executed
- [ ] `test_init_db_postgres_continues_after_statement_failure` — a failing statement does not prevent subsequent ones from running
- [ ] `test_init_db_postgres_each_statement_uses_own_connection` — `connect()` is called once per statement, not once for all
- [ ] Full backend suite: `python -m pytest backend/ -q` → 265 passed
- [ ] Frontend + typecheck + lint: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)