### PR TITLE
fix(ux): triage toasts replace instead of stack

### DIFF
--- a/frontend/src/__tests__/useTriageMutations.test.tsx
+++ b/frontend/src/__tests__/useTriageMutations.test.tsx
@@ -70,6 +70,7 @@ interface ToastAction {
   onClick: () => void;
 }
 interface ToastOpts {
+  id?: string;
   action?: ToastAction;
 }
 
@@ -167,6 +168,33 @@ describe('useTriageMutations — undo calls the API to revert server state', () 
     expect(lastArgs?.[1]?.action?.label).toBe('Undo');
   });
 
+  it('every action toast carries the shared triage id so rapid actions replace the previous toast', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    const article = makeArticle();
+
+    // Three rapid actions in sequence — each should carry the same id.
+    act(() => {
+      result.current.setState(article, 'done', 'Marked as read');
+    });
+    const afterDone = vi.mocked(toast).mock.lastCall as unknown as [string, ToastOpts?] | undefined;
+    expect(afterDone?.[1]?.id).toBe('triage');
+
+    act(() => {
+      result.current.toggleStar(article);
+    });
+    const afterStar = vi.mocked(toast).mock.lastCall as unknown as [string, ToastOpts?] | undefined;
+    expect(afterStar?.[1]?.id).toBe('triage');
+
+    act(() => {
+      result.current.sendLater(article, 1);
+    });
+    const afterLater = vi.mocked(toast).mock.lastCall as unknown as
+      | [string, ToastOpts?]
+      | undefined;
+    expect(afterLater?.[1]?.id).toBe('triage');
+  });
+
   it('setState blocks skipping a starred article', () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useTriageMutations(), { wrapper });
@@ -176,7 +204,9 @@ describe('useTriageMutations — undo calls the API to revert server state', () 
       result.current.setState(article, 'skipped', 'Skipped');
     });
 
-    expect(vi.mocked(toast).error).toHaveBeenCalledWith("Starred articles can't be skipped");
+    expect(vi.mocked(toast).error).toHaveBeenCalledWith("Starred articles can't be skipped", {
+      id: 'triage',
+    });
     expect(workflowApi.patchArticleState).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useTriageMutations.ts
+++ b/frontend/src/hooks/useTriageMutations.ts
@@ -1,5 +1,9 @@
 import { useQueryClient, useMutation, type QueryKey } from '@tanstack/react-query';
 import { toast } from 'sonner';
+
+// Single shared ID so every triage toast replaces the previous one rather than
+// stacking — rapid actions (read, skip, star) should show only the latest.
+const TRIAGE_TOAST_ID = 'triage';
 import type { WorkflowArticle, WorkflowState } from '../lib/workflowTypes';
 import {
   patchArticleState,
@@ -126,7 +130,7 @@ export function useTriageMutations() {
     onError: (_err, _vars, context) => {
       if (context?.querySnapshots) restoreQuerySnapshots(queryClient, context.querySnapshots);
       else if (context?.snap) restoreToCache(queryClient, context.snap.article);
-      toast.error('Action failed — changes reverted');
+      toast.error('Action failed — changes reverted', { id: TRIAGE_TOAST_ID });
     },
 
     onSettled: () => {
@@ -152,7 +156,7 @@ export function useTriageMutations() {
     onError: (_err, _vars, context) => {
       if (context?.querySnapshots) restoreQuerySnapshots(queryClient, context.querySnapshots);
       else if (context?.snap) restoreToCache(queryClient, context.snap.article);
-      toast.error('Action failed — changes reverted');
+      toast.error('Action failed — changes reverted', { id: TRIAGE_TOAST_ID });
     },
 
     onSettled: () => {
@@ -177,7 +181,7 @@ export function useTriageMutations() {
     onError: (_err, _vars, context) => {
       if (context?.querySnapshots) restoreQuerySnapshots(queryClient, context.querySnapshots);
       else if (context?.snap) restoreToCache(queryClient, context.snap.article);
-      toast.error('Action failed — changes reverted');
+      toast.error('Action failed — changes reverted', { id: TRIAGE_TOAST_ID });
     },
 
     onSettled: () => {
@@ -187,13 +191,14 @@ export function useTriageMutations() {
 
   function setState(article: WorkflowArticle, newState: WorkflowState, label: string) {
     if (newState === 'skipped' && article.starred) {
-      toast.error("Starred articles can't be skipped");
+      toast.error("Starred articles can't be skipped", { id: TRIAGE_TOAST_ID });
       return;
     }
     const snap = snapshot(article);
     const querySnapshots = snapshotArticleQueries(queryClient, article.id);
     setStateMutation.mutate({ article, newState });
     toast(label, {
+      id: TRIAGE_TOAST_ID,
       action: {
         label: 'Undo',
         onClick: () => {
@@ -214,6 +219,7 @@ export function useTriageMutations() {
     const querySnapshots = snapshotArticleQueries(queryClient, article.id);
     starMutation.mutate({ article, starred: nextStarred });
     toast(nextStarred ? 'Starred' : 'Unstarred', {
+      id: TRIAGE_TOAST_ID,
       action: {
         label: 'Undo',
         onClick: () => {
@@ -231,6 +237,7 @@ export function useTriageMutations() {
     const querySnapshots = snapshotArticleQueries(queryClient, article.id);
     sendLaterMutation.mutate({ article, days });
     toast('Snoozed to tomorrow', {
+      id: TRIAGE_TOAST_ID,
       action: {
         label: 'Undo',
         onClick: () => {


### PR DESCRIPTION
## Summary

- Rapid triage actions (mark read, skip, star, snooze) were each appending a new toast to the Sonner stack, resulting in multiple toasts visible at once
- Sonner's built-in mechanism for replacing a toast is a fixed `id`: calling `toast(label, { id: 'triage' })` updates the existing toast with that id instead of adding a new one
- Added `const TRIAGE_TOAST_ID = 'triage'` in `useTriageMutations.ts` and passed `id: TRIAGE_TOAST_ID` to every `toast()` and `toast.error()` call (6 call sites total)

## Test plan

- [ ] Updated `setState blocks skipping a starred article` assertion to include the `id` option
- [ ] New test: `every action toast carries the shared triage id so rapid actions replace the previous toast` — calls `setState`, `toggleStar`, and `sendLater` in sequence and asserts each toast options object has `id: 'triage'`
- [ ] All 237 frontend tests pass
- [ ] All 381 backend tests pass
- [ ] Lint, typecheck, pre-commit hooks all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)