### PR TITLE
feat(insights): AI-generated key takeaways for articles

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -139,6 +139,7 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body_status TEXT NOT NULL DEFAULT 'missing'",
+    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS insights TEXT",
     """
     ALTER TABLE articles ADD COLUMN IF NOT EXISTS search_vector tsvector
       GENERATED ALWAYS AS (

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -1,0 +1,117 @@
+"""AI-generated 'Why it matters' bullet points for articles.
+
+Calls gpt-4o-mini with the article text and caches the result in
+articles.insights (JSON) so the AI is invoked at most once per article.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from .body_fetch import get_article
+from .db import connect, init_db
+
+logger = logging.getLogger(__name__)
+
+_MODEL = "gpt-4o-mini"
+_MAX_CHARS = 8_000
+_PROMPT = (
+    "Given this news article, generate 3-5 concise bullet points explaining "
+    "why this story matters and what impact it could have. "
+    "Be specific and insightful. "
+    "Return only the bullet points, one per line, starting with '•'."
+)
+
+
+class InsightsNotConfiguredError(Exception):
+    """Raised when OPENAI_API_KEY is not set."""
+
+
+def _build_text(article: dict[str, Any]) -> str:
+    title = str(article.get("title") or "")
+    body = str(article.get("body") or "")
+    summary = str(article.get("summary") or "")
+    content = body if len(body) > len(summary) else summary
+    text = f"Title: {title}\n\n{content}" if title else content
+    return text[:_MAX_CHARS]
+
+
+def _parse_bullets(response_text: str) -> list[str]:
+    bullets: list[str] = []
+    for line in response_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("•"):
+            bullet = stripped[1:].strip()
+            if bullet:
+                bullets.append(bullet)
+    return bullets
+
+
+def generate_insights(article: dict[str, Any]) -> list[str]:
+    """Call OpenAI and return a list of bullet-point strings.
+
+    Raises InsightsNotConfiguredError when OPENAI_API_KEY is absent.
+    Raises RuntimeError on API failure.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = "OPENAI_API_KEY is not configured"
+        raise InsightsNotConfiguredError(msg)
+
+    text = _build_text(article)
+    if not text.strip():
+        return []
+
+    from openai import OpenAI  # lazy import — optional dep at import time
+
+    client = OpenAI(api_key=api_key)
+    logger.info("Generating insights for article %s", article.get("id"))
+    result = client.chat.completions.create(
+        model=_MODEL,
+        messages=[{"role": "user", "content": f"{_PROMPT}\n\n{text}"}],
+        max_tokens=512,
+    )
+    response_text = (result.choices[0].message.content or "").strip()
+    bullets = _parse_bullets(response_text)
+    logger.info("Insights generated for article %s: %d bullets", article.get("id"), len(bullets))
+    return bullets
+
+
+def get_or_generate_insights(
+    article_id: int,
+    user_id: int | None = None,
+    database_url: str | None = None,
+) -> list[str]:
+    """Return cached insights or generate + cache them.
+
+    Raises InsightsNotConfiguredError when OPENAI_API_KEY is absent and
+    no cached insights exist.
+    """
+    init_db(database_url=database_url)
+
+    with connect(database_url=database_url) as conn:
+        row = conn.execute("SELECT insights FROM articles WHERE id = %s", (article_id,)).fetchone()
+
+    if row is None:
+        return []
+
+    cached = row["insights"] if isinstance(row, dict) else row[0]
+    if cached is not None:
+        return list(json.loads(cached))
+
+    article = get_article(article_id, user_id=user_id)
+    if article is None:
+        return []
+
+    bullets = generate_insights(article)
+
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            "UPDATE articles SET insights = %s WHERE id = %s",
+            (json.dumps(bullets), article_id),
+        )
+
+    return bullets

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -413,6 +413,24 @@ def article_audio(
     return FileResponse(path, media_type="audio/mpeg", filename=f"article-{article_id}.mp3")
 
 
+@api.get("/api/articles/{article_id}/insights")
+def article_insights(
+    article_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from .insights import InsightsNotConfiguredError, get_or_generate_insights
+
+    try:
+        bullets = get_or_generate_insights(article_id, user_id=current_user["id"])
+    except InsightsNotConfiguredError as exc:
+        raise HTTPException(status_code=501, detail=str(exc)) from exc
+
+    if not bullets and not get_article(article_id, user_id=current_user["id"]):
+        raise HTTPException(status_code=404, detail="article not found")
+
+    return {"bullets": bullets}
+
+
 @api.patch("/api/articles/{article_id}/status")
 def update_status(article_id: int, payload: StatusUpdate) -> dict[str, Any]:
     try:

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -1,0 +1,259 @@
+"""Unit tests for news_dashboard.insights.
+
+All OpenAI calls are mocked — no network or live API key needed.
+DB-touching tests use the pg_clean fixture (live Postgres).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.db import connect
+from news_dashboard.insights import (
+    InsightsNotConfiguredError,
+    _build_text,
+    _parse_bullets,
+    generate_insights,
+    get_or_generate_insights,
+)
+
+# ── shared test data ──────────────────────────────────────────────────────────
+
+_ARTICLE: dict[str, Any] = {
+    "id": 1,
+    "title": "Test Headline",
+    "body": "This is the body text.",
+    "summary": "Short summary.",
+}
+
+_ARTICLE_NO_BODY: dict[str, Any] = {
+    "id": 2,
+    "title": "No Body",
+    "body": None,
+    "summary": "Only a summary.",
+}
+
+_ARTICLE_EMPTY: dict[str, Any] = {
+    "id": 3,
+    "title": "",
+    "body": None,
+    "summary": "",
+}
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _seed_article(pg_url: str, *, insights: str | None = None) -> int:
+    """Insert a minimal article row and return its id."""
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind)
+            VALUES ('test-src', 'Test', 'https://example.com', 'tech', 'rss_feed')
+            ON CONFLICT(slug) DO NOTHING
+            """
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, summary, insights
+            )
+            VALUES (
+              'https://example.com/a', 'https://example.com/a',
+              'Test Headline', 'test-src', 'Test', 'tech', 'rss_feed',
+              'A short summary.', %s
+            )
+            RETURNING id
+            """,
+            (insights,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+# ── _parse_bullets ────────────────────────────────────────────────────────────
+
+
+def test_parse_bullets_standard_format() -> None:
+    text = "• First insight\n• Second insight\n• Third insight"
+    assert _parse_bullets(text) == ["First insight", "Second insight", "Third insight"]
+
+
+def test_parse_bullets_strips_whitespace() -> None:
+    text = "  •  Padded bullet  \n• Another"
+    assert _parse_bullets(text) == ["Padded bullet", "Another"]
+
+
+def test_parse_bullets_ignores_non_bullet_lines() -> None:
+    text = "Here are the bullets:\n• Real bullet\nSome prose line\n• Another bullet"
+    assert _parse_bullets(text) == ["Real bullet", "Another bullet"]
+
+
+def test_parse_bullets_empty_string() -> None:
+    assert _parse_bullets("") == []
+
+
+def test_parse_bullets_no_bullets() -> None:
+    assert _parse_bullets("No bullets here at all.") == []
+
+
+# ── _build_text ───────────────────────────────────────────────────────────────
+
+
+def test_build_text_uses_body_when_longer_than_summary() -> None:
+    text = _build_text(_ARTICLE)
+    assert "body text" in text
+    assert "Short summary" not in text
+
+
+def test_build_text_falls_back_to_summary_when_no_body() -> None:
+    text = _build_text(_ARTICLE_NO_BODY)
+    assert "Only a summary" in text
+
+
+def test_build_text_includes_title() -> None:
+    text = _build_text(_ARTICLE)
+    assert "Test Headline" in text
+
+
+# ── generate_insights ─────────────────────────────────────────────────────────
+
+
+def test_generate_insights_raises_without_api_key() -> None:
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("OPENAI_API_KEY", None)
+        with pytest.raises(InsightsNotConfiguredError):
+            generate_insights(_ARTICLE)
+
+
+def test_generate_insights_returns_parsed_bullets() -> None:
+    mock_completion = MagicMock()
+    mock_completion.choices[
+        0
+    ].message.content = "• First bullet point\n• Second bullet point\n• Third bullet point"
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_completion
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        bullets = generate_insights(_ARTICLE)
+
+    assert bullets == ["First bullet point", "Second bullet point", "Third bullet point"]
+    mock_client.chat.completions.create.assert_called_once()
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["model"] == "gpt-4o-mini"
+    assert "Test Headline" in call_kwargs["messages"][0]["content"]
+
+
+def test_generate_insights_returns_empty_list_for_empty_article() -> None:
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+        result = generate_insights(_ARTICLE_EMPTY)
+    assert result == []
+
+
+# ── get_or_generate_insights ──────────────────────────────────────────────────
+
+
+def test_get_or_generate_insights_returns_cached_without_api_call(pg_clean: str) -> None:
+    cached = ["Cached bullet 1", "Cached bullet 2"]
+    article_id = _seed_article(pg_clean, insights=json.dumps(cached))
+
+    mock_client = MagicMock()
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        result = get_or_generate_insights(article_id, database_url=pg_clean)
+
+    assert result == cached
+    mock_client.chat.completions.create.assert_not_called()
+
+
+def test_get_or_generate_insights_generates_and_caches_when_missing(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean)
+
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = "• New bullet\n• Another bullet"
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_completion
+
+    fake_article = {
+        "id": article_id,
+        "title": "Test Headline",
+        "body": "body text",
+        "summary": "A short summary.",
+    }
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+        patch("news_dashboard.insights.get_article", return_value=fake_article),
+    ):
+        result = get_or_generate_insights(article_id, database_url=pg_clean)
+
+    assert result == ["New bullet", "Another bullet"]
+    mock_client.chat.completions.create.assert_called_once()
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT insights FROM articles WHERE id = %s", (article_id,)).fetchone()
+    stored = row["insights"] if isinstance(row, dict) else row[0]
+    assert json.loads(stored) == ["New bullet", "Another bullet"]
+
+
+def test_get_or_generate_insights_raises_without_api_key_when_not_cached(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean)
+
+    fake_article = {"id": article_id, "title": "T", "body": "body", "summary": "s"}
+
+    with (
+        patch.dict("os.environ", {}, clear=False),
+        patch("news_dashboard.insights.get_article", return_value=fake_article),
+    ):
+        import os
+
+        os.environ.pop("OPENAI_API_KEY", None)
+        with pytest.raises(InsightsNotConfiguredError):
+            get_or_generate_insights(article_id, database_url=pg_clean)
+
+
+def test_get_or_generate_insights_second_call_uses_cache(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean)
+    call_count: list[int] = []
+
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = "• Bullet"
+    mock_client = MagicMock()
+
+    def count_call(**_kwargs: object) -> object:
+        call_count.append(1)
+        return mock_completion
+
+    mock_client.chat.completions.create.side_effect = count_call
+
+    fake_article = {"id": article_id, "title": "T", "body": "body", "summary": "s"}
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+        patch("news_dashboard.insights.get_article", return_value=fake_article),
+    ):
+        r1 = get_or_generate_insights(article_id, database_url=pg_clean)
+        r2 = get_or_generate_insights(article_id, database_url=pg_clean)
+
+    assert r1 == r2 == ["Bullet"]
+    assert len(call_count) == 1, "AI called more than once — cache not working"
+
+
+def test_get_or_generate_insights_returns_empty_for_missing_article(pg_clean: str) -> None:
+    result = get_or_generate_insights(99999, database_url=pg_clean)
+    assert result == []

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -342,6 +342,51 @@ describe('ArticlePage — touch gesture state', () => {
   });
 });
 
