### PR TITLE
fix(ci): pass --publish never to electron-builder to avoid missing GH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,11 @@ jobs:
 
       - name: Build universal DMG
         working-directory: desktop
-        run: npm run build:mac
+        # --publish never: prevent electron-builder from trying to push to
+        # GitHub itself (it reads the publish: config and demands GH_TOKEN in
+        # CI).  The manifest files (latest-mac.yml) are still written to dist/
+        # and uploaded manually by the "Create GitHub Release" step below.
+        run: npm run build:mac -- --publish never
 
       - name: Find DMG and update manifest
         id: dmg


### PR DESCRIPTION
## What failed

The Release workflow's "Desktop DMG" job has been failing since PR #215 added the `publish:` section to `desktop/electron-builder.yml`.

Error from the logs:
```
Error: GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
at PublishManager.artifactCreatedWithoutExplicitPublishConfig
```

## Root cause

When `electron-builder` sees a `publish:` config and detects it's running in a GitHub Actions environment, it automatically tries to connect to the GitHub API to check for/clean up releases — even if no explicit `--publish` flag was passed. This requires `GH_TOKEN` to be available to the **build** step, which it isn't (and shouldn't be, since we upload artifacts manually with `gh release create` in a later step).

## Fix

Pass `--publish never` explicitly to `electron-builder`. This tells it to build the DMG and write `latest-mac.yml` to `dist/` (needed by `electron-updater`) without touching the GitHub API. The existing "Find DMG and update manifest" step picks up the manifest and uploads it alongside the DMG.

One-line change in `.github/workflows/release.yml`:
```
npm run build:mac -- --publish never
```

## Test plan

- [ ] CI on this PR goes green (no macOS runner needed for lint/test)
- [ ] Merge triggers Release workflow — "Build universal DMG" step passes
- [ ] `latest-mac.yml` still appears in the GitHub Release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)