### PR TITLE
fix(article): keep action bar viewport-fixed during slide-in animation

### DIFF
--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -181,6 +181,29 @@ describe('ArticlePage — body fetch', () => {
   });
 });
 
+// ─── Action bar viewport-fixed ───────────────────────────────────────────────
+
+describe('ArticlePage — action bar', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Text' })
+    );
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Text' })
+    );
+  });
+
+  it('renders the action bar', async () => {
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    // The action bar element must be present in the DOM.  It lives outside the
+    // motion-slide-in-right animated wrapper so position:fixed always resolves
+    // against the viewport rather than against an ancestor that carries a CSS
+    // transform during the 0.2 s entry animation (fixes #189).
+    expect(screen.getByTestId('action-bar')).toBeTruthy();
+  });
+});
+
 // ─── Back navigation ──────────────────────────────────────────────────────────
 
 describe('ArticlePage — back navigation', () => {

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -315,144 +315,155 @@ export function ArticlePage() {
     bodyMutation.isPending || (article.bodyStatus === 'missing' && bodyMutation.isIdle);
 
   return (
-    <div className="min-h-screen bg-background flex flex-col motion-slide-in-right">
-      {/* Sticky header */}
-      <header className="sticky top-0 z-20 border-b border-border bg-background/90 backdrop-blur">
-        <div className="mx-auto max-w-2xl flex h-12 items-center justify-between px-3">
-          <button
-            onClick={goBack}
-            className="inline-flex items-center gap-1 px-2 py-1 -ml-1 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-surface"
-          >
-            <ChevronLeft className="size-4" /> Back
-          </button>
-          <div className="flex items-center gap-1">
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* Header + scrollable content slide in together.  The action bar is a
+          sibling outside this wrapper so its position:fixed always resolves
+          against the viewport, even while the entry transform is active. */}
+      <div className="flex-1 flex flex-col motion-slide-in-right">
+        {/* Sticky header */}
+        <header className="sticky top-0 z-20 border-b border-border bg-background/90 backdrop-blur">
+          <div className="mx-auto max-w-2xl flex h-12 items-center justify-between px-3">
             <button
-              onClick={goPrev}
-              disabled={!prevId}
-              className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface disabled:opacity-30"
-              aria-label="Previous article"
+              onClick={goBack}
+              className="inline-flex items-center gap-1 px-2 py-1 -ml-1 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-surface"
             >
-              <ChevronLeft className="size-4" />
+              <ChevronLeft className="size-4" /> Back
             </button>
-            <button
-              onClick={goNext}
-              disabled={!nextId}
-              className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface disabled:opacity-30"
-              aria-label="Next article"
-            >
-              <ChevronRight className="size-4" />
-            </button>
-            <a
-              href={article.url}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface"
-              aria-label="Open original"
-            >
-              <ExternalLink className="size-4" />
-            </a>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={goPrev}
+                disabled={!prevId}
+                className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface disabled:opacity-30"
+                aria-label="Previous article"
+              >
+                <ChevronLeft className="size-4" />
+              </button>
+              <button
+                onClick={goNext}
+                disabled={!nextId}
+                className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface disabled:opacity-30"
+                aria-label="Next article"
+              >
+                <ChevronRight className="size-4" />
+              </button>
+              <a
+                href={article.url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface"
+                aria-label="Open original"
+              >
+                <ExternalLink className="size-4" />
+              </a>
+            </div>
           </div>
-        </div>
-      </header>
+        </header>
 
-      {/* Article content */}
-      <div
-        className="flex-1 pb-32 overflow-x-hidden"
-        onTouchStart={(e) => {
-          swipeRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-        }}
-        onTouchMove={(e) => {
-          if (!swipeRef.current) return;
-          const dx = e.touches[0].clientX - swipeRef.current.x;
-          const dy = Math.abs(e.touches[0].clientY - swipeRef.current.y);
-          if (dy < 40) setSwipeDx(dx);
-        }}
-        onTouchEnd={() => {
-          if (swipeDx < -80) goNext();
-          else if (swipeDx > 80) goPrev();
-          setSwipeDx(0);
-          swipeRef.current = null;
-        }}
-        onTouchCancel={() => {
-          swipeRef.current = null;
-          setSwipeDx(0);
-        }}
-      >
-        <article
-          className="mx-auto max-w-2xl px-5 pt-6"
-          style={{
-            transform: `translateX(${swipeDx * 0.3}px)`,
-            transition: swipeDx ? 'none' : 'transform 0.2s ease',
+        {/* Article content */}
+        <div
+          className="flex-1 pb-32 overflow-x-hidden"
+          onTouchStart={(e) => {
+            swipeRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+          }}
+          onTouchMove={(e) => {
+            if (!swipeRef.current) return;
+            const dx = e.touches[0].clientX - swipeRef.current.x;
+            const dy = Math.abs(e.touches[0].clientY - swipeRef.current.y);
+            if (dy < 40) setSwipeDx(dx);
+          }}
+          onTouchEnd={() => {
+            if (swipeDx < -80) goNext();
+            else if (swipeDx > 80) goPrev();
+            setSwipeDx(0);
+            swipeRef.current = null;
+          }}
+          onTouchCancel={() => {
+            swipeRef.current = null;
+            setSwipeDx(0);
           }}
         >
-          {/* Meta line */}
-          <div className="text-[11px] text-subtle flex items-center gap-1.5 flex-wrap">
-            <span className="font-medium text-muted-foreground">{article.sourceName}</span>
-            <span>·</span>
-            <span>{article.category}</span>
-            <span>·</span>
-            <span>{formatDate(article.publishedAt)}</span>
-            <span>·</span>
-            <span className={cn('font-medium', signalColor)}>{signalLabel(article.signal)}</span>
-          </div>
-
-          {/* Title */}
-          <h1 className="mt-3 text-[26px] md:text-[30px] font-semibold tracking-tight leading-tight">
-            {article.title}
-          </h1>
-
-          {/* Reading time — only shown once body is available */}
-          {article.bodyStatus === 'ok' && article.body && (
-            <div className="mt-2 flex items-center gap-1 text-[12px] text-muted-foreground">
-              <Clock className="size-3.5" strokeWidth={1.75} />
-              <span>{readingTime(article.body)} min read</span>
+          <article
+            className="mx-auto max-w-2xl px-5 pt-6"
+            style={{
+              transform: `translateX(${swipeDx * 0.3}px)`,
+              transition: swipeDx ? 'none' : 'transform 0.2s ease',
+            }}
+          >
+            {/* Meta line */}
+            <div className="text-[11px] text-subtle flex items-center gap-1.5 flex-wrap">
+              <span className="font-medium text-muted-foreground">{article.sourceName}</span>
+              <span>·</span>
+              <span>{article.category}</span>
+              <span>·</span>
+              <span>{formatDate(article.publishedAt)}</span>
+              <span>·</span>
+              <span className={cn('font-medium', signalColor)}>{signalLabel(article.signal)}</span>
             </div>
-          )}
 
-          {/* Why this matters */}
-          <div className="mt-4 rounded-lg border-l-2 border-accent bg-surface/60 px-4 py-3">
-            <div className="text-[10px] font-medium uppercase tracking-wider text-subtle mb-1">
-              Why this matters
-            </div>
-            <p className="text-[14px] leading-snug text-foreground">{article.reason}</p>
-          </div>
+            {/* Title */}
+            <h1 className="mt-3 text-[26px] md:text-[30px] font-semibold tracking-tight leading-tight">
+              {article.title}
+            </h1>
 
-          {/* Body */}
-          <div className="mt-8">
-            {bodyLoading ? (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground py-12">
-                <Loader2 className="size-4 animate-spin" /> Loading article…
+            {/* Reading time — only shown once body is available */}
+            {article.bodyStatus === 'ok' && article.body && (
+              <div className="mt-2 flex items-center gap-1 text-[12px] text-muted-foreground">
+                <Clock className="size-3.5" strokeWidth={1.75} />
+                <span>{readingTime(article.body)} min read</span>
               </div>
-            ) : article.bodyStatus === 'error' || !article.body ? (
-              <div className="rounded-lg border border-border bg-surface px-4 py-5">
-                <div className="flex items-start gap-2 mb-2">
-                  <AlertCircle className="size-4 mt-0.5 text-destructive shrink-0" />
-                  <div className="text-sm font-medium text-foreground">
-                    Couldn't extract article text
-                  </div>
-                </div>
-                <p className="text-sm text-muted-foreground mb-4">{article.summary}</p>
-                <a
-                  href={article.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1.5 rounded-md bg-foreground text-background px-3 py-1.5 text-sm font-medium hover:opacity-90"
-                >
-                  Open original <ExternalLink className="size-3.5" />
-                </a>
-              </div>
-            ) : (
-              <div
-                className="reader-prose"
-                dangerouslySetInnerHTML={{ __html: renderBody(article.body) }}
-              />
             )}
-          </div>
-        </article>
-      </div>
 
-      {/* Action bar */}
-      <div className="fixed bottom-0 inset-x-0 z-20 border-t border-border bg-background/95 backdrop-blur pb-[env(safe-area-inset-bottom)]">
+            {/* Why this matters */}
+            <div className="mt-4 rounded-lg border-l-2 border-accent bg-surface/60 px-4 py-3">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-subtle mb-1">
+                Why this matters
+              </div>
+              <p className="text-[14px] leading-snug text-foreground">{article.reason}</p>
+            </div>
+
+            {/* Body */}
+            <div className="mt-8">
+              {bodyLoading ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground py-12">
+                  <Loader2 className="size-4 animate-spin" /> Loading article…
+                </div>
+              ) : article.bodyStatus === 'error' || !article.body ? (
+                <div className="rounded-lg border border-border bg-surface px-4 py-5">
+                  <div className="flex items-start gap-2 mb-2">
+                    <AlertCircle className="size-4 mt-0.5 text-destructive shrink-0" />
+                    <div className="text-sm font-medium text-foreground">
+                      Couldn't extract article text
+                    </div>
+                  </div>
+                  <p className="text-sm text-muted-foreground mb-4">{article.summary}</p>
+                  <a
+                    href={article.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1.5 rounded-md bg-foreground text-background px-3 py-1.5 text-sm font-medium hover:opacity-90"
+                  >
+                    Open original <ExternalLink className="size-3.5" />
+                  </a>
+                </div>
+              ) : (
+                <div
+                  className="reader-prose"
+                  dangerouslySetInnerHTML={{ __html: renderBody(article.body) }}
+                />
+              )}
+            </div>
+          </article>
+        </div>
+      </div>
+      {/* end animated wrapper */}
+
+      {/* Action bar — intentionally outside the motion-slide-in-right wrapper
+          so position:fixed always resolves against the viewport, not against
+          an ancestor that carries a CSS transform during the entry animation */}
+      <div
+        data-testid="action-bar"
+        className="fixed bottom-0 inset-x-0 z-20 border-t border-border bg-background/95 backdrop-blur pb-[env(safe-area-inset-bottom)]"
+      >
         <div className="mx-auto max-w-2xl grid grid-cols-6 gap-1 p-2">
           <ActionBtn
             onClick={() => void doStar()}


### PR DESCRIPTION
Closes #189.

## Root cause

`ArticlePage` applied `motion-slide-in-right` to its **root** wrapper div. The `from` keyframe holds `transform: translateX(20px)`. During the 0.2 s animation, any ancestor with a non-`none` transform becomes the [containing block for `position:fixed` descendants](https://www.w3.org/TR/css-transforms-1/#containing-block-for-all-descendants), so the action bar was fixed relative to the animated div rather than the viewport for those 0.2 s — users could see it move/scroll.

After the animation the transform was gone (PR #166's fix: no `transform` on the `to` keyframe), so the bar re-anchored correctly — making it an intermittent, hard-to-catch bug.

## Fix

Move `motion-slide-in-right` from the root `<div>` to an **inner wrapper** that contains only the sticky header + scrollable content. The action bar is now a sibling of that wrapper — outside the animated element — so its `position: fixed` always resolves against the viewport, both during and after the animation.

The PR #166 keyframe fix (no `transform` on the `to` state) is unchanged and still guards against stale transform after animation end.

## Test

Added `data-testid="action-bar"` and a new test asserting the element is rendered. Combined with the existing "action bar buttons are individually accessible" regression test.

## Test plan

- [x] `make lint typecheck` — clean
- [x] `npm run test:frontend` — 219 tests passed
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)