### PR TITLE
[codex] refactor database layer for postgres only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,22 @@ jobs:
   test:
     name: Test & build
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: news_dashboard
+          POSTGRES_USER: news_dashboard
+          POSTGRES_PASSWORD: news_dashboard
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://news_dashboard:news_dashboard@localhost:5432/news_dashboard
     steps:
       - uses: actions/checkout@v4
 

--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -154,7 +154,8 @@ def verify_session_token(token: str) -> dict[str, Any] | None:
 def get_user_by_id(user_id: int) -> dict[str, Any] | None:
     with connect() as conn:
         row = conn.execute(
-            "SELECT id, username, email, is_admin, created_at, last_login_at FROM users WHERE id=?",
+            "SELECT id, username, email, is_admin, created_at, last_login_at "
+            "FROM users WHERE id=%s",
             (user_id,),
         ).fetchone()
         return row_to_dict(row) if row else None
@@ -164,7 +165,7 @@ def get_user_by_username(username: str) -> dict[str, Any] | None:
     with connect() as conn:
         row = conn.execute(
             "SELECT id, username, email, is_admin, created_at, last_login_at, password_hash"
-            " FROM users WHERE username=?",
+            " FROM users WHERE username=%s",
             (username,),
         ).fetchone()
         return row_to_dict(row) if row else None
@@ -174,7 +175,7 @@ def get_user_by_email(email: str) -> dict[str, Any] | None:
     with connect() as conn:
         row = conn.execute(
             "SELECT id, username, email, is_admin, created_at, last_login_at "
-            "FROM users WHERE email=?",
+            "FROM users WHERE email=%s",
             (email,),
         ).fetchone()
         return row_to_dict(row) if row else None
@@ -191,7 +192,7 @@ def create_user(
     with connect() as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash, email, is_admin)"
-            " VALUES(?, ?, ?, ?) RETURNING id, username, email, is_admin, created_at",
+            " VALUES(%s, %s, %s, %s) RETURNING id, username, email, is_admin, created_at",
             (username, password_hash, email, bool(is_admin)),
         ).fetchone()
         if row is None:
@@ -211,19 +212,19 @@ def list_users() -> list[dict[str, Any]]:
 def update_password(user_id: int, new_password: str) -> bool:
     new_hash = hash_password(new_password)
     with connect() as conn:
-        cursor = conn.execute("UPDATE users SET password_hash=? WHERE id=?", (new_hash, user_id))
+        cursor = conn.execute("UPDATE users SET password_hash=%s WHERE id=%s", (new_hash, user_id))
         return bool(cursor.rowcount > 0)
 
 
 def delete_user(user_id: int) -> bool:
     with connect() as conn:
-        cursor = conn.execute("DELETE FROM users WHERE id=?", (user_id,))
+        cursor = conn.execute("DELETE FROM users WHERE id=%s", (user_id,))
         return bool(cursor.rowcount > 0)
 
 
 def _touch_last_login(user_id: int) -> None:
     with connect() as conn:
-        conn.execute("UPDATE users SET last_login_at=CURRENT_TIMESTAMP WHERE id=?", (user_id,))
+        conn.execute("UPDATE users SET last_login_at=CURRENT_TIMESTAMP WHERE id=%s", (user_id,))
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -149,7 +149,7 @@ def _merge_user_state(
 ) -> dict[str, Any]:
     """Overlay per-user state from user_article_state onto an article dict in-place."""
     uas_row = conn.execute(
-        "SELECT * FROM user_article_state WHERE user_id = ? AND article_id = ?",
+        "SELECT * FROM user_article_state WHERE user_id = %s AND article_id = %s",
         (user_id, article_id),
     ).fetchone()
     uas = row_to_dict(uas_row) if uas_row else None
@@ -190,7 +190,7 @@ def get_article(
     """
     init_db(db_path)
     with connect(db_path) as conn:
-        row = conn.execute("SELECT * FROM articles WHERE id = ?", (article_id,)).fetchone()
+        row = conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
         if row is None:
             return None
         d = row_to_dict(row)
@@ -214,7 +214,7 @@ def fetch_and_cache_body(
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
-            "SELECT id, url, body_status FROM articles WHERE id = ?",
+            "SELECT id, url, body_status FROM articles WHERE id = %s",
             (article_id,),
         ).fetchone()
         if row is None:
@@ -228,8 +228,8 @@ def fetch_and_cache_body(
 
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE articles SET body = ?, body_status = ?,"
-            " updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            "UPDATE articles SET body = %s, body_status = %s,"
+            " updated_at = CURRENT_TIMESTAMP WHERE id = %s",
             (body if status == "ok" else None, status, article_id),
         )
 
@@ -247,7 +247,7 @@ def prefetch_article_bodies(limit: int = 20, db_path: Path | None = None) -> int
     with connect(db_path) as conn:
         rows = conn.execute(
             "SELECT id FROM articles WHERE body_status = 'missing'"
-            " ORDER BY discovered_at DESC LIMIT ?",
+            " ORDER BY discovered_at DESC LIMIT %s",
             (limit,),
         ).fetchall()
     ids = [int(row_to_dict(r)["id"]) for r in rows]

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -94,7 +94,7 @@ def _fetch_cited_articles(conn: Any, briefing_id: int) -> list[dict[str, Any]]:
 
 
 def _coerce_content(value: Any) -> Any:
-    """Normalise content: psycopg returns jsonb as dict already; SQLite TEXT needs decoding."""
+    """Normalise content from JSONB rows and tolerate older string payloads."""
     if isinstance(value, str):
         try:
             return json.loads(value)

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -2,170 +2,21 @@ from __future__ import annotations
 
 import logging
 import os
-import sqlite3
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-try:
-    import psycopg
-    from psycopg.rows import dict_row
-except ImportError:  # pragma: no cover - optional unless DATABASE_URL is PostgreSQL
-    psycopg = None  # type: ignore[assignment]
-    dict_row = None  # type: ignore[assignment]
+import psycopg
+from psycopg import sql
+from psycopg.rows import dict_row
 
-DB_PATH = Path(os.getenv("NEWS_DASHBOARD_DB", "/data/news-dashboard.db"))
 POSTGRES_PREFIXES = ("postgres:" + "//", "postgresql:" + "//")
+DB_PATH: Path | None = None
 
 logger = logging.getLogger(__name__)
-
-SQLITE_SCHEMA = """
-PRAGMA journal_mode=WAL;
-PRAGMA foreign_keys=ON;
-
-CREATE TABLE IF NOT EXISTS users (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  username      TEXT NOT NULL UNIQUE,
-  password_hash TEXT NOT NULL,
-  email         TEXT,
-  is_admin      INTEGER NOT NULL DEFAULT 0,
-  created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  last_login_at TEXT
-);
-
-CREATE TABLE IF NOT EXISTS sources (
-  slug TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  url TEXT NOT NULL,
-  category TEXT NOT NULL,
-  kind TEXT NOT NULL,
-  priority INTEGER NOT NULL DEFAULT 50,
-  enabled INTEGER NOT NULL DEFAULT 1,
-  last_checked_at TEXT,
-  last_success_at TEXT,
-  last_error TEXT,
-  last_fetched_count INTEGER NOT NULL DEFAULT 0,
-  last_inserted_count INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS articles (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  url TEXT NOT NULL UNIQUE,
-  canonical_url TEXT NOT NULL,
-  title TEXT NOT NULL,
-  source_slug TEXT NOT NULL REFERENCES sources(slug),
-  source_name TEXT NOT NULL,
-  category TEXT NOT NULL,
-  kind TEXT NOT NULL,
-  published_at TEXT,
-  discovered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  status TEXT NOT NULL DEFAULT 'new' CHECK(status IN ('new','read','saved','skipped','archived')),
-  importance_score INTEGER NOT NULL DEFAULT 50,
-  summary TEXT NOT NULL DEFAULT '',
-  reason TEXT NOT NULL DEFAULT '',
-  tags TEXT NOT NULL DEFAULT '',
-  read_at TEXT,
-  saved_at TEXT,
-  skipped_at TEXT,
-  archived_at TEXT,
-  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE IF NOT EXISTS ingest_runs (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  started_at TEXT NOT NULL,
-  finished_at TEXT,
-  duration_ms INTEGER,
-  total_new INTEGER,
-  total_errors INTEGER
-);
-
-CREATE TABLE IF NOT EXISTS ingest_run_sources (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id INTEGER REFERENCES ingest_runs(id),
-  source_name TEXT NOT NULL,
-  articles_found INTEGER,
-  articles_new INTEGER,
-  error_message TEXT
-);
-
-CREATE INDEX IF NOT EXISTS idx_articles_status ON articles(status);
-CREATE INDEX IF NOT EXISTS idx_articles_category ON articles(category);
-CREATE INDEX IF NOT EXISTS idx_articles_discovered ON articles(discovered_at DESC);
-CREATE INDEX IF NOT EXISTS idx_articles_source ON articles(source_slug);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
-  title, summary, reason, tags, source_name,
-  content=articles, content_rowid=id
-);
-
-CREATE TABLE IF NOT EXISTS ingest_runs (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  started_at TEXT NOT NULL,
-  finished_at TEXT,
-  duration_ms INTEGER,
-  total_new INTEGER,
-  total_errors INTEGER
-);
-
-CREATE TABLE IF NOT EXISTS ingest_run_sources (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id INTEGER REFERENCES ingest_runs(id),
-  source_name TEXT NOT NULL,
-  articles_found INTEGER,
-  articles_new INTEGER,
-  error_message TEXT
-);
-
-CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
-  ON ingest_run_sources(source_name, run_id DESC);
-CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at);
-CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id);
-"""
-
-# Additive columns to add when upgrading existing databases
-SQLITE_COLUMN_MIGRATIONS = [
-    ("sources", "last_success_at", "TEXT"),
-    ("sources", "last_error", "TEXT"),
-    ("sources", "last_fetched_count", "INTEGER NOT NULL DEFAULT 0"),
-    ("sources", "last_inserted_count", "INTEGER NOT NULL DEFAULT 0"),
-    ("articles", "canonical_id", "INTEGER REFERENCES articles(id)"),
-    ("articles", "embedding", "BLOB"),
-    ("articles", "body", "TEXT"),
-    ("articles", "body_status", "TEXT NOT NULL DEFAULT 'missing'"),
-    # #87 workflow state model
-    ("articles", "state", "TEXT NOT NULL DEFAULT 'today'"),
-    ("articles", "starred", "INTEGER NOT NULL DEFAULT 0"),
-    ("articles", "done_at", "TEXT"),
-    ("articles", "starred_at", "TEXT"),
-    ("articles", "later_until", "TEXT"),
-    ("articles", "restored_at", "TEXT"),
-    # #126 auth — owner column on sources
-    ("sources", "owner_user_id", "INTEGER REFERENCES users(id)"),
-    # #129 per-user briefings
-    ("briefings", "user_id", "INTEGER REFERENCES users(id)"),
-]
-
-# Data-only migrations run after column additions (idempotent via WHERE guard)
-SQLITE_DATA_MIGRATIONS = [
-    # Migrate legacy status → state+starred (only touches rows that still need it)
-    """UPDATE articles SET state = CASE status
-         WHEN 'new'      THEN 'today'
-         WHEN 'read'     THEN 'done'
-         WHEN 'saved'    THEN 'today'
-         WHEN 'skipped'  THEN 'skipped'
-         WHEN 'archived' THEN 'archived'
-         ELSE 'today'
-       END
-       WHERE state = 'today' AND status != 'new'""",
-    "UPDATE articles SET starred = 1, starred_at = saved_at WHERE status = 'saved' AND starred = 0",
-    (
-        "UPDATE articles SET done_at = read_at"
-        " WHERE status = 'read' AND done_at IS NULL AND read_at IS NOT NULL"
-    ),
-]
 
 POSTGRES_SCHEMA = [
     """
@@ -187,7 +38,7 @@ POSTGRES_SCHEMA = [
       category TEXT NOT NULL,
       kind TEXT NOT NULL,
       priority INTEGER NOT NULL DEFAULT 50,
-      enabled INTEGER NOT NULL DEFAULT 1,
+      enabled BOOLEAN NOT NULL DEFAULT TRUE,
       last_checked_at TEXT,
       last_success_at TEXT,
       last_error TEXT,
@@ -245,7 +96,6 @@ POSTGRES_SCHEMA = [
       error_message  TEXT
     )
     """,
-    # PostgreSQL FTS via tsvector — added as a generated column if not present
     """
     ALTER TABLE articles ADD COLUMN IF NOT EXISTS fts_vector tsvector
       GENERATED ALWAYS AS (
@@ -256,33 +106,48 @@ POSTGRES_SCHEMA = [
       ) STORED
     """,
     "CREATE INDEX IF NOT EXISTS idx_articles_fts ON articles USING gin(fts_vector)",
-    # Settings table for persistent configuration
     """
     CREATE TABLE IF NOT EXISTS settings (
       key   TEXT PRIMARY KEY,
       value TEXT NOT NULL
     )
     """,
-    # Source health columns (safe to run repeatedly)
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_success_at TEXT",
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_error TEXT",
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_fetched_count INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE sources ADD COLUMN IF NOT EXISTS last_inserted_count INTEGER NOT NULL DEFAULT 0",
-    # Deduplication column
+    """
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'sources' AND column_name = 'enabled' AND data_type = 'integer'
+      ) THEN
+        ALTER TABLE sources ALTER COLUMN enabled TYPE BOOLEAN USING enabled <> 0;
+      END IF;
+    END $$;
+    """,
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
-    # AI Q&A embeddings for saved/read article retrieval
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
-    # Full body text extracted on first reader open (#79)
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body_status TEXT NOT NULL DEFAULT 'missing'",
-    # #87 workflow state model: new columns + data migration from legacy status
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS state TEXT NOT NULL DEFAULT 'today'",
-    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS starred INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS starred BOOLEAN NOT NULL DEFAULT FALSE",
+    """
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'articles' AND column_name = 'starred' AND data_type = 'integer'
+      ) THEN
+        ALTER TABLE articles ALTER COLUMN starred TYPE BOOLEAN USING starred <> 0;
+      END IF;
+    END $$;
+    """,
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS done_at TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS starred_at TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS later_until TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS restored_at TEXT",
-    # Migrate existing status values to state + starred
     """
     UPDATE articles SET state = CASE status
       WHEN 'new'      THEN 'today'
