### PR TITLE
perf: GIN full-text search, column pruning, composite indexes, init_db cache, memo(ArticleRow)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from hashlib import sha256
@@ -17,6 +18,8 @@ POSTGRES_PREFIXES = ("postgres:" + "//", "postgresql:" + "//")
 DB_PATH: Path | None = None
 
 logger = logging.getLogger(__name__)
+_INIT_DB_LOCK = threading.Lock()
+_INITIALIZED_DATABASES: set[tuple[str, str | None, str]] = set()
 
 POSTGRES_SCHEMA = [
     """
@@ -136,6 +139,18 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body_status TEXT NOT NULL DEFAULT 'missing'",
+    """
+    ALTER TABLE articles ADD COLUMN IF NOT EXISTS search_vector tsvector
+      GENERATED ALWAYS AS (
+        to_tsvector(
+          'english',
+          coalesce(title, '') || ' ' || coalesce(summary, '') || ' ' ||
+          coalesce(reason, '') || ' ' || coalesce(tags, '') || ' ' ||
+          coalesce(source_name, '') || ' ' || coalesce(body, '')
+        )
+      ) STORED
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_articles_search ON articles USING gin(search_vector)",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS state TEXT NOT NULL DEFAULT 'today'",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS starred BOOLEAN NOT NULL DEFAULT FALSE",
     """
@@ -179,6 +194,19 @@ POSTGRES_SCHEMA = [
     ),
     "CREATE INDEX IF NOT EXISTS idx_articles_state ON articles(state)",
     "CREATE INDEX IF NOT EXISTS idx_articles_starred ON articles(starred)",
+    """
+    CREATE INDEX IF NOT EXISTS idx_articles_state_discovered_id
+      ON articles(state, discovered_at DESC, id DESC)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_articles_category_discovered_id
+      ON articles(category, discovered_at DESC, id DESC)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_articles_visible_discovered_id
+      ON articles(discovered_at DESC, id DESC)
+      WHERE canonical_id IS NULL
+    """,
     """
     CREATE INDEX IF NOT EXISTS idx_ingest_run_sources_source_run
       ON ingest_run_sources(source_name, run_id DESC)
@@ -269,6 +297,10 @@ POSTGRES_MULTIUSER_SCHEMA = [
         " ON user_article_state(user_id, starred) WHERE starred = TRUE"
     ),
     "CREATE INDEX IF NOT EXISTS idx_uas_article_id ON user_article_state(article_id)",
+    """
+    CREATE INDEX IF NOT EXISTS idx_uas_user_state_article
+      ON user_article_state(user_id, state, article_id)
+    """,
 ]
 
 
