### PR TITLE
fix(article): render action bar via portal to prevent compositor misalignment

### DIFF
--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -251,11 +251,26 @@ describe('ArticlePage — action bar', () => {
   it('renders the action bar', async () => {
     renderReader();
     await waitFor(() => screen.getByText('Test Article Title'));
-    // The action bar element must be present in the DOM.  It lives outside the
-    // motion-slide-in-right animated wrapper so position:fixed always resolves
-    // against the viewport rather than against an ancestor that carries a CSS
-    // transform during the 0.2 s entry animation (fixes #189).
     expect(screen.getByTestId('action-bar')).toBeTruthy();
+  });
+
+  it('action bar is a direct child of document.body (portal)', async () => {
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    const actionBar = screen.getByTestId('action-bar');
+    // The action bar is rendered via createPortal(…, document.body) so that
+    // position:fixed always resolves against the viewport — no ancestor or
+    // sibling CSS transform (including the motion-slide-in-right entry
+    // animation) can bleed into the compositor layer for the bar (fixes #196).
+    expect(actionBar.parentElement).toBe(document.body);
+  });
+
+  it('action bar is not a descendant of the animated wrapper', async () => {
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    const animatedWrapper = document.querySelector('.motion-slide-in-right');
+    const actionBar = screen.getByTestId('action-bar');
+    expect(animatedWrapper?.contains(actionBar)).toBe(false);
   });
 });
 

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -522,50 +523,58 @@ export function ArticlePage() {
       </div>
       {/* end animated wrapper */}
 
-      {/* Action bar — intentionally outside the motion-slide-in-right wrapper
-          so position:fixed always resolves against the viewport, not against
-          an ancestor that carries a CSS transform during the entry animation */}
-      <div
-        data-testid="action-bar"
-        className="fixed bottom-0 inset-x-0 z-20 border-t border-border bg-background/95 backdrop-blur pb-[env(safe-area-inset-bottom)]"
-      >
-        <div className="mx-auto max-w-2xl grid grid-cols-7 gap-1 p-2">
-          <ActionBtn
-            onClick={() => void doStar()}
-            icon={Star}
-            label={article.starred ? 'Unstar' : 'Star'}
-            active={article.starred}
-          />
-          <ActionBtn onClick={() => void doAction('done', 'Done')} icon={Check} label="Done" />
-          <ActionBtn onClick={() => void doAction('later', 'Later')} icon={Clock} label="Later" />
-          <ActionBtn
-            onClick={() => void doAction('skipped', 'Skipped')}
-            icon={XIcon}
-            label="Skip"
-            disabled={article.starred}
-          />
-          <ActionBtn
-            onClick={() => void doAction('archived', 'Archived')}
-            icon={Archive}
-            label="Archive"
-          />
-          <ActionBtn
-            onClick={handleListen}
-            icon={audioState === 'loading' ? Loader2 : audioState === 'playing' ? Square : Volume2}
-            label={
-              audioState === 'loading'
-                ? 'Loading…'
-                : audioState === 'playing'
-                  ? 'Stop'
-                  : audioState === 'paused'
-                    ? 'Resume'
-                    : 'Listen'
-            }
-            disabled={audioState === 'loading'}
-          />
-          <ActionBtn onClick={() => void handleShare()} icon={Share2} label="Share" />
-        </div>
-      </div>
+      {/* Action bar rendered via portal so its position:fixed always resolves
+          against the viewport regardless of any CSS transform that may exist on
+          an ancestor or sibling of the ArticlePage root during the entry
+          animation (motion-slide-in-right carries transform:translateX in its
+          from-keyframe; even as a sibling, some mobile browser compositors
+          bleed this transform onto nearby fixed elements for the first paint). */}
+      {createPortal(
+        <div
+          data-testid="action-bar"
+          className="fixed bottom-0 inset-x-0 z-20 border-t border-border bg-background/95 backdrop-blur pb-[env(safe-area-inset-bottom)]"
+        >
+          <div className="mx-auto max-w-2xl grid grid-cols-7 gap-1 p-2">
+            <ActionBtn
+              onClick={() => void doStar()}
+              icon={Star}
+              label={article.starred ? 'Unstar' : 'Star'}
+              active={article.starred}
+            />
+            <ActionBtn onClick={() => void doAction('done', 'Done')} icon={Check} label="Done" />
+            <ActionBtn onClick={() => void doAction('later', 'Later')} icon={Clock} label="Later" />
+            <ActionBtn
+              onClick={() => void doAction('skipped', 'Skipped')}
+              icon={XIcon}
+              label="Skip"
+              disabled={article.starred}
+            />
+            <ActionBtn
+              onClick={() => void doAction('archived', 'Archived')}
+              icon={Archive}
+              label="Archive"
+            />
+            <ActionBtn
+              onClick={handleListen}
+              icon={
+                audioState === 'loading' ? Loader2 : audioState === 'playing' ? Square : Volume2
+              }
+              label={
+                audioState === 'loading'
+                  ? 'Loading…'
+                  : audioState === 'playing'
+                    ? 'Stop'
+                    : audioState === 'paused'
+                      ? 'Resume'
+                      : 'Listen'
+              }
+              disabled={audioState === 'loading'}
+            />
+            <ActionBtn onClick={() => void handleShare()} icon={Share2} label="Share" />
+          </div>
+        </div>,
+        document.body
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Root cause

During the 0.2 s `slide-in-right` entry animation, the animated wrapper carries `transform: translateX(20px → 0)` in its `from` keyframe with `fill-mode: both`. Even though the action bar is already a **sibling** of this wrapper (not a child — PR #190 fixed that), some mobile browser compositors bleed the sibling's active transform onto nearby `position: fixed` layers for the first paint, causing the bar to appear momentarily offset before snapping to the correct viewport-bottom position.

## Fix

Render the action bar with `createPortal(…, document.body)`. As a direct child of `<body>` the bar has no ancestor with a transform, so `position: fixed` always resolves against the viewport — during the entry animation, after it, and through any future layout changes.

## Tests added
- **`action bar is a direct child of document.body (portal)`** — asserts `actionBar.parentElement === document.body`
- **`action bar is not a descendant of the animated wrapper`** — asserts `.motion-slide-in-right` does not contain the action bar

## Test plan
- [ ] `npm run test:frontend` — 232 tests pass (2 new structural tests)
- [ ] `npm run lint && npm run typecheck && npm run build` — clean

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)