### PR TITLE
feat(android): native Android APK via TWA wrapper

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,71 @@
+name: Android APK
+
+# Build and sign the TWA APK on demand or when android/ changes.
+# The signed APK is uploaded as a workflow artifact.
+#
+# Required repository secrets:
+#   ANDROID_KEYSTORE_BASE64   — base64-encoded android.keystore (JKS)
+#   ANDROID_KEYSTORE_PASSWORD — keystore password
+#   ANDROID_KEY_ALIAS         — key alias inside the keystore
+#   ANDROID_KEY_PASSWORD      — key entry password
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ['android/**']
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & sign APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # JDK 17 is required by Android Gradle Plugin 8.x
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Android SDK — installs build-tools, platform-tools, and cmdline-tools
+      - uses: android-actions/setup-android@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Decode the base64 keystore secret into the location twa-manifest.json expects
+      - name: Decode keystore
+        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/android.keystore
+
+      # Bubblewrap reads twa-manifest.json, generates the Gradle project, builds,
+      # and signs the APK in one step. Passwords come via CLI flags so the
+      # prompts are skipped in non-interactive CI.
+      - name: Build signed APK
+        working-directory: android
+        run: |
+          npx --yes @bubblewrap/cli@1.24.1 build \
+            --skipPwaValidation \
+            --signingKeyPassword "${{ secrets.ANDROID_KEY_PASSWORD }}" \
+            --signingKeyKeystorePassword "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+
+      # Locate the signed APK (Bubblewrap outputs to working dir or app/build/)
+      - name: Find APK
+        id: apk
+        run: |
+          APK=$(find android -name "*.apk" | grep -v unsigned | head -1)
+          echo "path=$APK" >> "$GITHUB_OUTPUT"
+          echo "Found APK: $APK"
+          ls -lh "$APK"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: news-dashboard-apk
+          path: ${{ steps.apk.outputs.path }}
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ data/*.db-*
 .worktrees/
 .claude/settings.local.json
 .claude/worktrees/
+
+# Android signing keystores — NEVER commit; store in GitHub Actions secrets
+android/*.keystore
+android/*.jks
+android/*.p12

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,103 @@
+# News Dashboard — Android TWA
+
+This directory contains the configuration for building a native Android APK
+that wraps the News Dashboard PWA (`https://news.lihor.ro`) using a
+[Trusted Web Activity](https://developer.chrome.com/docs/android/trusted-web-activity/).
+
+## What is a TWA?
+
+A Trusted Web Activity renders a PWA full-screen inside Chrome on Android with
+no address bar. It produces a real `.apk` that can be sideloaded or distributed
+through an app store. Unlike Chrome's WebAPK install path (which has known bugs
+around themed icons, update latency, and adaptive icon fidelity), a TWA APK is
+fully under your control.
+
+## How to build
+
+The GitHub Actions workflow `.github/workflows/android.yml` builds and signs the
+APK on every push to `android/` or on a manual `workflow_dispatch` trigger.
+
+To trigger manually:
+
+```
+gh workflow run android.yml
+```
+
+The signed APK is uploaded as a workflow artifact. Download it with:
+
+```
+gh run download <run-id> --name news-dashboard-apk
+```
+
+## Project structure
+
+| File | Purpose |
+|---|---|
+| `twa-manifest.json` | Bubblewrap config — source of truth for package ID, icons, colours, signing key ref |
+| `android.keystore` | **NOT in git** — signing keystore lives only in GitHub secrets |
+
+The Bubblewrap CLI reads `twa-manifest.json` and generates the full Gradle
+project at build time. You do not need to commit any Gradle files.
+
+## Signing key
+
+**Whoever holds this keystore controls all future APK updates.** Android
+enforces that every update of a package must be signed with the same key.
+
+The keystore is stored as a base64-encoded GitHub Actions secret:
+`ANDROID_KEYSTORE_BASE64`. It is _never_ committed to git (enforced by
+`.gitignore`). The four required secrets are:
+
+| Secret | Meaning |
+|---|---|
+| `ANDROID_KEYSTORE_BASE64` | `base64 -i android.keystore` output |
+| `ANDROID_KEYSTORE_PASSWORD` | keystore password |
+| `ANDROID_KEY_ALIAS` | key alias inside the keystore (`android`) |
+| `ANDROID_KEY_PASSWORD` | key entry password |
+
+### Key rotation / disaster recovery
+
+If the keystore is ever lost, new APK installs can use a new key, but **existing
+installs cannot be updated**. Back up the keystore securely outside of git
+(e.g. a password manager or encrypted off-site storage).
+
+To rotate or regenerate (only safe for a fresh install — breaks OTA updates to
+existing installs):
+
+```bash
+export PATH="$(brew --prefix openjdk@17)/bin:$PATH"
+
+keytool -genkeypair \
+  -alias android \
+  -keyalg RSA -keysize 2048 -validity 9125 \
+  -keystore android/android.keystore \
+  -dname "CN=News Dashboard, OU=App, O=Lihor, L=Iasi, S=Iasi, C=RO"
+
+# Get fingerprint for assetlinks.json
+keytool -list -v -keystore android/android.keystore -alias android \
+  | grep "SHA256:"
+
+# Re-upload to GitHub
+gh secret set ANDROID_KEYSTORE_BASE64 --body "$(base64 -i android/android.keystore)"
+```
+
+## Digital Asset Links
+
+For the TWA to render without a URL bar, `news.lihor.ro` must serve
+`/.well-known/assetlinks.json` containing the signing certificate fingerprint.
+
+The file is at `public/.well-known/assetlinks.json` in the repo. If you
+regenerate the keystore, update the `sha256_cert_fingerprints` field there.
+
+Current fingerprint (matches the keystore in GitHub secrets):
+```
+C6:AC:CD:86:57:77:00:3D:26:6A:DD:23:C7:38:29:0C:49:C2:D6:E9:31:1C:44:E2:43:97:2A:81:9E:1A:35:EE
+```
+
+## Adaptive icon and themed icons
+
+`twa-manifest.json` references `monochromeIconUrl`, which points to the
+`icon-monochrome-512.png` already served by the PWA. Bubblewrap embeds this as
+the `<monochrome>` layer of the Android adaptive icon in the generated APK.
+This is why a TWA gets proper Material You themed icon support while Chrome's
+WebAPK path does not.

--- a/android/twa-manifest.json
+++ b/android/twa-manifest.json
@@ -1,0 +1,48 @@
+{
+  "packageId": "ro.lihor.newsdashboard",
+  "host": "news.lihor.ro",
+  "name": "News Dashboard",
+  "launcherName": "News",
+  "display": "standalone",
+  "orientation": "default",
+  "themeColor": "#221f1a",
+  "navigationColor": "#221f1a",
+  "navigationColorDark": "#221f1a",
+  "navigationDividerColor": "#000000",
+  "navigationDividerColorDark": "#000000",
+  "backgroundColor": "#faf8f5",
+  "enableNotifications": false,
+  "startUrl": "/",
+  "iconUrl": "https://news.lihor.ro/icons/icon-512.png",
+  "maskableIconUrl": "https://news.lihor.ro/icons/icon-512-maskable.png",
+  "monochromeIconUrl": "https://news.lihor.ro/icons/icon-monochrome-512.png",
+  "splashScreenFadeOutDuration": 300,
+  "signingKey": {
+    "path": "android.keystore",
+    "alias": "android"
+  },
+  "appVersionName": "1.0.0",
+  "appVersionCode": 1,
+  "shortcuts": [],
+  "generatorApp": "bubblewrap-cli",
+  "webManifestUrl": "https://news.lihor.ro/manifest.webmanifest",
+  "fallbackType": "customtabs",
+  "features": {
+    "locationDelegation": {
+      "enabled": false
+    },
+    "playBilling": {
+      "enabled": false
+    }
+  },
+  "alphaDependencies": {
+    "enabled": false
+  },
+  "enableSiteSettingsShortcut": true,
+  "isChromeOSOnly": false,
+  "isMetaQuest": false,
+  "fullScopeUrl": "https://news.lihor.ro/",
+  "minSdkVersion": 24,
+  "fingerprints": [],
+  "retainedBundles": []
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "ro.lihor.newsdashboard",
+      "sha256_cert_fingerprints": [
+        "C6:AC:CD:86:57:77:00:3D:26:6A:DD:23:C7:38:29:0C:49:C2:D6:E9:31:1C:44:E2:43:97:2A:81:9E:1A:35:EE"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Closes #202

## What

Packages the News Dashboard PWA (`https://news.lihor.ro`) as a real, signed Android APK using a [Trusted Web Activity](https://developer.chrome.com/docs/android/trusted-web-activity/) shell built by Bubblewrap.

## Why

Chrome's WebAPK install path has well-documented reliability problems (see issue #202 for details). The chief motivation: Chrome does not translate `purpose: "monochrome"` manifest icons into the Android adaptive-icon monochrome layer inside the generated WebAPK — confirmed by a Google engineer as unimplemented — so Material You themed icons never apply to Chrome-installed PWAs. A TWA APK embeds the monochrome icon directly into the adaptive-icon resources the way native apps do, so themed icons work correctly.

## What's in this PR

| File | Purpose |
|---|---|
| `android/twa-manifest.json` | Bubblewrap config (package `ro.lihor.newsdashboard`, icons, colours, signing ref). CI reads this; no Gradle files needed in git. |
| `android/README.md` | Setup docs, key rotation instructions, secrets table |
| `public/.well-known/assetlinks.json` | Digital Asset Links — fingerprint of the signing cert so Chrome validates ownership and hides the URL bar in the TWA |
| `.github/workflows/android.yml` | `workflow_dispatch` + `android/**` push trigger; installs JDK 17 + Android SDK, decodes keystore from secrets, runs `bubblewrap build`, uploads signed APK as artifact |
| `.gitignore` | Blocks `android/*.keystore / *.jks / *.p12` — keystore never enters git |

## Secrets already set

`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD` are live in the repository secrets.

## Signing certificate fingerprint

```
C6:AC:CD:86:57:77:00:3D:26:6A:DD:23:C7:38:29:0C:49:C2:D6:E9:31:1C:44:E2:43:97:2A:81:9E:1A:35:EE
```

This is already in `public/.well-known/assetlinks.json` so the TWA URL-bar removal works immediately after deployment.

## Test plan

- [ ] Standard CI (lint, typecheck, backend tests, frontend tests, build) passes — zero changes to app logic
- [ ] Android workflow builds successfully on merge
- [ ] Signed APK installs on Android device
- [ ] TWA opens `news.lihor.ro` full-screen, no Chrome URL bar visible
- [ ] Themed icon applies when Material You themed icons are enabled (monochrome layer properly embedded by Bubblewrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)