### PR TITLE
feat: learn behavioral affinity from workflow actions (#221)

### DIFF
--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -1,10 +1,159 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db
+from .db import connect, init_db, row_to_dict
+
+BEHAVIORAL_MODEL_VERSION = "behavioral-affinity-v1"
+
+# Weight each workflow action contributes toward feature affinity.
+# Starred is handled separately as a flag bonus (see STAR_WEIGHT) because an
+# article can be starred while in any state.  Later is deliberately neutral:
+# it signals deferred interest, not rejection.
+STATE_SIGNAL_WEIGHTS: dict[str, float] = {
+    "done": 1.0,
+    "skipped": -1.0,
+    "archived": -1.0,
+    "later": 0.0,
+    "today": 0.0,
+}
+
+# Starred is the strongest positive signal; it stacks on top of the state weight.
+STAR_WEIGHT = 2.0
+
+# Laplace-style smoothing: shrinks affinity toward neutral when only a handful of
+# interactions exist for a feature, so a single click can't dominate scoring.
+AFFINITY_SMOOTHING = 2.0
+
+# Relative importance of each feature family when blending into one adjustment.
+SOURCE_AFFINITY_WEIGHT = 1.0
+CATEGORY_AFFINITY_WEIGHT = 1.0
+TOPIC_AFFINITY_WEIGHT = 1.0
+
+# Maximum number of points behavioral affinity can shift a score in either
+# direction.  Kept well below the base-score range so a high-quality article from
+# a noisy/disliked source can still rise — affinity nudges, it does not gate.
+AFFINITY_SCORE_SPAN = 25.0
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def parse_tags(tags: str | None) -> tuple[str, ...]:
+    """Split a stored comma-separated tag string into a normalized tuple."""
+    if not tags:
+        return ()
+    return tuple(t.strip().lower() for t in tags.split(",") if t.strip())
+
+
+@dataclass(frozen=True)
+class ArticleSignal:
+    """One past user/article interaction used to learn affinity."""
+
+    state: str
+    starred: bool
+    source_slug: str
+    category: str | None = None
+    tags: tuple[str, ...] = ()
+
+    @property
+    def weight(self) -> float:
+        """Signed strength of this interaction as an implicit-feedback signal."""
+        base = STATE_SIGNAL_WEIGHTS.get(self.state, 0.0)
+        if self.starred:
+            base += STAR_WEIGHT
+        return base
+
+
+@dataclass
+class AffinityProfile:
+    """Per-user, per-feature affinities learned from workflow actions.
+
+    Each affinity is normalized to roughly [-1, 1]: positive means the user
+    tends to engage with that feature, negative means they dismiss it.
+    """
+
+    sources: dict[str, float] = field(default_factory=dict)
+    categories: dict[str, float] = field(default_factory=dict)
+    topics: dict[str, float] = field(default_factory=dict)
+
+    def adjustment(self, source_slug: str, category: str | None, tags: tuple[str, ...]) -> float:
+        """Return the score delta (in points) for an article with these features."""
+        contributions: list[tuple[float, float]] = []
+        if source_slug in self.sources:
+            contributions.append((SOURCE_AFFINITY_WEIGHT, self.sources[source_slug]))
+        if category and category in self.categories:
+            contributions.append((CATEGORY_AFFINITY_WEIGHT, self.categories[category]))
+        topic_affinities = [self.topics[tag] for tag in tags if tag in self.topics]
+        if topic_affinities:
+            contributions.append(
+                (TOPIC_AFFINITY_WEIGHT, sum(topic_affinities) / len(topic_affinities))
+            )
+        if not contributions:
+            return 0.0
+        total_weight = sum(weight for weight, _ in contributions)
+        blended = sum(weight * affinity for weight, affinity in contributions) / total_weight
+        return _clamp(blended, -1.0, 1.0) * AFFINITY_SCORE_SPAN
+
+
+def _normalize_affinity(weighted_sum: float, count: int) -> float:
+    """Smoothed, normalized affinity in [-1, 1] for one feature value."""
+    smoothed = weighted_sum / (count + AFFINITY_SMOOTHING)
+    # Normalize against STAR_WEIGHT so a fully-starred history maps near +1.
+    return _clamp(smoothed / STAR_WEIGHT, -1.0, 1.0)
+
+
+def build_affinity_profile(signals: list[ArticleSignal]) -> AffinityProfile:
+    """Aggregate interaction signals into a normalized per-feature affinity profile."""
+    source_sum: dict[str, float] = defaultdict(float)
+    source_count: dict[str, int] = defaultdict(int)
+    category_sum: dict[str, float] = defaultdict(float)
+    category_count: dict[str, int] = defaultdict(int)
+    topic_sum: dict[str, float] = defaultdict(float)
+    topic_count: dict[str, int] = defaultdict(int)
+
+    for signal in signals:
+        weight = signal.weight
+        source_sum[signal.source_slug] += weight
+        source_count[signal.source_slug] += 1
+        if signal.category:
+            category_sum[signal.category] += weight
+            category_count[signal.category] += 1
+        for tag in signal.tags:
+            topic_sum[tag] += weight
+            topic_count[tag] += 1
+
+    return AffinityProfile(
+        sources={
+            slug: _normalize_affinity(total, source_count[slug])
+            for slug, total in source_sum.items()
+        },
+        categories={
+            cat: _normalize_affinity(total, category_count[cat])
+            for cat, total in category_sum.items()
+        },
+        topics={
+            tag: _normalize_affinity(total, topic_count[tag]) for tag, total in topic_sum.items()
+        },
+    )
+
+
+def score_article(
+    base_score: float,
+    *,
+    source_slug: str,
+    category: str | None,
+    tags: tuple[str, ...],
+    profile: AffinityProfile,
+) -> float:
+    """Combine a cold-start base score with learned affinity, clamped to [0, 100]."""
+    adjusted = base_score + profile.adjustment(source_slug, category, tags)
+    return _clamp(adjusted, 0.0, 100.0)
 
 
 def upsert_recommendation_score(
@@ -42,3 +191,101 @@ def upsert_recommendation_score(
                 model_version,
             ),
         )
+
+
+# States that constitute an explicit interaction worth learning from.
+_INTERACTION_STATES = ("done", "skipped", "archived", "later")
+
+
+def _load_user_signals(conn: Any, user_id: int) -> list[ArticleSignal]:
+    """Read the user's live workflow state + starred metadata into signals."""
+    rows = conn.execute(
+        """
+        SELECT uas.state, uas.starred, a.source_slug, a.category, a.tags
+        FROM user_article_state uas
+        JOIN articles a ON a.id = uas.article_id
+        WHERE uas.user_id = %s
+          AND (uas.starred IS TRUE OR uas.state IN ('done', 'skipped', 'archived', 'later'))
+        """,
+        (user_id,),
+    ).fetchall()
+    signals: list[ArticleSignal] = []
+    for row in rows:
+        d = row_to_dict(row)
+        signals.append(
+            ArticleSignal(
+                state=str(d.get("state") or "today"),
+                starred=bool(d.get("starred", False)),
+                source_slug=str(d["source_slug"]),
+                category=d.get("category"),
+                tags=parse_tags(d.get("tags")),
+            )
+        )
+    return signals
+
+
+def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]]:
+    """Read today/later-eligible articles with their cold-start base score."""
+    from .ingest import _COLD_START_RECOMMENDATION_SCORE_SQL
+
+    rows = conn.execute(
+        f"""
+        SELECT a.id, a.source_slug, a.category, a.tags,
+          {_COLD_START_RECOMMENDATION_SCORE_SQL} AS base_score
+        FROM articles a
+        LEFT JOIN sources src ON src.slug = a.source_slug
+        LEFT JOIN user_article_state uas
+          ON uas.article_id = a.id AND uas.user_id = %s
+        WHERE (a.canonical_id IS NULL OR COALESCE(uas.state, 'today') != 'archived')
+          AND COALESCE(uas.state, 'today') IN ('today', 'later')
+        ORDER BY a.discovered_at DESC, a.id DESC
+        LIMIT %s
+        """,
+        (user_id, limit),
+    ).fetchall()
+    return [row_to_dict(row) for row in rows]
+
+
+def recompute_user_recommendations(
+    user_id: int,
+    *,
+    db_path: Path | None = None,
+    limit: int = 1000,
+) -> int:
+    """Recompute and persist behavioral-affinity scores for a user's live feed.
+
+    Learns affinity from the user's workflow actions (starred/done/skipped/
+    archived/later) and blends it with each candidate article's cold-start base
+    score.  Returns the number of articles scored.  Pure scoring logic lives in
+    :func:`build_affinity_profile` / :func:`score_article` and is unit-testable
+    without touching the database.
+    """
+    init_db(db_path)
+    with connect(db_path) as conn:
+        profile = build_affinity_profile(_load_user_signals(conn, user_id))
+        candidates = _load_candidates(conn, user_id, limit)
+
+    scored = 0
+    for candidate in candidates:
+        base = float(candidate["base_score"])
+        source_slug = str(candidate["source_slug"])
+        category = candidate.get("category")
+        tags = parse_tags(candidate.get("tags"))
+        adjustment = profile.adjustment(source_slug, category, tags)
+        final_score = _clamp(base + adjustment, 0.0, 100.0)
+        upsert_recommendation_score(
+            user_id,
+            int(candidate["id"]),
+            final_score,
+            db_path=db_path,
+            cold_start_score=base,
+            signals={
+                "base_score": round(base, 4),
+                "affinity_adjustment": round(adjustment, 4),
+                "source_slug": source_slug,
+                "category": category,
+            },
+            model_version=BEHAVIORAL_MODEL_VERSION,
+        )
+        scored += 1
+    return scored

