### PR TITLE
feat(ux): reading time estimate on article page

### DIFF
--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -99,6 +99,38 @@ describe('ArticlePage — rendering', () => {
   });
 });
 
+// ─── Reading time ─────────────────────────────────────────────────────────────
+
+describe('ArticlePage — reading time', () => {
+  it('shows "X min read" when body is loaded', async () => {
+    // 400 words → 2 min read
+    const body = Array(400).fill('word').join(' ');
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(makeArticle({ body_status: 'ok', body }));
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(makeArticle({ body_status: 'ok', body }));
+
+    renderReader('42', makeArticle({ body_status: 'ok', body }));
+    await waitFor(() => expect(screen.getByText('2 min read')).toBeTruthy());
+  });
+
+  it('does not show reading time when body is not yet loaded', async () => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(makeArticle({ body_status: 'missing' }));
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(makeArticle({ body_status: 'missing' }));
+
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    expect(screen.queryByText(/min read/)).toBeNull();
+  });
+
+  it('shows minimum 1 min read for very short bodies', async () => {
+    const body = 'Short.';
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(makeArticle({ body_status: 'ok', body }));
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(makeArticle({ body_status: 'ok', body }));
+
+    renderReader('42', makeArticle({ body_status: 'ok', body }));
+    await waitFor(() => expect(screen.getByText('1 min read')).toBeTruthy());
+  });
+});
+
 // ─── Body fetch on open ───────────────────────────────────────────────────────
 
 describe('ArticlePage — body fetch', () => {

--- a/frontend/src/__tests__/readingTime.test.ts
+++ b/frontend/src/__tests__/readingTime.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readingTime } from '../lib/format';
+
+describe('readingTime', () => {
+  it('returns 1 for empty string', () => {
+    expect(readingTime('')).toBe(1);
+  });
+
+  it('returns 1 for whitespace-only string', () => {
+    expect(readingTime('   \n  ')).toBe(1);
+  });
+
+  it('returns 1 for a single word', () => {
+    expect(readingTime('Hello')).toBe(1);
+  });
+
+  it('returns 1 for 200 words', () => {
+    const text = Array(200).fill('word').join(' ');
+    expect(readingTime(text)).toBe(1);
+  });
+
+  it('rounds up: 201 words → 2 min', () => {
+    const text = Array(201).fill('word').join(' ');
+    expect(readingTime(text)).toBe(2);
+  });
+
+  it('returns 4 for 800 words', () => {
+    const text = Array(800).fill('word').join(' ');
+    expect(readingTime(text)).toBe(4);
+  });
+
+  it('rounds up: 201 words with extra whitespace and newlines', () => {
+    const text = Array(201).fill('word').join('\n  ');
+    expect(readingTime(text)).toBe(2);
+  });
+
+  it('handles a realistic article snippet', () => {
+    // 50 words — rounds up to 1
+    const text = 'The quick brown fox jumps over the lazy dog. '.repeat(10).trimEnd();
+    expect(readingTime(text)).toBe(1);
+  });
+});

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -53,6 +53,11 @@ export function formatInteger(value: number): string {
   return new Intl.NumberFormat().format(value);
 }
 
+export function readingTime(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words / 200));
+}
+
 export function relativeCountdown(isoStr: string | null): string {
   if (!isoStr) return '—';
   const ms = new Date(isoStr).getTime() - Date.now();

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -20,7 +20,7 @@ import { toast } from 'sonner';
 import { fetchArticle, fetchArticleBody, fetchArticleAudioUrl } from '@/api';
 import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflowApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
-import { formatDate, signalLabel } from '@/lib/format';
+import { formatDate, readingTime, signalLabel } from '@/lib/format';
 import { getReaderList } from '@/lib/readerList';
 import { cn } from '@/lib/utils';
 
@@ -400,6 +400,14 @@ export function ArticlePage() {
           <h1 className="mt-3 text-[26px] md:text-[30px] font-semibold tracking-tight leading-tight">
             {article.title}
           </h1>
+
+          {/* Reading time — only shown once body is available */}
+          {article.bodyStatus === 'ok' && article.body && (
+            <div className="mt-2 flex items-center gap-1 text-[12px] text-muted-foreground">
+              <Clock className="size-3.5" strokeWidth={1.75} />
+              <span>{readingTime(article.body)} min read</span>
+            </div>
+          )}
 
           {/* Why this matters */}
           <div className="mt-4 rounded-lg border-l-2 border-accent bg-surface/60 px-4 py-3">


### PR DESCRIPTION
Closes #187.

## Summary

- New `readingTime(text: string): number` util in `format.ts` — `ceil(words / 200)`, minimum 1
- ArticlePage shows `<Clock /> X min read` between the title and "Why this matters" block
- Only rendered when `body_status === 'ok'` and body is non-null; hidden while loading or on error

## Tests

- 8 unit tests in `readingTime.test.ts`: empty string, whitespace-only, single word, exact 200 words, 201 words rounds up, 800 words, multiline whitespace, realistic snippet
- 3 component tests in `articleReader.test.tsx`: correct value rendered, hidden while body pending, minimum 1 min for short bodies

## Test plan

- [x] `make lint typecheck` — clean
- [x] `npm run test:frontend` — 218 tests passed
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)