### PR TITLE
[codex] generate briefings from current-day news

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.coverage
 .venv/
 node_modules/
 frontend/dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,7 @@
 - Do not add SQLite runtime fallbacks, database-type sniffing, placeholder translation layers, or generic multi-database SQL.
 - `DATABASE_URL` must point to PostgreSQL, or the app must be configured with `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.
 - SQLite may appear only in legacy import/migration tooling that reads an old SQLite database and writes into PostgreSQL.
+
+## Git Workflow
+
+- Do not use `git push --no-verify` when pushing changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,6 @@
 
 ## Git Workflow
 
+- Before starting work, fetch and rebase on `origin/main`.
+- Keep working branches fast-forwardable with `origin/main`; resolve divergence by rebasing rather than merging.
 - Do not use `git push --no-verify` when pushing changes.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# News Dashboard
+
+News Dashboard is a private personal news reader that collects curated technical news, supports triage, and generates AI briefings over the user's news corpus.
+
+## Language
+
+**Article**:
+A news item discovered from a subscribed source.
+_Avoid_: Feed item, story
+
+**Workflow State**:
+The user's triage position for an article, such as today, later, done, skipped, or archived. Workflow State does not decide whether an article belongs to the day's news corpus.
+_Avoid_: Read status, started status
+
+**Today Feed**:
+The user's active triage queue for articles currently meant to be reviewed.
+_Avoid_: Current-day news, all news
+
+**Current-Day Report**:
+A generated briefing that summarizes all news discovered in the current-day window from the user's available sources, regardless of Workflow State.
+_Avoid_: Since-last-briefing report, Today-only briefing, inbox-only briefing
+
+**Source Subscription**:
+The set of news sources available to a user.
+_Avoid_: Feed filter, source state

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -18,6 +18,7 @@ from .db import connect, row_to_dict
 CANDIDATE_LIMIT = 40
 DEFAULT_BRIEFING_MODEL = "gpt-4o-mini"
 IDEMPOTENCY_WINDOW_MINUTES = 10
+CURRENT_DAY_SCOPE = "current_day"
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +62,9 @@ _CITED_ARTICLES_SQL = """
 _CANDIDATES_SQL = """
     SELECT id, title, url, source_name, category, summary, importance_score, discovered_at
     FROM articles
-    WHERE state = 'today'
-      AND discovered_at::timestamptz >= %s
+    WHERE discovered_at::timestamptz >= %s
+      AND discovered_at::timestamptz < %s
+      AND (canonical_id IS NULL OR state != 'archived')
     ORDER BY importance_score DESC NULLS LAST, discovered_at DESC
     LIMIT %s
 """
@@ -74,8 +76,9 @@ _CANDIDATES_SQL_USER = """
     LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = %s
     LEFT JOIN sources src ON src.slug = a.source_slug
     LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
-    WHERE COALESCE(uas.state, 'today') = 'today'
-      AND a.discovered_at::timestamptz >= %s
+    WHERE a.discovered_at::timestamptz >= %s
+      AND a.discovered_at::timestamptz < %s
+      AND (a.canonical_id IS NULL OR a.state != 'archived')
       AND (
         (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE) IS TRUE)
         OR src.owner_user_id = %s
@@ -137,6 +140,11 @@ def _get_since_at(
             # fallback: parse ISO string
             return datetime.fromisoformat(str(val))
     return datetime.now(timezone.utc) - timedelta(hours=24)
+
+
+def _current_day_since_at(until_at: datetime) -> datetime:
+    """Return the current-day briefing lower bound using the app's rolling 24-hour convention."""
+    return until_at - timedelta(hours=24)
 
 
 def _call_openai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
@@ -249,7 +257,7 @@ def _save_briefing(
             RETURNING id
             """,
             (
-                "since_last_briefing",
+                CURRENT_DAY_SCOPE,
                 since_at,
                 until_at,
                 "complete",
@@ -350,7 +358,7 @@ def _save_failed_briefing(
                 INSERT INTO briefings(scope, since_at, until_at, status, model, error, user_id)
                 VALUES (%s, %s, %s, %s, %s, %s, %s)
                 """,
-                ("since_last_briefing", since_at, until_at, "failed", model, str(exc), user_id),
+                (CURRENT_DAY_SCOPE, since_at, until_at, "failed", model, str(exc), user_id),
             )
     except Exception:
         logger.exception("Failed to persist failed-briefing row — original error follows")
@@ -361,21 +369,27 @@ def _save_failed_briefing(
 
 def select_candidates(
     since_at: datetime,
+    until_at: datetime | None = None,
     database_url: str | None = None,
     user_id: int | None = None,
 ) -> list[dict[str, Any]]:
-    """Return up to CANDIDATE_LIMIT today-state articles discovered after since_at.
+    """Return up to CANDIDATE_LIMIT current-day articles discovered within the window.
 
-    When user_id is provided, selects only articles from the user's subscribed sources
-    that are in the 'today' state for that user (via user_article_state).
+    Workflow state is intentionally ignored so generated reports can include news
+    the user has already opened, starred, postponed, skipped, or marked done.
+    When user_id is provided, source subscriptions still scope the article pool.
     """
+    resolved_until_at = until_at if until_at is not None else datetime.now(timezone.utc)
     with connect(database_url=database_url) as conn:
         if user_id is not None:
             rows = conn.execute(
-                _CANDIDATES_SQL_USER, (user_id, user_id, since_at, user_id, CANDIDATE_LIMIT)
+                _CANDIDATES_SQL_USER,
+                (user_id, user_id, since_at, resolved_until_at, user_id, CANDIDATE_LIMIT),
             ).fetchall()
         else:
-            rows = conn.execute(_CANDIDATES_SQL, (since_at, CANDIDATE_LIMIT)).fetchall()
+            rows = conn.execute(
+                _CANDIDATES_SQL, (since_at, resolved_until_at, CANDIDATE_LIMIT)
+            ).fetchall()
         return [row_to_dict(r) for r in rows]
 
 
@@ -405,10 +419,12 @@ def generate_briefing(
 
     _env_model = os.getenv("OPENAI_BRIEFING_MODEL", DEFAULT_BRIEFING_MODEL)
     resolved_model = model if model is not None else _env_model
-    since_at = _get_since_at(database_url, user_id=user_id)
     until_at = datetime.now(timezone.utc)
+    since_at = _current_day_since_at(until_at)
 
-    candidates = select_candidates(since_at, database_url=database_url, user_id=user_id)
+    candidates = select_candidates(
+        since_at, until_at=until_at, database_url=database_url, user_id=user_id
+    )
     if not candidates:
         return {"status": "no_candidates"}
 

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -15,6 +15,7 @@ from typing import Any
 import psycopg
 import pytest
 
+import news_dashboard.briefings as briefings_mod
 from news_dashboard.briefings import (
     CANDIDATE_LIMIT,
     IDEMPOTENCY_WINDOW_MINUTES,
@@ -42,6 +43,20 @@ def _seed_source(pg_url: str, slug: str = "test-source") -> None:
             """,
             (slug, "Test Source", f"https://example.com/{slug}", "tech", "rss_feed"),
         )
+
+
+def _seed_user(pg_url: str, username: str = "briefing-user") -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO users(username, password_hash)
+            VALUES (%s, %s)
+            RETURNING id
+            """,
+            (username, "hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
 
 
 def _seed_article(
@@ -86,12 +101,25 @@ def _seed_article(
     return int(row["id"])
 
 
+def _set_user_article_state(pg_url: str, user_id: int, article_id: int, state: str) -> None:
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state)
+            VALUES (%s, %s, %s)
+            ON CONFLICT(user_id, article_id) DO UPDATE SET state = excluded.state
+            """,
+            (user_id, article_id, state),
+        )
+
+
 def _seed_briefing(
     pg_url: str,
     *,
     title: str = "Test Brief",
     content: dict[str, Any] | None = None,
     created_at: str | None = None,
+    until_at: str = "2026-06-13T00:00:00+00:00",
 ) -> int:
     _content = content or {"sections": [], "worth_opening": []}
     extra_cols = ""
@@ -117,7 +145,7 @@ def _seed_briefing(
                 "complete",
                 "since_last_briefing",
                 "2026-06-12T00:00:00+00:00",
-                "2026-06-13T00:00:00+00:00",
+                until_at,
                 "claude-sonnet-4-6",
                 *extra_vals,
             ),
@@ -422,18 +450,118 @@ def test_get_since_at_uses_most_recent_briefing(pg_clean: str) -> None:
 # ── select_candidates ─────────────────────────────────────────────────────────
 
 
-def test_select_candidates_returns_only_today_articles(pg_clean: str) -> None:
+class _FakeCursor:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _FakeBriefingConn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    def __enter__(self) -> _FakeBriefingConn:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple[object, ...]) -> _FakeCursor:
+        self.calls.append((query, params))
+        return _FakeCursor(self.rows)
+
+
+def test_select_candidates_sql_ignores_global_workflow_state(monkeypatch: Any) -> None:
+    since_at = datetime(2026, 6, 17, 0, 0, tzinfo=timezone.utc)
+    until_at = datetime(2026, 6, 18, 0, 0, tzinfo=timezone.utc)
+    fake_conn = _FakeBriefingConn(
+        [{"id": 1, "title": "Done article", "importance_score": 90, "discovered_at": since_at}]
+    )
+
+    def _connect(**_: object) -> _FakeBriefingConn:
+        return fake_conn
+
+    monkeypatch.setattr(briefings_mod, "connect", _connect)
+
+    candidates = select_candidates(since_at, until_at=until_at, database_url="postgresql://test")
+
+    query, params = fake_conn.calls[0]
+    assert "state = 'today'" not in query
+    assert "discovered_at::timestamptz >= %s" in query
+    assert "discovered_at::timestamptz < %s" in query
+    assert params == (since_at, until_at, CANDIDATE_LIMIT)
+    assert candidates[0]["title"] == "Done article"
+
+
+def test_select_candidates_sql_ignores_user_workflow_state(monkeypatch: Any) -> None:
+    since_at = datetime(2026, 6, 17, 0, 0, tzinfo=timezone.utc)
+    until_at = datetime(2026, 6, 18, 0, 0, tzinfo=timezone.utc)
+    fake_conn = _FakeBriefingConn(
+        [
+            {
+                "id": 2,
+                "title": "User skipped article",
+                "importance_score": 80,
+                "discovered_at": since_at,
+            }
+        ]
+    )
+
+    def _connect(**_: object) -> _FakeBriefingConn:
+        return fake_conn
+
+    monkeypatch.setattr(briefings_mod, "connect", _connect)
+
+    candidates = select_candidates(
+        since_at,
+        until_at=until_at,
+        database_url="postgresql://test",
+        user_id=7,
+    )
+
+    query, params = fake_conn.calls[0]
+    assert "COALESCE(uas.state, 'today') = 'today'" not in query
+    assert "LEFT JOIN user_article_state" in query
+    assert params == (7, 7, since_at, until_at, 7, CANDIDATE_LIMIT)
+    assert candidates[0]["title"] == "User skipped article"
+
+
+def test_select_candidates_returns_current_day_articles_regardless_workflow_state(
+    pg_clean: str,
+) -> None:
     _seed_source(pg_clean)
     since_at = datetime.now(timezone.utc) - timedelta(hours=1)
     _seed_article(pg_clean, url="https://example.com/today-1", title="Today 1", state="today")
     _seed_article(pg_clean, url="https://example.com/later-1", title="Later 1", state="later")
-    _seed_article(pg_clean, url="https://example.com/new-1", title="New 1", state="new")
+    _seed_article(pg_clean, url="https://example.com/done-1", title="Done 1", state="done")
+    _seed_article(pg_clean, url="https://example.com/skipped-1", title="Skipped 1", state="skipped")
 
     candidates = select_candidates(since_at, database_url=pg_clean)
     titles = [a["title"] for a in candidates]
     assert "Today 1" in titles
-    assert "Later 1" not in titles
-    assert "New 1" not in titles
+    assert "Later 1" in titles
+    assert "Done 1" in titles
+    assert "Skipped 1" in titles
+
+
+def test_select_candidates_for_user_ignores_user_workflow_state(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    user_id = _seed_user(pg_clean)
+    since_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    article_id = _seed_article(
+        pg_clean,
+        url="https://example.com/user-done-1",
+        title="User Done 1",
+        state="today",
+    )
+    _set_user_article_state(pg_clean, user_id, article_id, "done")
+
+    candidates = select_candidates(since_at, database_url=pg_clean, user_id=user_id)
+
+    assert [a["title"] for a in candidates] == ["User Done 1"]
 
 
 def test_select_candidates_filters_by_since_at(pg_clean: str) -> None:
@@ -564,9 +692,33 @@ def test_generate_briefing_creates_briefing_row(pg_clean: str) -> None:
     assert result["title"] == "Fake Briefing"
     assert result["summary"] == "A fake summary."
     assert result["status"] == "complete"
-    assert result["scope"] == "since_last_briefing"
+    assert result["scope"] == "current_day"
     assert result["since_at"] is not None
     assert result["until_at"] is not None
+
+
+def test_generate_briefing_uses_current_day_window_not_previous_briefing_until(
+    pg_clean: str,
+) -> None:
+    _seed_source(pg_clean)
+    future_until_at = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+    _seed_briefing(pg_clean, until_at=future_until_at)
+    article_id = _seed_article(
+        pg_clean,
+        url="https://example.com/current-day-after-previous",
+        title="Current Day After Previous",
+        state="done",
+        discovered_at=(datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(),
+    )
+
+    result = generate_briefing(
+        database_url=pg_clean,
+        ai_fn=_fake_ai,
+        idempotency_window_minutes=0,
+    )
+
+    assert result["scope"] == "current_day"
+    assert {a["id"] for a in result["articles"]} == {article_id}
 
 
 def test_generate_briefing_links_section_citations(pg_clean: str) -> None:

--- a/docs/superpowers/specs/2026-06-13-saved-briefings-mobile-home-design.md
+++ b/docs/superpowers/specs/2026-06-13-saved-briefings-mobile-home-design.md
@@ -9,7 +9,7 @@ The next improvement should make the app more useful on a phone. The selected di
 ## Goals
 
 - Make the default mobile entry point a saved AI briefing, not a raw article queue.
-- Generate briefings from new inbox articles so the app is useful before triage.
+- Generate briefings from current-day source articles so the app stays useful even after triage.
 - Save each generated briefing as a durable artifact with timestamp, scope, content, and cited source articles.
 - Keep the current Today feed and article workflow intact.
 - Make citations lead directly into the existing article reader.
@@ -55,7 +55,7 @@ Add a `briefings` table:
 
 - `id`: primary key.
 - `created_at`: generation timestamp.
-- `scope`: text scope identifier, initially `since_last_briefing`.
+- `scope`: text scope identifier, initially `current_day`.
 - `since_at`: lower bound for considered article discovery time.
 - `until_at`: upper bound for considered article discovery time.
 - `status`: `complete` or `failed`.
@@ -100,10 +100,11 @@ Add briefing endpoints:
 
 `POST /api/briefings` behavior:
 
-- Select candidate articles from the Today/new inbox only.
-- Use `since_at` from the previous briefing's `until_at`; if no previous briefing exists, use the last 24 hours.
+- Select candidate articles from the current-day report corpus, not the Today Feed.
+- Use a current-day window rather than the previous briefing's `until_at`.
 - Set `until_at` to generation time.
-- Exclude archived, skipped, done, and later articles.
+- Include articles regardless of Workflow State, so already-opened, starred, done, skipped, and later articles still contribute to the report.
+- Keep source subscription scoping for the current user.
 - Cap candidates to 40 articles, ordered by importance score and recency.
 - Require AI configuration. Missing `OPENAI_API_KEY` or disabled AI should return a clear configured-state error.
 - Validate generated JSON before saving.
@@ -155,7 +156,7 @@ Backend tests:
 
 - Briefing tables initialize correctly.
 - Latest briefing returns an empty state when no saved brief exists.
-- Candidate selection includes only eligible new inbox articles in the time window.
+- Candidate selection includes eligible current-day articles in the time window regardless of Workflow State.
 - Generated briefing saves JSON content and article join rows.
 - Invalid generated citations are rejected or removed.
 - Missing AI configuration returns a clear error.
@@ -182,5 +183,5 @@ Implement without removing existing feed workflows:
 
 ## Fixed Defaults
 
-- The first briefing uses a 24-hour initial window.
+- Briefing generation uses the app's current-day window.
 - Briefing generation considers at most 40 candidate articles.

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -102,7 +102,8 @@ export function BriefPage() {
           <Newspaper className="size-10 text-subtle mb-3" strokeWidth={1.25} />
           <div className="text-sm font-medium text-foreground">No articles to brief</div>
           <div className="text-xs mt-1 max-w-xs">
-            No new articles in the Today feed. Check back after your next ingest.
+            No articles were discovered in the current-day window. Check back after your next
+            ingest.
           </div>
         </div>
         <div className="flex justify-center">


### PR DESCRIPTION
## Summary
- Generate manual briefings from the current-day article window instead of only untouched Today feed candidates.
- Keep source subscription scoping while ignoring per-user workflow state so done/later/skipped articles can still appear in the report.
- Document the Current-Day Report language, add push guardrails, and ignore local .coverage output.

## Validation
- pytest backend/tests/test_briefings_db.py backend/tests/test_briefings_api.py
- ruff check backend
- ruff format --check backend
- mypy backend
- ty check backend
- pyrefly check backend
- npm run lint --silent
- npm run format:check
- npm run typecheck
- npm run test:frontend --silent
- npm run build --silent

## Notes
- Full backend pytest requires a configured PostgreSQL DSN locally; without DATABASE_URL or POSTGRES_HOST it fails at database setup.