@@ -334,14 +366,43 @@ def connect(
 
 
 def init_db(_db_path: Path | None = None, database_url: str | None = None) -> None:
+    schema_fingerprint = sha256(
+        "\0".join(POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA).encode("utf-8")
+    ).hexdigest()
+    env_key = (
+        database_url
+        or os.getenv("DATABASE_URL")
+        or "|".join(
+            (
+                os.getenv("POSTGRES_HOST", ""),
+                os.getenv("POSTGRES_PORT", ""),
+                os.getenv("POSTGRES_DB", ""),
+                os.getenv("POSTGRES_USER", ""),
+            )
+        )
+    )
+    cache_key = (
+        str(_db_path or DB_PATH or ""),
+        env_key,
+        schema_fingerprint,
+    )
+    with _INIT_DB_LOCK:
+        if cache_key in _INITIALIZED_DATABASES:
+            return
+
     # Each statement runs in its own transaction so a harmless idempotency
     # failure does not leave later schema statements in an aborted transaction.
+    applied = 0
     for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
         try:
             with connect(_db_path, database_url=database_url) as conn:
                 conn.execute(statement)
+                applied += 1
         except Exception:  # idempotent best-effort schema statements
             logger.debug("Schema statement skipped (already applied): %.80s", statement)
+    if applied > 0:
+        with _INIT_DB_LOCK:
+            _INITIALIZED_DATABASES.add(cache_key)
 
 
 def _schema_name(token: Path) -> str:

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -616,7 +616,31 @@ def ingest_all(db_path: Path | None = None) -> dict[str, int]:
     return results
 
 
-_INTERNAL_ARTICLE_COLUMNS = frozenset({"embedding", "fts_vector"})
+_INTERNAL_ARTICLE_COLUMNS = frozenset({"embedding", "fts_vector", "search_vector"})
+_ARTICLE_LIST_COLUMNS = (
+    "id, url, canonical_url, canonical_id, title, source_slug, source_name,"
+    " category, kind, published_at, discovered_at, status, importance_score,"
+    " summary, reason, tags, read_at, saved_at, skipped_at, archived_at,"
+    " updated_at, body_status, state, starred, done_at, starred_at, later_until, restored_at"
+)
+
+
+def _article_list_select(alias: str | None = None) -> str:
+    if alias is None:
+        return _ARTICLE_LIST_COLUMNS
+    return ", ".join(f"{alias}.{column.strip()}" for column in _ARTICLE_LIST_COLUMNS.split(","))
+
+
+def _search_tsquery(value: str) -> str | None:
+    tokens = [
+        token.lower()
+        for token in re.findall(r"[A-Za-z0-9]+", value)
+        if len(token) >= 2 and not token.isdigit()
+    ]
+    if not tokens:
+        return None
+    return " & ".join(f"{token}:*" for token in tokens)
+
 
 # UAS columns that override article-level state when a user_id is provided
 _UAS_STATE_COLUMNS = frozenset(
@@ -812,7 +836,7 @@ def list_articles(  # noqa: PLR0913
     with connect(db_path) as conn:
         rows = conn.execute(
             (
-                f"SELECT * FROM articles {where}"
+                f"SELECT {_article_list_select()} FROM articles {where}"
                 " ORDER BY discovered_at DESC, id DESC LIMIT %s OFFSET %s"
             ),
             params,
@@ -883,7 +907,7 @@ def _list_articles_for_user(  # noqa: PLR0913
     all_params: list[object] = [user_id, user_id, *where_params, user_id, limit, offset]
 
     sql = f"""
-        SELECT a.*,
+        SELECT {_article_list_select("a")},
           COALESCE(uas.state, 'today') AS _uas_state,
           COALESCE(uas.starred, false)  AS _uas_starred,
           uas.done_at     AS _uas_done_at,
@@ -957,7 +981,7 @@ def search_articles(  # noqa: PLR0913
     user_id: int | None = None,
 ) -> list[dict[str, Any]]:
     init_db(db_path)
-    terms = [t for t in q.split() if len(t) >= 2]
+    tsquery = _search_tsquery(q)
     now_ts = now_iso()
 
     if user_id is not None:
@@ -978,14 +1002,10 @@ def search_articles(  # noqa: PLR0913
     clauses: list[str] = []
     params: list[Any] = []
 
-    # Full-text search across title, summary, reason, tags, source_name, body
-    for term in terms:
-        like = f"%{term}%"
-        clauses.append(
-            "(title ILIKE %s OR summary ILIKE %s OR reason ILIKE %s OR tags ILIKE %s"
-            " OR source_name ILIKE %s OR (body IS NOT NULL AND body ILIKE %s))"
-        )
-        params.extend([like, like, like, like, like, like])
+    # Full-text search across title, summary, reason, tags, source name, and cached body.
+    if tsquery:
+        clauses.append("search_vector @@ to_tsquery('english', %s)")
+        params.append(tsquery)
 
     # Archived exclusion — must come before state filter to avoid conflict
     if not include_archived:
@@ -1031,7 +1051,7 @@ def search_articles(  # noqa: PLR0913
     params.append(limit)
 
     sql = (
-        f"SELECT * FROM articles {where}"
+        f"SELECT {_article_list_select()} FROM articles {where}"
         " ORDER BY importance_score DESC, discovered_at DESC LIMIT %s"
     )
 
@@ -1054,17 +1074,13 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     date_range: str,
     now_ts: str,
 ) -> list[dict[str, Any]]:
-    terms = [t for t in q.split() if len(t) >= 2]
+    tsquery = _search_tsquery(q)
     clauses: list[str] = []
     where_params: list[Any] = []  # params only for WHERE predicates
 
-    for term in terms:
-        like = f"%{term}%"
-        clauses.append(
-            "(a.title ILIKE %s OR a.summary ILIKE %s OR a.reason ILIKE %s OR a.tags ILIKE %s"
-            " OR a.source_name ILIKE %s OR (a.body IS NOT NULL AND a.body ILIKE %s))"
-        )
-        where_params.extend([like, like, like, like, like, like])
+    if tsquery:
+        clauses.append("a.search_vector @@ to_tsquery('english', %s)")
+        where_params.append(tsquery)
 
     if not include_archived:
         clauses.append("COALESCE(uas.state, 'today') != 'archived'")
@@ -1114,7 +1130,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     all_params: list[Any] = [user_id, user_id, *where_params, user_id, limit]
 
     sql = f"""
-        SELECT a.*,
+        SELECT {_article_list_select("a")},
           COALESCE(uas.state, 'today') AS _uas_state,
           COALESCE(uas.starred, false)  AS _uas_starred,
           uas.done_at     AS _uas_done_at,

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -51,9 +51,28 @@ def list_source_health(db_path: Path | None = None) -> list[dict[str, Any]]:
         ).fetchall()
         run_rows = conn.execute(
             """
+            WITH ordered AS (
+              SELECT
+                source_name,
+                articles_new,
+                error_message,
+                ROW_NUMBER() OVER source_order AS row_number,
+                COUNT(*) FILTER (
+                  WHERE error_message IS NULL OR error_message = ''
+                ) OVER (
+                  PARTITION BY source_name
+                  ORDER BY run_id DESC, id DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                ) AS successes_before
+              FROM ingest_run_sources
+              WINDOW source_order AS (
+                PARTITION BY source_name ORDER BY run_id DESC, id DESC
+              )
+            )
             SELECT source_name, articles_new, error_message
-            FROM ingest_run_sources
-            ORDER BY run_id DESC, id DESC
+            FROM ordered
+            WHERE row_number = 1 OR COALESCE(successes_before, 0) = 0
+            ORDER BY source_name, row_number
             """
         ).fetchall()
 

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -107,3 +107,33 @@ def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> N
     assert len(connect_calls) == 3, "expected one connect() call per statement"
     for per_call in statements_per_call:
         assert len(per_call) == 1, "each connection must execute exactly one statement"
+
+
+def test_init_db_postgres_caches_successful_schema_runs(tmp_path: Any) -> None:
+    """Repeated hot-path init_db() calls should not replay every schema statement."""
+    connect_calls: list[str] = []
+
+    @contextmanager
+    def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
+        connect_calls.append("open")
+
+        class _Conn:
+            def execute(self, sql: str, params: Any = None) -> None:  # noqa: ARG002
+                return None
+
+        yield _Conn()
+
+    fake_schema = ["CREATE TABLE cache_test_a", "CREATE TABLE cache_test_b"]
+
+    with (
+        patch("news_dashboard.db.connect", fake_connect),
+        patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
+        patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+    ):
+        from news_dashboard.db import init_db
+
+        token = tmp_path / "cache-test.db"
+        init_db(token)
+        init_db(token)
+
+    assert len(connect_calls) == len(fake_schema)

--- a/backend/tests/test_search_filters.py
+++ b/backend/tests/test_search_filters.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from news_dashboard.db import connect, init_db
-from news_dashboard.ingest import search_articles, sync_sources
+from news_dashboard.ingest import list_articles, search_articles, sync_sources
 from news_dashboard.main import app
 
 
@@ -108,6 +108,22 @@ def test_search_by_body(db: Path) -> None:
     results = search_articles("pydantic", db_path=db)
     assert any(r["title"] == "Deep Dive" for r in results)
     assert all(r["title"] != "Other Article" for r in results)
+
+
+def test_search_results_omit_cached_body_payload(db: Path) -> None:
+    _insert(db, title="Deep Dive", body="The full text discusses pydantic validation in detail")
+    results = search_articles("pydantic", db_path=db)
+    article = next(r for r in results if r["title"] == "Deep Dive")
+    assert "body" not in article
+    assert article["body_status"] == "missing"
+
+
+def test_list_articles_omits_cached_body_payload(db: Path) -> None:
+    _insert(db, title="Deep Dive", body="Large cached article body")
+    articles = list_articles(db_path=db)
+    article = next(r for r in articles if r["title"] == "Deep Dive")
+    assert "body" not in article
+    assert article["body_status"] == "missing"
 
 
 def test_no_query_returns_empty_without_filters(db: Path) -> None:

--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Link } from 'react-router-dom';
 import { Star } from 'lucide-react';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
@@ -12,7 +13,7 @@ interface Props {
   showLaterUntil?: boolean;
 }
 
-export function ArticleRow({ article, focused, showLaterUntil }: Props) {
+function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
   const { setState, toggleStar } = useTriageMutations();
 
   const handleDone = () => setState(article, 'done', 'Read');
@@ -69,3 +70,5 @@ export function ArticleRow({ article, focused, showLaterUntil }: Props) {
     </SwipeableRow>
   );
 }
+
+export const ArticleRow = memo(ArticleRowComponent);


### PR DESCRIPTION
## Summary

- **GIN full-text search** — adds a `search_vector GENERATED ALWAYS AS` tsvector column (title + summary + reason + tags + source_name + body) with a GIN index; replaces the previous 6× ILIKE-per-term loop with a single `to_tsquery` prefix-match query
- **Column pruning** — introduces `_article_list_select()` so list and search endpoints never fetch the `body` column (large cached article text not needed for list views)
- **Composite indexes** — `(state, discovered_at DESC, id DESC)`, `(category, discovered_at DESC, id DESC)`, partial index on visible articles `(canonical_id IS NULL)`, and a covering index on `user_article_state(user_id, state, article_id)` for multi-user list queries
- **`init_db` caching** — fingerprints the schema by SHA-256 hash and skips re-applying all schema statements on hot-path calls; thread-safe via a module-level lock + set
- **`source_health` query** — replaces a full-table scan with a window-function CTE that returns only the most recent row + current error streak per source
- **`React.memo(ArticleRow)`** — skips re-renders when article props are unchanged during triage

## Test plan

- [ ] `make lint` — passes (ruff + prettier)
- [ ] `make typecheck` — passes (mypy strict + ty + pyrefly + tsc)
- [ ] `make test` with Docker/Postgres — new tests in `test_db_init.py` (init_db cache) and `test_search_filters.py` (body omitted from list/search results) cover the key behaviors; existing search filter tests cover the tsquery path end-to-end
- [ ] Triage actions feel snappier (no full-list refetch after each action)
- [ ] Search results load faster on large datasets (GIN vs sequential ILIKE scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)