### PR TITLE
feat(tts): Listen button + POST /api/articles/:id/audio

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -20,7 +20,7 @@ from fastapi import (
     Response,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse, StreamingResponse
+from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -392,6 +392,25 @@ def fetch_article_body(
     if not article:
         raise HTTPException(status_code=404, detail="article not found")
     return article
+
+
+@api.post("/api/articles/{article_id}/audio")
+def article_audio(
+    article_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> FileResponse:
+    from .tts import TTSNotConfiguredError, generate_audio
+
+    article = get_article(article_id, user_id=current_user["id"])
+    if not article:
+        raise HTTPException(status_code=404, detail="article not found")
+    try:
+        path = generate_audio(article_id, article)
+    except TTSNotConfiguredError as exc:
+        raise HTTPException(status_code=501, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return FileResponse(path, media_type="audio/mpeg", filename=f"article-{article_id}.mp3")
 
 
 @api.patch("/api/articles/{article_id}/status")

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -1,0 +1,83 @@
+"""Text-to-Speech generation for articles using the OpenAI TTS API.
+
+Generates MP3 audio for an article and caches it at
+DATA_DIR/audio/<article_id>.mp3.  Subsequent calls return the cached file
+without hitting the API again.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DATA_DIR = Path("/data")
+_VOICE = "alloy"
+_MODEL = "tts-1"
+_MAX_CHARS = 4096
+
+
+class TTSNotConfiguredError(Exception):
+    """Raised when OPENAI_API_KEY is not set."""
+
+
+def _data_dir() -> Path:
+    return Path(os.getenv("DATA_DIR", str(_DEFAULT_DATA_DIR)))
+
+
+def _audio_path(article_id: int, data_dir: Path | None = None) -> Path:
+    base = data_dir if data_dir is not None else _data_dir()
+    return base / "audio" / f"{article_id}.mp3"
+
+
+def _build_text(article: dict[str, Any]) -> str:
+    title = str(article.get("title") or "")
+    body = str(article.get("body") or "")
+    summary = str(article.get("summary") or "")
+    # Prefer full body; fall back to summary when body is absent or too short.
+    content = body if len(body) > len(summary) else summary
+    text = f"{title}.\n\n{content}" if title else content
+    return text[:_MAX_CHARS]
+
+
+def generate_audio(
+    article_id: int,
+    article: dict[str, Any],
+    data_dir: Path | None = None,
+) -> Path:
+    """Return path to cached MP3, generating it via OpenAI TTS if needed.
+
+    Raises TTSNotConfiguredError when OPENAI_API_KEY is absent.
+    Raises RuntimeError on API failure.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = "OPENAI_API_KEY is not configured"
+        raise TTSNotConfiguredError(msg)
+
+    path = _audio_path(article_id, data_dir)
+
+    if path.exists():
+        logger.debug("TTS cache hit for article %d", article_id)
+        return path
+
+    text = _build_text(article)
+    if not text.strip():
+        msg = "article has no readable text"
+        raise ValueError(msg)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    from openai import OpenAI  # lazy import — optional dep at import time
+
+    client = OpenAI(api_key=api_key)
+    logger.info("Generating TTS audio for article %d (%d chars)", article_id, len(text))
+    with client.audio.speech.with_streaming_response.create(
+        model=_MODEL, voice=_VOICE, input=text
+    ) as response:
+        response.stream_to_file(path)
+    logger.info("TTS audio cached at %s", path)
+    return path

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -1,0 +1,168 @@
+"""Unit tests for news_dashboard.tts.
+
+All OpenAI calls are mocked so these run without a live API key or network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.tts import TTSNotConfiguredError, _build_text, generate_audio
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+_ARTICLE: dict[str, Any] = {
+    "id": 42,
+    "title": "Test Article Title",
+    "body": "This is the full article body text.",
+    "summary": "Short summary.",
+}
+
+_ARTICLE_NO_BODY: dict[str, Any] = {
+    "id": 43,
+    "title": "No Body Article",
+    "body": None,
+    "summary": "Only a summary here.",
+}
+
+_ARTICLE_EMPTY: dict[str, Any] = {
+    "id": 44,
+    "title": "",
+    "body": None,
+    "summary": "",
+}
+
+
+# ── _build_text ───────────────────────────────────────────────────────────────
+
+
+def test_build_text_prefers_body_over_summary() -> None:
+    text = _build_text(_ARTICLE)
+    assert "full article body text" in text
+    assert "Short summary" not in text
+
+
+def test_build_text_falls_back_to_summary_when_no_body() -> None:
+    text = _build_text(_ARTICLE_NO_BODY)
+    assert "Only a summary here" in text
+
+
+def test_build_text_includes_title() -> None:
+    text = _build_text(_ARTICLE)
+    assert "Test Article Title" in text
+
+
+def test_build_text_truncates_to_max_chars() -> None:
+    long_article = {
+        "id": 1,
+        "title": "T",
+        "body": "x" * 10_000,
+        "summary": "",
+    }
+    text = _build_text(long_article)
+    assert len(text) <= 4096
+
+
+# ── generate_audio — no API key ───────────────────────────────────────────────
+
+
+def test_generate_audio_raises_when_no_api_key(tmp_path: Path) -> None:
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("OPENAI_API_KEY", None)
+        with pytest.raises(TTSNotConfiguredError):
+            generate_audio(42, _ARTICLE, data_dir=tmp_path)
+
+
+# ── generate_audio — cache miss (calls API) ───────────────────────────────────
+
+
+def test_generate_audio_calls_openai_and_writes_file(tmp_path: Path) -> None:
+    mock_response = MagicMock()
+
+    def fake_stream(path: Path) -> None:
+        path.write_bytes(b"fake-mp3-data")
+
+    mock_response.stream_to_file.side_effect = fake_stream
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.audio.speech.with_streaming_response.create.return_value = mock_response
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        path = generate_audio(42, _ARTICLE, data_dir=tmp_path)
+
+    assert path.exists()
+    assert path.read_bytes() == b"fake-mp3-data"
+    mock_client.audio.speech.with_streaming_response.create.assert_called_once()
+    call_kwargs = mock_client.audio.speech.with_streaming_response.create.call_args
+    assert call_kwargs.kwargs["model"] == "tts-1"
+    assert call_kwargs.kwargs["voice"] == "alloy"
+    assert "Test Article Title" in call_kwargs.kwargs["input"]
+
+
+# ── generate_audio — cache hit (skips API) ────────────────────────────────────
+
+
+def test_generate_audio_returns_cached_file_without_api_call(tmp_path: Path) -> None:
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    cached = audio_dir / "42.mp3"
+    cached.write_bytes(b"cached-mp3")
+
+    mock_client = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        path = generate_audio(42, _ARTICLE, data_dir=tmp_path)
+
+    assert path == cached
+    mock_client.audio.speech.with_streaming_response.create.assert_not_called()
+
+
+# ── generate_audio — empty article ────────────────────────────────────────────
+
+
+def test_generate_audio_raises_for_empty_article(tmp_path: Path) -> None:
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        pytest.raises(ValueError, match="no readable text"),
+    ):
+        generate_audio(44, _ARTICLE_EMPTY, data_dir=tmp_path)
+
+
+# ── generate_audio — creates audio directory if needed ───────────────────────
+
+
+def test_generate_audio_creates_audio_directory(tmp_path: Path) -> None:
+    mock_response = MagicMock()
+
+    def fake_stream(path: Path) -> None:
+        path.write_bytes(b"mp3")
+
+    mock_response.stream_to_file.side_effect = fake_stream
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    mock_client = MagicMock()
+    mock_client.audio.speech.with_streaming_response.create.return_value = mock_response
+
+    data_dir = tmp_path / "nonexistent"
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        path = generate_audio(42, _ARTICLE, data_dir=data_dir)
+
+    assert path.parent.is_dir()
+    assert path.exists()

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -86,7 +86,7 @@ describe('ArticlePage — rendering', () => {
     await waitFor(() => expect(screen.getByText('Back')).toBeTruthy());
   });
 
-  it('shows action bar with Star, Done, Later, Skip, Archive', async () => {
+  it('shows action bar with Star, Done, Later, Skip, Archive, Listen', async () => {
     renderReader();
     await waitFor(() => {
       expect(screen.getByText('Star')).toBeTruthy();
@@ -94,6 +94,7 @@ describe('ArticlePage — rendering', () => {
       expect(screen.getByText('Later')).toBeTruthy();
       expect(screen.getByText('Skip')).toBeTruthy();
       expect(screen.getByText('Archive')).toBeTruthy();
+      expect(screen.getByText('Listen')).toBeTruthy();
     });
   });
 });
@@ -190,12 +191,21 @@ describe('ArticlePage — touch gesture state', () => {
     // retained after the animation ends.
     renderReader();
     await waitFor(() => screen.getByText('Test Article Title'));
-    // All five action buttons must be present in the DOM.
+    // All six action buttons must be present in the DOM.
     expect(screen.getByRole('button', { name: /star/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /done/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /later/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /skip/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /archive/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /listen/i })).toBeTruthy();
+  });
+
+  it('listen button is accessible and enabled when article is loaded', async () => {
+    vi.spyOn(api, 'fetchArticleAudioUrl').mockResolvedValue('blob:fake');
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    const btn = screen.getByRole('button', { name: /listen/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('touchcancel on the article content resets swipe state without navigating', async () => {
@@ -219,5 +229,53 @@ describe('ArticlePage — touch gesture state', () => {
     fireEvent.touchStart(contentDiv, { touches: [{ clientX: 0, clientY: 0 }] });
     fireEvent.touchEnd(contentDiv);
     // No navigation error thrown = pass (MemoryRouter absorbs navigate calls).
+  });
+});
+
+// ─── TTS / Listen button ──────────────────────────────────────────────────────
+
+describe('ArticlePage — Listen / TTS', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full article text.' })
+    );
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full article text.' })
+    );
+  });
+
+  it('shows Listen button in idle state', async () => {
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    expect(screen.getByText('Listen')).toBeTruthy();
+  });
+
+  it('shows loading state while audio is being fetched', async () => {
+    let resolveAudio!: (url: string) => void;
+    vi.spyOn(api, 'fetchArticleAudioUrl').mockReturnValue(
+      new Promise<string>((res) => {
+        resolveAudio = res;
+      })
+    );
+
+    renderReader();
+    await waitFor(() => screen.getByText('Listen'));
+    await userEvent.click(screen.getByText('Listen'));
+
+    await waitFor(() => expect(screen.getByText('Loading…')).toBeTruthy());
+    const btn = screen.getByRole('button', { name: /loading/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+
+    resolveAudio('blob:fake');
+  });
+
+  it('shows error toast when audio fetch fails', async () => {
+    vi.spyOn(api, 'fetchArticleAudioUrl').mockRejectedValue(new Error('501 Not Implemented'));
+
+    renderReader();
+    await waitFor(() => screen.getByText('Listen'));
+    await userEvent.click(screen.getByText('Listen'));
+
+    await waitFor(() => expect(screen.getByText('Listen')).toBeTruthy());
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -63,6 +63,18 @@ export async function fetchArticleBody(id: number | string): Promise<Article> {
   return requestJson<Article>(`/api/articles/${id}/body`, { method: 'POST' });
 }
 
+export async function fetchArticleAudioUrl(id: number | string): Promise<string> {
+  const response = await fetch(`/api/articles/${id}/audio`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}
+
 export async function fetchSources(): Promise<Source[]> {
   const data = await requestJson<{ items: Source[] }>('/api/sources');
   return data.items;

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -13,9 +13,11 @@ import {
   Archive,
   AlertCircle,
   Loader2,
+  Volume2,
+  Square,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { fetchArticle, fetchArticleBody } from '@/api';
+import { fetchArticle, fetchArticleBody, fetchArticleAudioUrl } from '@/api';
 import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflowApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { formatDate, signalLabel } from '@/lib/format';
@@ -198,6 +200,61 @@ export function ArticlePage() {
     } catch {
       toast.error('Action failed');
     }
+  }
+
+  // TTS audio player
+  type AudioState = 'idle' | 'loading' | 'playing' | 'paused';
+  const [audioState, setAudioState] = useState<AudioState>('idle');
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioUrlRef = useRef<string | null>(null);
+
+  const audioMutation = useMutation({
+    mutationFn: () => fetchArticleAudioUrl(id!),
+    onSuccess: (url) => {
+      audioUrlRef.current = url;
+      const audio = new Audio(url);
+      audioRef.current = audio;
+      audio.onended = () => setAudioState('paused');
+      audio.onerror = () => {
+        toast.error('Audio playback failed');
+        setAudioState('idle');
+      };
+      void audio.play();
+      setAudioState('playing');
+    },
+    onError: () => {
+      toast.error('Could not load audio');
+      setAudioState('idle');
+    },
+  });
+
+  useEffect(() => {
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
+      }
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current);
+        audioUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  function handleListen() {
+    if (audioState === 'loading') return;
+    if (audioState === 'playing') {
+      audioRef.current?.pause();
+      setAudioState('paused');
+      return;
+    }
+    if (audioState === 'paused' && audioRef.current) {
+      void audioRef.current.play();
+      setAudioState('playing');
+      return;
+    }
+    setAudioState('loading');
+    audioMutation.mutate();
   }
 
   // Touch swipe
@@ -388,7 +445,7 @@ export function ArticlePage() {
 
       {/* Action bar */}
       <div className="fixed bottom-0 inset-x-0 z-20 border-t border-border bg-background/95 backdrop-blur pb-[env(safe-area-inset-bottom)]">
-        <div className="mx-auto max-w-2xl grid grid-cols-5 gap-1 p-2">
+        <div className="mx-auto max-w-2xl grid grid-cols-6 gap-1 p-2">
           <ActionBtn
             onClick={() => void doStar()}
             icon={Star}
@@ -407,6 +464,20 @@ export function ArticlePage() {
             onClick={() => void doAction('archived', 'Archived')}
             icon={Archive}
             label="Archive"
+          />
+          <ActionBtn
+            onClick={handleListen}
+            icon={audioState === 'loading' ? Loader2 : audioState === 'playing' ? Square : Volume2}
+            label={
+              audioState === 'loading'
+                ? 'Loading…'
+                : audioState === 'playing'
+                  ? 'Stop'
+                  : audioState === 'paused'
+                    ? 'Resume'
+                    : 'Listen'
+            }
+            disabled={audioState === 'loading'}
           />
         </div>
       </div>


### PR DESCRIPTION
Closes #185.

## Summary

- **Backend** — new `tts.py` module + `POST /api/articles/{article_id}/audio` route
  - Calls OpenAI `tts-1` / `alloy` voice; caches MP3 at `DATA_DIR/audio/<id>.mp3`
  - Returns cached file immediately on repeat requests (no API round-trip)
  - Returns `501` when `OPENAI_API_KEY` is absent (`TTSNotConfiguredError`)
  - Returns `404` if article not found; `422` if article has no readable text
- **Frontend** — sixth button in ArticlePage action bar: **Listen → Loading… → Stop → Resume**
  - Fetches audio via `POST /api/articles/:id/audio`, converts to object URL, plays in hidden `<audio>` element
  - Cleans up on unmount (pause + `URL.revokeObjectURL`)
  - Error toast on 501 (no key configured) or network failure

## Tests

- 9 backend unit tests (`test_tts.py`): cache hit/miss, empty article guard, directory creation, API key check, OpenAI call shape
- 4 new frontend tests in `articleReader.test.tsx`: Listen button renders, shows spinner while loading, disabled during load, returns to idle on error

## Test plan

- [x] `make lint typecheck` — clean
- [x] `source .env && make test` — 332 backend tests passed
- [x] `npm run lint typecheck test:frontend build` — 207 frontend tests passed, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)