@@ -294,21 +159,22 @@ POSTGRES_SCHEMA = [
     END
     WHERE state = 'today' AND status != 'new'
     """,
-    "UPDATE articles SET starred = 1, starred_at = saved_at WHERE status = 'saved' AND starred = 0",
+    (
+        "UPDATE articles SET starred = TRUE, starred_at = saved_at"
+        " WHERE status = 'saved' AND NOT starred"
+    ),
     (
         "UPDATE articles SET done_at = read_at"
         " WHERE status = 'read' AND done_at IS NULL AND read_at IS NOT NULL"
     ),
     "CREATE INDEX IF NOT EXISTS idx_articles_state ON articles(state)",
     "CREATE INDEX IF NOT EXISTS idx_articles_starred ON articles(starred)",
-    # Ingest run telemetry from issue #50. Stats endpoints read these tables.
     """
     CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
       ON ingest_run_sources(source_name, run_id DESC)
     """,
     "CREATE INDEX IF NOT EXISTS idx_ingest_runs_started ON ingest_runs(started_at)",
     "CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_run ON ingest_run_sources(run_id)",
-    # #101 Saved briefings — durable AI briefing artifacts
     """
     CREATE TABLE IF NOT EXISTS briefings (
       id          SERIAL PRIMARY KEY,
@@ -335,79 +201,14 @@ POSTGRES_SCHEMA = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_briefing_articles_briefing ON briefing_articles(briefing_id)",
-    # #126 Auth — owner column on sources (NULL = global catalog)
     (
         "ALTER TABLE sources ADD COLUMN IF NOT EXISTS"
         " owner_user_id INTEGER REFERENCES users(id) ON DELETE CASCADE"
     ),
-    # #129 Per-user briefings
     "ALTER TABLE briefings ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
     "CREATE INDEX IF NOT EXISTS idx_briefings_user ON briefings(user_id, created_at DESC)",
 ]
 
-# SQLite-compatible briefing tables (TEXT instead of JSONB/TIMESTAMPTZ, for tests only)
-SQLITE_BRIEFINGS_SCHEMA = """
-CREATE TABLE IF NOT EXISTS briefings (
-  id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  scope      TEXT NOT NULL DEFAULT 'since_last_briefing',
-  since_at   TEXT,
-  until_at   TEXT,
-  status     TEXT NOT NULL DEFAULT 'complete',
-  title      TEXT,
-  summary    TEXT,
-  content    TEXT,
-  model      TEXT,
-  error      TEXT,
-  user_id    INTEGER REFERENCES users(id)
-);
-
-CREATE TABLE IF NOT EXISTS briefing_articles (
-  briefing_id   INTEGER NOT NULL REFERENCES briefings(id),
-  article_id    INTEGER NOT NULL REFERENCES articles(id),
-  section_index   INTEGER,
-  citation_index  INTEGER,
-  PRIMARY KEY (briefing_id, article_id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_briefings_created ON briefings(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_briefing_articles_briefing ON briefing_articles(briefing_id);
-"""
-
-# SQLite-compatible multi-user tables (for tests)
-SQLITE_MULTIUSER_SCHEMA = """
-CREATE TABLE IF NOT EXISTS user_sources (
-  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  source_slug TEXT    NOT NULL REFERENCES sources(slug) ON DELETE CASCADE,
-  enabled     INTEGER NOT NULL DEFAULT 1,
-  added_at    TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (user_id, source_slug)
-);
-
-CREATE INDEX IF NOT EXISTS idx_user_sources_user ON user_sources(user_id, enabled);
-
-CREATE TABLE IF NOT EXISTS user_article_state (
-  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  article_id  INTEGER NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
-  state       TEXT NOT NULL DEFAULT 'today'
-                CHECK(state IN ('today','done','skipped','archived','later')),
-  starred     INTEGER NOT NULL DEFAULT 0,
-  done_at     TEXT,
-  starred_at  TEXT,
-  skipped_at  TEXT,
-  archived_at TEXT,
-  later_until TEXT,
-  restored_at TEXT,
-  updated_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (user_id, article_id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_uas_user_state ON user_article_state(user_id, state);
-CREATE INDEX IF NOT EXISTS idx_uas_user_starred ON user_article_state(user_id, starred);
-CREATE INDEX IF NOT EXISTS idx_uas_article_id ON user_article_state(article_id);
-"""
-
-# PostgreSQL multi-user tables
 POSTGRES_MULTIUSER_SCHEMA = [
     """
     CREATE TABLE IF NOT EXISTS user_sources (
@@ -470,135 +271,64 @@ def active_database_url(database_url: str | None = None) -> str:
     return f"postgresql://{user}:{password}@{host}:{port}/{database}"
 
 
-def is_postgres(database_url: str | None = None) -> bool:
-    try:
-        url = active_database_url(database_url)
-    except RuntimeError:
-        return False
-    return bool(url and url.startswith(POSTGRES_PREFIXES))
-
-
-def describe_database(db_path: Path | None = None, database_url: str | None = None) -> str:
-    try:
-        url = active_database_url(database_url)
-    except RuntimeError:
-        return str(db_path or DB_PATH)
-    if url:
-        parts = urlsplit(url)
-        if parts.password:
-            host = parts.hostname or ""
-            netloc = f"{parts.username}:***@{host}"
-            if parts.port:
-                netloc += f":{parts.port}"
-            return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
-        return url
-    return str(db_path or DB_PATH)
-
-
-class PostgresConnection:
-    """Thin adapter exposing a sqlite3-like ``execute`` API over a psycopg connection."""
-
-    def __init__(self, conn: Any) -> None:
-        self.conn = conn
-
-    def execute(self, sql: str, params: tuple[Any, ...] | list[Any] | None = None) -> Any:
-        return self.conn.execute(sql.replace("?", "%s"), params)
-
-    def commit(self) -> None:
-        self.conn.commit()
-
-    def close(self) -> None:
-        self.conn.close()
+def describe_database(_db_path: Path | None = None, database_url: str | None = None) -> str:
+    url = active_database_url(database_url)
+    parts = urlsplit(url)
+    if parts.password:
+        host = parts.hostname or ""
+        netloc = f"{parts.username}:***@{host}"
+        if parts.port:
+            netloc += f":{parts.port}"
+        return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+    return url
 
 
 @contextmanager
-def connect(db_path: Path | None = None, database_url: str | None = None) -> Iterator[Any]:
+def connect(
+    _db_path: Path | None = None,
+    database_url: str | None = None,
+) -> Iterator[Any]:
+    """Open a PostgreSQL connection using psycopg-native SQL and parameters."""
+    conn = psycopg.connect(active_database_url(database_url), row_factory=dict_row)
+    schema_token = _db_path or DB_PATH
     try:
-        url: str | None = active_database_url(database_url)
-    except RuntimeError:
-        url = None
-    if url and url.startswith(POSTGRES_PREFIXES):
-        # psycopg is an optional import; mypy sees it as always present
-        if psycopg is None:
-            message = "DATABASE_URL is PostgreSQL but psycopg is not installed"  # type: ignore[unreachable]
-            raise RuntimeError(message)
-        pg_conn = psycopg.connect(url, row_factory=dict_row)
-        wrapped = PostgresConnection(pg_conn)
-        try:
-            yield wrapped
-            wrapped.commit()
-        finally:
-            wrapped.close()
-        return
-
-    path = db_path or DB_PATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path)
-    conn.row_factory = sqlite3.Row
-    try:
+        if schema_token is not None:
+            schema = _schema_name(schema_token)
+            conn.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(schema)))
+            conn.execute(sql.SQL("SET search_path TO {}").format(sql.Identifier(schema)))
         yield conn
         conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
     finally:
         conn.close()
 
 
-def _apply_sqlite_column_migrations(conn: Any) -> None:
-    """Idempotently add new columns to existing SQLite databases."""
-    for table, column, typedef in SQLITE_COLUMN_MIGRATIONS:
+def init_db(_db_path: Path | None = None, database_url: str | None = None) -> None:
+    # Each statement runs in its own transaction so a harmless idempotency
+    # failure does not leave later schema statements in an aborted transaction.
+    for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
         try:
-            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {typedef}")
-        except sqlite3.OperationalError:
-            logger.debug("Column %s.%s already exists; skipping migration", table, column)
+            with connect(_db_path, database_url=database_url) as conn:
+                conn.execute(statement)
+        except Exception:  # idempotent best-effort schema statements
+            logger.debug("Schema statement skipped (already applied): %.80s", statement)
 
 
-def _build_fts_index(conn: Any) -> None:
-    """Populate FTS index from existing articles (safe to re-run)."""
-    try:
-        conn.execute("INSERT INTO articles_fts(articles_fts) VALUES('rebuild')")
-    except sqlite3.OperationalError:
-        logger.debug("FTS rebuild skipped: articles_fts not available")
-
-
-def _apply_sqlite_data_migrations(conn: Any) -> None:
-    """Idempotently run data-only migrations for SQLite (WHERE-guarded updates)."""
-    for sql in SQLITE_DATA_MIGRATIONS:
-        try:
-            conn.execute(sql)
-        except Exception:
-            logger.debug("Data migration skipped: %.80s", sql)
-
-
-def init_db(db_path: Path | None = None, database_url: str | None = None) -> None:
-    if is_postgres(database_url):
-        # Each statement runs in its own transaction so that a failed statement
-        # (e.g. column already exists without IF NOT EXISTS, data migration with
-        # no matching rows) does not leave the psycopg3 connection in ABORTED
-        # state and cause every subsequent statement — and the final commit() —
-        # to raise InFailedSqlTransaction.
-        for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
-            try:
-                with connect(db_path, database_url) as conn:
-                    conn.execute(statement)
-            except Exception:  # idempotent best-effort schema statements
-                logger.debug("Schema statement skipped (already applied): %.80s", statement)
-        return
-    with connect(db_path, database_url) as conn:
-        conn.executescript(SQLITE_SCHEMA)
-        conn.executescript(SQLITE_BRIEFINGS_SCHEMA)
-        conn.executescript(SQLITE_MULTIUSER_SCHEMA)
-        _apply_sqlite_column_migrations(conn)
-        _apply_sqlite_data_migrations(conn)
-        _build_fts_index(conn)
+def _schema_name(token: Path) -> str:
+    digest = sha256(str(token).encode("utf-8")).hexdigest()[:16]
+    return f"test_{digest}"
 
 
 def get_setting(key: str, default: str | None = None) -> str | None:
     """Read a value from the settings table."""
     try:
         with connect() as conn:
-            row = conn.execute("SELECT value FROM settings WHERE key=?", (key,)).fetchone()
+            row = conn.execute("SELECT value FROM settings WHERE key = %s", (key,)).fetchone()
             if row:
-                return str(row["value"] if isinstance(row, dict) else row[0])
-    except Exception:  # settings are optional; fall back to the default
+                return str(row["value"])
+    except Exception:
         logger.debug("Could not read setting %r; using default", key)
     return default
 
@@ -608,7 +338,7 @@ def set_setting(key: str, value: str) -> None:
     with connect() as conn:
         conn.execute(
             """
-            INSERT INTO settings(key, value) VALUES(?, ?)
+            INSERT INTO settings(key, value) VALUES(%s, %s)
             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
             """,
             (key, value),
@@ -616,10 +346,18 @@ def set_setting(key: str, value: str) -> None:
 
 
 def row_to_dict(row: Any) -> dict[str, Any]:
-    """Convert a sqlite3.Row or psycopg dict row into a plain dict."""
-    if isinstance(row, dict):
+    """Convert a psycopg dict row into a plain dict."""
+    if isinstance(row, Mapping):
         return dict(row)
-    return {key: row[key] for key in row.keys()}  # noqa: SIM118 - sqlite3.Row is not a Mapping
+    return {key: row[key] for key in row}
+
+
+def placeholders(values: Sequence[Any]) -> str:
+    """Return psycopg placeholders for a non-empty dynamic SQL list."""
+    if not values:
+        message = "placeholders() requires at least one value"
+        raise ValueError(message)
+    return ", ".join("%s" for _ in values)
 
 
 def insert_article_sql() -> str:
@@ -633,21 +371,21 @@ def insert_article_sql() -> str:
 
 
 def search_articles_sql(terms: list[str], limit: int) -> tuple[str, list[Any]]:
-    """Build a LIKE-based search query compatible with both SQLite and PostgreSQL."""
     if not terms:
-        return "SELECT * FROM articles ORDER BY discovered_at DESC LIMIT ?", [limit]
+        return "SELECT * FROM articles ORDER BY discovered_at DESC LIMIT %s", [limit]
     clauses = []
     params: list[Any] = []
     for term in terms:
         like = f"%{term}%"
         clauses.append(
-            "(title LIKE ? OR summary LIKE ? OR tags LIKE ? OR source_name LIKE ? OR reason LIKE ?)"
+            "(title ILIKE %s OR summary ILIKE %s OR tags ILIKE %s"
+            " OR source_name ILIKE %s OR reason ILIKE %s)"
         )
         params.extend([like, like, like, like, like])
     params.append(limit)
     where = " AND ".join(clauses)
     sql = (
         f"SELECT * FROM articles WHERE {where} "
-        "ORDER BY importance_score DESC, discovered_at DESC LIMIT ?"
+        "ORDER BY importance_score DESC, discovered_at DESC LIMIT %s"
     )
     return sql, params

--- a/backend/news_dashboard/digest.py
+++ b/backend/news_dashboard/digest.py
@@ -51,7 +51,7 @@ def _get_top_new_articles(limit: int = 10) -> list[dict[str, Any]]:
             SELECT * FROM articles
             WHERE status = 'new'
             ORDER BY importance_score DESC, discovered_at DESC
-            LIMIT ?
+            LIMIT %s
             """,
             (limit,),
         ).fetchall()

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -3,7 +3,7 @@
 Embedding model : text-embedding-3-small (OpenAI)
 Answer model    : gpt-4o-mini (OpenAI)
 Storage         : articles.embedding BLOB (serialized float32 numpy array)
-Retrieval       : pure-Python cosine similarity (no sqlite-vss needed)
+Retrieval       : pure-Python cosine similarity over stored vectors
 """
 
 from __future__ import annotations
@@ -94,7 +94,7 @@ def ensure_article_embedded(article_id: int, db_path: Any = None) -> None:
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
-            "SELECT id, title, summary, embedding FROM articles WHERE id=?",
+            "SELECT id, title, summary, embedding FROM articles WHERE id=%s",
             (article_id,),
         ).fetchone()
         if row is None or row["embedding"] is not None:
@@ -105,7 +105,7 @@ def ensure_article_embedded(article_id: int, db_path: Any = None) -> None:
         vector = _embed(text)
         blob = _pack(vector)
         conn.execute(
-            "UPDATE articles SET embedding=? WHERE id=?",
+            "UPDATE articles SET embedding=%s WHERE id=%s",
             (blob, article_id),
         )
 
@@ -137,7 +137,7 @@ def embed_all_eligible(db_path: Any = None, *, include_all: bool = False) -> int
 
         with _connect(db_path) as conn:
             conn.execute(
-                "UPDATE articles SET embedding=? WHERE id=?",
+                "UPDATE articles SET embedding=%s WHERE id=%s",
                 (blob, row["id"]),
             )
         count += 1

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import feedparser
 
-from .db import connect, init_db, insert_article_sql, is_postgres, row_to_dict
+from .db import connect, init_db, insert_article_sql, placeholders, row_to_dict
 from .ingest_events import ingest_events
 from .sources import DEFAULT_SOURCES, SourceDefinition
 
@@ -289,7 +289,7 @@ def _find_canonical(conn: Any, canonical_url: str, title: str) -> int | None:
     row = conn.execute(
         """
         SELECT id FROM articles
-        WHERE canonical_url=? AND (canonical_id IS NULL OR canonical_id=id)
+        WHERE canonical_url=%s AND (canonical_id IS NULL OR canonical_id=id)
         LIMIT 1
         """,
         (canonical_url,),
@@ -302,7 +302,7 @@ def _find_canonical(conn: Any, canonical_url: str, title: str) -> int | None:
     rows = conn.execute(
         """SELECT id, title FROM articles
            WHERE canonical_id IS NULL
-             AND discovered_at >= ?
+             AND discovered_at >= %s
            ORDER BY discovered_at DESC
            LIMIT 200""",
         (cutoff,),
@@ -322,7 +322,7 @@ def sync_sources(db_path: Path | None = None) -> None:
             conn.execute(
                 """
                 INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
-                VALUES (?, ?, ?, ?, ?, ?, 1)
+                VALUES (%s, %s, %s, %s, %s, %s, TRUE)
                 ON CONFLICT(slug) DO UPDATE SET
                   name=excluded.name,
                   url=excluded.url,
@@ -403,7 +403,7 @@ def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> Sou
                              url, canonical_url, title, source_slug, source_name, category, kind,
                              published_at, summary, reason, importance_score, tags,
                              status, canonical_id
-                           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?)
+                           ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'archived', %s)
                            ON CONFLICT (url) DO NOTHING""",
                         (
                             url,
@@ -423,13 +423,15 @@ def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> Sou
                     )
                     # Tag canonical article's source list (stored in reason prefix)
                     conn.execute(
-                        """UPDATE articles SET updated_at=? WHERE id=? AND canonical_id IS NULL""",
+                        """
+                        UPDATE articles
+                           SET updated_at=%s
+                         WHERE id=%s AND canonical_id IS NULL
+                        """,
                         (now_iso(), canonical_id),
                     )
                 else:
                     sql = insert_article_sql()
-                    if not is_postgres():
-                        sql = sql.replace("%s", "?")
                     cursor = conn.execute(
                         sql,
                         (
@@ -451,9 +453,9 @@ def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> Sou
 
             conn.execute(
                 """UPDATE sources SET
