### PR TITLE
feat: show compact recommendation labels in Today (#224)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -994,7 +994,9 @@ def _list_articles_for_user(  # noqa: PLR0913
           uas.skipped_at  AS _uas_skipped_at,
           uas.archived_at AS _uas_archived_at,
           uas.later_until AS _uas_later_until,
-          uas.restored_at AS _uas_restored_at
+          uas.restored_at AS _uas_restored_at,
+          uar.recommendation_score AS _uar_recommendation_score,
+          uar.model_version        AS _uar_recommendation_model
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
         LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
@@ -1023,6 +1025,9 @@ def _list_articles_for_user(  # noqa: PLR0913
             d["archived_at"] = d.pop("_uas_archived_at", None)
             d["later_until"] = d.pop("_uas_later_until", None)
             d["restored_at"] = d.pop("_uas_restored_at", None)
+            rec_score = d.pop("_uar_recommendation_score", None)
+            d["recommendation_score"] = float(rec_score) if rec_score is not None else None
+            d["recommendation_model"] = d.pop("_uar_recommendation_model", None)
             articles.append(d)
         _attach_also_from(conn, articles)
         return articles

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -176,6 +176,32 @@ def test_pg_list_articles_unstarred_filter(pg_env: str) -> None:
     assert any(a["id"] == aid_b for a in unstarred)
 
 
+def test_pg_list_articles_exposes_recommendation_metadata(pg_env: str) -> None:
+    """list_articles must surface recommendation_score/model for compact Today labels."""
+    from news_dashboard.ingest import list_articles
+    from news_dashboard.recommendations import upsert_recommendation_score
+
+    pg_url = pg_env
+    _add_global_source(pg_url, "pg-src-rec")
+    uid = _make_user(pg_url, "rec-user")
+    aid_scored = _add_article(pg_url, source_slug="pg-src-rec", url_suffix="rec-scored")
+    aid_unscored = _add_article(pg_url, source_slug="pg-src-rec", url_suffix="rec-unscored")
+
+    upsert_recommendation_score(uid, aid_scored, 82.5, model_version="semantic-hybrid-v1")
+
+    results = list_articles(state="today", user_id=uid)
+    by_id = {a["id"]: a for a in results}
+
+    scored = by_id[aid_scored]
+    assert scored["recommendation_score"] == pytest.approx(82.5)
+    assert scored["recommendation_model"] == "semantic-hybrid-v1"
+
+    # Articles without recommendation metadata degrade gracefully to None.
+    unscored = by_id[aid_unscored]
+    assert unscored["recommendation_score"] is None
+    assert unscored["recommendation_model"] is None
+
+
 def test_pg_list_articles_today_without_uas(pg_env: str) -> None:
     """list_articles state=today must work when no UAS row exists (NULL coalesces to false)."""
     from news_dashboard.ingest import list_articles

--- a/frontend/src/__tests__/recommendationLabel.test.tsx
+++ b/frontend/src/__tests__/recommendationLabel.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ArticleRow } from '../components/article/ArticleRow';
+import { recommendationLabel, RECOMMENDATION_LABEL_TEXT } from '../lib/recommendation';
+import type { WorkflowArticle } from '../lib/workflowTypes';
+
+const setState = vi.fn();
+const toggleStar = vi.fn();
+
+vi.mock('../hooks/useTriageMutations', () => ({
+  useTriageMutations: () => ({ setState, toggleStar, sendLater: vi.fn() }),
+  ARTICLES_KEY: 'articles',
+}));
+
+function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
+  return {
+    id: '42',
+    title: 'Readable article',
+    sourceId: 'source',
+    sourceName: 'Source',
+    category: 'ai-llm',
+    url: 'https://example.com/readable',
+    publishedAt: '2026-06-16T10:00:00Z',
+    ingestedAt: '2026-06-16T11:00:00Z',
+    reason: 'This is why it matters.',
+    summary: 'Summary text.',
+    signal: 'high',
+    tags: ['ai'],
+    bodyStatus: 'missing',
+    state: 'today',
+    starred: false,
+    ...overrides,
+  };
+}
+
+function renderRow(article: WorkflowArticle) {
+  return render(
+    <MemoryRouter initialEntries={['/today']}>
+      <Routes>
+        <Route path="/today" element={<ArticleRow article={article} />} />
+        <Route path="/a/:id" element={<div data-testid="reader">Reader</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('recommendationLabel — score bands', () => {
+  it('maps high scores to Recommended', () => {
+    expect(recommendationLabel(95)).toBe('recommended');
+    expect(recommendationLabel(70)).toBe('recommended');
+  });
+
+  it('maps mid scores to Relevant', () => {
+    expect(recommendationLabel(69.9)).toBe('relevant');
+    expect(recommendationLabel(45)).toBe('relevant');
+  });
+
+  it('maps low scores to Low signal', () => {
+    expect(recommendationLabel(44.9)).toBe('low');
+    expect(recommendationLabel(0)).toBe('low');
+  });
+
+  it('returns null for missing or invalid scores', () => {
+    expect(recommendationLabel(undefined)).toBeNull();
+    expect(recommendationLabel(null)).toBeNull();
+    expect(recommendationLabel(NaN)).toBeNull();
+  });
+});
+
+describe('ArticleRow — compact recommendation labels', () => {
+  it('renders the recommendation label when a score is present', () => {
+    renderRow(makeArticle({ recommendationScore: 82 }));
+    const label = screen.getByTestId('recommendation-label');
+    expect(label.textContent).toBe(RECOMMENDATION_LABEL_TEXT.recommended);
+    expect(label.getAttribute('data-source')).toBe('recommendation');
+    expect(label.className).toContain('text-signal-high');
+  });
+
+  it('renders the Relevant band for mid scores', () => {
+    renderRow(makeArticle({ recommendationScore: 50 }));
+    const label = screen.getByTestId('recommendation-label');
+    expect(label.textContent).toBe('Relevant');
+    expect(label.className).toContain('text-signal-mid');
+  });
+
+  it('falls back to the importance signal label when no score is present', () => {
+    renderRow(makeArticle({ recommendationScore: undefined, signal: 'high' }));
+    const label = screen.getByTestId('recommendation-label');
+    expect(label.textContent).toBe('High signal');
+    expect(label.getAttribute('data-source')).toBe('signal');
+    expect(label.className).toContain('text-signal-high');
+  });
+});
+
+describe('ArticleRow — existing workflows keep working', () => {
+  it('keeps the article link for keyboard/tap opening', () => {
+    renderRow(makeArticle({ recommendationScore: 82 }));
+    const link = screen.getByRole('link', { name: /readable article/i });
+    expect(link.getAttribute('href')).toBe('/a/42');
+  });
+
+  it('fires the done action on swipe-right (mobile-friendly row interaction)', () => {
+    setState.mockClear();
+    renderRow(makeArticle({ recommendationScore: 50 }));
+    const link = screen.getByRole('link', { name: /readable article/i });
+    const touchTarget = link.parentElement!;
+    fireEvent.touchStart(touchTarget, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchMove(touchTarget, { touches: [{ clientX: 100, clientY: 0 }] });
+    fireEvent.touchEnd(touchTarget);
+    expect(setState).toHaveBeenCalledWith(expect.objectContaining({ id: '42' }), 'done', 'Read');
+  });
+});

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -63,6 +63,7 @@ export function adaptArticle(a: LegacyArticle): WorkflowArticle {
     reason: a.reason,
     summary: a.summary,
     signal: scoreToSignal(a.importance_score),
+    recommendationScore: a.recommendation_score ?? undefined,
     tags: parseTags(a.tags),
     body: a.body ?? undefined,
     bodyStatus: a.body_status ?? 'missing',

--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Star } from 'lucide-react';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
 import { relativeTime, signalLabel } from '@/lib/format';
+import { recommendationLabel, RECOMMENDATION_LABEL_TEXT } from '@/lib/recommendation';
 import { cn } from '@/lib/utils';
 import { SwipeableRow } from './SwipeableRow';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
@@ -20,10 +21,15 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
   const handleSkip = () => setState(article, 'skipped', 'Skipped');
   const handleStar = () => toggleStar(article);
 
-  const signalColor =
-    article.signal === 'high'
+  // Prefer the personalized recommendation band when the article has been ranked
+  // for this user; otherwise fall back to the importance-derived visual signal so
+  // unranked rows degrade gracefully instead of going blank.
+  const recLabel = recommendationLabel(article.recommendationScore);
+  const labelText = recLabel ? RECOMMENDATION_LABEL_TEXT[recLabel] : signalLabel(article.signal);
+  const labelColor =
+    recLabel === 'recommended' || (!recLabel && article.signal === 'high')
       ? 'text-signal-high'
-      : article.signal === 'mid'
+      : recLabel === 'relevant' || (!recLabel && article.signal === 'mid')
         ? 'text-signal-mid'
         : 'text-signal-low';
 
@@ -58,7 +64,13 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
         </h3>
         <p className="text-[13px] leading-snug text-foreground/80 line-clamp-1">{article.reason}</p>
         <div className="mt-1.5 flex items-center gap-2 text-[11px]">
-          <span className={cn('font-medium', signalColor)}>{signalLabel(article.signal)}</span>
+          <span
+            className={cn('font-medium', labelColor)}
+            data-testid="recommendation-label"
+            data-source={recLabel ? 'recommendation' : 'signal'}
+          >
+            {labelText}
+          </span>
           {showLaterUntil && article.later_until && (
             <>
               <span className="text-subtle">·</span>

--- a/frontend/src/lib/recommendation.ts
+++ b/frontend/src/lib/recommendation.ts
@@ -1,0 +1,30 @@
+/**
+ * Compact recommendation labels for the Today feed.
+ *
+ * The backend exposes a per-user `recommendation_score` (0–100) blended from
+ * behavioral affinity, semantic similarity, freshness, and novelty. We collapse
+ * that continuous score into three scannable bands so a ranked feed stays
+ * readable without surfacing raw numbers. When no score is available (the user
+ * has no recommendation metadata for an article yet) the helper returns `null`,
+ * and callers fall back to the existing importance-derived visual signal.
+ */
+
+export type RecommendationLabel = 'recommended' | 'relevant' | 'low';
+
+// Band thresholds on the 0–100 recommendation score. Tuned so "Recommended" is
+// reserved for genuinely strong matches while most ranked items read "Relevant".
+const RECOMMENDED_THRESHOLD = 70;
+const RELEVANT_THRESHOLD = 45;
+
+export function recommendationLabel(score: number | null | undefined): RecommendationLabel | null {
+  if (score == null || Number.isNaN(score)) return null;
+  if (score >= RECOMMENDED_THRESHOLD) return 'recommended';
+  if (score >= RELEVANT_THRESHOLD) return 'relevant';
+  return 'low';
+}
+
+export const RECOMMENDATION_LABEL_TEXT: Record<RecommendationLabel, string> = {
+  recommended: 'Recommended',
+  relevant: 'Relevant',
+  low: 'Low signal',
+};

--- a/frontend/src/lib/workflowTypes.ts
+++ b/frontend/src/lib/workflowTypes.ts
@@ -14,6 +14,8 @@ export interface WorkflowArticle {
   reason: string;
   summary: string;
   signal: Signal;
+  /** Per-user recommendation score (0–100); undefined when not yet ranked. */
+  recommendationScore?: number;
   tags: string[];
   body?: string;
   bodyStatus: 'ok' | 'missing' | 'error';

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -31,6 +31,8 @@ export interface Article {
   canonical_id?: number | null;
   body?: string | null;
   body_status?: 'ok' | 'missing' | 'error';
+  recommendation_score?: number | null;
+  recommendation_model?: string | null;
 }
 
 export interface User {


### PR DESCRIPTION
Closes #224

## What changed

Surfaces compact, scannable recommendation labels in the Today feed so the ranked list reads clearly without raw scores or visual clutter.

### Backend
- `list_articles` (per-user path) now selects `uar.recommendation_score` and `uar.model_version`, exposing them on each Today article as `recommendation_score` / `recommendation_model`. Articles with no recommendation row return `null` for both.

### Frontend
- New pure helper `lib/recommendation.ts` collapses the 0–100 score into three bands: **Recommended** (≥70), **Relevant** (≥45), **Low signal** (<45); returns `null` when no score is available.
- `ArticleRow` renders the recommendation band label, falling back to the existing importance-derived signal label when an article has no recommendation metadata — so unranked rows degrade gracefully.
- `recommendationScore` threaded through the `WorkflowArticle` adapter and `Article` type.

## Acceptance criteria
- [x] Today API responses include recommendation metadata when available
- [x] Rows render Recommended / Relevant / Low signal without clutter
- [x] Graceful fallback to existing visual signal when metadata is absent
- [x] Triage shortcuts, row focus, opening, swipe, starring, mobile tap flows unchanged
- [x] Frontend tests cover label rendering, fallback, keyboard (link), and mobile (swipe) interaction

## Testing
- `npm run lint && npm run typecheck && npm run test:frontend && npm run build` — green (269 tests)
- Backend `make lint && make typecheck` — green; `pytest` recommendation/ingest/postgres suites — 38 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)