### PR TITLE
fix(briefings): pass user_id when re-reading briefing after insert

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -302,7 +302,7 @@ def _save_briefing(
                     (briefing_id, aid),
                 )
 
-    result = get_briefing(briefing_id, database_url=database_url)
+    result = get_briefing(briefing_id, database_url=database_url, user_id=user_id)
     if result is None:
         msg = f"Could not re-read briefing {briefing_id} after insert"
         raise BriefingGenerationError(msg)
@@ -339,7 +339,7 @@ def _find_recent_briefing(
             ).fetchone()
     if row is None:
         return None
-    return get_briefing(int(row_to_dict(row)["id"]), database_url=database_url)
+    return get_briefing(int(row_to_dict(row)["id"]), database_url=database_url, user_id=user_id)
 
 
 def _save_failed_briefing(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,11 +17,35 @@ session behaviour should clear ``app.dependency_overrides`` themselves.
 from __future__ import annotations
 
 import os
+import subprocess
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 
 from news_dashboard.db import init_db
+
+# Load .env from the main repo root so tests can run without manually exporting
+# DATABASE_URL. Works in both regular checkouts and git worktrees.
+# setdefault means CI-provided env vars always take precedence.
+try:
+    _git_common = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    _repo_root = Path(_git_common).parent
+    if not _repo_root.is_absolute():
+        _repo_root = (Path.cwd() / _repo_root).resolve()
+    _env_file = _repo_root / ".env"
+    if _env_file.exists():
+        for _line in _env_file.read_text().splitlines():
+            if _line and not _line.startswith("#") and "=" in _line:
+                _key, _, _val = _line.partition("=")
+                os.environ.setdefault(_key.strip(), _val.strip())
+except Exception:  # noqa: S110
+    pass
 
 # Ensure SESSION_SECRET is set for all tests so auth module can load.
 os.environ.setdefault("TEST_SESSION_SECRET", "test-secret-key-not-for-production")

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -69,19 +69,17 @@ def _seed_article(
     state: str = "new",
     discovered_at: str | None = None,
 ) -> int:
-    extra_cols = ""
-    extra_vals: tuple[object, ...] = ()
-    if discovered_at is not None:
-        extra_cols = ", discovered_at"
-        extra_vals = (discovered_at,)
+    # Use a Python-computed timestamp so discovered_at is always behind any
+    # subsequent datetime.now() call even when Docker's clock is slightly ahead.
+    ts = discovered_at or (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
     with connect(database_url=pg_url) as conn:
         row = conn.execute(
-            f"""
+            """
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, importance_score, state{extra_cols}
+              category, kind, importance_score, state, discovered_at
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s{", %s" if discovered_at else ""})
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -94,7 +92,7 @@ def _seed_article(
                 "rss_feed",
                 importance_score,
                 state,
-                *extra_vals,
+                ts,
             ),
         ).fetchone()
     assert row is not None
@@ -122,20 +120,17 @@ def _seed_briefing(
     until_at: str = "2026-06-13T00:00:00+00:00",
 ) -> int:
     _content = content or {"sections": [], "worth_opening": []}
-    extra_cols = ""
-    extra_vals: tuple[object, ...] = ()
-    if created_at:
-        extra_cols = ", created_at"
-        extra_vals = (created_at,)
+    # Always set created_at from Python's clock so it's behind any subsequent
+    # datetime.now() call even when Docker's clock is slightly ahead.
+    ts = created_at or (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
 
     with connect(database_url=pg_url) as conn:
         row = conn.execute(
-            f"""
+            """
             INSERT INTO briefings(
-              title, summary, content, status, scope, since_at, until_at, model
-              {extra_cols}
+              title, summary, content, status, scope, since_at, until_at, model, created_at
             )
-            VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s, %s{", %s" if created_at else ""})
+            VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -147,7 +142,7 @@ def _seed_briefing(
                 "2026-06-12T00:00:00+00:00",
                 until_at,
                 "claude-sonnet-4-6",
-                *extra_vals,
+                ts,
             ),
         ).fetchone()
     assert row is not None

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -866,6 +866,28 @@ def test_generate_briefing_skips_idempotency_when_window_is_zero(pg_clean: str) 
     assert len(list_briefings(database_url=pg_clean)) == 2  # old + new
 
 
+def test_generate_briefing_with_user_id_succeeds_on_reread(pg_clean: str) -> None:
+    """Regression: _save_briefing must pass user_id to get_briefing after insert.
+
+    Briefings owned by a user have a non-NULL user_id column, so get_briefing
+    with user_id=None (the previous bug) silently returned None and raised
+    "Could not re-read briefing N after insert".
+    """
+    _seed_source(pg_clean)
+    user_id = _seed_user(pg_clean, username="reread-user")
+    _seed_article(
+        pg_clean,
+        url="https://example.com/user-reread-a1",
+        title="User Article 1",
+        state="today",
+    )
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai, user_id=user_id)
+
+    assert result["title"] == "Fake Briefing"
+    assert result["status"] == "complete"
+
+
 def test_generate_briefing_ignores_failed_rows_in_idempotency_check(pg_clean: str) -> None:
     _seed_source(pg_clean)
     a1 = _seed_article(pg_clean, url="https://example.com/h1", title="H1", state="today")


### PR DESCRIPTION
## Summary

- **Root cause:** `_save_briefing` called `get_briefing(briefing_id)` without `user_id`, so the query used `AND user_id IS NULL` and returned `None` for any user-owned briefing, raising `"Could not re-read briefing N after insert"`. Same bug in `_find_recent_briefing`.
- **Fix:** Pass `user_id=user_id` in both call sites (`briefings.py` lines 305 and 342).
- **Test fixes:** Two `test_briefings_db.py` seed helpers (`_seed_article`, `_seed_briefing`) used Postgres `CURRENT_TIMESTAMP` as the default timestamp — when Docker's clock is slightly ahead of the host, this caused freshly-seeded rows to appear *after* Python's `datetime.now()`, silently emptying time-window query results. Both helpers now use a Python-computed timestamp so the seeded time is always behind any subsequent `datetime.now()`.
- **conftest improvement:** `conftest.py` now auto-loads `.env` from the repo root (works in worktrees too via `git rev-parse --git-common-dir`), so `pytest` and the pre-push hook find `DATABASE_URL` without requiring `source .env` each session.

## Test plan

- [ ] `make lint typecheck` — clean
- [ ] `pytest` (320/320 pass, no `source .env` needed)
- [ ] Pre-push hook runs all gates including `pytest (backend)` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)