### PR TITLE
fix(release): quote DMG path in bash array to handle spaces in filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,14 +220,14 @@ jobs:
 
           Built from ${{ needs.version.outputs.tag }}."
 
-          ASSETS="${{ steps.dmg.outputs.path }}"
+          ASSETS=("${{ steps.dmg.outputs.path }}")
           MANIFEST="${{ steps.dmg.outputs.manifest }}"
           if [ -n "$MANIFEST" ] && [ -f "$MANIFEST" ]; then
-            ASSETS="$ASSETS $MANIFEST"
+            ASSETS+=("$MANIFEST")
           fi
 
           gh release create "desktop-v$V" \
-            $ASSETS \
+            "${ASSETS[@]}" \
             --title "Desktop App v$V" \
             --notes "$NOTES" \
             --latest


### PR DESCRIPTION
## Summary

- The DMG filename is `News Dashboard-{version}-universal.dmg` (space in product name)
- The previous code stored the path in a shell string and expanded it unquoted: `gh release create ... $ASSETS` — this split the path on the space, causing `no matches found for 'desktop/dist/News'`
- Fix: use a bash array `ASSETS=("path")` / `ASSETS+=("manifest")` and expand with `"${ASSETS[@]}"` so the path stays as a single argument regardless of spaces

## Test plan

- [ ] Merge this PR and confirm the next Release workflow run's "Desktop DMG → Create GitHub Release" step succeeds
- [ ] Verify `desktop-v*` release is published with the DMG and `latest-mac.yml` attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)