### PR TITLE
[codex] fix Postgres body fetch test hang

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -177,6 +177,15 @@ def _merge_user_state(
     return d
 
 
+def _article_from_row(row: Any, conn: Any, article_id: int, user_id: int | None) -> dict[str, Any]:
+    d = row_to_dict(row)
+    d.pop("embedding", None)
+    d.pop("fts_vector", None)
+    if user_id is not None:
+        _merge_user_state(d, conn, article_id, user_id)
+    return d
+
+
 def get_article(
     article_id: int,
     db_path: Path | None = None,
@@ -193,12 +202,7 @@ def get_article(
         row = conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
         if row is None:
             return None
-        d = row_to_dict(row)
-        d.pop("embedding", None)
-        d.pop("fts_vector", None)
-        if user_id is not None:
-            _merge_user_state(d, conn, article_id, user_id)
-        return d
+        return _article_from_row(row, conn, article_id, user_id)
 
 
 def fetch_and_cache_body(
@@ -213,15 +217,12 @@ def fetch_and_cache_body(
     """
     init_db(db_path)
     with connect(db_path) as conn:
-        row = conn.execute(
-            "SELECT id, url, body_status FROM articles WHERE id = %s",
-            (article_id,),
-        ).fetchone()
+        row = conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
         if row is None:
             return None
         row_d = row_to_dict(row)
         if row_d.get("body_status") == "ok":
-            return get_article(article_id, db_path=db_path, user_id=user_id)
+            return _article_from_row(row, conn, article_id, user_id)
 
     url = row_d["url"]
     body, status = extract_body(url)

--- a/backend/tests/test_ask_scope.py
+++ b/backend/tests/test_ask_scope.py
@@ -17,9 +17,22 @@ def _pack(vector: list[float]) -> bytes:
     return struct.pack(f"{len(vector)}f", *vector)
 
 
+def _seed_source(db_path: Path, slug: str = "test-source", name: str = "TestSource") -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, 'engineering', 'rss', 50, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, name, f"https://example.com/{slug}.xml"),
+        )
+
+
 def _seed_articles(db_path: Path) -> None:
     """Insert one article per legacy status with a pre-set embedding."""
     init_db(db_path)
+    _seed_source(db_path)
     embedding = _pack([0.1] * 10)
     statuses = ["new", "saved", "read", "skipped", "archived"]
     with connect(db_path) as conn:
@@ -129,6 +142,7 @@ def test_ask_default_scope_returns_answer(tmp_path: Path, monkeypatch: pytest.Mo
     """ask() with include_all=False succeeds when saved+read count >= MIN_ARTICLES."""
     db_path = tmp_path / "ask.db"
     init_db(db_path)
+    _seed_source(db_path, "s", "S")
     embedding = _pack([0.1] * 10)
     with connect(db_path) as conn:
         for i in range(1, 8):  # 7 saved/read articles — above MIN_ARTICLES=5
@@ -185,6 +199,7 @@ def test_ask_include_all_widens_corpus(tmp_path: Path, monkeypatch: pytest.Monke
     """ask(include_all=True) includes new+skipped articles in the pool."""
     db_path = tmp_path / "ask.db"
     init_db(db_path)
+    _seed_source(db_path, "s", "S")
     embedding = _pack([0.1] * 10)
     # Insert 6 articles with status 'new' — not picked up by default scope
     with connect(db_path) as conn:


### PR DESCRIPTION
## Summary
- seed source rows in ask-scope tests before inserting articles, matching the real Postgres foreign key
- return cached body-fetch rows from the current connection instead of re-entering get_article while the transaction is still open

## Root cause
The CI suite now runs against PostgreSQL. Some legacy tests inserted articles without corresponding sources, causing FK failures. The body-cache hit path also returned through get_article while still inside an open connection context, which re-ran schema initialization and could block on PostgreSQL DDL/transaction locks.

## Validation
- ruff check backend/news_dashboard/body_fetch.py backend/tests/test_ask_scope.py
- ruff format --check backend/news_dashboard/body_fetch.py backend/tests/test_ask_scope.py
- mypy backend
- targeted pytest command was attempted locally, but this machine has no DATABASE_URL/Postgres service, so it fails at expected Postgres configuration setup rather than the CI failure.