### PR TITLE
feat: add ty + pyrefly type checkers, make backend pass all three

### DIFF
--- a/.claude/skills/python-dev/SKILL.md
+++ b/.claude/skills/python-dev/SKILL.md
@@ -5,11 +5,12 @@ description: >-
   this skill ANY time you create or edit a .py file, add or change a Python
   dependency, write or fix a pytest test, or are about to commit/push Python
   changes — even for a "small" edit. It tells you how to write code that passes
-  this project's ruff + mypy(strict) + pytest gates the first time, how to keep
-  dependencies and lockfiles clean, what test patterns to follow, and which
-  project-specific gotchas (PostgreSQL-only, tz-aware datetimes, no print) will
-  otherwise bite you. Triggers on: Python, .py, FastAPI, pytest, ruff, mypy,
-  backend changes, "run the backend tests", "why does mypy fail".
+  this project's ruff + mypy(strict) + ty + pyrefly + pytest gates the first
+  time, how to keep dependencies and lockfiles clean, what test patterns to
+  follow, and which project-specific gotchas (PostgreSQL-only, tz-aware
+  datetimes, no print) will otherwise bite you. Triggers on: Python, .py,
+  FastAPI, pytest, ruff, mypy, ty, pyrefly, type checker, backend changes,
+  "run the backend tests", "why does the type check fail".
 ---
 
 # Python development in this repo
@@ -40,8 +41,12 @@ Run `pip install -e '.[dev]'` (or `make install`) once if the tools aren't impor
 ## 1. While writing code — clear the gates by construction
 
 The ruff rule set here is large (see `[tool.ruff.lint]` in `pyproject.toml`) and
-mypy runs in `strict` mode with `warn_unreachable`. The patterns that trip
-agents most often, and how to avoid them:
+**three** type checkers must all pass: `mypy` (strict, `warn_unreachable`), `ty`
+(Astral), and `pyrefly` (Meta) — configured under `[tool.mypy]`, `[tool.ty]`,
+and `[tool.pyrefly]`. They overlap but each catches things the others miss (e.g.
+pyrefly flags possibly-unbound locals, ty flags LSP-violating overrides), so
+write code that satisfies all three rather than the most lenient. The patterns
+that trip agents most often, and how to avoid them:
 
 - **Type everything.** Strict mypy means every function needs annotated params
   and return type; no implicit `Any`. Public modules ship types (`py.typed`).
@@ -60,9 +65,12 @@ agents most often, and how to avoid them:
 - **Comprehensions/simplify (`C4`/`SIM`/`RET`/`PERF`):** prefer the idiom ruff
   wants; when it flags, take the suggestion rather than `# noqa`.
 
-When you genuinely must suppress a rule, use a *scoped* `# noqa: <CODE>` with a
-reason — never a blanket ignore, and never edit `pyproject.toml` to disable a
-rule to make your code pass.
+When you genuinely must suppress a finding, scope it to the one tool and one
+rule, with a reason: ruff → `# noqa: <CODE>`, mypy → `# type: ignore[<code>]`,
+ty → `# ty: ignore[<rule>]`, pyrefly → `# pyrefly: ignore[<rule>]`. Prefer
+fixing the code over suppressing; reserve ignores for genuine third-party or
+tool limitations (e.g. ty mis-resolving psycopg's overloaded `connect`). Never a
+blanket ignore, and never edit `pyproject.toml` to disable a rule to pass.
 
 ## 2. Project guardrails (don't regress these)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,18 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: ty
+        name: ty
+        entry: ty check backend
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: pyrefly
+        name: pyrefly
+        entry: pyrefly check backend
+        language: system
+        types: [python]
+        pass_filenames: false
       - id: eslint
         name: eslint
         entry: npm run lint --silent
@@ -49,10 +61,39 @@ repos:
         files: \.(ts|tsx)$
         pass_filenames: false
 
-      # ── pre-push: run the test suites before code leaves the machine ───────
-      # These are deliberately on the `pre-push` stage, not `pre-commit`: tests
-      # are too slow to run on every commit, but must pass before a push.
+      # ── pre-push: full quality gate before code leaves the machine ─────────
+      # The linters/type-checkers also run on the pre-push stage (in addition to
+      # pre-commit) so a push is blocked even if some commits skipped hooks.
+      # Tests live here only — too slow for every commit.
       # Enable with: pre-commit install --hook-type pre-push
+      - id: ruff-push
+        name: ruff (pre-push)
+        entry: ruff check backend
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]
+      - id: mypy-push
+        name: mypy (pre-push)
+        entry: mypy backend
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]
+      - id: ty-push
+        name: ty (pre-push)
+        entry: ty check backend
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]
+      - id: pyrefly-push
+        name: pyrefly (pre-push)
+        entry: pyrefly check backend
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]
       - id: pytest
         name: pytest (backend)
         entry: pytest

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ format:
 ## typecheck: run static type checkers
 typecheck:
 	mypy backend
+	ty check backend
+	pyrefly check backend
 	npm run typecheck --silent
 
 ## test: run backend + frontend test suites

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -74,7 +74,7 @@ class _BodyExtractor(HTMLParser):
         self._chunks: list[str] = []
         self._current: list[str] = []
 
-    def handle_starttag(self, tag: str, _attrs: list[tuple[str, str | None]]) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: ARG002
         if self._skip_depth or tag in _SKIP_TAGS:
             self._skip_depth += 1
             return

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -315,7 +315,9 @@ def connect(
     database_url: str | None = None,
 ) -> Iterator[Any]:
     """Open a PostgreSQL connection using psycopg-native SQL and parameters."""
