### PR TITLE
feat(share): add Share button to article action bar

### DIFF
--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -387,6 +387,58 @@ describe('ArticlePage — AI insights', () => {
   });
 });
 
+// ─── Share button ─────────────────────────────────────────────────────────────
+
+describe('ArticlePage — Share button', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full article text.' })
+    );
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full article text.' })
+    );
+    vi.spyOn(api, 'fetchArticleInsights').mockResolvedValue([]);
+  });
+
+  it('shows Share button in the action bar', async () => {
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    expect(screen.getByRole('button', { name: /share/i })).toBeTruthy();
+  });
+
+  it('calls navigator.share with article title and url when supported', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: shareMock,
+      configurable: true,
+    });
+
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    await userEvent.click(screen.getByRole('button', { name: /share/i }));
+
+    expect(shareMock).toHaveBeenCalledWith({
+      title: 'Test Article Title',
+      url: 'https://example.com/article',
+    });
+  });
+
+  it('copies to clipboard when navigator.share is unavailable', async () => {
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+    const clipboardMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: clipboardMock },
+      configurable: true,
+    });
+
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    await userEvent.click(screen.getByRole('button', { name: /share/i }));
+
+    expect(clipboardMock).toHaveBeenCalledWith('https://example.com/article');
+  });
+});
+
 // ─── TTS / Listen button ──────────────────────────────────────────────────────
 
 describe('ArticlePage — Listen / TTS', () => {

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   Volume2,
   Square,
+  Share2,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { fetchArticle, fetchArticleBody, fetchArticleAudioUrl, fetchArticleInsights } from '@/api';
@@ -269,6 +270,16 @@ export function ArticlePage() {
     audioMutation.mutate();
   }
 
+  async function handleShare() {
+    if (!article) return;
+    if (navigator.share) {
+      await navigator.share({ title: article.title, url: article.url });
+    } else {
+      await navigator.clipboard.writeText(article.url);
+      toast('Link copied!');
+    }
+  }
+
   // Touch swipe
   const swipeRef = useRef<{ x: number; y: number } | null>(null);
   const [swipeDx, setSwipeDx] = useState(0);
@@ -518,7 +529,7 @@ export function ArticlePage() {
         data-testid="action-bar"
         className="fixed bottom-0 inset-x-0 z-20 border-t border-border bg-background/95 backdrop-blur pb-[env(safe-area-inset-bottom)]"
       >
-        <div className="mx-auto max-w-2xl grid grid-cols-6 gap-1 p-2">
+        <div className="mx-auto max-w-2xl grid grid-cols-7 gap-1 p-2">
           <ActionBtn
             onClick={() => void doStar()}
             icon={Star}
@@ -552,6 +563,7 @@ export function ArticlePage() {
             }
             disabled={audioState === 'loading'}
           />
+          <ActionBtn onClick={() => void handleShare()} icon={Share2} label="Share" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- New **Share** button (lucide `Share2`) added as the 7th slot in the action bar grid (updated to `grid-cols-7`)
- On mobile: calls `navigator.share({ title, url })` to trigger the native OS share sheet
- On desktop (no Web Share API): falls back to `navigator.clipboard.writeText(url)` + "Link copied!" toast

## Test plan
- [ ] `npm run test:frontend` — 230 tests pass (3 new Share tests)
- [ ] `npm run lint && npm run typecheck && npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)