--- a/backend/tests/test_behavioral_affinity.py
+++ b/backend/tests/test_behavioral_affinity.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import news_dashboard.db as db_mod
+from news_dashboard.db import connect, init_db
+from news_dashboard.recommendations import (
+    AFFINITY_SCORE_SPAN,
+    ArticleSignal,
+    build_affinity_profile,
+    parse_tags,
+    recompute_user_recommendations,
+    score_article,
+)
+
+pytestmark = pytest.mark.postgres
+
+
+# ── Pure scoring logic (no database) ──────────────────────────────────────────
+
+
+def test_parse_tags_normalizes_and_drops_empties() -> None:
+    assert parse_tags(" Agents, LLM ,, python ") == ("agents", "llm", "python")
+    assert parse_tags(None) == ()
+    assert parse_tags("") == ()
+
+
+def test_starred_is_strongest_positive_signal() -> None:
+    starred = ArticleSignal(state="today", starred=True, source_slug="s")
+    done = ArticleSignal(state="done", starred=False, source_slug="s")
+    later = ArticleSignal(state="later", starred=False, source_slug="s")
+    assert starred.weight > done.weight > 0.0
+    assert later.weight == 0.0
+
+
+def test_positive_signals_raise_and_negative_signals_lower_scores() -> None:
+    liked = build_affinity_profile(
+        [
+            ArticleSignal(state="done", starred=True, source_slug="good", category="ai"),
+            ArticleSignal(state="done", starred=False, source_slug="good", category="ai"),
+        ]
+    )
+    disliked = build_affinity_profile(
+        [
+            ArticleSignal(state="skipped", starred=False, source_slug="bad", category="crypto"),
+            ArticleSignal(state="archived", starred=False, source_slug="bad", category="crypto"),
+        ]
+    )
+    base = 50.0
+    assert score_article(base, source_slug="good", category="ai", tags=(), profile=liked) > base
+    assert (
+        score_article(base, source_slug="bad", category="crypto", tags=(), profile=disliked) < base
+    )
+
+
+def test_later_is_neutral_not_negative() -> None:
+    profile = build_affinity_profile(
+        [
+            ArticleSignal(state="later", starred=False, source_slug="src", category="ai"),
+            ArticleSignal(state="later", starred=False, source_slug="src", category="ai"),
+        ]
+    )
+    base = 50.0
+    assert score_article(base, source_slug="src", category="ai", tags=(), profile=profile) == base
+
+
+def test_source_category_and_topic_affinities_each_influence_score() -> None:
+    profile = build_affinity_profile(
+        [
+            ArticleSignal(
+                state="done",
+                starred=True,
+                source_slug="src",
+                category="ai",
+                tags=("agents",),
+            )
+        ]
+        * 3
+    )
+    assert profile.adjustment("src", None, ()) > 0  # source alone
+    assert profile.adjustment("other", "ai", ()) > 0  # category alone
+    assert profile.adjustment("other", None, ("agents",)) > 0  # topic alone
+
+
+def test_strong_article_from_disliked_source_can_still_rise() -> None:
+    """A bounded penalty means a high-base article isn't gated out by source."""
+    disliked = build_affinity_profile(
+        [ArticleSignal(state="skipped", starred=False, source_slug="noisy")] * 50
+    )
+    strong_from_noisy = score_article(
+        95.0, source_slug="noisy", category=None, tags=(), profile=disliked
+    )
+    weak_from_neutral = score_article(
+        40.0, source_slug="neutral", category=None, tags=(), profile=disliked
+    )
+    assert strong_from_noisy >= 95.0 - AFFINITY_SCORE_SPAN
+    assert strong_from_noisy > weak_from_neutral
+
+
+def test_scores_are_clamped_to_unit_range() -> None:
+    liked = build_affinity_profile(
+        [ArticleSignal(state="done", starred=True, source_slug="src")] * 10
+    )
+    assert score_article(99.0, source_slug="src", category=None, tags=(), profile=liked) <= 100.0
+    disliked = build_affinity_profile(
+        [ArticleSignal(state="skipped", starred=False, source_slug="src")] * 10
+    )
+    assert score_article(1.0, source_slug="src", category=None, tags=(), profile=disliked) >= 0.0
+
+
+# ── Database-backed recompute ─────────────────────────────────────────────────
+
+
+def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
+    db_path = tmp_path / name
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+    init_db(db_path)
+    return db_path
+
+
+def _make_user(db_path: Path, username: str) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, %s, 'rss_feed', %s, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml", category, priority),
+        )
+
+
+def _insert_article(
+    db_path: Path,
+    slug: str,
+    suffix: str,
+    *,
+    category: str = "tech",
+    importance: int = 50,
+    tags: str = "",
+) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, importance_score, tags, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/articles/{suffix}",
+                f"https://example.com/articles/{suffix}",
+                f"Article {suffix}",
+                slug,
+                slug.title(),
+                category,
+                importance,
+                tags,
+                "2026-06-21T10:00:00+00:00",
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _set_state(
+    db_path: Path, user_id: int, article_id: int, *, state: str, starred: bool = False
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state, starred)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT(user_id, article_id) DO UPDATE SET
+              state = excluded.state, starred = excluded.starred
+            """,
+            (user_id, article_id, state, starred),
+        )
+
+
+def _persisted_score(db_path: Path, user_id: int, article_id: int) -> float:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT recommendation_score FROM user_article_recommendations"
+            " WHERE user_id = %s AND article_id = %s",
+            (user_id, article_id),
+        ).fetchone()
+    assert row is not None
+    return float(row["recommendation_score"])
+
+
+def test_recompute_persists_affinity_adjusted_scores(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "recompute.db")
+    _insert_source(db_path, "loved", category="ai", priority=50)
+    _insert_source(db_path, "hated", category="crypto", priority=50)
+    user_id = _make_user(db_path, "alice")
+
+    # History: star/done on the loved source, skip/archive on the hated one.
+    for i in range(3):
+        liked = _insert_article(db_path, "loved", f"liked-{i}", category="ai")
+        _set_state(db_path, user_id, liked, state="done", starred=True)
+        disliked = _insert_article(db_path, "hated", f"disliked-{i}", category="crypto")
+        _set_state(db_path, user_id, disliked, state="skipped")
+
+    # Two fresh candidates with identical base, differing only by source/category.
+    good = _insert_article(db_path, "loved", "candidate-good", category="ai")
+    bad = _insert_article(db_path, "hated", "candidate-bad", category="crypto")
+
+    count = recompute_user_recommendations(user_id, db_path=db_path)
+    assert count >= 2
+    assert _persisted_score(db_path, user_id, good) > _persisted_score(db_path, user_id, bad)
+
+
+def test_recompute_is_isolated_per_user(tmp_path: Path, monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "isolated.db")
+    _insert_source(db_path, "src-a", category="ai")
+    _insert_source(db_path, "src-b", category="crypto")
+    alice = _make_user(db_path, "alice")
+    bob = _make_user(db_path, "bob")
+
+    for i in range(3):
+        a = _insert_article(db_path, "src-a", f"a-{i}", category="ai")
+        b = _insert_article(db_path, "src-b", f"b-{i}", category="crypto")
+        # Alice likes A, dislikes B; Bob does the opposite.
+        _set_state(db_path, alice, a, state="done", starred=True)
+        _set_state(db_path, alice, b, state="skipped")
+        _set_state(db_path, bob, b, state="done", starred=True)
+        _set_state(db_path, bob, a, state="skipped")
+
+    cand_a = _insert_article(db_path, "src-a", "cand-a", category="ai")
+    cand_b = _insert_article(db_path, "src-b", "cand-b", category="crypto")
+
+    recompute_user_recommendations(alice, db_path=db_path)
+    recompute_user_recommendations(bob, db_path=db_path)
+
+    assert _persisted_score(db_path, alice, cand_a) > _persisted_score(db_path, alice, cand_b)
+    assert _persisted_score(db_path, bob, cand_b) > _persisted_score(db_path, bob, cand_a)
+
+
+def test_recompute_with_no_history_keeps_base_scores(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "no-history.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "only", category="ai")
+
+    assert recompute_user_recommendations(user_id, db_path=db_path) == 1
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT recommendation_score, cold_start_score"
+            " FROM user_article_recommendations WHERE user_id = %s AND article_id = %s",
+            (user_id, article),
+        ).fetchone()
+    assert row is not None
+    # No interactions → affinity profile is empty → score equals the cold-start base.
+    assert float(row["recommendation_score"]) == pytest.approx(float(row["cold_start_score"]))


### PR DESCRIPTION
Closes #221.

## What this does

Turns a user's workflow actions into implicit feedback that shapes future Today-feed scoring, reading the **live per-user `user_article_state` + starred metadata** rather than legacy article status fields.

- **Starred** → strongest positive signal (stacks on top of state weight)
- **Done** → positive
- **Skip / Archive** → negative
- **Later** → neutral (deferred interest, never a penalty)

Affinity is learned per **source**, **category**, and **topic/tag**, normalized to roughly [-1, 1] with Laplace smoothing so a single interaction can't dominate. It is applied as a **bounded** adjustment (±`AFFINITY_SCORE_SPAN` = 25 pts) on top of the existing cold-start base score — so a strong article from a noisy/disliked source can still rise instead of being gated out at the source level.

## Design

- `build_affinity_profile(signals)` and `score_article(...)` are **pure functions**, unit-testable with no DB.
- `recompute_user_recommendations(user_id)` wires them to the DB: loads the user's interactions, builds the profile, scores today/later candidates against the cold-start base, and persists via `upsert_recommendation_score` (model_version `behavioral-affinity-v1`). The existing Today ordering already prefers persisted scores over the cold-start fallback.

## Tests

`backend/tests/test_behavioral_affinity.py` covers: positive raises / negative lowers, Later-neutral, source/category/topic affinity each influencing score, strong-article-from-disliked-source still rising, clamping, per-user isolation, and the no-history (= base score) case.

`make lint`, `make typecheck`, and the new + existing recommendation tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)