### PR TITLE
fix(android): pre-configure Bubblewrap SDK paths in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,13 +39,22 @@ jobs:
         with:
           node-version: '20'
 
+      # Pre-configure Bubblewrap so it uses the JDK and Android SDK already set
+      # up by the actions above. Without this, Bubblewrap prompts to install its
+      # own JDK (which blocks non-interactive CI).
+      - name: Configure Bubblewrap SDK paths
+        run: |
+          mkdir -p ~/.bubblewrap
+          printf '{"jdkPath":"%s","androidSdkPath":"%s"}\n' \
+            "$JAVA_HOME" "$ANDROID_SDK_ROOT" > ~/.bubblewrap/config.json
+          cat ~/.bubblewrap/config.json
+
       # Decode the base64 keystore secret into the location twa-manifest.json expects
       - name: Decode keystore
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/android.keystore
 
       # Bubblewrap reads twa-manifest.json, generates the Gradle project, builds,
-      # and signs the APK in one step. Passwords come via CLI flags so the
-      # prompts are skipped in non-interactive CI.
+      # and signs the APK. Passwords are supplied via CLI flags to skip prompts.
       - name: Build signed APK
         working-directory: android
         run: |


### PR DESCRIPTION
Fixes the Android build workflow that failed on first run because Bubblewrap prompts "Do you want Bubblewrap to install the JDK?" when `~/.bubblewrap/config.json` is absent — exits non-zero in non-interactive CI.

Adds a step that writes the config file pointing at the JDK (`$JAVA_HOME`) and Android SDK (`$ANDROID_SDK_ROOT`) already installed by the preceding `setup-java` / `setup-android` actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)