-    conn = psycopg.connect(active_database_url(database_url), row_factory=dict_row)
+    # ty mis-resolves psycopg's overloaded connect() and infers the default
+    # tuple row_factory; mypy and pyrefly both accept dict_row here.
+    conn = psycopg.connect(active_database_url(database_url), row_factory=dict_row)  # ty: ignore[invalid-argument-type]
     schema_token = _db_path or DB_PATH
     try:
         if schema_token is not None:

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -1212,6 +1212,7 @@ def transition_article_state(  # noqa: PLR0912
         if base is None:
             return None
 
+        uas: dict[str, Any] | None = None
         if user_id is not None:
             uas = _get_uas_row(conn, article_id, user_id)
             current_state = str((uas or {}).get("state") or "today")
@@ -1222,7 +1223,7 @@ def transition_article_state(  # noqa: PLR0912
 
         if current_state == new_state:
             if user_id is not None:
-                return _merge_uas(base, uas if "uas" in dir() else None)
+                return _merge_uas(base, uas)
             return base
 
         if (current_state, new_state) not in _ALLOWED_TRANSITIONS:
@@ -1347,6 +1348,7 @@ def send_article_later(
         if base is None:
             return None
 
+        uas: dict[str, Any] | None = None
         if user_id is not None:
             uas = _get_uas_row(conn, article_id, user_id)
             current_state = str((uas or {}).get("state") or "today")

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -50,7 +50,7 @@ class _SimpleHTTPHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(self.__class__.html)
 
-    def log_message(self, *args: object) -> None:
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
         pass
 
 

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -54,7 +54,8 @@ def _make_user(pg_url: str, username: str) -> int:
             (username, "x"),
         ).fetchone()
         conn.commit()
-    return int(row[0])  # type: ignore[index]
+    assert row is not None
+    return int(row[0])
 
 
 def _add_global_source(pg_url: str, slug: str) -> None:
@@ -107,7 +108,8 @@ def _add_article(pg_url: str, *, source_slug: str, url_suffix: str = "1") -> int
             ),
         ).fetchone()
         conn.commit()
-    return int(row[0])  # type: ignore[index]
+    assert row is not None
+    return int(row[0])
 
 
 def _api_client(uid: int, username: str = "user") -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dev = [
   "httpx>=0.27.0",
   "ruff>=0.8.0",
   "mypy>=1.13.0",
+  "ty>=0.0.49",
+  "pyrefly>=1.1.0",
   "pre-commit>=4.0.0",
   "testcontainers[postgres]>=4.8.0",
 ]
@@ -138,3 +140,20 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disallow_untyped_decorators = false
+
+# ── ty (Astral type checker) ─────────────────────────────────────────────────
+[tool.ty.environment]
+# Resolve the `news_dashboard` package from backend/, mirroring mypy's
+# files=["backend"] and pytest's pythonpath=["backend"]. Without this, ty falls
+# back to whatever editable install is on sys.path (possibly a stale worktree).
+python-version = "3.14"
+extra-paths = ["backend"]
+
+[tool.ty.src]
+include = ["backend"]
+
+# ── pyrefly (Meta type checker) ──────────────────────────────────────────────
+[tool.pyrefly]
+python-version = "3.14"
+project-includes = ["backend"]
+search-path = ["backend"]


### PR DESCRIPTION
## What & why

Adds Astral's **ty** and Meta's **pyrefly** alongside the existing **mypy**, and fixes the genuine issues they surfaced so the backend is clean under all three. Builds on the enforcement gates from #175.

Each checker catches things the others miss — pyrefly flagged a possibly-unbound local that mypy and ruff both passed; ty flagged LSP-violating method overrides. Running all three raises the reliability bar.

## Tooling
- `ty` + `pyrefly` added to dev deps, with `[tool.ty]` / `[tool.pyrefly]` config pinned to resolve `news_dashboard` from `backend/` (mirrors mypy's `files=["backend"]`) so module resolution is deterministic regardless of editable-install state.
- `make typecheck` now runs mypy + ty + pyrefly.
- pre-commit: ty + pyrefly run on the **pre-commit** stage; ruff/mypy/ty/pyrefly also gate the **pre-push** stage alongside the test suites.

## Code fixes (found by ty/pyrefly, missed by mypy)
- **ingest.py** — initialize `uas` before the `user_id` branch in two functions so it can't be possibly-unbound; removes the `"uas" in dir()` hack (pyrefly `unbound-name`). Behavior-preserving.
- **body_fetch.py / test_body_fetch.py** — align overridden `HTMLParser` / `BaseHTTPRequestHandler` method signatures with their base classes (ty `invalid-method-override` / LSP).
- **test_postgres_types.py** — assert `fetchone()` is not `None` before subscripting (ty `not-subscriptable`); drops the now-unneeded `# type: ignore`.
- **db.py** — scoped `# ty: ignore` for psycopg's overloaded `connect()`, which ty mis-resolves but mypy and pyrefly accept.

## Verification
- `ruff`, `ruff format`, `mypy`, `ty`, `pyrefly` all clean locally (verified in a fresh venv with dev deps).
- ⚠️ Backend `pytest` could **not** run locally — the suite needs PostgreSQL via Docker, which wasn't available in this environment. Relying on CI to run the test suite. Changes are minimal and behavior-preserving.

## Notes
- `uv.lock` not regenerated (uv not available locally); `make install` uses pip and picks up the new deps. Worth a `uv lock` follow-up.
- A stray remote branch `chore/dev-skills-and-gates` (same single commit) is left over from a branch-name reshuffle — safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)