### PR TITLE
feat: add semantic similarity to hybrid recommendation score (#222)

### DIFF
--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -41,6 +41,29 @@ def _unpack(blob: bytes) -> list[float]:
     return list(struct.unpack(f"{n}f", blob))
 
 
+def decode_embedding(blob: bytes) -> list[float]:
+    """Public helper: deserialize a stored embedding BLOB into a float vector."""
+    return _unpack(blob)
+
+
+# ── Embedding source text ──────────────────────────────────────────────────
+
+
+def embedding_text(
+    title: str | None,
+    summary: str | None,
+    reason: str | None = None,
+    tags: str | None = None,
+) -> str:
+    """Build the text fed to the embedding model from an article's fields.
+
+    Uses title, summary, reason, and tags — no full-body extraction required.
+    Empty fields are dropped so missing data never adds noise.
+    """
+    parts = [part.strip() for part in (title, summary, reason, tags) if part and part.strip()]
+    return " ".join(parts)
+
+
 # ── OpenAI embedding ───────────────────────────────────────────────────────
 
 
@@ -84,6 +107,11 @@ def _cosine(a: list[float], b: list[float]) -> float:
     return float(dot / (norm_a * norm_b))
 
 
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Public helper: cosine similarity between two embedding vectors."""
+    return _cosine(a, b)
+
+
 # ── Lazy embedding of saved/read articles ─────────────────────────────────
 
 
@@ -94,12 +122,12 @@ def ensure_article_embedded(article_id: int, db_path: Any = None) -> None:
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
-            "SELECT id, title, summary, embedding FROM articles WHERE id=%s",
+            "SELECT id, title, summary, reason, tags, embedding FROM articles WHERE id=%s",
             (article_id,),
         ).fetchone()
         if row is None or row["embedding"] is not None:
             return  # already embedded or gone
-        text = f"{row['title']} {row['summary']}".strip()
+        text = embedding_text(row["title"], row["summary"], row["reason"], row["tags"])
         if not text:
             return
         vector = _embed(text)
@@ -122,13 +150,14 @@ def embed_all_eligible(db_path: Any = None, *, include_all: bool = False) -> int
     init_db(db_path)
     with connect(db_path) as conn:
         query = (
-            f"SELECT id, title, summary FROM articles WHERE {status_filter} AND embedding IS NULL"
+            "SELECT id, title, summary, reason, tags FROM articles "
+            f"WHERE {status_filter} AND embedding IS NULL"
         )
         rows = conn.execute(query).fetchall()
 
     count = 0
     for row in rows:
-        text = f"{row['title']} {row['summary']}".strip()
+        text = embedding_text(row["title"], row["summary"], row["reason"], row["tags"])
         if not text:
             continue
         vector = _embed(text)

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -9,6 +9,7 @@ from typing import Any
 from .db import connect, init_db, row_to_dict
 
 BEHAVIORAL_MODEL_VERSION = "behavioral-affinity-v1"
+SEMANTIC_MODEL_VERSION = "semantic-hybrid-v1"
 
 # Weight each workflow action contributes toward feature affinity.
 # Starred is handled separately as a flag bonus (see STAR_WEIGHT) because an
@@ -38,6 +39,12 @@ TOPIC_AFFINITY_WEIGHT = 1.0
 # direction.  Kept well below the base-score range so a high-quality article from
 # a noisy/disliked source can still rise — affinity nudges, it does not gate.
 AFFINITY_SCORE_SPAN = 25.0
+
+# Maximum points semantic similarity to the user's valued history can add to a
+# score.  Like affinity, it is a bounded lift that blends with — never replaces —
+# the behavioral and cold-start factors, so semantic scoring degrading to a
+# no-op simply leaves the other factors in charge.
+SEMANTIC_SCORE_SPAN = 25.0
 
 
 def _clamp(value: float, low: float, high: float) -> float:
@@ -156,6 +163,50 @@ def score_article(
     return _clamp(adjusted, 0.0, 100.0)
 
 
+def build_semantic_profile(vectors: list[list[float]]) -> list[float] | None:
+    """Mean-pool valued-history embeddings into one taste vector.
+
+    Returns ``None`` when there are no usable vectors (no embedded history),
+    which callers treat as "semantic scoring unavailable" and fall back to the
+    non-semantic path.
+    """
+    centroid: list[float] | None = None
+    used = 0
+    for vector in vectors:
+        if not vector:
+            continue
+        if centroid is None:
+            centroid = list(vector)
+        elif len(vector) == len(centroid):
+            for i, value in enumerate(vector):
+                centroid[i] += value
+        else:
+            continue  # skip mismatched dimensions defensively
+        used += 1
+    if centroid is None or used == 0:
+        return None
+    return [value / used for value in centroid]
+
+
+def semantic_adjustment(
+    candidate_vector: list[float] | None,
+    profile_vector: list[float] | None,
+) -> float:
+    """Score delta (in points) from semantic similarity to the user's taste.
+
+    Degrades to ``0.0`` when either the candidate or the profile vector is
+    missing, so missing embeddings never disturb the rest of the score.
+    """
+    if not candidate_vector or not profile_vector:
+        return 0.0
+    if len(candidate_vector) != len(profile_vector):
+        return 0.0
+    from .embeddings import cosine_similarity
+
+    similarity = cosine_similarity(candidate_vector, profile_vector)
+    return _clamp(similarity, -1.0, 1.0) * SEMANTIC_SCORE_SPAN
+
+
 def upsert_recommendation_score(
     user_id: int,
     article_id: int,
@@ -224,13 +275,40 @@ def _load_user_signals(conn: Any, user_id: int) -> list[ArticleSignal]:
     return signals
 
 
+def _load_user_history_vectors(conn: Any, user_id: int) -> list[list[float]]:
+    """Decode embeddings of the user's valued history (starred or done).
+
+    Articles without an embedding are skipped, so an empty list means "no
+    embedded history" and semantic scoring stays disabled for this user.
+    """
+    from .embeddings import decode_embedding
+
+    rows = conn.execute(
+        """
+        SELECT a.embedding
+        FROM user_article_state uas
+        JOIN articles a ON a.id = uas.article_id
+        WHERE uas.user_id = %s
+          AND a.embedding IS NOT NULL
+          AND (uas.starred IS TRUE OR uas.state = 'done')
+        """,
+        (user_id,),
+    ).fetchall()
+    vectors: list[list[float]] = []
+    for row in rows:
+        blob = row_to_dict(row).get("embedding")
+        if blob is not None:
+            vectors.append(decode_embedding(bytes(blob)))
+    return vectors
+
+
 def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]]:
     """Read today/later-eligible articles with their cold-start base score."""
     from .ingest import _COLD_START_RECOMMENDATION_SCORE_SQL
 
     rows = conn.execute(
         f"""
-        SELECT a.id, a.source_slug, a.category, a.tags,
+        SELECT a.id, a.source_slug, a.category, a.tags, a.embedding,
           {_COLD_START_RECOMMENDATION_SCORE_SQL} AS base_score
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
@@ -263,8 +341,10 @@ def recompute_user_recommendations(
     init_db(db_path)
     with connect(db_path) as conn:
         profile = build_affinity_profile(_load_user_signals(conn, user_id))
+        semantic_profile = build_semantic_profile(_load_user_history_vectors(conn, user_id))
         candidates = _load_candidates(conn, user_id, limit)
 
+    model_version = SEMANTIC_MODEL_VERSION if semantic_profile else BEHAVIORAL_MODEL_VERSION
     scored = 0
     for candidate in candidates:
         base = float(candidate["base_score"])
@@ -272,7 +352,9 @@ def recompute_user_recommendations(
         category = candidate.get("category")
         tags = parse_tags(candidate.get("tags"))
         adjustment = profile.adjustment(source_slug, category, tags)
-        final_score = _clamp(base + adjustment, 0.0, 100.0)
+        candidate_vector = _decode_candidate_embedding(candidate.get("embedding"))
+        semantic = semantic_adjustment(candidate_vector, semantic_profile)
+        final_score = _clamp(base + adjustment + semantic, 0.0, 100.0)
         upsert_recommendation_score(
             user_id,
             int(candidate["id"]),
@@ -282,10 +364,20 @@ def recompute_user_recommendations(
             signals={
                 "base_score": round(base, 4),
                 "affinity_adjustment": round(adjustment, 4),
+                "semantic_adjustment": round(semantic, 4),
                 "source_slug": source_slug,
                 "category": category,
             },
-            model_version=BEHAVIORAL_MODEL_VERSION,
+            model_version=model_version,
         )
         scored += 1
     return scored
+
+
+def _decode_candidate_embedding(blob: Any) -> list[float] | None:
+    """Best-effort decode of a candidate's stored embedding, ``None`` if absent."""
+    if blob is None:
+        return None
+    from .embeddings import decode_embedding
+
+    return decode_embedding(bytes(blob))

--- a/backend/tests/test_semantic_similarity.py
+++ b/backend/tests/test_semantic_similarity.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import news_dashboard.db as db_mod
+import news_dashboard.embeddings as embeddings_mod
+from news_dashboard.db import connect, init_db
+from news_dashboard.embeddings import embedding_text, ensure_article_embedded
+from news_dashboard.recommendations import (
+    SEMANTIC_SCORE_SPAN,
+    build_semantic_profile,
+    recompute_user_recommendations,
+    semantic_adjustment,
+)
+
+pytestmark = pytest.mark.postgres
+
+
+# ── Pure semantic logic (no database) ─────────────────────────────────────────
+
+
+def test_embedding_text_combines_fields_and_drops_blanks() -> None:
+    assert embedding_text("Title", "Summary", "Reason", "tag1,tag2") == (
+        "Title Summary Reason tag1,tag2"
+    )
+    # Missing fields are skipped rather than leaving stray whitespace.
+    assert embedding_text("Title", "", None, "  ") == "Title"
+    assert embedding_text(None, None, None, None) == ""
+
+
+def test_build_semantic_profile_averages_vectors() -> None:
+    profile = build_semantic_profile([[1.0, 0.0], [0.0, 1.0]])
+    assert profile == [0.5, 0.5]
+
+
+def test_build_semantic_profile_returns_none_without_vectors() -> None:
+    assert build_semantic_profile([]) is None
+    assert build_semantic_profile([[]]) is None
+
+
+def test_semantic_adjustment_rewards_similarity() -> None:
+    profile = [1.0, 0.0]
+    aligned = semantic_adjustment([1.0, 0.0], profile)
+    orthogonal = semantic_adjustment([0.0, 1.0], profile)
+    assert aligned == pytest.approx(SEMANTIC_SCORE_SPAN)
+    assert orthogonal == pytest.approx(0.0)
+    assert aligned > orthogonal
+
+
+def test_semantic_adjustment_degrades_when_vectors_missing() -> None:
+    assert semantic_adjustment(None, [1.0, 0.0]) == 0.0
+    assert semantic_adjustment([1.0, 0.0], None) == 0.0
+    # Mismatched dimensions are treated as unavailable rather than crashing.
+    assert semantic_adjustment([1.0, 0.0, 0.0], [1.0, 0.0]) == 0.0
+
+
+# ── Database-backed recompute ─────────────────────────────────────────────────
+
+
+def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
+    db_path = tmp_path / name
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+    init_db(db_path)
+    return db_path
+
+
+def _make_user(db_path: Path, username: str) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, %s, 'rss_feed', %s, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml", category, priority),
+        )
+
+
+def _insert_article(
+    db_path: Path,
+    slug: str,
+    suffix: str,
+    *,
+    category: str = "tech",
+    importance: int = 50,
+    embedding: list[float] | None = None,
+) -> int:
+    blob = struct.pack(f"{len(embedding)}f", *embedding) if embedding is not None else None
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, importance_score, discovered_at, embedding
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/articles/{suffix}",
+                f"https://example.com/articles/{suffix}",
+                f"Article {suffix}",
+                slug,
+                slug.title(),
+                category,
+                importance,
+                "2026-06-21T10:00:00+00:00",
+                blob,
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _set_state(
+    db_path: Path, user_id: int, article_id: int, *, state: str, starred: bool = False
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state, starred)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT(user_id, article_id) DO UPDATE SET
+              state = excluded.state, starred = excluded.starred
+            """,
+            (user_id, article_id, state, starred),
+        )
+
+
+def _persisted_score(db_path: Path, user_id: int, article_id: int) -> float:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT recommendation_score FROM user_article_recommendations"
+            " WHERE user_id = %s AND article_id = %s",
+            (user_id, article_id),
+        ).fetchone()
+    assert row is not None
+    return float(row["recommendation_score"])
+
+
+def test_semantic_lift_raises_similar_articles(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "semantic-lift.db")
+    _insert_source(db_path, "src", category="tech", priority=50)
+    user_id = _make_user(db_path, "alice")
+
+    # Valued history points the taste vector toward [1, 0].
+    history = _insert_article(db_path, "src", "history", embedding=[1.0, 0.0])
+    _set_state(db_path, user_id, history, state="done", starred=True)
+
+    # Two fresh candidates, identical except for their embeddings.
+    similar = _insert_article(db_path, "src", "similar", embedding=[0.95, 0.05])
+    different = _insert_article(db_path, "src", "different", embedding=[0.0, 1.0])
+
+    recompute_user_recommendations(user_id, db_path=db_path)
+
+    assert _persisted_score(db_path, user_id, similar) > _persisted_score(
+        db_path, user_id, different
+    )
+
+
+def test_missing_candidate_embedding_falls_back_to_non_semantic(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "missing-embed.db")
+    _insert_source(db_path, "src", category="tech", priority=50)
+    user_id = _make_user(db_path, "alice")
+
+    history = _insert_article(db_path, "src", "history", embedding=[1.0, 0.0])
+    _set_state(db_path, user_id, history, state="done", starred=True)
+
+    # Candidate has no embedding → semantic lift is skipped, score == cold start.
+    candidate = _insert_article(db_path, "src", "no-embed", embedding=None)
+
+    recompute_user_recommendations(user_id, db_path=db_path)
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT recommendation_score, signals"
+            " FROM user_article_recommendations WHERE user_id = %s AND article_id = %s",
+            (user_id, candidate),
+        ).fetchone()
+    assert row is not None
+    # No embedding on the candidate → semantic lift contributes nothing; the
+    # rest of the (behavioral + cold-start) score is still computed normally.
+    assert row["signals"]["semantic_adjustment"] == pytest.approx(0.0)
+
+
+def test_recompute_survives_unavailable_embedding_generation(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "embed-down.db")
+    _insert_source(db_path, "src", category="tech", priority=50)
+    user_id = _make_user(db_path, "alice")
+
+    # The embedding service is down: any generation attempt raises.
+    def _boom(_text: str) -> list[float]:
+        message = "embedding service unavailable"
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(embeddings_mod, "_embed", _boom)
+
+    history = _insert_article(db_path, "src", "history", embedding=None)
+    _set_state(db_path, user_id, history, state="done", starred=True)
+    candidate = _insert_article(db_path, "src", "candidate", embedding=None)
+
+    # Failed generation surfaces to callers (which wrap it in try/except)...
+    with pytest.raises(RuntimeError):
+        ensure_article_embedded(history, db_path)
+
+    # ...and recompute still produces scores with no embeddings present.
+    assert recompute_user_recommendations(user_id, db_path=db_path) >= 1
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT model_version FROM user_article_recommendations"
+            " WHERE user_id = %s AND article_id = %s",
+            (user_id, candidate),
+        ).fetchone()
+    assert row is not None
+    # No embedded history → behavioral (non-semantic) model version.
+    assert row["model_version"] == "behavioral-affinity-v1"
+
+
+def test_semantic_scoring_is_isolated_per_user(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "semantic-isolated.db")
+    _insert_source(db_path, "src", category="tech", priority=50)
+    alice = _make_user(db_path, "alice")
+    bob = _make_user(db_path, "bob")
+
+    # Alice's taste points toward [1, 0]; Bob's toward [0, 1].
+    a_hist = _insert_article(db_path, "src", "a-hist", embedding=[1.0, 0.0])
+    b_hist = _insert_article(db_path, "src", "b-hist", embedding=[0.0, 1.0])
+    _set_state(db_path, alice, a_hist, state="done", starred=True)
+    _set_state(db_path, bob, b_hist, state="done", starred=True)
+
+    cand_x = _insert_article(db_path, "src", "cand-x", embedding=[1.0, 0.0])
+    cand_y = _insert_article(db_path, "src", "cand-y", embedding=[0.0, 1.0])
+
+    recompute_user_recommendations(alice, db_path=db_path)
+    recompute_user_recommendations(bob, db_path=db_path)
+
+    # Each user ranks the candidate matching their own history higher.
+    assert _persisted_score(db_path, alice, cand_x) > _persisted_score(db_path, alice, cand_y)
+    assert _persisted_score(db_path, bob, cand_y) > _persisted_score(db_path, bob, cand_x)


### PR DESCRIPTION
Closes #222.

## What this does

Adds **semantic similarity** as one factor in the hybrid recommendation score, blended with the existing behavioral-affinity and cold-start factors rather than replacing them.

- **Embedding source text** (`embedding_text`) is built from **title, summary, reason, and tags** — no full article body extraction. Lazy embedding at ingest / status-change now uses these fields.
- **Per-user taste vector**: a user's *valued history* (starred or done articles that have embeddings) is mean-pooled into one centroid (`build_semantic_profile`).
- **Candidate scoring**: each Today/Later candidate with an embedding gets a cosine-similarity lift toward that taste vector, applied as a **bounded ±`SEMANTIC_SCORE_SPAN` (25 pt)** adjustment on top of `base + affinity` — so semantic nudges, it never gates.

## Graceful degradation

- Candidate or history articles **without embeddings** → semantic lift is `0`, the non-semantic score stands.
- **No embedded history** → falls back to the `behavioral-affinity-v1` model version.
- **Embedding service failures** already surface to the lazy-embed call sites in `ingest`/`main`, which wrap them in try/except — ingestion and Today loading keep working.

## Design

`build_semantic_profile(vectors)` and `semantic_adjustment(candidate, profile)` are **pure functions**, unit-testable with no DB. `recompute_user_recommendations` wires them to the DB alongside the existing affinity profile and persists scores under `semantic-hybrid-v1` (or `behavioral-affinity-v1` when no semantic signal is available).

## Tests

`backend/tests/test_semantic_similarity.py` covers: embedding-text composition, profile averaging, semantic lift raising similar articles, missing embeddings, unavailable embedding generation, and per-user isolation.

`make lint`, `make typecheck`, and `make test` (404 backend + 260 frontend) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)