+// ─── AI insights ─────────────────────────────────────────────────────────────
+
+describe('ArticlePage — AI insights', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full article text.' })
+    );
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full article text.' })
+    );
+  });
+
+  it('shows insights section with bullets when loaded', async () => {
+    vi.spyOn(api, 'fetchArticleInsights').mockResolvedValue([
+      'First insight bullet',
+      'Second insight bullet',
+    ]);
+    renderReader();
+    await waitFor(() => expect(screen.getByText('First insight bullet')).toBeTruthy());
+    expect(screen.getByText('Second insight bullet')).toBeTruthy();
+    expect(screen.getByTestId('insights-section')).toBeTruthy();
+  });
+
+  it('shows analyzing spinner while insights are loading', async () => {
+    vi.spyOn(api, 'fetchArticleInsights').mockReturnValue(new Promise(() => undefined));
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    expect(screen.getByText('Analyzing…')).toBeTruthy();
+  });
+
+  it('hides insights section on 501 error', async () => {
+    vi.spyOn(api, 'fetchArticleInsights').mockRejectedValue(new Error('501 Not Implemented'));
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    await waitFor(() => expect(screen.queryByTestId('insights-section')).toBeNull());
+  });
+
+  it('hides insights section when bullets list is empty', async () => {
+    vi.spyOn(api, 'fetchArticleInsights').mockResolvedValue([]);
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    await waitFor(() => expect(screen.queryByTestId('insights-section')).toBeNull());
+  });
+});
+
 // ─── TTS / Listen button ──────────────────────────────────────────────────────
 
 describe('ArticlePage — Listen / TTS', () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -75,6 +75,11 @@ export async function fetchArticleAudioUrl(id: number | string): Promise<string>
   return URL.createObjectURL(blob);
 }
 
