### PR TITLE
perf(triage): stop refetching the full article list on every triage action

### DIFF
--- a/frontend/src/__tests__/useTriageMutations.test.tsx
+++ b/frontend/src/__tests__/useTriageMutations.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement } from 'react';
 import { toast } from 'sonner';
@@ -194,5 +194,37 @@ describe('useTriageMutations — undo calls the API to revert server state', () 
     });
 
     expect(queryClient.getQueryData([ARTICLES_KEY, 'today'])).toEqual([]);
+  });
+});
+
+describe('useTriageMutations — settles caches without a full article refetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    patchArticleStatePromise = Promise.resolve({});
+  });
+
+  it('marks article lists stale without refetching and refreshes summary counts', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    const article = makeArticle({ state: 'today' });
+
+    await act(async () => {
+      result.current.setState(article, 'done', 'Marked as read');
+      await patchArticleStatePromise;
+    });
+
+    // Article lists are marked stale but NOT refetched (refetchType: 'none'),
+    // so a triage click never triggers a full list round-trip to the backend.
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: [ARTICLES_KEY],
+        refetchType: 'none',
+      });
+    });
+    // Summary counts aren't derivable from the cache, so they still refetch.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['summary'] });
+    // No invalidation ever forces an immediate article-list refetch.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: [ARTICLES_KEY] });
   });
 });

--- a/frontend/src/hooks/useTriageMutations.ts
+++ b/frontend/src/hooks/useTriageMutations.ts
@@ -81,6 +81,22 @@ function restoreToCache(queryClient: ReturnType<typeof useQueryClient>, article:
   });
 }
 
+/**
+ * Settle the caches after a triage action resolves (success, error, or undo).
+ *
+ * The optimistic `applyPatchToCache`/`restoreQuerySnapshots` already left every
+ * state-filtered article list correct, and the triage endpoints (`/state`,
+ * `/star`, `/later`) have no cross-article side effects — so refetching the full
+ * article list on every click only adds a network round-trip and risks a
+ * flicker/reorder on a remote backend. Mark the lists stale *without* an
+ * immediate refetch (they refresh lazily on the next mount) and only refetch the
+ * cheap summary counts, which aren't derivable from the cache.
+ */
+function settleArticleCaches(queryClient: ReturnType<typeof useQueryClient>) {
+  void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY], refetchType: 'none' });
+  void queryClient.invalidateQueries({ queryKey: ['summary'] });
+}
+
 // ─── Hook ───────────────────────────────────────────────────────────────────
 
 export function useTriageMutations() {
@@ -114,8 +130,7 @@ export function useTriageMutations() {
     },
 
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY] });
-      void queryClient.invalidateQueries({ queryKey: ['summary'] });
+      settleArticleCaches(queryClient);
     },
   });
 
@@ -141,8 +156,7 @@ export function useTriageMutations() {
     },
 
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY] });
-      void queryClient.invalidateQueries({ queryKey: ['summary'] });
+      settleArticleCaches(queryClient);
     },
   });
 
@@ -167,7 +181,7 @@ export function useTriageMutations() {
     },
 
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY] });
+      settleArticleCaches(queryClient);
     },
   });
 
@@ -186,8 +200,7 @@ export function useTriageMutations() {
           restoreQuerySnapshots(queryClient, querySnapshots);
           void patchArticleState(snap.article.id, snap.article.state, snap.article.starred).then(
             () => {
-              void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY] });
-              void queryClient.invalidateQueries({ queryKey: ['summary'] });
+              settleArticleCaches(queryClient);
             }
           );
         },
@@ -206,8 +219,7 @@ export function useTriageMutations() {
         onClick: () => {
           restoreQuerySnapshots(queryClient, querySnapshots);
           void patchArticleStar(snap.article.id, snap.article.starred).then(() => {
-            void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY] });
-            void queryClient.invalidateQueries({ queryKey: ['summary'] });
+            settleArticleCaches(queryClient);
           });
         },
       },
@@ -225,8 +237,7 @@ export function useTriageMutations() {
           restoreQuerySnapshots(queryClient, querySnapshots);
           void patchArticleState(snap.article.id, snap.article.state, snap.article.starred).then(
             () => {
-              void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY] });
-              void queryClient.invalidateQueries({ queryKey: ['summary'] });
+              settleArticleCaches(queryClient);
             }
           );
         },


### PR DESCRIPTION
## Problem

Clicking **read / skip / star / snooze** on the news list feels slow on the deployed app.

The interactions are *already* optimistic — [#177](https://github.com/ioachim-hub/news-dashboard/pull/177) made `applyPatchToCache` remove an article from any state-filtered list it no longer belongs to, so the row leaves on the click frame. But every action still fired a **full refetch of the entire article list** in `onSettled`:

```ts
onSettled: () => {
  void queryClient.invalidateQueries({ queryKey: [ARTICLES_KEY] }); // full list refetch, every click
  void queryClient.invalidateQueries({ queryKey: ['summary'] });
}
```

On a remote backend that's a network round-trip per interaction, and when triaging quickly it's a refetch storm that can flicker/reorder the list a beat after the row leaves.

## Change

The triage endpoints (`/state`, `/star`, `/later`) have **no cross-article side effects** (`done` only schedules a background embed of that same article), so the optimistic cache is already correct after `onMutate`. Every settle/undo path now goes through one `settleArticleCaches` helper that:

- marks the article lists **stale without an immediate refetch** (`refetchType: 'none'`) — they refresh lazily on the next mount, and
- still refetches the **cheap summary counts**, which aren't derivable from the cache.

Net effect: triage interactions are instant *and* no longer hit the backend for a full list on every click.

## Notes

- Builds on top of #177 (which is on `main` but not yet on the deployed branch).
- Error path is unaffected: `restoreQuerySnapshots` already restores the exact pre-mutation cache, so no forced refetch is needed there.

## Test plan

- [x] `npm run lint` (max-warnings 0)
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run test:frontend` — 203 passed, incl. new test asserting article lists are marked stale with `refetchType: 'none'` and summary still refetches
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)