### PR TITLE
feat(pwa): add monochrome icon for Android 13+ themed icons

### DIFF
--- a/frontend/src/__tests__/pwa.test.ts
+++ b/frontend/src/__tests__/pwa.test.ts
@@ -67,6 +67,13 @@ describe('PWA manifest — icons', () => {
     expect(icon).toBeDefined();
   });
 
+  it('declares a monochrome icon (enables Android 13+ themed/tinted icons)', () => {
+    const icon = MANIFEST.icons.find((i) => i.purpose === 'monochrome');
+    expect(icon).toBeDefined();
+    expect(icon?.type).toBe('image/svg+xml');
+    expect(icon?.src).toBe('/icons/icon-monochrome.svg');
+  });
+
   it('all icon src paths start with /', () => {
     MANIFEST.icons.forEach((icon) => {
       expect(icon.src.startsWith('/')).toBe(true);

--- a/public/icons/icon-monochrome.svg
+++ b/public/icons/icon-monochrome.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Headline bar -->
+  <rect x="5" y="5" width="22" height="4" rx="1.5" fill="#000000"/>
+
+  <!-- Left column text lines -->
+  <rect x="5" y="12" width="10" height="2" rx="1" fill="#000000"/>
+  <rect x="5" y="16" width="10" height="2" rx="1" fill="#000000"/>
+  <rect x="5" y="20" width="8"  height="2" rx="1" fill="#000000"/>
+  <rect x="5" y="24" width="9"  height="2" rx="1" fill="#000000"/>
+
+  <!-- Right column image / card placeholder -->
+  <rect x="18" y="12" width="9" height="9" rx="2" fill="#000000"/>
+  <!-- Small caption line under image -->
+  <rect x="18" y="23" width="9" height="1.5" rx="0.75" fill="#000000"/>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -31,6 +31,12 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
+    },
+    {
+      "src": "/icons/icon-monochrome.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "monochrome"
     }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         'icons/icon-192.png',
         'icons/icon-512.png',
         'icons/icon-512-maskable.png',
+        'icons/icon-monochrome.svg',
       ],
       manifest: false,
       workbox: {


### PR DESCRIPTION
## Summary

Android 13+ (Material You / themed icons) tints app icons to match the system colour theme, but only when the manifest includes an icon with `"purpose": "monochrome"`. Without it the icon always renders in its fixed colours regardless of the user's dark/light preference.

- **`public/icons/icon-monochrome.svg`** — same newspaper silhouette as the favicon, background removed, all shapes solid black (`#000000`). The OS uses this as a mask and applies the user's chosen accent/tint colour automatically.
- **`public/manifest.webmanifest`** — new entry: `{ src: "/icons/icon-monochrome.svg", sizes: "any", type: "image/svg+xml", purpose: "monochrome" }` alongside the existing `any maskable` icons.
- **`vite.config.ts`** — icon added to `includeAssets` so Workbox precaches it (picked up automatically by the existing `**/*.svg` glob in `globPatterns`; precache count went 31 → 33).
- **`pwa.test.ts`** — new assertion: manifest declares a monochrome icon with the correct `src` and `type`.

## Test plan

- [x] New test: `declares a monochrome icon (enables Android 13+ themed/tinted icons)` — passes
- [x] Full frontend suite: 233 passed (was 232)
- [x] `make lint typecheck` — clean
- [x] `npm run build` — clean, Workbox precaches the new SVG
- [x] Pre-push hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)