+export async function fetchArticleInsights(id: number | string): Promise<string[]> {
+  const data = await requestJson<{ bullets: string[] }>(`/api/articles/${id}/insights`);
+  return data.bullets;
+}
+
 export async function fetchSources(): Promise<Source[]> {
   const data = await requestJson<{ items: Source[] }>('/api/sources');
   return data.items;

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -17,7 +17,7 @@ import {
   Square,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { fetchArticle, fetchArticleBody, fetchArticleAudioUrl } from '@/api';
+import { fetchArticle, fetchArticleBody, fetchArticleAudioUrl, fetchArticleInsights } from '@/api';
 import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflowApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { formatDate, readingTime, signalLabel } from '@/lib/format';
@@ -157,6 +157,18 @@ export function ArticlePage() {
     // Run once per article id; bodyMutation is intentionally omitted from deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
+
+  const {
+    data: insightBullets,
+    isLoading: insightsLoading,
+    isError: insightsError,
+  } = useQuery({
+    queryKey: ['article-insights', id],
+    queryFn: () => fetchArticleInsights(id!),
+    enabled: !!id,
+    retry: false,
+    staleTime: Infinity,
+  });
 
   // Prev/next navigation from sessionStorage list
   const readerList = getReaderList();
@@ -423,6 +435,37 @@ export function ArticlePage() {
                 <span>{readingTime(article.body)} min read</span>
               </div>
             )}
+
+            {/* AI insights — hidden on 501/error, spinner while loading */}
+            {!insightsError &&
+              (insightsLoading || (insightBullets && insightBullets.length > 0)) && (
+                <div
+                  className="mt-4 rounded-lg border border-border bg-surface/40 px-4 py-3"
+                  data-testid="insights-section"
+                >
+                  <div className="text-[10px] font-medium uppercase tracking-wider text-subtle mb-2">
+                    Key takeaways
+                  </div>
+                  {insightsLoading ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="size-3.5 animate-spin" />
+                      <span>Analyzing…</span>
+                    </div>
+                  ) : (
+                    <ul className="space-y-1.5">
+                      {insightBullets!.map((bullet, i) => (
+                        <li
+                          key={i}
+                          className="flex items-start gap-2 text-[13px] leading-snug text-foreground"
+                        >
+                          <span className="mt-0.5 shrink-0 text-accent">•</span>
+                          <span>{bullet}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
 
             {/* Why this matters */}
             <div className="mt-4 rounded-lg border-l-2 border-accent bg-surface/60 px-4 py-3">


### PR DESCRIPTION
## Summary
- New `GET /api/articles/:id/insights` endpoint calls gpt-4o-mini with the article title + body/summary, parses `•`-prefixed bullet lines, and caches the JSON result in `articles.insights`
- `ArticlePage` fetches insights in parallel with the body on mount; renders a "Key takeaways" bullet list; silently hides the section on 501 or any error
- 16 new backend tests (pure-function + Postgres integration); 4 new frontend tests

## Test plan
- [ ] `source .env && make test` — 356 backend tests pass
- [ ] `npm run test:frontend` — 227 frontend tests pass
- [ ] `make lint typecheck` — all linters and three type-checkers clean
- [ ] `npm run build` — production build succeeds

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)