### PR TITLE
feat(android): publish signed APK as GitHub Release on push to main

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,7 +1,7 @@
 name: Android APK
 
-# Build and sign the TWA APK on demand or when android/ changes.
-# The signed APK is uploaded as a workflow artifact.
+# Build, sign, and publish the TWA APK as a GitHub Release on every push to
+# main, and on manual workflow_dispatch triggers.
 #
 # Required repository secrets:
 #   ANDROID_KEYSTORE_BASE64   — base64-encoded android.keystore (JKS)
@@ -13,10 +13,9 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths: ['android/**']
 
 permissions:
-  contents: read
+  contents: write  # required to create GitHub Releases
 
 jobs:
   build:
@@ -56,12 +55,37 @@ jobs:
         run: |
           APK=$(find android/app/build/outputs/apk/release -name "*.apk" | head -1)
           echo "path=$APK" >> "$GITHUB_OUTPUT"
-          echo "Found APK: $APK"
           ls -lh "$APK"
 
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: news-dashboard-apk
-          path: ${{ steps.apk.outputs.path }}
-          retention-days: 30
+      # Derive version tag from twa-manifest.json + run number so every release
+      # has a unique, monotonically increasing tag.
+      # Tag format: android-v{versionName}-{run_number}, e.g. android-v1.0.0-42
+      - name: Compute release tag
+        id: version
+        run: |
+          VERSION=$(jq -r '.appVersionName' android/twa-manifest.json)
+          TAG="android-v${VERSION}-${{ github.run_number }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Tag: $TAG"
+
+      # Rename the APK to something descriptive before attaching to the release
+      - name: Rename APK
+        id: rename
+        run: |
+          DEST="news-dashboard-${{ steps.version.outputs.tag }}.apk"
+          cp "${{ steps.apk.outputs.path }}" "$DEST"
+          echo "path=$DEST" >> "$GITHUB_OUTPUT"
+
+      # Publish a GitHub Release with the signed APK as a downloadable asset.
+      # --latest marks this as the latest release so the Releases page always
+      # shows the most recent build at the top.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            "${{ steps.rename.outputs.path }}" \
+            --title "Android APK v${{ steps.version.outputs.version }} (#${{ github.run_number }})" \
+            --notes "Built from commit ${{ github.sha }} on \`${{ github.ref_name }}\`." \
+            --latest


### PR DESCRIPTION
## Summary

- Triggers on every push to `main` (removed the `android/**` path filter — any merge should produce a fresh release)
- Renames the APK to `news-dashboard-android-v{version}-{run_number}.apk` for clarity
- Creates a GitHub Release tagged `android-v{versionName}-{run_number}` with the signed APK attached, marked `--latest`
- Keeps `workflow_dispatch` for manual rebuilds
- Changes `contents: read` → `contents: write` (required to create releases)

Users can now navigate to the repo's Releases page on their phone and download the latest APK directly — no CLI needed.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, Android build workflow runs and a release appears at `github.com/ioachim-hub/news-dashboard/releases`
- [ ] Release has the signed APK as a downloadable asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)