### PR TITLE
feat: expose inspectable recommendation explanations (#225)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -996,7 +996,8 @@ def _list_articles_for_user(  # noqa: PLR0913
           uas.later_until AS _uas_later_until,
           uas.restored_at AS _uas_restored_at,
           uar.recommendation_score AS _uar_recommendation_score,
-          uar.model_version        AS _uar_recommendation_model
+          uar.model_version        AS _uar_recommendation_model,
+          uar.signals              AS _uar_recommendation_signals
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
         LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
@@ -1028,6 +1029,10 @@ def _list_articles_for_user(  # noqa: PLR0913
             rec_score = d.pop("_uar_recommendation_score", None)
             d["recommendation_score"] = float(rec_score) if rec_score is not None else None
             d["recommendation_model"] = d.pop("_uar_recommendation_model", None)
+            # The signals JSONB carries the per-factor breakdown (affinity,
+            # semantic, freshness, novelty) used to produce on-demand
+            # explanations; absent for unranked articles.
+            d["recommendation_signals"] = d.pop("_uar_recommendation_signals", None)
             articles.append(d)
         _attach_also_from(conn, articles)
         return articles

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -187,7 +187,19 @@ def test_pg_list_articles_exposes_recommendation_metadata(pg_env: str) -> None:
     aid_scored = _add_article(pg_url, source_slug="pg-src-rec", url_suffix="rec-scored")
     aid_unscored = _add_article(pg_url, source_slug="pg-src-rec", url_suffix="rec-unscored")
 
-    upsert_recommendation_score(uid, aid_scored, 82.5, model_version="semantic-hybrid-v1")
+    upsert_recommendation_score(
+        uid,
+        aid_scored,
+        82.5,
+        model_version="semantic-hybrid-v1",
+        signals={
+            "affinity_adjustment": 8.0,
+            "semantic_adjustment": 12.0,
+            "freshness_adjustment": 3.0,
+            "novelty_adjustment": 0.0,
+            "source_slug": "pg-src-rec",
+        },
+    )
 
     results = list_articles(state="today", user_id=uid)
     by_id = {a["id"]: a for a in results}
@@ -195,11 +207,15 @@ def test_pg_list_articles_exposes_recommendation_metadata(pg_env: str) -> None:
     scored = by_id[aid_scored]
     assert scored["recommendation_score"] == pytest.approx(82.5)
     assert scored["recommendation_model"] == "semantic-hybrid-v1"
+    # The per-factor signal breakdown powers on-demand explanations (#225).
+    assert scored["recommendation_signals"]["semantic_adjustment"] == pytest.approx(12.0)
+    assert scored["recommendation_signals"]["affinity_adjustment"] == pytest.approx(8.0)
 
     # Articles without recommendation metadata degrade gracefully to None.
     unscored = by_id[aid_unscored]
     assert unscored["recommendation_score"] is None
     assert unscored["recommendation_model"] is None
+    assert unscored["recommendation_signals"] is None
 
 
 def test_pg_list_articles_today_without_uas(pg_env: str) -> None:

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -445,6 +445,75 @@ describe('ArticlePage — AI insights (on-demand)', () => {
   });
 });
 
