### PR TITLE
[codex] Rank Today by recommendation scores

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -302,6 +302,24 @@ POSTGRES_MULTIUSER_SCHEMA = [
     CREATE INDEX IF NOT EXISTS idx_uas_user_state_article
       ON user_article_state(user_id, state, article_id)
     """,
+    """
+    CREATE TABLE IF NOT EXISTS user_article_recommendations (
+      user_id              INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      article_id           BIGINT  NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+      recommendation_score DOUBLE PRECISION NOT NULL,
+      cold_start_score     DOUBLE PRECISION,
+      signals              JSONB NOT NULL DEFAULT '{}'::jsonb,
+      model_version        TEXT NOT NULL DEFAULT 'cold-start-v1',
+      computed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (user_id, article_id),
+      CHECK (recommendation_score >= 0 AND recommendation_score <= 100)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_uar_user_score
+      ON user_article_recommendations(user_id, recommendation_score DESC, article_id)
+    """,
 ]
 
 

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -695,6 +695,44 @@ _UAS_STATE_COLUMNS = frozenset(
     }
 )
 
+_COLD_START_RECOMMENDATION_SCORE_SQL = """
+    (
+      LEAST(GREATEST(COALESCE(a.importance_score, 50), 0), 100)::double precision * 0.45
+      + LEAST(GREATEST(COALESCE(src.priority, 50), 0), 100)::double precision * 0.25
+      + CASE lower(COALESCE(a.category, ''))
+          WHEN 'ai' THEN 8.0
+          WHEN 'ai-ml' THEN 8.0
+          WHEN 'python' THEN 7.0
+          WHEN 'security' THEN 6.0
+          WHEN 'devtools' THEN 5.0
+          WHEN 'tech' THEN 4.0
+          ELSE 2.0
+        END
+      + CASE
+          WHEN lower(COALESCE(a.tags, '')) ~ '(agents|llm|python|security|release)' THEN 8.0
+          WHEN lower(COALESCE(a.title, '') || ' ' || COALESCE(a.summary, ''))
+            ~ '(agent|llm|python|security|release)' THEN 5.0
+          ELSE 0.0
+        END
+      + CASE
+          WHEN a.discovered_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '36 hours' THEN 12.0
+          WHEN a.discovered_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '7 days' THEN 7.0
+          WHEN a.discovered_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '30 days' THEN 3.0
+          ELSE 0.0
+        END
+    )
+"""
+
+
+def _article_order_clause(*, state: str | None) -> str:
+    if state == "today":
+        return (
+            "ORDER BY "
+            f"COALESCE(uar.recommendation_score, {_COLD_START_RECOMMENDATION_SCORE_SQL}) DESC,"
+            " a.discovered_at DESC, a.id DESC"
+        )
+    return "ORDER BY a.discovered_at DESC, a.id DESC"
+
 
 def _article_dict(row: Any) -> dict[str, Any]:
     """Convert a DB row to a dict, stripping internal-only columns.
@@ -940,10 +978,12 @@ def _list_articles_for_user(  # noqa: PLR0913
     # Final param order matches SQL left-to-right:
     # 1. us_src JOIN: user_id
     # 2. uas JOIN:    user_id
-    # 3. WHERE:       where_params
-    # 4. owner check: user_id
-    # 5. LIMIT/OFFSET
-    all_params: list[object] = [user_id, user_id, *where_params, user_id, limit, offset]
+    # 3. uar JOIN:    user_id
+    # 4. WHERE:       where_params
+    # 5. owner check: user_id
+    # 6. LIMIT/OFFSET
+    all_params: list[object] = [user_id, user_id, user_id, *where_params, user_id, limit, offset]
+    order_clause = _article_order_clause(state=state)
 
     sql = f"""
         SELECT {_article_list_select("a")},
@@ -959,12 +999,14 @@ def _list_articles_for_user(  # noqa: PLR0913
         LEFT JOIN sources src ON src.slug = a.source_slug
         LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
         LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = %s
+        LEFT JOIN user_article_recommendations uar
+          ON uar.article_id = a.id AND uar.user_id = %s
         {where}
           AND (
             (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true))
             OR src.owner_user_id = %s
           )
-        ORDER BY a.discovered_at DESC, a.id DESC
+        {order_clause}
         LIMIT %s OFFSET %s
     """
     with connect(db_path) as conn:

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db
+
+
+def upsert_recommendation_score(
+    user_id: int,
+    article_id: int,
+    recommendation_score: float,
+    *,
+    db_path: Path | None = None,
+    cold_start_score: float | None = None,
+    signals: dict[str, Any] | None = None,
+    model_version: str = "cold-start-v1",
+) -> None:
+    """Persist recommendation metadata for one user/article pair."""
+    init_db(db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_recommendations(
+              user_id, article_id, recommendation_score, cold_start_score, signals, model_version
+            )
+            VALUES (%s, %s, %s, %s, %s::jsonb, %s)
+            ON CONFLICT(user_id, article_id) DO UPDATE SET
+              recommendation_score = excluded.recommendation_score,
+              cold_start_score = excluded.cold_start_score,
+              signals = excluded.signals,
+              model_version = excluded.model_version,
+              updated_at = NOW()
+            """,
+            (
+                user_id,
+                article_id,
+                float(recommendation_score),
+                cold_start_score,
+                json.dumps(signals or {}),
+                model_version,
+            ),
+        )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -124,8 +124,8 @@ def pg_clean(pg_url: str) -> str:
 
     with psycopg.connect(pg_url) as conn:
         conn.execute(
-            "TRUNCATE user_article_state, user_sources, briefing_articles, briefings,"
-            " articles, sources, users RESTART IDENTITY CASCADE"
+            "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
+            " briefing_articles, briefings, articles, sources, users RESTART IDENTITY CASCADE"
         )
         conn.commit()
     return pg_url

--- a/backend/tests/test_database_config.py
+++ b/backend/tests/test_database_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from news_dashboard.db import (
+    POSTGRES_MULTIUSER_SCHEMA,
     POSTGRES_SCHEMA,
     active_database_url,
     describe_database,
@@ -22,6 +23,14 @@ def test_postgres_articles_schema_includes_embedding_column() -> None:
 
     assert "embedding bytea" in postgres_schema
     assert "alter table articles add column if not exists embedding bytea" in postgres_schema
+
+
+def test_postgres_schema_includes_user_article_recommendations() -> None:
+    postgres_schema = "\n".join(POSTGRES_MULTIUSER_SCHEMA).lower()
+
+    assert "create table if not exists user_article_recommendations" in postgres_schema
+    assert "primary key (user_id, article_id)" in postgres_schema
+    assert "idx_uar_user_score" in postgres_schema
 
 
 def test_database_url_is_required(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_today_recommendations.py
+++ b/backend/tests/test_today_recommendations.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import news_dashboard.db as db_mod
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.ingest import sync_sources
+from news_dashboard.main import app
+from news_dashboard.recommendations import upsert_recommendation_score
+
+pytestmark = pytest.mark.postgres
+
+
+def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
+    db_path = tmp_path / name
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+    init_db(db_path)
+    return db_path
+
+
+def _make_user(db_path: Path, username: str) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_source(
+    db_path: Path,
+    slug: str,
+    *,
+    category: str = "tech",
+    priority: int = 50,
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, %s, 'rss_feed', %s, TRUE)
+            ON CONFLICT(slug) DO UPDATE SET
+              name = excluded.name,
+              url = excluded.url,
+              category = excluded.category,
+              priority = excluded.priority,
+              enabled = TRUE
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml", category, priority),
+        )
+
+
+def _insert_article(
+    db_path: Path,
+    slug: str,
+    suffix: str,
+    *,
+    category: str = "tech",
+    importance: int = 50,
+    tags: str = "",
+    discovered_at: str = "2026-06-21T10:00:00+00:00",
+) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, importance_score, tags, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/articles/{suffix}",
+                f"https://example.com/articles/{suffix}",
+                f"Article {suffix}",
+                slug,
+                slug.title(),
+                category,
+                importance,
+                tags,
+                discovered_at,
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int, username: str) -> TestClient:
+    fake_user = {"id": user_id, "username": username, "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _today_ids(client: TestClient) -> list[int]:
+    response = client.get("/api/articles", params={"state": "today", "limit": 20})
+    assert response.status_code == 200
+    return [int(item["id"]) for item in response.json()["items"]]
+
+
+def test_today_endpoint_orders_by_persisted_scores_and_keeps_missing_visible(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "today-recs.db")
+    _insert_source(db_path, "quiet-source", category="misc", priority=1)
+    user_id = _make_user(db_path, "alice")
+
+    low = _insert_article(
+        db_path,
+        "quiet-source",
+        "persisted-low",
+        category="misc",
+        importance=1,
+        discovered_at="2026-06-20T10:00:00+00:00",
+    )
+    high = _insert_article(
+        db_path,
+        "quiet-source",
+        "persisted-high",
+        category="misc",
+        importance=1,
+        discovered_at="2026-06-19T10:00:00+00:00",
+    )
+    missing = _insert_article(
+        db_path,
+        "quiet-source",
+        "missing-score",
+        category="misc",
+        importance=1,
+        discovered_at="2020-01-01T00:00:00+00:00",
+    )
+
+    upsert_recommendation_score(user_id, low, 20.0, db_path=db_path)
+    upsert_recommendation_score(user_id, high, 95.0, db_path=db_path)
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            ids = _today_ids(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert ids[:3] == [high, low, missing]
+    assert set(ids) >= {high, low, missing}
+
+
+def test_today_recommendation_scores_are_isolated_per_user(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "per-user-recs.db")
+    _insert_source(db_path, "shared-source", category="misc", priority=1)
+    alice_id = _make_user(db_path, "alice")
+    bob_id = _make_user(db_path, "bob")
+    first = _insert_article(db_path, "shared-source", "first", category="misc", importance=1)
+    second = _insert_article(db_path, "shared-source", "second", category="misc", importance=1)
+
+    upsert_recommendation_score(alice_id, first, 90.0, db_path=db_path)
+    upsert_recommendation_score(alice_id, second, 10.0, db_path=db_path)
+    upsert_recommendation_score(bob_id, first, 10.0, db_path=db_path)
+    upsert_recommendation_score(bob_id, second, 90.0, db_path=db_path)
+
+    try:
+        with _client_for(alice_id, "alice") as client:
+            alice_ids = _today_ids(client)
+        with _client_for(bob_id, "bob") as client:
+            bob_ids = _today_ids(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert alice_ids[:2] == [first, second]
+    assert bob_ids[:2] == [second, first]
+
+
+def test_today_endpoint_uses_cold_start_fallback_for_missing_scores(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "cold-start-recs.db")
+    sync_sources(db_path)
+    _insert_source(db_path, "hot-ai-source", category="ai", priority=95)
+    _insert_source(db_path, "low-priority-source", category="misc", priority=1)
+    user_id = _make_user(db_path, "alice")
+
+    old_low_signal = _insert_article(
+        db_path,
+        "low-priority-source",
+        "old-low-signal",
+        category="misc",
+        importance=1,
+        tags="",
+        discovered_at="2020-01-01T00:00:00+00:00",
+    )
+    recent_topic_match = _insert_article(
+        db_path,
+        "hot-ai-source",
+        "recent-topic-match",
+        category="ai",
+        importance=80,
+        tags="agents,llm",
+        discovered_at="2026-06-21T12:00:00+00:00",
+    )
+    older_important = _insert_article(
+        db_path,
+        "hot-ai-source",
+        "older-important",
+        category="ai",
+        importance=70,
+        tags="",
+        discovered_at="2026-06-10T12:00:00+00:00",
+    )
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            ids = _today_ids(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert ids[:3] == [recent_topic_match, older_important, old_low_signal]


### PR DESCRIPTION
## Summary

- Add `user_article_recommendations` for per-user/per-article recommendation score metadata.
- Rank authenticated Today Feed results by persisted recommendation score when available.
- Fall back to a cold-start score using importance, recency, source priority, category/source priors, and lightweight topic/tag priors while keeping all eligible Today articles visible.
- Add backend/API coverage for Today ordering, all-visible behavior, per-user isolation, and missing-score fallback.

Closes #220

## Verification

- `PATH="$PWD/.venv/bin:$PATH" pre-commit run`
- `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_database_config.py backend/tests/test_db_init.py backend/tests/test_today_recommendations.py -q`
- `PATH="$PWD/.venv/bin:$PWD/node_modules/.bin:$PATH" DATABASE_URL='postgresql://localhost:55432/news_dashboard_test' TEST_DATABASE_URL='postgresql://localhost:55432/news_dashboard_test' pre-commit run --hook-stage pre-push --all-files`
- `PATH="$PWD/.venv/bin:$PWD/node_modules/.bin:$PATH" DATABASE_URL='postgresql://localhost:55432/news_dashboard_test' TEST_DATABASE_URL='postgresql://localhost:55432/news_dashboard_test' git push -u origin codex/issue-220-today-recommendation-scores`

## Notes

Local live PostgreSQL tests initially skipped because Docker/testcontainers were unavailable. I installed PostgreSQL 16 via Homebrew and ran a temporary local cluster on port 55432 for the final pre-push backend test gate.
