### PR TITLE
[codex] tighten public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,21 @@
 # News Dashboard
 
-News Dashboard is a self-hosted technical news inbox. It ingests curated
-RSS/Atom feeds and selected scraped sources into PostgreSQL, then provides a
-React interface for triage, reading state, source health, run history, briefings,
-and search.
+Self-hosted technical news inbox for curated feeds, article triage, source
+health, search, briefings, and saved/read history.
 
-The project is designed as a small modular monolith: a FastAPI backend, a Vite
-React frontend, PostgreSQL for durable storage, and optional OpenAI-powered
-features for briefings and question answering over saved or read articles.
+The app uses a FastAPI backend, a Vite React frontend, PostgreSQL storage, and
+optional OpenAI features for embeddings, Ask AI, and briefings.
 
 ## Features
 
-- Curated source registry for Python, AI/LLM, agents, cloud infrastructure,
-  engineering, trending stories, and repository feeds.
-- Feed ingestion from RSS/Atom, GitHub release feeds, Hacker News/GitHub
-  trending feeds, and custom scraped pages.
-- Article workflow for new, read, saved, skipped, archived, starred, and
-  snoozed items.
-- Source health, ingestion run history, dashboard statistics, and search.
-- Multi-user authentication with local password bootstrap or optional Keycloak.
-- Optional OpenAI integration for article embeddings, Ask AI, and generated
-  briefings.
-- Docker, Helm, and GitHub Actions support for deployment.
+- Curated Python, AI/LLM, agents, cloud, engineering, trending, and repository feeds.
+- RSS/Atom ingestion, GitHub release feeds, Hacker News/GitHub trending feeds, and custom scraped sources.
+- Article states: new, read, saved, skipped, archived, starred, and snoozed.
+- Source health, ingest run history, dashboard stats, and search.
+- Local password auth with first-admin bootstrap.
+- Optional Keycloak login.
+- Optional OpenAI embeddings, Ask AI, and generated briefings.
+- Docker, Helm, and GitHub Actions deployment support.
 
 ## Stack
 
@@ -32,43 +26,41 @@ features for briefings and question answering over saved or read articles.
 
 ## Requirements
 
-- Python 3.14 or newer.
-- Node.js and npm compatible with the checked-in `package-lock.json`.
-- PostgreSQL 16 or newer.
-- Docker and Docker Compose for the containerized workflow.
-- An OpenAI API key only if you enable AI features.
+- Python 3.14+
+- Node.js and npm compatible with `package-lock.json`
+- PostgreSQL 16+
+- Docker and Docker Compose for the container flow
+- OpenAI API key for AI features
 
 ## Configuration
 
-Runtime database configuration is PostgreSQL-only. Configure either
-`DATABASE_URL` or the `POSTGRES_*` variables:
+Runtime storage is PostgreSQL only. Set `DATABASE_URL` or the split
+`POSTGRES_*` variables.
 
-| Variable | Purpose |
+| Variable | Use |
 | --- | --- |
-| `DATABASE_URL` | Full PostgreSQL DSN, for example `postgresql://user:pass@localhost:5432/news_dashboard`. |
-| `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Split PostgreSQL connection settings used when `DATABASE_URL` is not set. |
-| `SESSION_SECRET` | Required for signed login sessions. Generate with `python -c "import secrets; print(secrets.token_hex(32))"`. |
-| `BOOTSTRAP_ADMIN_USERNAME`, `BOOTSTRAP_ADMIN_PASSWORD` | Optional first local admin account. Used only when the user table is empty. |
-| `OPENAI_API_KEY` | Optional. Enables embeddings, Ask AI, and briefing generation. |
-| `KEYCLOAK_AUTH_ENABLED`, `KEYCLOAK_SERVER_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET` | Optional Keycloak login integration. See [docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md). |
-| `CORS_ORIGINS` | Optional comma-separated origins for browser development. |
+| `DATABASE_URL` | PostgreSQL DSN. |
+| `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | PostgreSQL connection parts used when `DATABASE_URL` is unset. |
+| `SESSION_SECRET` | Signed session key. Generate with `python -c "import secrets; print(secrets.token_hex(32))"`. |
+| `BOOTSTRAP_ADMIN_USERNAME`, `BOOTSTRAP_ADMIN_PASSWORD` | First local admin account. Used only when no users exist. |
+| `OPENAI_API_KEY` | Enables embeddings, Ask AI, and briefings. |
+| `KEYCLOAK_AUTH_ENABLED`, `KEYCLOAK_SERVER_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET` | Enables Keycloak. See [docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md). |
+| `CORS_ORIGINS` | Comma-separated browser dev origins. |
 
-SQLite is not a runtime database. It is supported only as a legacy import source
-for `news-dashboard-migrate sqlite-to-postgres`.
+SQLite is supported only as a legacy import source for
+`news-dashboard-migrate sqlite-to-postgres`.
 
 ## Quick Start
 