+// ─── Why recommended (on-demand explanation, #225) ────────────────────────────
+
+describe('ArticlePage — why recommended (on-demand)', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full article text.' })
+    );
+  });
+
+  it('keeps the explanation collapsed by default to avoid clutter', async () => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({
+        body_status: 'ok',
+        body: 'Text',
+        recommendation_score: 82,
+        recommendation_signals: { semantic_adjustment: 12 },
+      })
+    );
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    expect(screen.getByTestId('why-recommended-button')).toBeTruthy();
+    expect(screen.queryByTestId('why-recommended-section')).toBeNull();
+  });
+
+  it('reveals concise factor reasons on demand', async () => {
+    const scored = makeArticle({
+      body_status: 'ok',
+      body: 'Text',
+      recommendation_score: 88,
+      recommendation_signals: { affinity_adjustment: 8, semantic_adjustment: 12 },
+    });
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(scored);
+    // The body-fetch response replaces the cached article, so it must carry the
+    // same recommendation metadata for the explanation to survive body load.
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(scored);
+    renderReader();
+    await waitFor(() => screen.getByTestId('why-recommended-button'));
+    await userEvent.click(screen.getByTestId('why-recommended-button'));
+    await waitFor(() => expect(screen.getByTestId('why-recommended-section')).toBeTruthy());
+    expect(screen.getByText('Matches sources and topics you engage with')).toBeTruthy();
+    expect(screen.getByText('Similar to articles you’ve starred or read')).toBeTruthy();
+  });
+
+  it('shows a useful fallback when recommendation metadata is missing', async () => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Text' })
+    );
+    renderReader();
+    await waitFor(() => screen.getByTestId('why-recommended-button'));
+    await userEvent.click(screen.getByTestId('why-recommended-button'));
+    await waitFor(() => expect(screen.getByTestId('why-recommended-section')).toBeTruthy());
+    expect(
+      screen.getByText('Not personalized yet — shown based on general importance')
+    ).toBeTruthy();
+  });
+
+  it('can be toggled closed again, preserving the clean reader', async () => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Text', recommendation_score: 70 })
+    );
+    renderReader();
+    await waitFor(() => screen.getByTestId('why-recommended-button'));
+    await userEvent.click(screen.getByTestId('why-recommended-button'));
+    await waitFor(() => expect(screen.getByTestId('why-recommended-section')).toBeTruthy());
+    await userEvent.click(screen.getByTestId('why-recommended-button'));
+    await waitFor(() => expect(screen.queryByTestId('why-recommended-section')).toBeNull());
+  });
+});
+
 // ─── Share button ─────────────────────────────────────────────────────────────
 
 describe('ArticlePage — Share button', () => {

--- a/frontend/src/__tests__/recommendationLabel.test.tsx
+++ b/frontend/src/__tests__/recommendationLabel.test.tsx
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ArticleRow } from '../components/article/ArticleRow';
-import { recommendationLabel, RECOMMENDATION_LABEL_TEXT } from '../lib/recommendation';
+import {
+  recommendationLabel,
+  recommendationExplanation,
+  RECOMMENDATION_LABEL_TEXT,
+} from '../lib/recommendation';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 
 const setState = vi.fn();
@@ -110,5 +114,55 @@ describe('ArticleRow — existing workflows keep working', () => {
     fireEvent.touchMove(touchTarget, { touches: [{ clientX: 100, clientY: 0 }] });
     fireEvent.touchEnd(touchTarget);
     expect(setState).toHaveBeenCalledWith(expect.objectContaining({ id: '42' }), 'done', 'Read');
+  });
+});
+
+describe('recommendationExplanation — concise factor reasons', () => {
+  it('names each factor that meaningfully lifted the score', () => {
+    const { reasons, fallback } = recommendationExplanation({
+      score: 85,
+      signals: {
+        affinity_adjustment: 8,
+        semantic_adjustment: 12,
+        freshness_adjustment: 3,
+        novelty_adjustment: 4,
+      },
+    });
+    expect(fallback).toBe(false);
+    expect(reasons).toEqual([
+      'Matches sources and topics you engage with',
+      'Similar to articles you’ve starred or read',
+      'Fresh and timely right now',
+      'Brings something new to your feed',
+    ]);
+  });
+
+  it('omits factors that did not contribute', () => {
+    const { reasons } = recommendationExplanation({
+      score: 60,
+      signals: {
+        affinity_adjustment: 0,
+        semantic_adjustment: 9,
+        freshness_adjustment: 0.2,
+        novelty_adjustment: -1,
+      },
+    });
+    expect(reasons).toEqual(['Similar to articles you’ve starred or read']);
+  });
+
+  it('falls back to a useful reason when a score exists but no factor stands out', () => {
+    const { reasons, fallback } = recommendationExplanation({
+      score: 48,
+      signals: { affinity_adjustment: 0, semantic_adjustment: 0 },
+    });
+    expect(fallback).toBe(true);
+    expect(reasons).toEqual(['Ranked by overall relevance and importance for you']);
+  });
+
+  it('explains unranked articles rather than rendering an empty list', () => {
+    const { reasons, fallback } = recommendationExplanation({});
+    expect(fallback).toBe(true);
+    expect(reasons).toEqual(['Not personalized yet — shown based on general importance']);
+    expect(reasons.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -64,6 +64,8 @@ export function adaptArticle(a: LegacyArticle): WorkflowArticle {
     summary: a.summary,
     signal: scoreToSignal(a.importance_score),
     recommendationScore: a.recommendation_score ?? undefined,
+    recommendationModel: a.recommendation_model ?? undefined,
+    recommendationSignals: a.recommendation_signals ?? undefined,
     tags: parseTags(a.tags),
     body: a.body ?? undefined,
     bodyStatus: a.body_status ?? 'missing',

--- a/frontend/src/lib/recommendation.ts
+++ b/frontend/src/lib/recommendation.ts
@@ -9,6 +9,8 @@
  * and callers fall back to the existing importance-derived visual signal.
  */
 
+import type { RecommendationSignals } from './workflowTypes';
+
 export type RecommendationLabel = 'recommended' | 'relevant' | 'low';
 
 // Band thresholds on the 0–100 recommendation score. Tuned so "Recommended" is
@@ -28,3 +30,73 @@ export const RECOMMENDATION_LABEL_TEXT: Record<RecommendationLabel, string> = {
   relevant: 'Relevant',
   low: 'Low signal',
 };
+
+// ─── On-demand explanations ───────────────────────────────────────────────────
+
+/**
+ * Minimum signed point contribution for a factor to be worth naming. Tiny
+ * adjustments (sub-point nudges) are noise and would produce misleading reasons,
+ * so we only surface factors that meaningfully moved the score.
+ */
+const FACTOR_REASON_THRESHOLD = 1.0;
+
+export interface RecommendationExplanation {
+  /** Concise, user-facing reasons naming the real contributing factors. */
+  reasons: string[];
+  /**
+   * True when no per-factor signals were available and the explanation falls
+   * back to a generic-but-useful description (cold-start or unranked article).
+   */
+  fallback: boolean;
+}
+
+interface ExplanationInput {
+  score?: number | null;
+  signals?: RecommendationSignals | null;
+}
+
+/**
+ * Derive concise explanation reasons from recommendation metadata.
+ *
+ * Each contributing factor (behavioral affinity, semantic similarity, freshness,
+ * novelty) is named only when it actually lifted the score by a meaningful
+ * amount, so the explanation reflects real signals rather than boilerplate. When
+ * no per-factor breakdown is present — an unranked article, or a cold-start score
+ * with no learned signals yet — we return a single useful fallback reason rather
+ * than an empty or misleading list.
+ */
+export function recommendationExplanation(input: ExplanationInput): RecommendationExplanation {
+  const { score, signals } = input;
+  const reasons: string[] = [];
+
+  if (signals) {
+    if ((signals.affinity_adjustment ?? 0) >= FACTOR_REASON_THRESHOLD) {
+      reasons.push('Matches sources and topics you engage with');
+    }
+    if ((signals.semantic_adjustment ?? 0) >= FACTOR_REASON_THRESHOLD) {
+      reasons.push('Similar to articles you’ve starred or read');
+    }
+    if ((signals.freshness_adjustment ?? 0) >= FACTOR_REASON_THRESHOLD) {
+      reasons.push('Fresh and timely right now');
+    }
+    if ((signals.novelty_adjustment ?? 0) >= FACTOR_REASON_THRESHOLD) {
+      reasons.push('Brings something new to your feed');
+    }
+  }
+
+  if (reasons.length > 0) {
+    return { reasons, fallback: false };
+  }
+
+  // No factor stood out. Produce a useful fallback rather than an empty UI.
+  if (score != null && !Number.isNaN(score)) {
+    return {
+      reasons: ['Ranked by overall relevance and importance for you'],
+      fallback: true,
+    };
+  }
+  return {
+    reasons: ['Not personalized yet — shown based on general importance'],
+    fallback: true,
+  };
+}

--- a/frontend/src/lib/workflowTypes.ts
+++ b/frontend/src/lib/workflowTypes.ts
@@ -2,6 +2,22 @@ export type WorkflowState = 'today' | 'later' | 'done' | 'skipped' | 'archived';
 
 export type Signal = 'high' | 'mid' | 'low';
 
+/**
+ * Per-factor recommendation breakdown persisted alongside the blended score.
+ * Each `*_adjustment` is the signed point contribution that factor made to the
+ * final score; fields are optional because older rows or cold-start scoring may
+ * omit factors that did not apply.
+ */
+export interface RecommendationSignals {
+  base_score?: number;
+  affinity_adjustment?: number;
+  semantic_adjustment?: number;
+  freshness_adjustment?: number;
+  novelty_adjustment?: number;
+  source_slug?: string | null;
+  category?: string | null;
+}
+
 export interface WorkflowArticle {
   id: string;
   title: string;
@@ -16,6 +32,10 @@ export interface WorkflowArticle {
   signal: Signal;
   /** Per-user recommendation score (0–100); undefined when not yet ranked. */
   recommendationScore?: number;
+  /** Model version that produced the score; undefined when not yet ranked. */
+  recommendationModel?: string;
+  /** Per-factor breakdown powering on-demand explanations; undefined when unranked. */
+  recommendationSignals?: RecommendationSignals;
   tags: string[];
   body?: string;
   bodyStatus: 'ok' | 'missing' | 'error';

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -18,6 +18,7 @@ import {
   Square,
   Share2,
   Sparkles,
+  Lightbulb,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { fetchArticle, fetchArticleBody, fetchArticleAudioUrl, fetchArticleInsights } from '@/api';
@@ -25,6 +26,7 @@ import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflo
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { formatDate, readingTime, signalLabel } from '@/lib/format';
 import { getReaderList } from '@/lib/readerList';
+import { recommendationExplanation } from '@/lib/recommendation';
 import { cn } from '@/lib/utils';
 
 function renderBody(md: string): string {
@@ -274,6 +276,10 @@ export function ArticlePage() {
     }
   }
 
+  // On-demand recommendation explanation — kept collapsed by default so the
+  // reader surface stays clean until the user asks why the article was ranked.
+  const [showWhyRecommended, setShowWhyRecommended] = useState(false);
+
   // Touch swipe
   const swipeRef = useRef<{ x: number; y: number } | null>(null);
   const [swipeDx, setSwipeDx] = useState(0);
@@ -488,6 +494,50 @@ export function ArticlePage() {
                 Why this matters
               </div>
               <p className="text-[14px] leading-snug text-foreground">{article.reason}</p>
+            </div>
+
+            {/* Why recommended — on-demand explanation of the personalized ranking.
+                Collapsed by default to keep the reader clean; expands to concise
+                reasons naming the real factors (affinity, similarity, freshness,
+                novelty) or a useful fallback when no breakdown is available. */}
+            <div className="mt-3">
+              <button
+                onClick={() => setShowWhyRecommended((v) => !v)}
+                data-testid="why-recommended-button"
+                aria-expanded={showWhyRecommended}
+                className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface/40 px-3 py-1.5 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-surface transition-colors"
+              >
+                <Lightbulb className="size-3.5" strokeWidth={1.75} />
+                {showWhyRecommended ? 'Hide why recommended' : 'Why recommended?'}
+              </button>
+              {showWhyRecommended &&
+                (() => {
+                  const explanation = recommendationExplanation({
+                    score: article.recommendationScore,
+                    signals: article.recommendationSignals,
+                  });
+                  return (
+                    <div
+                      className="mt-2 rounded-lg border border-border bg-surface/40 px-4 py-3"
+                      data-testid="why-recommended-section"
+                    >
+                      <div className="text-[10px] font-medium uppercase tracking-wider text-subtle mb-2">
+                        Why recommended
+                      </div>
+                      <ul className="space-y-1.5">
+                        {explanation.reasons.map((reason, i) => (
+                          <li
+                            key={i}
+                            className="flex items-start gap-2 text-[13px] leading-snug text-foreground"
+                          >
+                            <span className="mt-0.5 shrink-0 text-accent">•</span>
+                            <span>{reason}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  );
+                })()}
             </div>
 
             {/* Body */}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,6 @@
-import type { WorkflowState } from './lib/workflowTypes';
+import type { RecommendationSignals, WorkflowState } from './lib/workflowTypes';
+
+export type { RecommendationSignals };
 
 export type ArticleStatus = 'new' | 'read' | 'saved' | 'skipped' | 'archived';
 
@@ -33,6 +35,7 @@ export interface Article {
   body_status?: 'ok' | 'missing' | 'error';
   recommendation_score?: number | null;
   recommendation_model?: string | null;
+  recommendation_signals?: RecommendationSignals | null;
 }
 
 export interface User {


### PR DESCRIPTION
Closes #225.

## What

Adds on-demand recommendation explanations so an interested user can inspect *why* an article was ranked for them, while the Today feed stays clean.

## Backend
- `list_articles` now surfaces the stored `signals` JSONB as `recommendation_signals` next to the existing score/model. Unranked articles degrade to `None`.

## Frontend
- New `recommendationExplanation()` helper derives concise, user-facing reasons from the signal breakdown, naming only factors that meaningfully contributed: source/topic affinity, semantic similarity, freshness, novelty.
- Missing or fallback-only metadata produces a useful explanation rather than an empty/misleading UI.
- The article detail surface gains a collapsed-by-default **"Why recommended?"** disclosure. The Today feed and all existing row/detail interactions are unchanged.

## Tests
- Backend: `recommendation_signals` exposed for scored articles, `None` for unscored.
- Frontend: reason derivation (factor selection, omission, fallbacks), on-demand display toggle, missing-metadata fallback, and preservation of existing reader interactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)