### PR TITLE
chore: python/typescript dev skills + lint/test enforcement gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "statusMessage": "Auto-fixing (ruff/eslint/prettier)",
+            "command": "{ f=$(jq -r '.tool_input.file_path // empty'); [ -z \"$f\" ] && exit 0; case \"$f\" in *.py) ruff check --fix \"$f\" && ruff format \"$f\";; *.ts|*.tsx|*.mjs) npx --no-install eslint --fix \"$f\" && npx --no-install prettier --write \"$f\";; esac; } 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/python-dev/SKILL.md
+++ b/.claude/skills/python-dev/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: python-dev
+description: >-
+  Standards and verification gate for writing Python in this repository. Use
+  this skill ANY time you create or edit a .py file, add or change a Python
+  dependency, write or fix a pytest test, or are about to commit/push Python
+  changes — even for a "small" edit. It tells you how to write code that passes
+  this project's ruff + mypy(strict) + pytest gates the first time, how to keep
+  dependencies and lockfiles clean, what test patterns to follow, and which
+  project-specific gotchas (PostgreSQL-only, tz-aware datetimes, no print) will
+  otherwise bite you. Triggers on: Python, .py, FastAPI, pytest, ruff, mypy,
+  backend changes, "run the backend tests", "why does mypy fail".
+---
+
+# Python development in this repo
+
+The backend lives in `backend/news_dashboard/`, tests in `backend/tests/`. The
+toolchain is already configured and strict — your job is to write code that
+clears it on the first try, not to reinvent or relax it.
+
+## 0. Detect before you act
+
+Never assume commands. This repo standardizes entry points in the `Makefile` —
+**prefer those**, they're what CI runs (`make check`). Confirm what exists:
+
+```bash
+ls Makefile pyproject.toml uv.lock 2>/dev/null   # what governs the project
+grep -E '^(lint|typecheck|test|check|format|install):' Makefile
+```
+
+- If `make` targets exist (they do here): use `make lint`, `make typecheck`,
+  `make test`, `make check`.
+- If you're in a *different* project with no Makefile, fall back to the raw
+  tools you find configured (`ruff`, `mypy`, `pytest`), and read
+  [references/bootstrap.md](references/bootstrap.md) only when a project has
+  **no** Python tooling at all and you're setting it up from scratch.
+
+Run `pip install -e '.[dev]'` (or `make install`) once if the tools aren't importable.
+
+## 1. While writing code — clear the gates by construction
+
+The ruff rule set here is large (see `[tool.ruff.lint]` in `pyproject.toml`) and
+mypy runs in `strict` mode with `warn_unreachable`. The patterns that trip
+agents most often, and how to avoid them:
+
+- **Type everything.** Strict mypy means every function needs annotated params
+  and return type; no implicit `Any`. Public modules ship types (`py.typed`).
+  Use `X | None`, not `Optional[X]`; built-in generics (`list[str]`), not `List`.
+- **No `print` in library code** (`T20`). Use the module logger. Log with
+  `%`-style lazy args, not f-strings (`G`): `log.info("loaded %s", n)`.
+- **Datetimes must be timezone-aware** (`DTZ`). Use `datetime.now(timezone.utc)`.
+  Note the repo deliberately keeps `timezone.utc` over `UTC` (`UP017` ignored) —
+  don't "modernize" it.
+- **Errors:** raise with a message assigned to a variable first if it's long
+  (`EM`/`TRY` rules); custom exceptions over bare `Exception`; don't `log.error`
+  and re-raise the same thing.
+- **Security (`S`/bandit):** no `assert` in runtime code, no `shell=True`, no
+  hardcoded secrets, parameterize SQL. The repo allows `S608` only for SQL built
+  from trusted literal identifiers — match that bar, don't widen it.
+- **Comprehensions/simplify (`C4`/`SIM`/`RET`/`PERF`):** prefer the idiom ruff
+  wants; when it flags, take the suggestion rather than `# noqa`.
+
+When you genuinely must suppress a rule, use a *scoped* `# noqa: <CODE>` with a
+reason — never a blanket ignore, and never edit `pyproject.toml` to disable a
+rule to make your code pass.
+
+## 2. Project guardrails (don't regress these)
+
+These are decisions encoded in config/`AGENTS.md` that an unaware edit will undo:
+
+- **PostgreSQL only.** Runtime code uses PostgreSQL SQL + psycopg param style.
+  Do **not** add SQLite fallbacks, db-type sniffing, or placeholder-translation
+  layers. SQLite appears only in legacy import/migration tooling.
+- **Ruff `target-version = py313`** on a `requires-python >=3.14` project is
+  intentional (avoids PEP 758 rewrites mypy can't parse). Leave it.
+- **Lazy imports are deliberate** (`PLC0415` ignored) for optional deps / startup
+  cost / cycles — keep them where they are.
+- Config files (`pyproject.toml`, `.pre-commit-config.yaml`) are not yours to
+  loosen to pass checks. If a rule seems wrong, raise it; don't silently flip it.
+
+## 3. Tests — author them to this project's style
+
+- Framework is **pytest** with `flake8-pytest-style` (`PT`) enforced. Use
+  `pytest.raises`, parametrize with `@pytest.mark.parametrize`, name fixtures
+  clearly. `assert` is allowed in tests (per-file ignore), not in app code.
+- **Postgres in tests:** the suite uses `testcontainers[postgres]`. Don't mock
+  the DB into a fake; spin a container fixture like the existing tests
+  (`backend/tests/conftest.py`). Read a neighbor test before writing a new one.
+- **No live network.** Stub `httpx`/feed fetches; tests must pass offline.
+  `filterwarnings = error` for the package's own DeprecationWarnings — don't
+  introduce deprecated calls.
+- Put a test next to the behavior you changed. A bug fix without a regression
+  test is incomplete.
+
+## 4. Dependencies — keep them clean
+
+- Add deps by editing `pyproject.toml` (`dependencies` or the `dev` extra) and
+  keeping `uv.lock` in sync (`uv lock`), or `uv add <pkg>` if uv is your driver.
+  Don't `pip install` into the env and forget the manifest.
+- Pin sanely (`>=` floors, as the repo does); avoid unpinned/`latest`.
+- For third-party packages without type stubs, add a targeted
+  `[[tool.mypy.overrides]]` with `ignore_missing_imports = true` (see existing
+  feedparser/apscheduler entries) — scoped to that module only.
+- Check new/updated deps for known CVEs (`pip-audit` / `uv pip audit`) and flag
+  anything serious rather than pulling it in silently.
+
+## 5. Before you say "done" — run the gate
+
+Do not report success on unverified code. Run, in order, and fix until clean:
+
+```bash
+make lint        # ruff check + ruff format --check
+make typecheck   # mypy strict
+make test        # pytest --cov --cov-report=term-missing
+```
+
+`make format` auto-fixes lint/format issues. Quote the real output when
+reporting results; if something fails, say so — don't claim green on red.
+
+## 6. Before pushing
+
+`make test` must pass before any push — tests are **not** in the pre-commit
+hook (too slow), so they're the easy thing to skip. A `pre-push` git hook backs
+this up (`pre-commit install --hook-type pre-push`); if the hook isn't installed
+in this clone, run the tests manually. Never `--no-verify` past a failing gate.

--- a/.claude/skills/python-dev/references/bootstrap.md
+++ b/.claude/skills/python-dev/references/bootstrap.md
@@ -1,0 +1,68 @@
+# Bootstrapping Python tooling in a project that has none
+
+Read this only when a project has **no** Python lint/type/test setup and you've
+been asked to establish one. If config already exists, follow it instead — do
+not overwrite a working setup.
+
+The target is the same stack this repo proved out: **ruff** (lint + format),
+**mypy strict**, **pytest** (+ coverage), wired through **pre-commit** and a
+`Makefile`, with **uv** for locking.
+
+## Minimum `pyproject.toml`
+
+```toml
+[tool.ruff]
+line-length = 100
+src = ["src"]            # adjust to the package root
+
+[tool.ruff.lint]
+select = ["E","W","F","I","N","UP","B","A","C4","DTZ","EM","G","ISC","PIE",
+          "PT","RET","RSE","S","SIM","T20","ARG","PERF","PL","RUF","TRY"]
+ignore = ["ISC001"]      # conflicts with the formatter
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101", "PLR0915"]   # asserts + long tests are fine in tests
+
+[tool.mypy]
+strict = true
+warn_unreachable = true
+pretty = true
+
+[tool.pytest.ini_options]
+addopts = "-ra --strict-markers --strict-config"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+```
+
+## pre-commit + pre-push
+
+Put ruff (with `--fix`) and ruff-format as managed hooks, and mypy as a local
+`system` hook. Add a **pre-push** stage that runs the test suite so tests gate
+the push without slowing every commit:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+Install both hook types:
+
+```bash
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+## Makefile entry points
+
+Mirror this repo's `make lint` / `typecheck` / `test` / `check` so humans and
+CI share one path. `check` should chain `lint typecheck test`.
+
+Tune ruff/mypy strictness to the team's appetite, but start strict — relaxing
+later is easy; retrofitting types onto a loose codebase is not.

--- a/.claude/skills/typescript-dev/SKILL.md
+++ b/.claude/skills/typescript-dev/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: typescript-dev
+description: >-
+  Standards and verification gate for writing TypeScript/React in this
+  repository. Use this skill ANY time you create or edit a .ts/.tsx file, touch
+  vite/eslint/tsconfig, add an npm dependency, write or fix a vitest or
+  Playwright test, or are about to commit/push frontend changes — even for a
+  "small" edit. It tells you how to write code that passes this project's
+  eslint(--max-warnings 0) + prettier + tsc(strict) + vitest gates the first
+  time, when to write unit vs e2e tests, how to keep package.json/lockfile
+  clean, and which React/PWA gotchas will otherwise bite you. Triggers on:
+  TypeScript, React, .tsx, frontend, vite, eslint, prettier, tsc, vitest,
+  playwright, "run the frontend tests", "why does the build fail".
+---
+
+# TypeScript development in this repo
+
+The frontend is React + Vite + Tailwind in `frontend/src/`, with Radix UI,
+TanStack Query, Zustand, and React Router. Unit tests use **vitest** +
+Testing Library; end-to-end tests use **Playwright** in `e2e/`. The toolchain is
+already configured and strict — write code that clears it on the first try.
+
+## 0. Detect before you act
+
+Prefer the canonical entry points. `npm` scripts (`package.json`) and `make`
+targets are what CI runs. Confirm what exists:
+
+```bash
+cat package.json | sed -n '/"scripts"/,/}/p'
+grep -E '^(lint|typecheck|test|check):' Makefile 2>/dev/null
+```
+
+Key scripts here: `lint`, `lint:fix`, `format`, `format:check`, `typecheck`
+(`tsc -b --noEmit`), `build` (`tsc -b && vite build`), `test:frontend`
+(`vitest run`). At repo level, `make lint typecheck test` covers both stacks.
+
+Run `npm install` if `node_modules` is stale. If you're in a *different* project
+with no frontend tooling at all, read
+[references/bootstrap.md](references/bootstrap.md).
+
+## 1. While writing code — clear the gates by construction
+
+ESLint runs flat-config with `typescript-eslint`, `react-hooks`, and
+`react-refresh`, and the lint script uses **`--max-warnings 0`** — a warning is a
+failure. `tsc` builds with project references and strict typing. Common traps:
+
+- **No `any`.** Type props, hooks, and API payloads. Prefer `unknown` + a
+  narrowing check over `any`; derive types from Zod/response shapes where they
+  exist rather than hand-rolling drift.
+- **Rules of Hooks** (`react-hooks`): hooks at top level only; complete
+  dependency arrays in `useEffect`/`useMemo`/`useCallback`. Don't silence the
+  exhaustive-deps warning — fix the dependency or restructure.
+- **react-refresh:** a component file should export only components (move
+  constants/helpers out) so fast-refresh stays intact.
+- **No stray `console.log`** in committed code; remove debugging output.
+- **Prettier owns formatting** (`eslint-config-prettier` disables conflicting
+  lint rules). Don't hand-format — run `npm run format`.
+- Honor `.prettierrc.json` / `.editorconfig`; don't override style inline.
+
+When a rule genuinely doesn't apply, use a scoped
+`// eslint-disable-next-line <rule> -- reason`, never a file-wide disable, and
+never edit `eslint.config.mjs`/`tsconfig.json` just to make your code pass.
+
+## 2. Project guardrails (don't regress these)
+
+- This is a **PWA** (`vite-plugin-pwa`) with a generated service worker and a
+  `manifest.webmanifest`. Be careful with caching/offline behavior; don't break
+  the SW registration or asset precaching.
+- The app is served as an SPA behind the backend (`test_spa_static.py` asserts
+  this) — keep client routing and the built asset paths consistent.
+- UI primitives in `frontend/src/components/ui/*` follow the shadcn/Radix
+  pattern. Reuse and extend them; don't fork a one-off button.
+- `tsconfig`/`eslint`/`vite` config encode deliberate choices — raise issues
+  rather than loosening them to go green.
+
+## 3. Tests — unit vs e2e, and how to write each
+
+Choose the cheapest test that proves the behavior:
+
+- **vitest + Testing Library** (`*.test.tsx` near the component) for component
+  logic, hooks, rendering, and state. Query by role/text like a user; assert on
+  behavior, not implementation. `happy-dom`/`jsdom` are configured — no real
+  browser needed. Use `@testing-library/user-event` for interaction.
+- **Playwright** (`e2e/*.spec.ts`) only for real cross-page flows: navigation,
+  keyboard shortcuts, command palette, PWA, auth — things unit tests can't cover.
+  These are slower; don't push pure component logic into e2e.
+- Mock network at the boundary (don't hit live services); a fix without a test
+  for the regression is incomplete. Read a neighboring test before writing a new
+  one to match fixtures and conventions.
+
+## 4. Dependencies — keep them clean
+
+- Add deps with `npm install <pkg>` (or `-D` for dev) so `package.json` **and**
+  `package-lock.json` update together; commit both. Don't hand-edit versions and
+  leave the lockfile stale.
+- Avoid `"latest"` for new deps — pin a caret range like the rest. (Some
+  existing entries use `latest`; don't add more.)
+- Run `npm audit` on dependency changes and flag serious CVEs instead of
+  pulling them in silently. Prefer adding to an existing Radix/utility rather
+  than introducing a redundant library.
+
+## 5. Before you say "done" — run the gate
+
+Do not report success on unverified code. Run, in order, and fix until clean:
+
+```bash
+npm run lint            # eslint --max-warnings 0
+npm run format:check    # prettier
+npm run typecheck       # tsc -b --noEmit
+npm run test:frontend   # vitest run
+npm run build           # tsc -b && vite build  (catches build-only breakage)
+```
+
+`npm run lint:fix` and `npm run format` auto-fix the first two. Quote real
+output when reporting; if it fails, say so — don't claim green on red.
+
+## 6. Before pushing
+
+The full frontend test suite (`npm run test:frontend`) plus `npm run build`
+must pass before any push. Tests are **not** in the pre-commit hook (too slow),
+so a `pre-push` git hook backs this up
+(`pre-commit install --hook-type pre-push`); if it isn't installed in this
+clone, run them manually. Playwright e2e is heavier — run it when you touched
+flows it covers or before a release. Never `--no-verify` past a failing gate.

--- a/.claude/skills/typescript-dev/references/bootstrap.md
+++ b/.claude/skills/typescript-dev/references/bootstrap.md
@@ -1,0 +1,76 @@
+# Bootstrapping TypeScript tooling in a project that has none
+
+Read this only when a project has **no** frontend lint/type/test setup and
+you've been asked to establish one. If config already exists, follow it — don't
+overwrite a working setup.
+
+Target stack (what this repo proved out): **ESLint flat config** with
+`typescript-eslint` + `react-hooks` + `react-refresh`, **Prettier**, **strict
+`tsc`** with project references, **vitest** + Testing Library for units,
+**Playwright** for e2e.
+
+## tsconfig
+
+Enable strictness from day one:
+
+```jsonc
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+## package.json scripts
+
+```jsonc
+{
+  "typecheck": "tsc -b --noEmit",
+  "lint": "eslint . --max-warnings 0",
+  "lint:fix": "eslint . --fix",
+  "format": "prettier --write src",
+  "format:check": "prettier --check src",
+  "test": "vitest run",
+  "test:coverage": "vitest run --coverage"
+}
+```
+
+`--max-warnings 0` is the point: it makes warnings block CI, so they get fixed
+instead of accumulating.
+
+## ESLint flat config
+
+Compose `@eslint/js` recommended + `typescript-eslint` recommended +
+`eslint-plugin-react-hooks` + `eslint-plugin-react-refresh`, and put
+`eslint-config-prettier` **last** so Prettier owns formatting.
+
+## pre-commit + pre-push
+
+Run eslint, prettier `--check`, and tsc as local `system` hooks on commit; run
+the test suite at the **pre-push** stage so tests gate the push without slowing
+commits:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: vitest
+        name: vitest
+        entry: npm run test --silent
+        language: system
+        files: \.(ts|tsx)$
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+Install both hook types:
+
+```bash
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+Start strict and relax only with reason — loosening later is cheap, retrofitting
+types and tests onto a loose codebase is not.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tsconfig.tsbuildinfo
 data/*.db
 data/*.db-*
 .worktrees/
+.claude/settings.local.json
+.claude/worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,22 @@ repos:
         language: system
         files: \.(ts|tsx)$
         pass_filenames: false
+
+      # ── pre-push: run the test suites before code leaves the machine ───────
+      # These are deliberately on the `pre-push` stage, not `pre-commit`: tests
+      # are too slow to run on every commit, but must pass before a push.
+      # Enable with: pre-commit install --hook-type pre-push
+      - id: pytest
+        name: pytest (backend)
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]
+      - id: vitest
+        name: vitest (frontend)
+        entry: npm run test:frontend --silent
+        language: system
+        files: \.(ts|tsx)$
+        pass_filenames: false
+        stages: [pre-push]


### PR DESCRIPTION
## What & why

Adds two project skills that encode this repo's coding standards and verification workflow, plus the automation that enforces them. These guide (and gate) Python and TypeScript development so changes clear `ruff`/`mypy`/`pytest` and `eslint`/`prettier`/`tsc`/`vitest` the first time.

## Changes

**Skills** (`.claude/skills/`)
- `python-dev` — backend standards (typed/strict mypy, no `print`, tz-aware datetimes, security lint, project guardrails like PostgreSQL-only and `target-version=py313`), the `make lint/typecheck/test` gate, pytest + testcontainers patterns, dependency hygiene.
- `typescript-dev` — frontend standards (no `any`, Rules of Hooks, `--max-warnings 0`, PWA/SPA guardrails), the lint/format/typecheck/test/build gate, unit (vitest) vs e2e (Playwright) guidance, lockfile/audit hygiene.
- Each is **detect-then-act** (prefers existing `make`/`npm` entry points) with a `references/bootstrap.md` for greenfield projects.

**Enforcement**
- **Per edit** — PostToolUse hook (`.claude/settings.json`) auto-runs `ruff` / `eslint`+`prettier` on each edited `.py`/`.ts(x)` file (fast fixers only).
- **On push** — `pytest` + `vitest` added to the `pre-push` stage of `.pre-commit-config.yaml`. Tests previously ran nowhere automatic; file-scoped so a frontend-only push won't run pytest.
- `.gitignore` now excludes local-only `.claude/settings.local.json` and `.claude/worktrees/`.

## Notes
- Activating the pre-push hooks locally requires `pre-commit install --hook-type pre-push` (already run on this machine).
- The per-edit hook only affects Claude Code sessions (it's a harness hook), not plain CLI usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)