-Start the full container stack:
+Run the container stack:
 
 ```bash
 docker compose up --build
 ```
 
-The app listens on [http://localhost:8080](http://localhost:8080). The Compose
-stack includes PostgreSQL and uses the local credentials defined in
-`docker-compose.yml`.
+Open [http://localhost:8080](http://localhost:8080).
 
-To ingest sources inside the running app container:
+Run ingestion in the app container:
 
 ```bash
 docker compose exec news-dashboard news-dashboard ingest
@@ -76,7 +68,7 @@ docker compose exec news-dashboard news-dashboard ingest
 
 ## Local Development
 
-Create the Python environment and install frontend dependencies:
+Install backend and frontend dependencies:
 
 ```bash
 python -m venv .venv
@@ -86,7 +78,7 @@ npm install
 pre-commit install
 ```
 
-Start a local PostgreSQL database:
+Start PostgreSQL:
 
 ```bash
 docker run --rm -d \
@@ -98,7 +90,7 @@ docker run --rm -d \
   postgres:16-alpine
 ```
 
-Configure the backend process:
+Set backend env:
 
 ```bash
 export DATABASE_URL=postgresql://news_dashboard:news-dashboard-local-password@localhost:5432/news_dashboard
@@ -107,14 +99,14 @@ export BOOTSTRAP_ADMIN_USERNAME=admin
 export BOOTSTRAP_ADMIN_PASSWORD=change-me
 ```
 
-Initialize the schema, sync sources, and optionally ingest articles:
+Initialize schema and sources:
 
 ```bash
 news-dashboard init
 news-dashboard ingest
 ```
 
-Run the backend and frontend in separate terminals:
+Run backend and frontend:
 
 ```bash
 uvicorn news_dashboard.main:app --reload --app-dir backend
@@ -127,56 +119,52 @@ Open [http://localhost:5173](http://localhost:5173).
 
 ```bash
 make lint        # ruff, eslint, prettier checks
-make format      # auto-format backend and frontend code
+make format      # auto-format backend and frontend
 make typecheck   # mypy and TypeScript
 make test        # backend and frontend tests
 make build       # production frontend build
-make check       # lint, typecheck, tests, and build
+make check       # full CI suite
 ```
-
-CI runs the same checks on pull requests.
 
 ## Project Layout
 
 ```text
-backend/news_dashboard/   FastAPI app, ingestion, auth, scheduler, CLI, database layer
-frontend/src/             React application
+backend/news_dashboard/   FastAPI app, ingest, auth, scheduler, CLI, database layer
+frontend/src/             React app
 docs/                     Architecture, product, deployment, and auth notes
 helm/news-dashboard/      Kubernetes chart
-deploy/                   Deployment support files
-scripts/                  Maintenance and helper scripts
+deploy/                   Deployment files
+scripts/                  Maintenance scripts
 ```
 
 ## Deployment
 
-The production image serves the built frontend from the FastAPI backend on port
-`8080`. For a local container run, use Docker Compose. For Kubernetes, use the
-Helm chart:
+The production image serves the built frontend through FastAPI on port `8080`.
+
+For Kubernetes:
 
 ```bash
 helm upgrade --install news-dashboard ./helm/news-dashboard
 ```
 
-Authentication should be enabled before exposing an instance beyond a trusted
-network. Keycloak deployment notes live in
-[docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md), and HTTPS/Caddy notes live in
+Enable auth before exposing an instance outside a trusted network. See
+[docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md) and
 [docs/CADDY_HTTPS_SETUP.md](docs/CADDY_HTTPS_SETUP.md).
 
 ## Contributing
 
-Issues and pull requests are welcome. Before opening a PR, run `make check` when
-your local environment has the required Python, Node, PostgreSQL, and browser
-test dependencies installed.
+Issues and PRs are welcome. Run `make check` before opening a PR when local
+Python, Node, PostgreSQL, and browser test dependencies are installed.
 
-Runtime database code should remain PostgreSQL-specific: use psycopg parameter
-style, PostgreSQL SQL features, and the existing database helpers. Do not add
-SQLite runtime fallbacks or generic multi-database abstraction layers.
+Keep runtime database code PostgreSQL-specific: psycopg parameters, PostgreSQL
+SQL, and existing database helpers. Do not add SQLite runtime fallbacks or
+generic multi-database layers.
 
 ## Security
 
 Do not commit secrets, API keys, database credentials, or production session
-secrets. Use environment variables or deployment secrets instead.
+keys. Use environment variables or deployment secrets.
 
 ## License
 
-This repository does not currently include an open-source license.
+This repository does not include an open-source license.


### PR DESCRIPTION
## Summary

- tighten the public README after the first rewrite
- shorten setup, feature, deployment, and contribution text
- keep the PostgreSQL-only runtime guidance explicit

## Validation

- git diff --check
- pre-commit hooks during commit and push