-                     last_checked_at=?, last_success_at=?, last_error=NULL,
-                     last_fetched_count=?, last_inserted_count=?
-                   WHERE slug=?""",
+                     last_checked_at=%s, last_success_at=%s, last_error=NULL,
+                     last_fetched_count=%s, last_inserted_count=%s
+                   WHERE slug=%s""",
                 (checked_at, checked_at, fetched, inserted, source.slug),
             )
 
@@ -462,9 +464,9 @@ def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> Sou
         with connect(db_path) as conn:
             conn.execute(
                 """UPDATE sources SET
-                     last_checked_at=?, last_error=?,
+                     last_checked_at=%s, last_error=%s,
                      last_fetched_count=0, last_inserted_count=0
-                   WHERE slug=?""",
+                   WHERE slug=%s""",
                 (checked_at, error_msg, source.slug),
             )
         return SourceIngestOutcome(
@@ -504,7 +506,7 @@ def _create_ingest_run(db_path: Path | None, started_at: str) -> int:
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
-            "INSERT INTO ingest_runs(started_at) VALUES (?) RETURNING id",
+            "INSERT INTO ingest_runs(started_at) VALUES (%s) RETURNING id",
             (started_at,),
         ).fetchone()
     return int(_row_value(row, "id", 0))
@@ -517,7 +519,7 @@ def _record_ingest_source(run_id: int, outcome: SourceIngestOutcome, db_path: Pa
             INSERT INTO ingest_run_sources(
               run_id, source_name, articles_found, articles_new, error_message
             )
-            VALUES (?, ?, ?, ?, ?)
+            VALUES (%s, %s, %s, %s, %s)
             """,
             (
                 run_id,
@@ -541,8 +543,8 @@ def _finish_ingest_run(
         conn.execute(
             """
             UPDATE ingest_runs
-               SET finished_at=?, duration_ms=?, total_new=?, total_errors=?
-             WHERE id=?
+               SET finished_at=%s, duration_ms=%s, total_new=%s, total_errors=%s
+             WHERE id=%s
             """,
             (finished_at, duration_ms, total_new, total_errors, run_id),
         )
@@ -571,7 +573,7 @@ def ingest_all(db_path: Path | None = None) -> dict[str, int]:
         with connect(db_path) as conn:
             private_rows = conn.execute(
                 "SELECT slug, name, url, category, kind, priority"
-                " FROM sources WHERE owner_user_id IS NOT NULL AND enabled = 1"
+                " FROM sources WHERE owner_user_id IS NOT NULL AND enabled IS TRUE"
             ).fetchall()
         for row in private_rows:
             r = row_to_dict(row)
@@ -678,9 +680,12 @@ def _fetch_uas_map(conn: Any, article_ids: list[int], user_id: int) -> dict[int,
     """Return a map of article_id → UAS row dict for the given user and article IDs."""
     if not article_ids:
         return {}
-    placeholders = ",".join("?" * len(article_ids))
+    article_placeholders = placeholders(article_ids)
     rows = conn.execute(
-        f"SELECT * FROM user_article_state WHERE user_id = ? AND article_id IN ({placeholders})",
+        (
+            "SELECT * FROM user_article_state"
+            f" WHERE user_id = %s AND article_id IN ({article_placeholders})"
+        ),
         [user_id, *article_ids],
     ).fetchall()
     return {row_to_dict(r)["article_id"]: row_to_dict(r) for r in rows}
@@ -688,7 +693,7 @@ def _fetch_uas_map(conn: Any, article_ids: list[int], user_id: int) -> dict[int,
 
 def _get_uas_row(conn: Any, article_id: int, user_id: int) -> dict[str, Any] | None:
     row = conn.execute(
-        "SELECT * FROM user_article_state WHERE user_id = ? AND article_id = ?",
+        "SELECT * FROM user_article_state WHERE user_id = %s AND article_id = %s",
         (user_id, article_id),
     ).fetchone()
     return row_to_dict(row) if row else None
@@ -714,7 +719,7 @@ def _upsert_uas(  # noqa: PLR0913
         INSERT INTO user_article_state(
           user_id, article_id, state, starred,
           done_at, starred_at, skipped_at, archived_at, later_until, restored_at, updated_at
-        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT(user_id, article_id) DO UPDATE SET
           state = excluded.state,
           starred = excluded.starred,
@@ -782,31 +787,34 @@ def list_articles(  # noqa: PLR0913
             "archived": "archived",
         }
         mapped = legacy_map.get(status, status)
-        clauses.append("state = ?")
+        clauses.append("state = %s")
         params.append(mapped)
         if status == "saved":
-            clauses.append("starred = 1")
+            clauses.append("starred IS TRUE")
     if state:
         if state == "today":
             clauses.append(
                 "(state = 'today'"
-                " OR (state = 'later' AND later_until IS NOT NULL AND later_until <= ?))"
+                " OR (state = 'later' AND later_until IS NOT NULL AND later_until <= %s))"
             )
             params.append(now)
         else:
-            clauses.append("state = ?")
+            clauses.append("state = %s")
             params.append(state)
     if starred is not None:
-        clauses.append("starred = ?")
-        params.append(1 if starred else 0)
+        clauses.append("starred = %s")
+        params.append(bool(starred))
     if category:
-        clauses.append("category = ?")
+        clauses.append("category = %s")
         params.append(category)
     where = f"WHERE {' AND '.join(clauses)}"
     params.extend([limit, offset])
     with connect(db_path) as conn:
         rows = conn.execute(
-            f"SELECT * FROM articles {where} ORDER BY discovered_at DESC, id DESC LIMIT ? OFFSET ?",
+            (
+                f"SELECT * FROM articles {where}"
+                " ORDER BY discovered_at DESC, id DESC LIMIT %s OFFSET %s"
+            ),
             params,
         ).fetchall()
         articles = [_article_dict(row) for row in rows]
@@ -851,17 +859,17 @@ def _list_articles_for_user(  # noqa: PLR0913
             art_clauses.append(
                 "(uas.state IS NULL OR uas.state = 'today'"
                 " OR (uas.state = 'later' AND uas.later_until IS NOT NULL"
-                " AND uas.later_until <= ?))"
+                " AND uas.later_until <= %s))"
             )
             where_params.append(now)
         else:
-            art_clauses.append("COALESCE(uas.state, 'today') = ?")
+            art_clauses.append("COALESCE(uas.state, 'today') = %s")
             where_params.append(state)
     if starred is not None:
-        art_clauses.append("COALESCE(uas.starred, false) = ?")
+        art_clauses.append("COALESCE(uas.starred, false) = %s")
         where_params.append(bool(starred))
     if category:
-        art_clauses.append("a.category = ?")
+        art_clauses.append("a.category = %s")
         where_params.append(category)
 
     where = f"WHERE {' AND '.join(art_clauses)}"
@@ -886,15 +894,15 @@ def _list_articles_for_user(  # noqa: PLR0913
           uas.restored_at AS _uas_restored_at
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
-        LEFT JOIN user_sources us_src ON us_src.user_id = ? AND us_src.source_slug = a.source_slug
-        LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = ?
+        LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
+        LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = %s
         {where}
           AND (
             (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true))
-            OR src.owner_user_id = ?
+            OR src.owner_user_id = %s
           )
         ORDER BY a.discovered_at DESC, a.id DESC
-        LIMIT ? OFFSET ?
+        LIMIT %s OFFSET %s
     """
     with connect(db_path) as conn:
         rows = conn.execute(sql, all_params).fetchall()
@@ -920,11 +928,11 @@ def _attach_also_from(conn: Any, articles: list[dict[str, Any]]) -> None:
     article_ids = [a["id"] for a in articles]
     if not article_ids:
         return
-    placeholders = ",".join("?" * len(article_ids))
+    article_placeholders = placeholders(article_ids)
     dup_rows = conn.execute(
         f"""
         SELECT canonical_id, source_name FROM articles
-        WHERE canonical_id IN ({placeholders}) AND state='archived'
+        WHERE canonical_id IN ({article_placeholders}) AND state='archived'
         """,
         article_ids,
     ).fetchall()
@@ -974,8 +982,8 @@ def search_articles(  # noqa: PLR0913
     for term in terms:
         like = f"%{term}%"
         clauses.append(
-            "(title LIKE ? OR summary LIKE ? OR reason LIKE ? OR tags LIKE ?"
-            " OR source_name LIKE ? OR (body IS NOT NULL AND body LIKE ?))"
+            "(title ILIKE %s OR summary ILIKE %s OR reason ILIKE %s OR tags ILIKE %s"
+            " OR source_name ILIKE %s OR (body IS NOT NULL AND body ILIKE %s))"
         )
         params.extend([like, like, like, like, like, like])
 
@@ -985,8 +993,8 @@ def search_articles(  # noqa: PLR0913
 
     # State filter (multi-select; overrides archived exclusion for explicit archived selection)
     if states:
-        placeholders = ",".join("?" * len(states))
-        clauses.append(f"state IN ({placeholders})")
+        state_placeholders = placeholders(states)
+        clauses.append(f"state IN ({state_placeholders})")
         params.extend(states)
         if include_archived is False and "archived" in states:
             # User explicitly wants archived — remove the exclusion clause we just added
@@ -994,36 +1002,37 @@ def search_articles(  # noqa: PLR0913
 
     # Category filter
     if categories:
-        placeholders = ",".join("?" * len(categories))
-        clauses.append(f"category IN ({placeholders})")
+        category_placeholders = placeholders(categories)
+        clauses.append(f"category IN ({category_placeholders})")
         params.extend(categories)
 
     # Source filter
     if sources:
-        placeholders = ",".join("?" * len(sources))
-        clauses.append(f"source_slug IN ({placeholders})")
+        source_placeholders = placeholders(sources)
+        clauses.append(f"source_slug IN ({source_placeholders})")
         params.extend(sources)
 
     # Starred filter
     if starred_only:
-        clauses.append("starred = 1")
+        clauses.append("starred IS TRUE")
 
     # Date range filter
     if date_range == "today":
-        clauses.append("discovered_at >= datetime(?, '-1 day')")
+        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '1 day'")
         params.append(now_ts)
     elif date_range == "week":
-        clauses.append("discovered_at >= datetime(?, '-7 days')")
+        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '7 days'")
         params.append(now_ts)
     elif date_range == "month":
-        clauses.append("discovered_at >= datetime(?, '-30 days')")
+        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
         params.append(now_ts)
 
     where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
     params.append(limit)
 
     sql = (
-        f"SELECT * FROM articles {where} ORDER BY importance_score DESC, discovered_at DESC LIMIT ?"
+        f"SELECT * FROM articles {where}"
+        " ORDER BY importance_score DESC, discovered_at DESC LIMIT %s"
     )
 
     with connect(db_path) as conn:
@@ -1052,8 +1061,8 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     for term in terms:
         like = f"%{term}%"
         clauses.append(
-            "(a.title LIKE ? OR a.summary LIKE ? OR a.reason LIKE ? OR a.tags LIKE ?"
-            " OR a.source_name LIKE ? OR (a.body IS NOT NULL AND a.body LIKE ?))"
+            "(a.title ILIKE %s OR a.summary ILIKE %s OR a.reason ILIKE %s OR a.tags ILIKE %s"
+            " OR a.source_name ILIKE %s OR (a.body IS NOT NULL AND a.body ILIKE %s))"
         )
         where_params.extend([like, like, like, like, like, like])
 
@@ -1061,38 +1070,38 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
         clauses.append("COALESCE(uas.state, 'today') != 'archived'")
 
     if states:
-        placeholders = ",".join("?" * len(states))
-        clauses.append(f"COALESCE(uas.state, 'today') IN ({placeholders})")
+        state_placeholders = placeholders(states)
+        clauses.append(f"COALESCE(uas.state, 'today') IN ({state_placeholders})")
         where_params.extend(states)
         if include_archived is False and "archived" in states:
             clauses.remove("COALESCE(uas.state, 'today') != 'archived'")
 
     if categories:
-        placeholders = ",".join("?" * len(categories))
-        clauses.append(f"a.category IN ({placeholders})")
+        category_placeholders = placeholders(categories)
+        clauses.append(f"a.category IN ({category_placeholders})")
         where_params.extend(categories)
 
     if sources:
-        placeholders = ",".join("?" * len(sources))
-        clauses.append(f"a.source_slug IN ({placeholders})")
+        source_placeholders = placeholders(sources)
+        clauses.append(f"a.source_slug IN ({source_placeholders})")
         where_params.extend(sources)
 
     if starred_only:
         clauses.append("COALESCE(uas.starred, false) = true")
 
     if date_range == "today":
-        clauses.append("a.discovered_at >= datetime(?, '-1 day')")
+        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '1 day'")
         where_params.append(now_ts)
     elif date_range == "week":
-        clauses.append("a.discovered_at >= datetime(?, '-7 days')")
+        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '7 days'")
         where_params.append(now_ts)
     elif date_range == "month":
-        clauses.append("a.discovered_at >= datetime(?, '-30 days')")
+        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
         where_params.append(now_ts)
 
     # Source subscription filter appended to WHERE
     src_filter = (
-        "(src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true)) OR src.owner_user_id = ?"
+        "(src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true)) OR src.owner_user_id = %s"
     )
     if clauses:
         clauses.append(f"({src_filter})")
@@ -1116,10 +1125,10 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
           uas.restored_at AS _uas_restored_at
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
-        LEFT JOIN user_sources us_src ON us_src.user_id = ? AND us_src.source_slug = a.source_slug
-        LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = ?
+        LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
+        LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = %s
         {where}
-        ORDER BY a.importance_score DESC, a.discovered_at DESC LIMIT ?
+        ORDER BY a.importance_score DESC, a.discovered_at DESC LIMIT %s
     """
     with connect(db_path) as conn:
         rows = conn.execute(sql, all_params).fetchall()
@@ -1154,15 +1163,15 @@ def set_article_status(
     with connect(db_path) as conn:
         if timestamp_column:
             conn.execute(
-                f"UPDATE articles SET status=?, {timestamp_column}=?, updated_at=? WHERE id=?",
+                f"UPDATE articles SET status=%s, {timestamp_column}=%s, updated_at=%s WHERE id=%s",
                 (status, now_iso(), now_iso(), article_id),
             )
         else:
             conn.execute(
-                "UPDATE articles SET status=?, updated_at=? WHERE id=?",
+                "UPDATE articles SET status=%s, updated_at=%s WHERE id=%s",
                 (status, now_iso(), article_id),
             )
-        row = conn.execute("SELECT * FROM articles WHERE id=?", (article_id,)).fetchone()
+        row = conn.execute("SELECT * FROM articles WHERE id=%s", (article_id,)).fetchone()
         result = _article_dict(row) if row else None
 
     # Lazily embed articles when they become saved/read (fire-and-forget; ignore errors)
@@ -1178,7 +1187,7 @@ def set_article_status(
 
 
 def _get_article_row(conn: Any, article_id: int) -> dict[str, Any] | None:
-    row = conn.execute("SELECT * FROM articles WHERE id=?", (article_id,)).fetchone()
+    row = conn.execute("SELECT * FROM articles WHERE id=%s", (article_id,)).fetchone()
     return _article_dict(row) if row else None
 
 
@@ -1247,26 +1256,26 @@ def transition_article_state(  # noqa: PLR0912
                 _get_uas_row(conn, article_id, user_id),
             )
         else:
-            timestamp_sets: list[str] = ["state = ?", "updated_at = ?"]
+            timestamp_sets: list[str] = ["state = %s", "updated_at = %s"]
             params: list[Any] = [new_state, ts]
 
             if new_state == "done":
-                timestamp_sets.append("done_at = ?")
+                timestamp_sets.append("done_at = %s")
                 params.append(ts)
             elif new_state == "skipped":
-                timestamp_sets.append("skipped_at = ?")
+                timestamp_sets.append("skipped_at = %s")
                 params.append(ts)
             elif new_state == "archived":
-                timestamp_sets.append("archived_at = ?")
+                timestamp_sets.append("archived_at = %s")
                 params.append(ts)
             elif new_state == "today":
-                timestamp_sets.append("restored_at = ?")
+                timestamp_sets.append("restored_at = %s")
                 timestamp_sets.append("later_until = NULL")
                 params.append(ts)
 
             set_clause = ", ".join(timestamp_sets)
             params.append(article_id)
-            conn.execute(f"UPDATE articles SET {set_clause} WHERE id = ?", params)
+            conn.execute(f"UPDATE articles SET {set_clause} WHERE id = %s", params)
             result = _get_article_row(conn, article_id)
 
     return result
@@ -1304,12 +1313,14 @@ def set_article_starred(
 
         if starred:
             conn.execute(
-                "UPDATE articles SET starred = 1, starred_at = ?, updated_at = ? WHERE id = ?",
+                "UPDATE articles"
+                " SET starred = TRUE, starred_at = %s, updated_at = %s"
+                " WHERE id = %s",
                 (ts, ts, article_id),
             )
         else:
             conn.execute(
-                "UPDATE articles SET starred = 0, updated_at = ? WHERE id = ?",
+                "UPDATE articles SET starred = FALSE, updated_at = %s WHERE id = %s",
                 (ts, article_id),
             )
 
@@ -1366,7 +1377,7 @@ def send_article_later(
             return _merge_uas(dict(base), _get_uas_row(conn, article_id, user_id))
 
         conn.execute(
-            "UPDATE articles SET state = 'later', later_until = ?, updated_at = ? WHERE id = ?",
+            "UPDATE articles SET state = 'later', later_until = %s, updated_at = %s WHERE id = %s",
             (later_until, ts, article_id),
         )
         return _get_article_row(conn, article_id)
@@ -1393,13 +1404,13 @@ def get_user_summary(user_id: int, db_path: Path | None = None) -> dict[str, Any
             FROM articles a
             LEFT JOIN sources src ON src.slug = a.source_slug
             LEFT JOIN user_sources us_src
-                   ON us_src.user_id = ? AND us_src.source_slug = a.source_slug
+                   ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
             LEFT JOIN user_article_state uas
-                   ON uas.article_id = a.id AND uas.user_id = ?
+                   ON uas.article_id = a.id AND uas.user_id = %s
             WHERE (a.canonical_id IS NULL OR COALESCE(uas.state, 'today') != 'archived')
               AND (
                 (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true))
-                OR src.owner_user_id = ?
+                OR src.owner_user_id = %s
               )
             GROUP BY COALESCE(uas.state, 'today'), COALESCE(uas.starred, false), a.category
             """,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -476,10 +476,10 @@ def sources(
             """
             SELECT s.*,
               CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, true)
-                   ELSE (s.enabled = 1) END AS user_enabled
+                   ELSE (s.enabled IS TRUE) END AS user_enabled
             FROM sources s
-            LEFT JOIN user_sources us ON us.source_slug = s.slug AND us.user_id = ?
-            WHERE s.owner_user_id IS NULL OR s.owner_user_id = ?
+            LEFT JOIN user_sources us ON us.source_slug = s.slug AND us.user_id = %s
+            WHERE s.owner_user_id IS NULL OR s.owner_user_id = %s
             ORDER BY s.category, s.priority DESC, s.name
             """,
             (uid, uid),
@@ -504,17 +504,17 @@ def create_source(
     slug = payload.slug or re.sub(r"[^a-z0-9-]", "-", payload.name.lower()).strip("-")
     init_db()
     with connect() as conn:
-        existing = conn.execute("SELECT 1 FROM sources WHERE slug = ?", (slug,)).fetchone()
+        existing = conn.execute("SELECT 1 FROM sources WHERE slug = %s", (slug,)).fetchone()
         if existing:
             raise HTTPException(status_code=409, detail=f"source slug {slug!r} already exists")
         conn.execute(
             """
             INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
-            VALUES (?, ?, ?, ?, 'rss_feed', 0, 1, ?)
+            VALUES (%s, %s, %s, %s, 'rss_feed', 0, TRUE, %s)
             """,
             (slug, payload.name, payload.url, payload.category, uid),
         )
-        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+        row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
     return row_to_dict(row)
 
 
@@ -527,13 +527,13 @@ def delete_source(
     uid = current_user["id"]
     init_db()
     with connect() as conn:
-        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+        row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="source not found")
         src = row_to_dict(row)
         if src.get("owner_user_id") != uid:
             raise HTTPException(status_code=403, detail="cannot delete a source you don't own")
-        conn.execute("DELETE FROM sources WHERE slug = ?", (slug,))
+        conn.execute("DELETE FROM sources WHERE slug = %s", (slug,))
     return {"status": "deleted"}
 
 
@@ -552,7 +552,7 @@ def set_source_enabled(
     uid = current_user["id"]
     init_db()
     with connect() as conn:
-        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+        row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="source not found")
         src = row_to_dict(row)
@@ -561,7 +561,7 @@ def set_source_enabled(
             conn.execute(
                 """
                 INSERT INTO user_sources(user_id, source_slug, enabled)
-                VALUES (?, ?, ?)
+                VALUES (%s, %s, %s)
                 ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = excluded.enabled
                 """,
                 (uid, slug, bool(payload.enabled)),
@@ -571,10 +571,10 @@ def set_source_enabled(
             if src.get("owner_user_id") != uid:
                 raise HTTPException(status_code=403, detail="cannot modify a source you don't own")
             conn.execute(
-                "UPDATE sources SET enabled = ? WHERE slug = ?",
-                (1 if payload.enabled else 0, slug),
+                "UPDATE sources SET enabled = %s WHERE slug = %s",
+                (bool(payload.enabled), slug),
             )
-        row = conn.execute("SELECT * FROM sources WHERE slug = ?", (slug,)).fetchone()
+        row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
     return {**row_to_dict(row), "subscribed": payload.enabled}
 
 

--- a/backend/news_dashboard/migrate.py
+++ b/backend/news_dashboard/migrate.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 import typer
 
 from .auth import hash_password
-from .db import POSTGRES_PREFIXES, connect, init_db, row_to_dict
+from .db import connect, init_db, row_to_dict
 
 app = typer.Typer(help="Migration helpers for news-dashboard")
 
@@ -85,7 +85,7 @@ def sqlite_to_postgres(
                   slug, name, url, category, kind, priority, enabled, last_checked_at,
                   last_success_at, last_error, last_fetched_count, last_inserted_count
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT(slug) DO UPDATE SET
                   name=excluded.name,
                   url=excluded.url,
@@ -109,7 +109,10 @@ def sqlite_to_postgres(
                   url, canonical_url, title, source_slug, source_name, category, kind, published_at,
                   summary, reason, importance_score, tags, status, discovered_at, read_at, saved_at,
                   skipped_at, archived_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (
+                  %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                  %s, %s, %s, %s, %s, %s, %s, %s, %s
+                )
                 ON CONFLICT (url) DO UPDATE SET
                   title=excluded.title,
                   source_slug=excluded.source_slug,
@@ -135,26 +138,13 @@ def sqlite_to_postgres(
     )
 
 
-def _is_postgres() -> bool:
-    """Return True when the active database is PostgreSQL."""
-    url = os.getenv("DATABASE_URL") or ""
-    host = os.getenv("POSTGRES_HOST") or ""
-    return url.startswith(POSTGRES_PREFIXES) or bool(host)
-
-
-def _ph() -> str:
-    """SQL parameter placeholder: %s for PostgreSQL, ? for SQLite."""
-    return "%s" if _is_postgres() else "?"
-
-
 def _row_count(row: Any) -> int:
-    """Extract an integer from a COUNT(*) row, handling PG vs SQLite naming."""
+    """Extract an integer from a PostgreSQL COUNT(*) row."""
     if row is None:
         return 0
     try:
         d = row_to_dict(row)
-        # PostgreSQL names the column 'count'; SQLite names it 'COUNT(*)'
-        return int(d.get("count") or d.get("COUNT(*)") or 0)
+        return int(d.get("count") or 0)
     except Exception:
         try:
             return int(row[0])
@@ -166,22 +156,13 @@ def _check_prerequisites(conn: Any) -> list[str]:
     """Return a list of missing prerequisite schema items."""
     missing: list[str] = []
     required_tables = ["users", "user_article_state", "user_sources"]
-    try:
-        existing = {
-            r[0]
-            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-        }
-        missing.extend(f"table '{t}'" for t in required_tables if t not in existing)
-    except Exception:
-        # PostgreSQL — check via information_schema
-        ph = _ph()
-        for tbl in required_tables:
-            row = conn.execute(
-                f"SELECT 1 FROM information_schema.tables WHERE table_name = {ph}",
-                (tbl,),
-            ).fetchone()
-            if row is None:
-                missing.append(f"table '{tbl}'")
+    for tbl in required_tables:
+        row = conn.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = %s",
+            (tbl,),
+        ).fetchone()
+        if row is None:
+            missing.append(f"table '{tbl}'")
 
     try:
         conn.execute("SELECT user_id FROM briefings LIMIT 0")
@@ -196,11 +177,7 @@ def migrate_multi_user(  # noqa: PLR0912, PLR0915
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Print planned actions only")] = False,
 ) -> None:
     """Promote existing single-tenant data to the first user account."""
-    db_path_env = os.getenv("NEWS_DASHBOARD_DB")
-    db_path = Path(db_path_env) if db_path_env else None
-    ph = _ph()
-
-    with connect(db_path) as conn:
+    with connect() as conn:
         # ── 1. Check prerequisites ─────────────────────────────────────────────
         missing = _check_prerequisites(conn)
         if missing:
@@ -230,10 +207,13 @@ def migrate_multi_user(  # noqa: PLR0912, PLR0915
             else:
                 pw_hash = hash_password(seed_password)
                 row = conn.execute(
-                    f"INSERT INTO users(username, password_hash, is_admin)"
-                    f" VALUES({ph}, {ph}, 1) RETURNING id",
+                    "INSERT INTO users(username, password_hash, is_admin)"
+                    " VALUES(%s, %s, TRUE) RETURNING id",
                     (seed_username, pw_hash),
                 ).fetchone()
+                if row is None:
+                    message = "User insert returned no row"
+                    raise RuntimeError(message)
                 seed_uid = int(row_to_dict(row)["id"])
                 typer.echo(f"Created seed user {seed_username!r} (id={seed_uid}, is_admin=1)")
 
@@ -246,7 +226,12 @@ def migrate_multi_user(  # noqa: PLR0912, PLR0915
             """
             SELECT id, state, starred, done_at, starred_at, later_until, restored_at, skipped_at
             FROM articles
-            WHERE (state != 'today' OR starred = 1 OR done_at IS NOT NULL OR starred_at IS NOT NULL)
+            WHERE (
+              state != 'today'
+              OR starred IS TRUE
+              OR done_at IS NOT NULL
+              OR starred_at IS NOT NULL
+            )
             """
         ).fetchall()
 
@@ -257,18 +242,18 @@ def migrate_multi_user(  # noqa: PLR0912, PLR0915
                 uas_inserted += 1
                 continue
             conn.execute(
-                f"""
+                """
                 INSERT INTO user_article_state(
                   user_id, article_id, state, starred,
                   done_at, starred_at, skipped_at, later_until, restored_at
-                ) VALUES ({ph}, {ph}, {ph}, {ph}, {ph}, {ph}, {ph}, {ph}, {ph})
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT(user_id, article_id) DO NOTHING
                 """,
                 (
                     seed_uid,
                     d["id"],
                     d.get("state", "today"),
-                    1 if d.get("starred") else 0,
+                    bool(d.get("starred")),
                     d.get("done_at"),
                     d.get("starred_at"),
                     d.get("skipped_at"),
@@ -290,16 +275,16 @@ def migrate_multi_user(  # noqa: PLR0912, PLR0915
             typer.echo(f"[dry-run] Would migrate {briefing_count} briefing(s) → user_id={seed_uid}")
         else:
             conn.execute(
-                f"UPDATE briefings SET user_id = {ph} WHERE user_id IS NULL",
+                "UPDATE briefings SET user_id = %s WHERE user_id IS NULL",
                 (seed_uid,),
             )
             typer.echo(f"Migrated {briefing_count} briefing(s) → user_id={seed_uid}")
 
         # ── 5. Seed source subscriptions ──────────────────────────────────────
         enabled_sources = conn.execute(
-            f"SELECT slug FROM sources"
-            f" WHERE enabled = 1"
-            f" AND (owner_user_id IS NULL OR owner_user_id = {ph})",
+            "SELECT slug FROM sources"
+            " WHERE enabled IS TRUE"
+            " AND (owner_user_id IS NULL OR owner_user_id = %s)",
             (seed_uid,),
         ).fetchall()
 
@@ -310,8 +295,8 @@ def migrate_multi_user(  # noqa: PLR0912, PLR0915
                 us_inserted += 1
                 continue
             conn.execute(
-                f"INSERT INTO user_sources(user_id, source_slug, enabled)"
-                f" VALUES({ph}, {ph}, 1) ON CONFLICT(user_id, source_slug) DO NOTHING",
+                "INSERT INTO user_sources(user_id, source_slug, enabled)"
+                " VALUES(%s, %s, TRUE) ON CONFLICT(user_id, source_slug) DO NOTHING",
                 (seed_uid, slug),
             )
             us_inserted += 1

--- a/backend/news_dashboard/run_history.py
+++ b/backend/news_dashboard/run_history.py
@@ -69,10 +69,10 @@ def list_ingest_runs(
     from_iso = _iso(from_)
     to_iso = _iso(to)
     if from_iso:
-        filters.append("started_at >= ?")
+        filters.append("started_at >= %s")
         params.append(from_iso)
     if to_iso:
-        filters.append("started_at <= ?")
+        filters.append("started_at <= %s")
         params.append(to_iso)
     where = " AND ".join(filters)
     offset = (page - 1) * per_page
@@ -113,7 +113,7 @@ def list_ingest_runs(
             FROM ingest_runs r
             WHERE {where}
             ORDER BY r.started_at DESC, r.id DESC
-            LIMIT ? OFFSET ?
+            LIMIT %s OFFSET %s
             """,
             (*params, per_page, offset),
         ).fetchall()
@@ -132,7 +132,7 @@ def get_ingest_run_sources(
 ) -> list[dict[str, Any]] | None:
     init_db(db_path)
     with connect(db_path) as conn:
-        exists = conn.execute("SELECT id FROM ingest_runs WHERE id=?", (run_id,)).fetchone()
+        exists = conn.execute("SELECT id FROM ingest_runs WHERE id=%s", (run_id,)).fetchone()
         if not exists:
             return None
         rows = conn.execute(
@@ -145,7 +145,7 @@ def get_ingest_run_sources(
               COALESCE(articles_new, 0) AS articles_new,
               error_message
             FROM ingest_run_sources
-            WHERE run_id=?
+            WHERE run_id=%s
             ORDER BY id ASC
             """,
             (run_id,),

--- a/backend/news_dashboard/stats.py
+++ b/backend/news_dashboard/stats.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db, row_to_dict
+from .db import connect, init_db, placeholders, row_to_dict
 
 # Status values that count as "handled" (not sitting in inbox)
 _HANDLED_STATUSES = ("read", "saved", "skipped", "archived")
@@ -107,7 +107,7 @@ def ingested_vs_handled(db_path: Path | None = None, days: int = 14) -> list[dic
             row_to_dict(r)
             for r in conn.execute(
                 "SELECT DATE(discovered_at) AS day, COUNT(*) AS n FROM articles "
-                "WHERE discovered_at >= ? GROUP BY day",
+                "WHERE discovered_at >= %s GROUP BY day",
                 (since,),
             ).fetchall()
         ]
@@ -118,7 +118,7 @@ def ingested_vs_handled(db_path: Path | None = None, days: int = 14) -> list[dic
                 SELECT DATE(COALESCE(skipped_at, saved_at, read_at, archived_at)) AS day,
                        COUNT(*) AS n
                 FROM articles
-                WHERE discovered_at >= ?
+                WHERE discovered_at >= %s
                   AND (skipped_at IS NOT NULL OR saved_at IS NOT NULL
                        OR read_at IS NOT NULL OR archived_at IS NOT NULL)
                 GROUP BY day
@@ -159,21 +159,25 @@ def triage_metrics(db_path: Path | None = None) -> dict[str, Any]:
     with connect(db_path) as conn:
         total = row_to_dict(
             conn.execute(
-                "SELECT COUNT(*) AS n FROM articles WHERE discovered_at >= ?",
+                "SELECT COUNT(*) AS n FROM articles WHERE discovered_at >= %s",
                 (week_ago,),
             ).fetchone()
         )["n"]
 
+        status_placeholders = placeholders(_HANDLED_STATUSES)
         handled = row_to_dict(
             conn.execute(
-                f"SELECT COUNT(*) AS n FROM articles WHERE discovered_at >= ? AND status IN ({','.join('?' * len(_HANDLED_STATUSES))})",  # noqa: E501
+                (
+                    "SELECT COUNT(*) AS n FROM articles"
+                    f" WHERE discovered_at >= %s AND status IN ({status_placeholders})"
+                ),
                 (week_ago, *_HANDLED_STATUSES),
             ).fetchone()
         )["n"]
 
         saved = row_to_dict(
             conn.execute(
-                "SELECT COUNT(*) AS n FROM articles WHERE discovered_at >= ? AND status = 'saved'",
+                "SELECT COUNT(*) AS n FROM articles WHERE discovered_at >= %s AND status = 'saved'",
                 (week_ago,),
             ).fetchone()
         )["n"]
@@ -185,7 +189,7 @@ def triage_metrics(db_path: Path | None = None) -> dict[str, Any]:
                 SELECT discovered_at,
                        COALESCE(skipped_at, saved_at, read_at, archived_at) AS triaged_at
                 FROM articles
-                WHERE discovered_at >= ?
+                WHERE discovered_at >= %s
                   AND (skipped_at IS NOT NULL OR saved_at IS NOT NULL
                        OR read_at IS NOT NULL OR archived_at IS NOT NULL)
                 """,
@@ -273,7 +277,7 @@ def category_mix(db_path: Path | None = None, days: int = 14) -> list[dict[str, 
                 """
                 SELECT DATE(discovered_at) AS day, category, COUNT(*) AS n
                 FROM articles
-                WHERE discovered_at >= ?
+                WHERE discovered_at >= %s
                 GROUP BY day, category
                 ORDER BY day ASC
                 """,
@@ -311,7 +315,7 @@ def _load_stats_rows(
             """
             SELECT id, started_at, finished_at, duration_ms, total_new, total_errors
             FROM ingest_runs
-            WHERE started_at >= ? AND started_at <= ?
+            WHERE started_at >= %s AND started_at <= %s
             ORDER BY started_at ASC, id ASC
             """,
             (_to_query_value(start), _to_query_value(end)),
@@ -321,7 +325,7 @@ def _load_stats_rows(
         if not run_ids:
             return [], []
 
-        placeholders = ", ".join("?" for _ in run_ids)
+        run_placeholders = placeholders(run_ids)
         source_rows = conn.execute(
             f"""
             SELECT
@@ -334,7 +338,7 @@ def _load_stats_rows(
               ingest_runs.started_at
             FROM ingest_run_sources
             JOIN ingest_runs ON ingest_runs.id = ingest_run_sources.run_id
-            WHERE ingest_run_sources.run_id IN ({placeholders})
+            WHERE ingest_run_sources.run_id IN ({run_placeholders})
             ORDER BY ingest_runs.started_at ASC, ingest_run_sources.id ASC
             """,
             tuple(run_ids),

--- a/backend/tests/test_ask_scope.py
+++ b/backend/tests/test_ask_scope.py
@@ -30,7 +30,7 @@ def _seed_articles(db_path: Path) -> None:
                     id, url, canonical_url, title, source_slug, source_name,
                     category, kind, status, importance_score, summary, reason,
                     tags, embedding
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     i,
@@ -138,7 +138,7 @@ def test_ask_default_scope_returns_answer(tmp_path: Path, monkeypatch: pytest.Mo
                     id, url, canonical_url, title, source_slug, source_name,
                     category, kind, status, importance_score, summary, reason,
                     tags, embedding
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     i,
@@ -195,7 +195,7 @@ def test_ask_include_all_widens_corpus(tmp_path: Path, monkeypatch: pytest.Monke
                     id, url, canonical_url, title, source_slug, source_name,
                     category, kind, status, importance_score, summary, reason,
                     tags, embedding
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     i,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -42,7 +42,7 @@ def _fresh_client() -> TestClient:
 
 @pytest.fixture
 def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Fresh SQLite DB with DB_PATH patched so auth helpers use it."""
+    """Fresh PostgreSQL test schema with DB_PATH patched so auth helpers use it."""
     db = tmp_path / "test.db"
     init_db(db)
     monkeypatch.setattr(db_mod, "DB_PATH", db)

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -122,7 +122,7 @@ def test_fetch_and_cache_body_success(tmp_path: Path) -> None:
 
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE articles SET url=?, canonical_url=? WHERE id=?",
+            "UPDATE articles SET url=%s, canonical_url=%s WHERE id=%s",
             (url, url, article_id),
         )
 
@@ -141,7 +141,7 @@ def test_fetch_and_cache_body_cache_hit(tmp_path: Path) -> None:
 
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE articles SET body='cached text', body_status='ok' WHERE id=?",
+            "UPDATE articles SET body='cached text', body_status='ok' WHERE id=%s",
             (article_id,),
         )
 
@@ -203,10 +203,14 @@ def test_get_article_returns_none_for_missing(tmp_path: Path) -> None:
 def _seed_user(db_path: Path, username: str = "alice") -> int:
     with connect(db_path) as conn:
         conn.execute(
-            "INSERT OR IGNORE INTO users(username, password_hash, is_admin) VALUES (?, 'x', 0)",
+            """
+            INSERT INTO users(username, password_hash, is_admin)
+            VALUES (%s, 'x', FALSE)
+            ON CONFLICT(username) DO NOTHING
+            """,
             (username,),
         )
-        row = conn.execute("SELECT id FROM users WHERE username=?", (username,)).fetchone()
+        row = conn.execute("SELECT id FROM users WHERE username=%s", (username,)).fetchone()
     return int(row["id"] if isinstance(row, dict) else row[0])
 
 
@@ -230,7 +234,7 @@ def test_get_article_with_uas_returns_user_state(tmp_path: Path) -> None:
         conn.execute(
             """
             INSERT INTO user_article_state(user_id, article_id, state, starred, done_at)
-            VALUES (?, ?, 'done', 1, '2024-06-01T12:00:00')
+            VALUES (%s, %s, 'done', TRUE, '2024-06-01T12:00:00')
             """,
             (user_id, article_id),
         )
@@ -251,7 +255,7 @@ def test_get_article_with_user_id_does_not_bleed_across_users(tmp_path: Path) ->
     with connect(db_path) as conn:
         conn.execute(
             "INSERT INTO user_article_state(user_id, article_id, state, starred)"
-            " VALUES (?, ?, 'done', 1)",
+            " VALUES (%s, %s, 'done', TRUE)",
             (user_a, article_id),
         )
 
@@ -271,12 +275,12 @@ def test_fetch_and_cache_body_with_user_id_reflects_state(tmp_path: Path) -> Non
 
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE articles SET body='cached', body_status='ok' WHERE id=?",
+            "UPDATE articles SET body='cached', body_status='ok' WHERE id=%s",
             (article_id,),
         )
         conn.execute(
             "INSERT INTO user_article_state(user_id, article_id, state, starred)"
-            " VALUES (?, ?, 'done', 1)",
+            " VALUES (%s, %s, 'done', TRUE)",
             (user_id, article_id),
         )
 
@@ -310,7 +314,7 @@ def test_prefetch_article_bodies_fetches_missing(tmp_path: Path) -> None:
 
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE articles SET url=?, canonical_url=?, body_status='missing' WHERE id=?",
+            "UPDATE articles SET url=%s, canonical_url=%s, body_status='missing' WHERE id=%s",
             (url, url, article_id),
         )
 
@@ -320,7 +324,7 @@ def test_prefetch_article_bodies_fetches_missing(tmp_path: Path) -> None:
     assert count == 1
 
     with connect(db_path) as conn:
-        row = conn.execute("SELECT body_status FROM articles WHERE id=?", (article_id,)).fetchone()
+        row = conn.execute("SELECT body_status FROM articles WHERE id=%s", (article_id,)).fetchone()
     status = row["body_status"] if isinstance(row, dict) else row[0]
     assert status == "ok"
 
@@ -331,7 +335,7 @@ def test_prefetch_article_bodies_skips_already_ok(tmp_path: Path) -> None:
 
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE articles SET body='already here', body_status='ok' WHERE id=?",
+            "UPDATE articles SET body='already here', body_status='ok' WHERE id=%s",
             (article_id,),
         )
 

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -1,8 +1,7 @@
 """Tests for #101: persist and read saved briefings — API layer.
 
 Strategy:
-- Table-init tests: run init_db() against a SQLite tmp DB to verify that the
-  briefings and briefing_articles tables are created (DDL is database-agnostic).
+- Schema tests inspect the PostgreSQL DDL constants for the saved briefing tables.
 - API-contract tests: use FastAPI's TestClient and monkeypatch the imported
   names in news_dashboard.main (the module that actually calls them) so no
   PostgreSQL connection is required.  Patching the *importer's* namespace is
@@ -14,15 +13,13 @@ actual psycopg %s parameterisation, JSONB round-trip, and NULLS LAST ordering.
 
 from __future__ import annotations
 
-import sqlite3
-from pathlib import Path
 from typing import Any
 
 from fastapi.testclient import TestClient
 
 import news_dashboard.main as main_mod
 from news_dashboard.briefings import BriefingAINotConfiguredError, BriefingGenerationError
-from news_dashboard.db import init_db
+from news_dashboard.db import POSTGRES_SCHEMA
 from news_dashboard.main import app
 
 client = TestClient(app, raise_server_exceptions=True)
@@ -82,43 +79,29 @@ _SAMPLE_LIST_ITEM = {
 }
 
 
-def _sqlite_tables(db: Path) -> set[str]:
-    with sqlite3.connect(db) as conn:
-        return {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-
-
-def _sqlite_cols(db: Path, table: str) -> set[str]:
-    with sqlite3.connect(db) as conn:
-        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
-
-
 # ── Table initialisation ──────────────────────────────────────────────────────
 
 
-def test_init_db_creates_briefings_table(tmp_path: Path) -> None:
-    db = tmp_path / "briefings_init.db"
-    init_db(db)
-    assert "briefings" in _sqlite_tables(db)
+def test_schema_creates_briefings_table() -> None:
+    schema = "\n".join(POSTGRES_SCHEMA).lower()
+    assert "create table if not exists briefings" in schema
 
 
-def test_init_db_creates_briefing_articles_table(tmp_path: Path) -> None:
-    db = tmp_path / "briefings_init.db"
-    init_db(db)
-    assert "briefing_articles" in _sqlite_tables(db)
+def test_schema_creates_briefing_articles_table() -> None:
+    schema = "\n".join(POSTGRES_SCHEMA).lower()
+    assert "create table if not exists briefing_articles" in schema
 
 
-def test_briefings_table_columns(tmp_path: Path) -> None:
-    db = tmp_path / "briefings_init.db"
-    init_db(db)
-    cols = _sqlite_cols(db, "briefings")
-    assert {"id", "created_at", "scope", "since_at", "until_at", "content"} <= cols
+def test_briefings_table_columns() -> None:
+    schema = "\n".join(POSTGRES_SCHEMA).lower()
+    for column in ("id", "created_at", "scope", "since_at", "until_at", "content"):
+        assert column in schema
 
 
-def test_briefing_articles_table_columns(tmp_path: Path) -> None:
-    db = tmp_path / "briefings_init.db"
-    init_db(db)
-    cols = _sqlite_cols(db, "briefing_articles")
-    assert {"briefing_id", "article_id", "section_index", "citation_index"} <= cols
+def test_briefing_articles_table_columns() -> None:
+    schema = "\n".join(POSTGRES_SCHEMA).lower()
+    for column in ("briefing_id", "article_id", "section_index", "citation_index"):
+        assert column in schema
 
 
 # ── GET /api/briefings/latest — empty state ───────────────────────────────────

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -30,7 +30,6 @@ def test_init_db_postgres_applies_all_statements(tmp_path: Any) -> None:
     fake_schema = ["CREATE TABLE a", "CREATE TABLE b", "CREATE TABLE c"]
 
     with (
-        patch("news_dashboard.db.is_postgres", return_value=True),
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
@@ -64,7 +63,6 @@ def test_init_db_postgres_continues_after_statement_failure(tmp_path: Any) -> No
     fake_schema = ["stmt_ok_1", "WILL_FAIL", "stmt_ok_2"]
 
     with (
-        patch("news_dashboard.db.is_postgres", return_value=True),
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
@@ -98,7 +96,6 @@ def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> N
     fake_schema = ["stmt_a", "stmt_b", "stmt_c"]
 
     with (
-        patch("news_dashboard.db.is_postgres", return_value=True),
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),

--- a/backend/tests/test_migrate_multi_user.py
+++ b/backend/tests/test_migrate_multi_user.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 import news_dashboard.db as db_mod
 from news_dashboard.db import connect, init_db
 from news_dashboard.ingest import sync_sources
-from news_dashboard.migrate import _check_prerequisites, _ph, _row_count, app
+from news_dashboard.migrate import _check_prerequisites, _row_count, app
 
 runner = CliRunner()
 
@@ -27,7 +27,7 @@ def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "done"
             """
             INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
               category, kind, state, starred)
-            VALUES (?, ?, ?, ?, ?, 'tech', 'rss_feed', ?, 0)
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', %s, FALSE)
             RETURNING id
             """,
             (
@@ -42,29 +42,7 @@ def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "done"
     return int(row[0] if isinstance(row, tuple) else row["id"])
 
 
-# ── _ph and _row_count helpers ────────────────────────────────────────────────
-
-
-def test_ph_returns_question_mark_without_postgres_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    monkeypatch.delenv("POSTGRES_HOST", raising=False)
-    assert _ph() == "?"
-
-
-def test_ph_returns_percent_s_with_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pw@localhost/db")
-    assert _ph() == "%s"
-
-
-def test_ph_returns_percent_s_with_postgres_host(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    monkeypatch.setenv("POSTGRES_HOST", "localhost")
-    assert _ph() == "%s"
-
-
-def test_row_count_sqlite_style() -> None:
-    # Simulate a sqlite3.Row-like dict with COUNT(*) key
-    assert _row_count({"COUNT(*)": 7}) == 7
+# ── _row_count helper ─────────────────────────────────────────────────────────
 
 
 def test_row_count_postgres_style() -> None:
@@ -101,7 +79,7 @@ def test_prerequisites_detect_missing_table(tmp_path: Path) -> None:
 
 def test_migration_creates_seed_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = _setup_db(tmp_path)
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -117,7 +95,7 @@ def test_migration_creates_seed_user(tmp_path: Path, monkeypatch: pytest.MonkeyP
 def test_migration_migrates_article_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = _setup_db(tmp_path)
     aid = _insert_article(db, url_suffix="m1", state="done")
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -126,7 +104,7 @@ def test_migration_migrates_article_state(tmp_path: Path, monkeypatch: pytest.Mo
 
     with connect(db) as conn:
         uas = conn.execute(
-            "SELECT state FROM user_article_state WHERE article_id = ?", (aid,)
+            "SELECT state FROM user_article_state WHERE article_id = %s", (aid,)
         ).fetchone()
     assert uas is not None
     assert uas[0] == "done"
@@ -136,7 +114,7 @@ def test_migration_seeds_source_subscriptions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     db = _setup_db(tmp_path)
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -151,7 +129,7 @@ def test_migration_seeds_source_subscriptions(
 def test_migration_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = _setup_db(tmp_path)
     _insert_article(db, url_suffix="i1", state="done")
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -171,7 +149,7 @@ def test_migration_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 def test_migration_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = _setup_db(tmp_path)
     _insert_article(db, url_suffix="d1", state="done")
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -193,7 +171,7 @@ def test_migration_aborts_on_missing_schema(
     init_db(db)
     with connect(db) as conn:
         conn.execute("DROP TABLE IF EXISTS user_article_state")
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -210,7 +188,7 @@ def test_migration_skips_user_creation_if_exists(
     from news_dashboard.auth import create_user
 
     create_user("existing", "pass")
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -35,7 +35,7 @@ def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "today
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
               category, kind, state
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -238,7 +238,7 @@ def test_snooze_returns_to_today_after_expiry(tmp_path: Path) -> None:
     expired_ts = "2020-01-01T00:00:00+00:00"
     with connect(db) as conn:
         conn.execute(
-            "UPDATE user_article_state SET later_until = ? WHERE article_id = ? AND user_id = ?",
+            "UPDATE user_article_state SET later_until = %s WHERE article_id = %s AND user_id = %s",
             (expired_ts, aid, uid),
         )
 
@@ -328,7 +328,7 @@ def test_api_state_transition_writes_uas(tmp_path: Path, monkeypatch: pytest.Mon
         # Confirm UAS row was written, article table state unchanged
         with connect(tmp_path / "api2.db") as conn:
             uas = conn.execute(
-                "SELECT * FROM user_article_state WHERE article_id = ? AND user_id = ?",
+                "SELECT * FROM user_article_state WHERE article_id = %s AND user_id = %s",
                 (aid, uid),
             ).fetchone()
             assert uas is not None
@@ -337,7 +337,7 @@ def test_api_state_transition_writes_uas(tmp_path: Path, monkeypatch: pytest.Mon
             uas_d = row_to_dict(uas)
             assert uas_d["state"] == "done"
 
-            art = conn.execute("SELECT state FROM articles WHERE id = ?", (aid,)).fetchone()
+            art = conn.execute("SELECT state FROM articles WHERE id = %s", (aid,)).fetchone()
             art_d = row_to_dict(art)
             assert art_d["state"] == "today"  # article table untouched
     finally:

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -64,7 +64,7 @@ def _add_global_source(pg_url: str, slug: str) -> None:
         conn.execute(
             """
             INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
-            VALUES (%s, %s, 'https://example.com/feed', 'tech', 'rss_feed', 50, 1)
+            VALUES (%s, %s, 'https://example.com/feed', 'tech', 'rss_feed', 50, TRUE)
             ON CONFLICT(slug) DO NOTHING
             """,
             (slug, slug),
@@ -441,8 +441,8 @@ def test_pg_user_sources_enabled_is_boolean(pg_clean: str) -> None:
     assert row[0] == "boolean"
 
 
-def test_pg_articles_starred_is_integer(pg_clean: str) -> None:
-    """articles.starred is added via ALTER TABLE as INTEGER — verify no regression."""
+def test_pg_articles_starred_is_boolean(pg_clean: str) -> None:
+    """articles.starred must be a boolean column in PostgreSQL."""
     import psycopg
 
     with psycopg.connect(pg_clean) as conn:
@@ -453,4 +453,4 @@ def test_pg_articles_starred_is_integer(pg_clean: str) -> None:
             """,
         ).fetchone()
     assert row is not None
-    assert row[0] == "integer"
+    assert row[0] == "boolean"

--- a/backend/tests/test_run_history.py
+++ b/backend/tests/test_run_history.py
@@ -19,11 +19,13 @@ def _insert_run(
         cursor = conn.execute(
             """
             INSERT INTO ingest_runs(started_at, finished_at, duration_ms, total_new, total_errors)
-            VALUES (?, ?, ?, ?, ?)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING id
             """,
             (started_at, finished_at, duration_ms, total_new, total_errors),
         )
-        return int(cursor.lastrowid)
+        row = cursor.fetchone()
+        return int(row["id"])
 
 
 def _insert_source(
@@ -41,7 +43,7 @@ def _insert_source(
             INSERT INTO ingest_run_sources(
               run_id, source_name, articles_found, articles_new, error_message
             )
-            VALUES (?, ?, ?, ?, ?)
+            VALUES (%s, %s, %s, %s, %s)
             """,
             (run_id, source_name, articles_found, articles_new, error_message),
         )

--- a/backend/tests/test_run_history_api.py
+++ b/backend/tests/test_run_history_api.py
@@ -18,20 +18,22 @@ def _seed_db(db_path: Path) -> tuple[int, int]:
             """
             INSERT INTO ingest_runs(started_at, finished_at, duration_ms, total_new, total_errors)
             VALUES ('2026-06-06T10:00:00+00:00', '2026-06-06T10:00:02+00:00', 2000, 3, 1)
+            RETURNING id
             """
-        ).lastrowid
+        ).fetchone()["id"]
         r2 = conn.execute(
             """
             INSERT INTO ingest_runs(started_at, finished_at, duration_ms, total_new, total_errors)
             VALUES ('2026-06-06T11:00:00+00:00', '2026-06-06T11:00:01+00:00', 1000, 1, 0)
+            RETURNING id
             """
-        ).lastrowid
+        ).fetchone()["id"]
         conn.execute(
             """
             INSERT INTO ingest_run_sources(
               run_id, source_name, articles_found, articles_new, error_message
             )
-            VALUES (?, 'Python Insider', 5, 3, NULL)
+            VALUES (%s, 'Python Insider', 5, 3, NULL)
             """,
             (r1,),
         )
@@ -40,7 +42,7 @@ def _seed_db(db_path: Path) -> tuple[int, int]:
             INSERT INTO ingest_run_sources(
               run_id, source_name, articles_found, articles_new, error_message
             )
-            VALUES (?, 'Broken Feed', 0, 0, 'timeout')
+            VALUES (%s, 'Broken Feed', 0, 0, 'timeout')
             """,
             (r1,),
         )
@@ -49,7 +51,7 @@ def _seed_db(db_path: Path) -> tuple[int, int]:
             INSERT INTO ingest_run_sources(
               run_id, source_name, articles_found, articles_new, error_message
             )
-            VALUES (?, 'Hacker News', 10, 1, NULL)
+            VALUES (%s, 'Hacker News', 10, 1, NULL)
             """,
             (r2,),
         )
@@ -58,7 +60,6 @@ def _seed_db(db_path: Path) -> tuple[int, int]:
 
 def test_list_runs_returns_paginated_response(tmp_path: Path, monkeypatch: Any) -> None:
     db = tmp_path / "api_runs.db"
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
     import news_dashboard.db as db_mod
     import news_dashboard.run_history as rh_mod
 
@@ -80,7 +81,6 @@ def test_list_runs_returns_paginated_response(tmp_path: Path, monkeypatch: Any) 
 
 def test_list_runs_pagination(tmp_path: Path, monkeypatch: Any) -> None:
     db = tmp_path / "api_page.db"
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
     import news_dashboard.db as db_mod
     import news_dashboard.run_history as rh_mod
 
@@ -106,7 +106,6 @@ def test_list_runs_pagination(tmp_path: Path, monkeypatch: Any) -> None:
 
 def test_get_run_sources_returns_breakdown(tmp_path: Path, monkeypatch: Any) -> None:
     db = tmp_path / "api_sources.db"
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
     import news_dashboard.db as db_mod
     import news_dashboard.run_history as rh_mod
 
@@ -129,7 +128,6 @@ def test_get_run_sources_returns_breakdown(tmp_path: Path, monkeypatch: Any) -> 
 
 def test_get_run_sources_404_for_unknown_id(tmp_path: Path, monkeypatch: Any) -> None:
     db = tmp_path / "api_404.db"
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
     import news_dashboard.db as db_mod
     import news_dashboard.run_history as rh_mod
 
@@ -143,7 +141,6 @@ def test_get_run_sources_404_for_unknown_id(tmp_path: Path, monkeypatch: Any) ->
 
 def test_list_runs_empty_state(tmp_path: Path, monkeypatch: Any) -> None:
     db = tmp_path / "api_empty.db"
-    monkeypatch.setenv("NEWS_DASHBOARD_DB", str(db))
     import news_dashboard.db as db_mod
     import news_dashboard.run_history as rh_mod
 

--- a/backend/tests/test_search_filters.py
+++ b/backend/tests/test_search_filters.py
@@ -27,7 +27,7 @@ def _insert(  # noqa: PLR0913
     source_slug: str = "python-insider",
     source_name: str = "Python Insider",
     state: str = "today",
-    starred: int = 0,
+    starred: bool = False,
     url_suffix: str = "",
 ) -> int:
     url = f"https://example.com/{title.lower().replace(' ', '-')}{url_suffix}"
@@ -38,7 +38,7 @@ def _insert(  # noqa: PLR0913
               url, canonical_url, title, source_slug, source_name,
               category, kind, state, starred, summary, reason, tags, body
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -166,8 +166,8 @@ def test_include_archived(db: Path) -> None:
 
 
 def test_starred_only(db: Path) -> None:
-    _insert(db, title="Starred Art", starred=1, url_suffix="-1")
-    _insert(db, title="Normal Art", starred=0, url_suffix="-2")
+    _insert(db, title="Starred Art", starred=True, url_suffix="-1")
+    _insert(db, title="Normal Art", starred=False, url_suffix="-2")
 
     results = search_articles(db_path=db, starred_only=True)
     titles = [r["title"] for r in results]
@@ -235,9 +235,9 @@ def test_q_plus_state_filter(db: Path) -> None:
 
 
 def test_starred_plus_category_filter(db: Path) -> None:
-    _insert(db, title="Starred Python", category="python", starred=1, url_suffix="-1")
-    _insert(db, title="Unstarred Python", category="python", starred=0, url_suffix="-2")
-    _insert(db, title="Starred AI", category="ai-llm", starred=1, url_suffix="-3")
+    _insert(db, title="Starred Python", category="python", starred=True, url_suffix="-1")
+    _insert(db, title="Unstarred Python", category="python", starred=False, url_suffix="-2")
+    _insert(db, title="Starred AI", category="ai-llm", starred=True, url_suffix="-3")
 
     results = search_articles(db_path=db, starred_only=True, categories=["python"])
     titles = [r["title"] for r in results]
@@ -251,7 +251,7 @@ def test_starred_plus_category_filter(db: Path) -> None:
 
 @pytest.fixture
 def api_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Spin up a throwaway SQLite DB and patch the app to use it."""
+    """Use an isolated PostgreSQL schema and patch the app to use it."""
     import news_dashboard.db as db_mod
     import news_dashboard.ingest as ingest_mod
 

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -28,7 +28,7 @@ def _insert_article(conn: Any, n: int = 1) -> None:
             """INSERT INTO articles(
                  url, canonical_url, title, source_slug, source_name, category, kind
                )
-               VALUES (?, ?, ?, 'python-insider', 'Python Insider', 'python', 'rss_feed')
+               VALUES (%s, %s, %s, 'python-insider', 'Python Insider', 'python', 'rss_feed')
                ON CONFLICT (url) DO NOTHING""",
             (f"https://example.com/art-{i}", f"https://example.com/art-{i}", f"Article {i}"),
         )
@@ -52,7 +52,7 @@ def test_source_error_tracked(tmp_path: Path) -> None:
     with connect(db) as conn:
         conn.execute(
             "INSERT INTO sources(slug, name, url, category, kind, priority, enabled) "
-            "VALUES (?, ?, ?, ?, ?, 50, 1) ON CONFLICT(slug) DO NOTHING",
+            "VALUES (%s, %s, %s, %s, %s, 50, TRUE) ON CONFLICT(slug) DO NOTHING",
             (bad.slug, bad.name, bad.url, bad.category, bad.kind),
         )
 
@@ -63,7 +63,7 @@ def test_source_error_tracked(tmp_path: Path) -> None:
 
     with connect(db) as conn:
         row = conn.execute(
-            "SELECT last_error, last_checked_at FROM sources WHERE slug=?", (bad.slug,)
+            "SELECT last_error, last_checked_at FROM sources WHERE slug=%s", (bad.slug,)
         ).fetchone()
         assert row["last_error"] is not None, "last_error should be set on failure"
         assert row["last_checked_at"] is not None, "last_checked_at should be set even on failure"
@@ -75,7 +75,7 @@ def test_source_health_error_streak_resets_after_success(tmp_path: Path) -> None
     with connect(db) as conn:
         for run_id, error in ((1, "timeout"), (2, "HTTP 500"), (3, None)):
             conn.execute(
-                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                "INSERT INTO ingest_runs(id, started_at) VALUES (%s, %s)",
                 (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
             )
             conn.execute(
@@ -83,7 +83,7 @@ def test_source_health_error_streak_resets_after_success(tmp_path: Path) -> None
                 INSERT INTO ingest_run_sources(
               run_id, source_name, articles_found, articles_new, error_message
             )
-                VALUES (?, 'Python Insider', 10, ?, ?)
+                VALUES (%s, 'Python Insider', 10, %s, %s)
                 """,
                 (run_id, 3 if error is None else 0, error),
             )
@@ -100,7 +100,7 @@ def test_source_health_counts_leading_errors_and_sorts_first(tmp_path: Path) -> 
     with connect(db) as conn:
         for run_id in (1, 2, 3):
             conn.execute(
-                "INSERT INTO ingest_runs(id, started_at) VALUES (?, ?)",
+                "INSERT INTO ingest_runs(id, started_at) VALUES (%s, %s)",
                 (run_id, f"2026-06-0{run_id}T00:00:00+00:00"),
             )
         conn.execute(

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -37,7 +37,7 @@ def _insert_article(db_path: Path, *, source_slug: str, url_suffix: str = "1") -
             """
             INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
               category, kind, state)
-            VALUES (?, ?, ?, ?, ?, 'tech', 'rss_feed', 'today')
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', 'today')
             RETURNING id
             """,
             (
@@ -65,7 +65,7 @@ def _add_private_source(db_path: Path, *, slug: str, owner_user_id: int) -> None
         conn.execute(
             """
             INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
-            VALUES (?, ?, 'https://example.com/feed', 'tech', 'rss_feed', 0, 1, ?)
+            VALUES (%s, %s, 'https://example.com/feed', 'tech', 'rss_feed', 0, TRUE, %s)
             ON CONFLICT(slug) DO NOTHING
             """,
             (slug, slug, owner_user_id),
@@ -98,7 +98,7 @@ def test_unsubscribed_source_articles_hidden(tmp_path: Path) -> None:
     # Explicitly unsubscribe
     with connect(db) as conn:
         conn.execute(
-            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (?, ?, 0)",
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (%s, %s, FALSE)",
             (uid, slug),
         )
 
@@ -117,11 +117,11 @@ def test_resubscription_shows_articles_again(tmp_path: Path) -> None:
     # Unsubscribe then re-subscribe
     with connect(db) as conn:
         conn.execute(
-            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (?, ?, 0)",
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (%s, %s, FALSE)",
             (uid, slug),
         )
         conn.execute(
-            "UPDATE user_sources SET enabled = 1 WHERE user_id = ? AND source_slug = ?",
+            "UPDATE user_sources SET enabled = TRUE WHERE user_id = %s AND source_slug = %s",
             (uid, slug),
         )
 
@@ -159,7 +159,7 @@ def test_unsubscription_is_per_user(tmp_path: Path) -> None:
     # Alice unsubscribes
     with connect(db) as conn:
         conn.execute(
-            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (?, ?, 0)",
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (%s, %s, FALSE)",
             (uid_a, slug),
         )
 

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -31,7 +31,7 @@ def _insert_run(
             INSERT INTO ingest_runs(
               id, started_at, finished_at, duration_ms, total_new, total_errors
             )
-            VALUES (?, ?, ?, ?, ?, ?)
+            VALUES (%s, %s, %s, %s, %s, %s)
             """,
             (run_id, started_at, started_at, duration_ms, total_new, total_errors),
         )
@@ -41,7 +41,7 @@ def _insert_run(
                 INSERT INTO ingest_run_sources(
               run_id, source_name, articles_found, articles_new, error_message
             )
-                VALUES (?, ?, ?, ?, ?)
+                VALUES (%s, %s, %s, %s, %s)
                 """,
                 (run_id, source_name, found, new, error),
             )
@@ -183,7 +183,7 @@ def _insert_article(  # noqa: PLR0913
               url, canonical_url, title, source_slug, source_name, category, kind,
               published_at, summary, reason, importance_score, tags,
               status, discovered_at, skipped_at, saved_at, read_at, archived_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (url) DO NOTHING
             """,
             (

--- a/backend/tests/test_summary_user_scoped.py
+++ b/backend/tests/test_summary_user_scoped.py
@@ -60,7 +60,7 @@ def _insert_article(
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
               category, kind, state
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -81,8 +81,9 @@ def _insert_private_source(db_path: Path, *, slug: str, owner_user_id: int) -> N
     with connect(db_path) as conn:
         conn.execute(
             """
-            INSERT OR IGNORE INTO sources(slug, name, url, category, kind, owner_user_id, enabled)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id, enabled)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT(slug) DO NOTHING
             """,
             (slug, slug, f"https://{slug}.example.com", "AI/LLM", "rss_feed", owner_user_id, True),
         )
@@ -206,7 +207,7 @@ def test_user_disabled_source_excludes_articles(tmp_path: Path) -> None:
         conn.execute(
             """
             INSERT INTO user_sources(user_id, source_slug, enabled)
-            VALUES (?, ?, ?)
+            VALUES (%s, %s, %s)
             ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = excluded.enabled
             """,
             (uid, "python-insider", False),

--- a/backend/tests/test_workflow_state.py
+++ b/backend/tests/test_workflow_state.py
@@ -17,7 +17,7 @@ from news_dashboard.ingest import (
 )
 
 
-def _insert_article(db_path: Path, *, state: str = "today", starred: int = 0) -> int:
+def _insert_article(db_path: Path, *, state: str = "today", starred: bool = False) -> int:
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
@@ -26,7 +26,7 @@ def _insert_article(db_path: Path, *, state: str = "today", starred: int = 0) ->
               url, canonical_url, title, source_slug, source_name,
               category, kind, state, starred
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -196,7 +196,7 @@ def test_disallowed_transitions(tmp_path: Path, from_state: str, to_state: str) 
 def test_starred_cannot_be_skipped(tmp_path: Path) -> None:
     db = tmp_path / "news.db"
     sync_sources(db)
-    aid = _insert_article(db, state="today", starred=1)
+    aid = _insert_article(db, state="today", starred=True)
     with pytest.raises(ValueError, match="starred articles cannot be skipped"):
         transition_article_state(aid, "skipped", db_path=db)
 
@@ -204,7 +204,7 @@ def test_starred_cannot_be_skipped(tmp_path: Path) -> None:
 def test_unstarred_can_be_skipped(tmp_path: Path) -> None:
     db = tmp_path / "news.db"
     sync_sources(db)
-    aid = _insert_article(db, state="today", starred=0)
+    aid = _insert_article(db, state="today", starred=False)
     updated = transition_article_state(aid, "skipped", db_path=db)
     assert updated is not None
     assert updated["state"] == "skipped"
@@ -216,7 +216,7 @@ def test_unstarred_can_be_skipped(tmp_path: Path) -> None:
 def test_star_article(tmp_path: Path) -> None:
     db = tmp_path / "news.db"
     sync_sources(db)
-    aid = _insert_article(db, state="today", starred=0)
+    aid = _insert_article(db, state="today", starred=False)
     updated = set_article_starred(aid, True, db_path=db)
     assert updated is not None
     assert updated["starred"] in (1, True)
@@ -226,7 +226,7 @@ def test_star_article(tmp_path: Path) -> None:
 def test_unstar_article(tmp_path: Path) -> None:
     db = tmp_path / "news.db"
     sync_sources(db)
-    aid = _insert_article(db, state="today", starred=1)
+    aid = _insert_article(db, state="today", starred=True)
     updated = set_article_starred(aid, False, db_path=db)
     assert updated is not None
     assert updated["starred"] in (0, False)
@@ -248,7 +248,7 @@ def test_expired_later_appears_in_today(tmp_path: Path) -> None:
               url, canonical_url, title, source_slug, source_name,
               category, kind, state, later_until
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'later', ?)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, 'later', %s)
             """,
             (
                 "https://example.com/expired-later",
@@ -279,7 +279,7 @@ def test_active_later_does_not_appear_in_today(tmp_path: Path) -> None:
               url, canonical_url, title, source_slug, source_name,
               category, kind, state, later_until
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'later', ?)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, 'later', %s)
             """,
             (
                 "https://example.com/active-later",
@@ -335,43 +335,43 @@ def test_missing_article_returns_none(tmp_path: Path) -> None:
 def test_migration_mapping(tmp_path: Path) -> None:
     """Verify that existing legacy status rows get migrated to the new state column."""
     db = tmp_path / "news.db"
-    # Insert articles with old status values before running migrations
-    import sqlite3
-
-    raw = sqlite3.connect(str(db))
-    raw.execute(
-        """
-        CREATE TABLE IF NOT EXISTS articles (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          url TEXT NOT NULL UNIQUE,
-          canonical_url TEXT NOT NULL DEFAULT '',
-          title TEXT NOT NULL DEFAULT '',
-          source_slug TEXT NOT NULL DEFAULT 'python-insider',
-          source_name TEXT NOT NULL DEFAULT 'Python Insider',
-          category TEXT NOT NULL DEFAULT 'python',
-          kind TEXT NOT NULL DEFAULT 'rss_feed',
-          published_at TEXT,
-          discovered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-          status TEXT NOT NULL DEFAULT 'new',
-          importance_score INTEGER NOT NULL DEFAULT 50,
-          summary TEXT NOT NULL DEFAULT '',
-          reason TEXT NOT NULL DEFAULT '',
-          tags TEXT NOT NULL DEFAULT '',
-          read_at TEXT,
-          saved_at TEXT,
-          skipped_at TEXT,
-          archived_at TEXT,
-          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    with connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE articles (
+              id BIGSERIAL PRIMARY KEY,
+              url TEXT NOT NULL UNIQUE,
+              canonical_url TEXT NOT NULL DEFAULT '',
+              title TEXT NOT NULL DEFAULT '',
+              source_slug TEXT NOT NULL DEFAULT 'python-insider',
+              source_name TEXT NOT NULL DEFAULT 'Python Insider',
+              category TEXT NOT NULL DEFAULT 'python',
+              kind TEXT NOT NULL DEFAULT 'rss_feed',
+              published_at TEXT,
+              discovered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              status TEXT NOT NULL DEFAULT 'new',
+              importance_score INTEGER NOT NULL DEFAULT 50,
+              summary TEXT NOT NULL DEFAULT '',
+              reason TEXT NOT NULL DEFAULT '',
+              tags TEXT NOT NULL DEFAULT '',
+              read_at TEXT,
+              saved_at TEXT,
+              skipped_at TEXT,
+              archived_at TEXT,
+              updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
         )
-        """
-    )
-    for status in ["new", "read", "saved", "skipped", "archived"]:
-        raw.execute(
-            "INSERT INTO articles(url, canonical_url, title, status) VALUES (?, ?, ?, ?)",
-            (f"https://example.com/{status}", f"https://example.com/{status}", status, status),
-        )
-    raw.commit()
-    raw.close()
+        for status in ["new", "read", "saved", "skipped", "archived"]:
+            conn.execute(
+                "INSERT INTO articles(url, canonical_url, title, status) VALUES (%s, %s, %s, %s)",
+                (
+                    f"https://example.com/{status}",
+                    f"https://example.com/{status}",
+                    status,
+                    status,
+                ),
+            )
 
     # Running init_db triggers migration
     init_db(db)
@@ -386,9 +386,9 @@ def test_migration_mapping(tmp_path: Path) -> None:
         )
         for row in rows
     }
-    assert mapping["new"] == ("today", 0)
-    assert mapping["read"] == ("done", 0)
+    assert mapping["new"] == ("today", False)
+    assert mapping["read"] == ("done", False)
     assert mapping["saved"][0] == "today"
     assert mapping["saved"][1] in (1, True)
-    assert mapping["skipped"] == ("skipped", 0)
-    assert mapping["archived"] == ("archived", 0)
+    assert mapping["skipped"] == ("skipped", False)
+    assert mapping["archived"] == ("archived", False)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ flowchart TB
   subgraph LocalDev["Local development"]
     Vite["Vite React dev server<br/>localhost:5173"]
     FastAPIDev["FastAPI backend<br/>uvicorn news_dashboard.main:app"]
-    SQLite["SQLite fallback<br/>NEWS_DASHBOARD_DB"]
+    PostgresDev["PostgreSQL<br/>DATABASE_URL or POSTGRES_*"]
   end
 
   subgraph Container["Docker / Production image"]
@@ -54,7 +54,7 @@ flowchart TB
 
   User --> Vite
   Vite --> FastAPIDev
-  FastAPIDev --> SQLite
+  FastAPIDev --> PostgresDev
 
   User --> Caddy --> Service --> Deployment
   Deployment --> App
@@ -83,14 +83,14 @@ flowchart LR
     Ingest["ingest.py<br/>feed parsing, tagging, scoring, insert"]
     Scraper["scraper.py<br/>custom scraped-page handlers"]
     Sources["sources.py<br/>curated source registry"]
-    DB["db.py<br/>SQLite/Postgres abstraction + schema"]
+    DB["db.py<br/>PostgreSQL connection + schema"]
     Scheduler["scheduler.py<br/>APScheduler ingest + digest jobs"]
     Digest["digest.py<br/>daily email + mark-read token"]
     CLI["cli.py<br/>init, ingest, articles"]
     Migrate["migrate.py<br/>SQLite to Postgres migration"]
   end
 
-  Database["articles + sources tables<br/>Postgres production<br/>SQLite local/test fallback"]
+  Database["articles + sources tables<br/>PostgreSQL"]
 
   Browser --> APIClient --> Main
   Main --> Ingest
@@ -118,7 +118,7 @@ sequenceDiagram
   participant Ingest as ingest_all()
   participant Sources as DEFAULT_SOURCES
   participant Feed as RSS/Atom or Scraper
-  participant DB as Postgres or SQLite
+  participant DB as PostgreSQL
   participant UI as React UI
 
   Trigger->>API: POST /api/ingest or news-dashboard ingest
@@ -213,7 +213,7 @@ flowchart LR
 - `backend/news_dashboard/ingest.py`: ingestion pipeline, URL canonicalization, source health updates, summaries, tags, and scoring.
 - `backend/news_dashboard/sources.py`: curated source registry.
 - `backend/news_dashboard/scraper.py`: custom scraped-page handlers, currently for Anthropic News.
-- `backend/news_dashboard/db.py`: SQLite/Postgres schema and connection abstraction.
+- `backend/news_dashboard/db.py`: PostgreSQL configuration, psycopg connection handling, and schema setup.
 - `backend/news_dashboard/scheduler.py`: in-process APScheduler jobs for ingest and digest.
 - `backend/news_dashboard/digest.py`: daily digest email and signed mark-read links.
 - `backend/news_dashboard/cli.py`: maintenance commands.
@@ -229,7 +229,7 @@ The database has two main tables:
 - `sources`: source registry and health information, including `last_checked_at`, `last_success_at`, `last_error`, `last_fetched_count`, and `last_inserted_count`.
 - `articles`: normalized article records, including source metadata, category, kind, publication/discovery timestamps, status, importance score, summary, reason, tags, and status-specific timestamps.
 
-SQLite also creates an FTS5 virtual table. PostgreSQL adds a generated `tsvector` column and GIN index, although the current search implementation uses a cross-database `LIKE` query for compatibility.
+PostgreSQL adds a generated `tsvector` column and GIN index. User-facing search uses PostgreSQL-native `ILIKE` filters today, leaving the generated full-text index available for a future ranking pass.
 
 ## How It Works
 
@@ -243,7 +243,7 @@ For production, GitHub Actions tests the Python backend, builds the frontend, bu
 
 ## Operational Notes
 
-- The production database is PostgreSQL by default; SQLite remains a local/test fallback.
+- PostgreSQL is required in every runtime environment. SQLite is only a legacy migration input for importing old local data into PostgreSQL.
 - The React app is served separately only in local development. In the production image, the built frontend is served by FastAPI.
 - There are two scheduling mechanisms: in-process APScheduler and the Kubernetes CronJob. If duplicate ingestion is undesirable, configure one of them as the authoritative scheduler.
 - Authentication is handled outside the app by host-level Caddy Basic Auth, according to the repository deployment notes.


### PR DESCRIPTION
## Summary
- Remove runtime SQLite fallback and hidden placeholder translation from the database layer
- Move backend runtime SQL/tests to psycopg/PostgreSQL semantics
- Update architecture docs and CI test job to reflect PostgreSQL-only runtime

## Validation
- ruff check backend
- ruff format --check backend
- mypy backend
- pytest backend/tests/test_database_config.py backend/tests/test_db_init.py backend/tests/test_briefings_api.py
- pytest --collect-only -q
- npm run lint --silent
- npm run format:check --silent
- npm run typecheck --silent
- npm run test:frontend --silent
- npm run build --silent

## Note
Full backend DB test execution needs a live PostgreSQL server. This local machine has no Docker/Postgres binaries, so CI now provisions Postgres for the test job.