### PR TITLE
[codex] surface hanging pytest diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
           python-version: '3.14'
           cache: pip
       - run: pip install -e '.[dev]'
-      - run: pytest -v --cov --cov-report=term-missing
+      - run: >
+          pytest -v --cov --cov-report=term-missing --durations=20
+          -o faulthandler_timeout=120 -o faulthandler_exit_on_timeout=true
         env:
           DATABASE_URL: postgresql://news_dashboard:news_dashboard@127.0.0.1:5432/news_dashboard
           TEST_DATABASE_URL: postgresql://news_dashboard:news_dashboard@127.0.0.1:5432/news_dashboard


### PR DESCRIPTION
## Summary
- add pytest slow-duration reporting in CI
- add faulthandler timeout/exit so hanging tests produce stack traces instead of blocking silently

## Why
The rerun of the main Test & build job reached pytest and stayed in that step without logs. This makes the next run fail with useful diagnostics after 120 seconds on a stuck test.

## Validation
- pre-commit hooks during commit: YAML check passed
- branch pushed to origin/codex/fix-ci-postgres-service