### PR TITLE
feat: recalculate and observe stale recommendation scores (#226)

### DIFF
--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -29,5 +29,28 @@ def articles(status: str | None = None, limit: int = 20) -> None:
         )
 
 
+@app.command(name="rec-health")
+def rec_health() -> None:
+    """Print a diagnostic snapshot of stale/missing recommendation scores."""
+    from .recommendation_jobs import recommendation_health
+
+    health = recommendation_health()
+    for key in ("total_scores", "stale_scores", "outdated_scores", "missing_scores"):
+        typer.echo(f"{key}: {health[key]}")
+    typer.echo(f"oldest_computed_at: {health['oldest_computed_at']}")
+    for entry in health["by_model_version"]:
+        typer.echo(f"  {entry['model_version']}: {entry['count']}")
+
+
+@app.command(name="rec-recalc")
+def rec_recalc() -> None:
+    """Recalculate stale, missing, or superseded recommendation scores."""
+    from .recommendation_jobs import recalculate_stale_recommendations
+
+    summary = recalculate_stale_recommendations()
+    for key, value in summary.as_dict().items():
+        typer.echo(f"{key}: {value}")
+
+
 if __name__ == "__main__":
     app()

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -320,6 +320,16 @@ POSTGRES_MULTIUSER_SCHEMA = [
     CREATE INDEX IF NOT EXISTS idx_uar_user_score
       ON user_article_recommendations(user_id, recommendation_score DESC, article_id)
     """,
+    # `stale` flags scores whose inputs changed (preference history) and that need
+    # a background recalculation; the partial index keeps the "find stale" sweep cheap.
+    (
+        "ALTER TABLE user_article_recommendations"
+        " ADD COLUMN IF NOT EXISTS stale BOOLEAN NOT NULL DEFAULT FALSE"
+    ),
+    """
+    CREATE INDEX IF NOT EXISTS idx_uar_user_stale
+      ON user_article_recommendations(user_id) WHERE stale = TRUE
+    """,
 ]
 
 

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -846,6 +846,12 @@ def _upsert_uas(  # noqa: PLR0913
             updated_at,
         ),
     )
+    # A workflow/star change reshapes this user's affinity + semantic profile, so
+    # every stored score derived from it is now stale and eligible for a
+    # background recalculation (see recommendation_jobs.recalculate_stale_recommendations).
+    from .recommendation_jobs import mark_user_recommendations_stale
+
+    mark_user_recommendations_stale(conn, user_id)
 
 
 def list_articles(  # noqa: PLR0913

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -682,6 +682,20 @@ def ingest_run_sources(run_id: int) -> dict[str, Any]:
     return {"items": run_sources}
 
 
+@api.get("/api/recommendations/health", dependencies=_admin_dep)
+def recommendations_health_endpoint() -> dict[str, Any]:
+    from .recommendation_jobs import recommendation_health
+
+    return recommendation_health()
+
+
+@api.post("/api/recommendations/recalculate", dependencies=_admin_dep)
+def recommendations_recalculate_endpoint() -> dict[str, Any]:
+    from .recommendation_jobs import recalculate_stale_recommendations
+
+    return recalculate_stale_recommendations().as_dict()
+
+
 @api.get("/api/stats/overview", dependencies=_admin_dep)
 def stats_overview_endpoint(
     from_: Annotated[str, Query(alias="from")],

--- a/backend/news_dashboard/recommendation_jobs.py
+++ b/backend/news_dashboard/recommendation_jobs.py
@@ -1,0 +1,232 @@
+"""Background repair and observability for recommendation scores.
+
+The Today read path is intentionally a cheap LEFT JOIN against
+``user_article_recommendations`` that falls back to the cold-start SQL when a
+score is absent — it never recomputes the model synchronously.  This module
+provides the *out-of-band* path that keeps those stored scores fresh:
+
+* :func:`mark_user_recommendations_stale` flags a user's scores after a
+  preference change so they become eligible for recalculation.
+* :func:`find_recalculation_candidates` finds users whose scores are stale,
+  missing, or produced by a superseded scoring formula / embedding scheme.
+* :func:`recalculate_stale_recommendations` recomputes those users in the
+  background, isolating per-user failures so one bad user (or a transient
+  scoring error during ingestion) never blocks the rest.
+* :func:`recommendation_health` reports counts operators can use to diagnose
+  stale or missing recommendation data without reading the whole table.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db, row_to_dict
+from .recommendations import CURRENT_MODEL_VERSIONS, recompute_user_recommendations
+
+logger = logging.getLogger(__name__)
+
+# An article is a live recommendation candidate for a user when it is in their
+# today/later feed (mirrors the candidate predicate in ``_load_candidates``).
+_CANDIDATE_PREDICATE = (
+    "(a.canonical_id IS NULL OR COALESCE(uas.state, 'today') != 'archived')"
+    " AND COALESCE(uas.state, 'today') IN ('today', 'later')"
+)
+
+
+@dataclass(frozen=True)
+class RecalculationSummary:
+    """Outcome of a background recalculation sweep."""
+
+    users_considered: int = 0
+    users_recalculated: int = 0
+    users_failed: int = 0
+    scores_written: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "users_considered": self.users_considered,
+            "users_recalculated": self.users_recalculated,
+            "users_failed": self.users_failed,
+            "scores_written": self.scores_written,
+        }
+
+
+def mark_user_recommendations_stale(
+    conn: Any,
+    user_id: int,
+) -> None:
+    """Flag all of a user's stored scores stale after a preference change.
+
+    A workflow action (done/skip/archive/later/star) changes the affinity and
+    semantic profile that every one of the user's scores is derived from, so the
+    whole set is marked eligible for recalculation rather than trying to guess
+    which individual articles moved.  Runs on the caller's connection so it joins
+    the same transaction as the state write.
+    """
+    conn.execute(
+        "UPDATE user_article_recommendations SET stale = TRUE WHERE user_id = %s AND stale = FALSE",
+        (user_id,),
+    )
+
+
+def find_recalculation_candidates(
+    *,
+    db_path: Path | None = None,
+    database_url: str | None = None,
+) -> list[int]:
+    """Return ids of users with stale, missing, or superseded scores.
+
+    A user needs recalculation when any of these hold:
+
+    * an existing score is flagged ``stale`` (preference history changed), or
+    * an existing score was produced by a model version no longer current
+      (scoring formula or embedding scheme changed), or
+    * a live today/later candidate article has no stored score at all (new
+      article ingested, or a score that previously failed to persist).
+    """
+    init_db(db_path, database_url=database_url)
+    versions = list(CURRENT_MODEL_VERSIONS)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT u.id
+            FROM users u
+            WHERE EXISTS (
+                SELECT 1 FROM user_article_recommendations uar
+                WHERE uar.user_id = u.id
+                  AND (uar.stale = TRUE OR uar.model_version <> ALL(%s))
+            )
+            OR EXISTS (
+                SELECT 1 FROM articles a
+                LEFT JOIN user_article_state uas
+                  ON uas.article_id = a.id AND uas.user_id = u.id
+                LEFT JOIN user_article_recommendations uar
+                  ON uar.user_id = u.id AND uar.article_id = a.id
+                WHERE {_CANDIDATE_PREDICATE}
+                  AND uar.user_id IS NULL
+            )
+            ORDER BY u.id
+            """,
+            (versions,),
+        ).fetchall()
+    return [int(row_to_dict(row)["id"]) for row in rows]
+
+
+def recalculate_stale_recommendations(
+    *,
+    db_path: Path | None = None,
+    database_url: str | None = None,
+    limit_per_user: int = 1000,
+) -> RecalculationSummary:
+    """Recompute scores for every user with stale/missing/superseded scores.
+
+    Each user is recomputed independently and guarded so a single failure is
+    logged and counted but never aborts the sweep — this is what lets ingestion
+    continue when scoring transiently fails for one user.
+    """
+    user_ids = find_recalculation_candidates(db_path=db_path, database_url=database_url)
+    recalculated = 0
+    failed = 0
+    scores = 0
+    for user_id in user_ids:
+        try:
+            scores += recompute_user_recommendations(
+                user_id,
+                db_path=db_path,
+                database_url=database_url,
+                limit=limit_per_user,
+            )
+            recalculated += 1
+        except Exception:
+            failed += 1
+            logger.exception("Recommendation recalculation failed for user %s", user_id)
+    summary = RecalculationSummary(
+        users_considered=len(user_ids),
+        users_recalculated=recalculated,
+        users_failed=failed,
+        scores_written=scores,
+    )
+    logger.info(
+        "Recommendation recalculation complete: considered=%d recalculated=%d failed=%d written=%d",
+        summary.users_considered,
+        summary.users_recalculated,
+        summary.users_failed,
+        summary.scores_written,
+    )
+    return summary
+
+
+def recommendation_health(
+    *,
+    db_path: Path | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Diagnostic snapshot of stored recommendation freshness.
+
+    Returns total/stale/outdated score counts, the number of live candidate
+    pairs missing a score, a per-model-version breakdown, and the oldest score
+    timestamp — enough to diagnose stale or missing recommendation data from a
+    single admin call without scanning the table by hand.
+    """
+    init_db(db_path, database_url=database_url)
+    versions = list(CURRENT_MODEL_VERSIONS)
+    with connect(db_path, database_url=database_url) as conn:
+        totals = row_to_dict(
+            conn.execute(
+                """
+                SELECT
+                  COUNT(*) AS total_scores,
+                  COUNT(*) FILTER (WHERE stale) AS stale_scores,
+                  COUNT(*) FILTER (WHERE model_version <> ALL(%s)) AS outdated_scores,
+                  MIN(computed_at) AS oldest_computed_at,
+                  MAX(updated_at) AS newest_updated_at
+                FROM user_article_recommendations
+                """,
+                (versions,),
+            ).fetchone()
+        )
+        missing = row_to_dict(
+            conn.execute(
+                f"""
+                SELECT COUNT(*) AS missing_scores
+                FROM users u
+                JOIN articles a ON TRUE
+                LEFT JOIN user_article_state uas
+                  ON uas.article_id = a.id AND uas.user_id = u.id
+                LEFT JOIN user_article_recommendations uar
+                  ON uar.user_id = u.id AND uar.article_id = a.id
+                WHERE {_CANDIDATE_PREDICATE}
+                  AND uar.user_id IS NULL
+                """,
+            ).fetchone()
+        )
+        by_version = [
+            row_to_dict(row)
+            for row in conn.execute(
+                """
+                SELECT model_version, COUNT(*) AS count
+                FROM user_article_recommendations
+                GROUP BY model_version
+                ORDER BY count DESC, model_version
+                """,
+            ).fetchall()
+        ]
+
+    oldest = totals.get("oldest_computed_at")
+    newest = totals.get("newest_updated_at")
+    return {
+        "total_scores": int(totals.get("total_scores") or 0),
+        "stale_scores": int(totals.get("stale_scores") or 0),
+        "outdated_scores": int(totals.get("outdated_scores") or 0),
+        "missing_scores": int(missing.get("missing_scores") or 0),
+        "oldest_computed_at": oldest.isoformat() if oldest is not None else None,
+        "newest_updated_at": newest.isoformat() if newest is not None else None,
+        "current_model_versions": sorted(CURRENT_MODEL_VERSIONS),
+        "by_model_version": [
+            {"model_version": row.get("model_version"), "count": int(row.get("count") or 0)}
+            for row in by_version
+        ],
+    }

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -12,6 +12,14 @@ BEHAVIORAL_MODEL_VERSION = "behavioral-affinity-v1"
 SEMANTIC_MODEL_VERSION = "semantic-hybrid-v1"
 NOVELTY_MODEL_VERSION = "novelty-freshness-v1"
 
+# Model versions :func:`recompute_user_recommendations` writes today.  Any stored
+# recommendation whose ``model_version`` is outside this set was produced by an
+# older scoring formula or embedding scheme and is eligible for a background
+# repair recompute (see :mod:`news_dashboard.recommendation_jobs`).
+CURRENT_MODEL_VERSIONS: frozenset[str] = frozenset(
+    {BEHAVIORAL_MODEL_VERSION, NOVELTY_MODEL_VERSION}
+)
+
 # Weight each workflow action contributes toward feature affinity.
 # Starred is handled separately as a flag bonus (see STAR_WEIGHT) because an
 # article can be starred while in any state.  Later is deliberately neutral:
@@ -272,30 +280,33 @@ def novelty_adjustment(
     return dissimilarity * _quality_factor(importance) * NOVELTY_SCORE_SPAN
 
 
-def upsert_recommendation_score(
+def upsert_recommendation_score(  # noqa: PLR0913
     user_id: int,
     article_id: int,
     recommendation_score: float,
     *,
     db_path: Path | None = None,
+    database_url: str | None = None,
     cold_start_score: float | None = None,
     signals: dict[str, Any] | None = None,
     model_version: str = "cold-start-v1",
 ) -> None:
     """Persist recommendation metadata for one user/article pair."""
-    init_db(db_path)
-    with connect(db_path) as conn:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
         conn.execute(
             """
             INSERT INTO user_article_recommendations(
-              user_id, article_id, recommendation_score, cold_start_score, signals, model_version
+              user_id, article_id, recommendation_score, cold_start_score,
+              signals, model_version, stale
             )
-            VALUES (%s, %s, %s, %s, %s::jsonb, %s)
+            VALUES (%s, %s, %s, %s, %s::jsonb, %s, FALSE)
             ON CONFLICT(user_id, article_id) DO UPDATE SET
               recommendation_score = excluded.recommendation_score,
               cold_start_score = excluded.cold_start_score,
               signals = excluded.signals,
               model_version = excluded.model_version,
+              stale = FALSE,
               updated_at = NOW()
             """,
             (
@@ -396,6 +407,7 @@ def recompute_user_recommendations(
     user_id: int,
     *,
     db_path: Path | None = None,
+    database_url: str | None = None,
     limit: int = 1000,
 ) -> int:
     """Recompute and persist behavioral-affinity scores for a user's live feed.
@@ -406,8 +418,8 @@ def recompute_user_recommendations(
     :func:`build_affinity_profile` / :func:`score_article` and is unit-testable
     without touching the database.
     """
-    init_db(db_path)
-    with connect(db_path) as conn:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
         profile = build_affinity_profile(_load_user_signals(conn, user_id))
         semantic_profile = build_semantic_profile(_load_user_history_vectors(conn, user_id))
         candidates = _load_candidates(conn, user_id, limit)
@@ -435,6 +447,7 @@ def recompute_user_recommendations(
             int(candidate["id"]),
             final_score,
             db_path=db_path,
+            database_url=database_url,
             cold_start_score=base,
             signals={
                 "base_score": round(base, 4),

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -34,6 +34,19 @@ def _run_ingest() -> None:
             prefetch_article_bodies()
     except Exception:
         logger.exception("Scheduled ingest failed")
+    # Repair stale/missing scores out-of-band.  Guarded separately so a
+    # recalculation or scoring failure never fails the ingest run itself.
+    _run_recommendation_recalc()
+
+
+def _run_recommendation_recalc() -> None:
+    from .recommendation_jobs import recalculate_stale_recommendations
+
+    try:
+        summary = recalculate_stale_recommendations()
+        logger.info("Recommendation recalculation: %s", summary.as_dict())
+    except Exception:
+        logger.exception("Recommendation recalculation failed")
 
 
 def _run_briefing() -> None:

--- a/backend/tests/test_recommendation_recalc.py
+++ b/backend/tests/test_recommendation_recalc.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import news_dashboard.db as db_mod
+import news_dashboard.recommendation_jobs as jobs
+from news_dashboard.db import connect, init_db
+from news_dashboard.ingest import list_articles, transition_article_state
+from news_dashboard.recommendation_jobs import (
+    find_recalculation_candidates,
+    recalculate_stale_recommendations,
+    recommendation_health,
+)
+
+pytestmark = pytest.mark.postgres
+
+
+# ── Fixtures / helpers ────────────────────────────────────────────────────────
+
+
+def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
+    db_path = tmp_path / name
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+    init_db(db_path)
+    return db_path
+
+
+def _make_user(db_path: Path, username: str) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, %s, 'rss_feed', %s, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml", category, priority),
+        )
+
+
+def _insert_article(db_path: Path, slug: str, suffix: str, *, category: str = "tech") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, importance_score, tags, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', 50, '', %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/articles/{suffix}",
+                f"https://example.com/articles/{suffix}",
+                f"Article {suffix}",
+                slug,
+                slug.title(),
+                category,
+                "2026-06-21T10:00:00+00:00",
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _set_state(db_path: Path, user_id: int, article_id: int, *, state: str) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state)
+            VALUES (%s, %s, %s)
+            ON CONFLICT(user_id, article_id) DO UPDATE SET state = excluded.state
+            """,
+            (user_id, article_id, state),
+        )
+
+
+def _insert_rec(
+    db_path: Path,
+    user_id: int,
+    article_id: int,
+    *,
+    score: float = 10.0,
+    model_version: str = "behavioral-affinity-v1",
+    stale: bool = False,
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_recommendations(
+              user_id, article_id, recommendation_score, model_version, stale
+            )
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (user_id, article_id, score, model_version, stale),
+        )
+
+
+def _rec_row(db_path: Path, user_id: int, article_id: int) -> dict[str, Any] | None:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT recommendation_score, model_version, stale"
+            " FROM user_article_recommendations WHERE user_id = %s AND article_id = %s",
+            (user_id, article_id),
+        ).fetchone()
+    return dict(row) if row is not None else None
+
+
+# ── Stale / missing / superseded repair ───────────────────────────────────────
+
+
+def test_stale_score_is_recalculated_and_cleared(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "stale.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "a", category="ai")
+    _insert_rec(db_path, user_id, article, score=1.0, stale=True)
+
+    assert user_id in find_recalculation_candidates(db_path=db_path)
+    summary = recalculate_stale_recommendations(db_path=db_path)
+    assert summary.users_recalculated == 1
+
+    row = _rec_row(db_path, user_id, article)
+    assert row is not None
+    assert row["stale"] is False
+    # Cold-start base for a priority-50 source is well above the stub 1.0 score.
+    assert row["recommendation_score"] != pytest.approx(1.0)
+
+
+def test_missing_score_is_created(tmp_path: Path, monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "missing.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "a", category="ai")
+
+    assert _rec_row(db_path, user_id, article) is None
+    assert user_id in find_recalculation_candidates(db_path=db_path)
+
+    summary = recalculate_stale_recommendations(db_path=db_path)
+    assert summary.scores_written >= 1
+    assert _rec_row(db_path, user_id, article) is not None
+
+
+def test_superseded_model_version_is_repaired(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "superseded.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "a", category="ai")
+    # An old formula/embedding scheme persisted this row; it is not stale-flagged
+    # but its model_version is no longer current, so it must be repaired.
+    _insert_rec(db_path, user_id, article, model_version="cold-start-v1", stale=False)
+
+    assert user_id in find_recalculation_candidates(db_path=db_path)
+    recalculate_stale_recommendations(db_path=db_path)
+
+    row = _rec_row(db_path, user_id, article)
+    assert row is not None
+    assert row["model_version"] != "cold-start-v1"
+
+
+# ── Failure fallback ──────────────────────────────────────────────────────────
+
+
+def test_per_user_failure_does_not_abort_sweep(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "failure.db")
+    _insert_source(db_path, "src", category="ai")
+    alice = _make_user(db_path, "alice")
+    bob = _make_user(db_path, "bob")
+    art_a = _insert_article(db_path, "src", "a", category="ai")
+    art_b = _insert_article(db_path, "src", "b", category="ai")
+    _set_state(db_path, alice, art_a, state="today")
+    _set_state(db_path, bob, art_b, state="today")
+
+    from news_dashboard.recommendations import recompute_user_recommendations as real
+
+    def flaky(user_id: int, **kwargs: Any) -> int:
+        if user_id == alice:
+            message = "transient scoring failure"
+            raise RuntimeError(message)
+        return real(user_id, **kwargs)
+
+    monkeypatch.setattr(jobs, "recompute_user_recommendations", flaky)
+
+    summary = recalculate_stale_recommendations(db_path=db_path)
+    assert summary.users_failed == 1
+    assert summary.users_recalculated == 1
+    # Bob's score was still written despite Alice failing.
+    assert _rec_row(db_path, bob, art_b) is not None
+
+
+# ── Today read does not recompute synchronously ───────────────────────────────
+
+
+def test_today_read_does_not_compute_scores(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "today-read.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "a", category="ai")
+
+    items = list_articles(state="today", user_id=user_id, db_path=db_path)
+    assert any(item["id"] == article for item in items)
+
+    # Reading Today must not synchronously materialize or recompute scores.
+    assert _rec_row(db_path, user_id, article) is None
+
+
+# ── Preference change marks scores stale ──────────────────────────────────────
+
+
+def test_preference_change_marks_scores_stale(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "pref.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    art_one = _insert_article(db_path, "src", "one", category="ai")
+    art_two = _insert_article(db_path, "src", "two", category="ai")
+    _insert_rec(db_path, user_id, art_one, stale=False)
+
+    # Acting on a *different* article still reshapes the profile behind art_one.
+    transition_article_state(art_two, "done", user_id=user_id, db_path=db_path)
+
+    row = _rec_row(db_path, user_id, art_one)
+    assert row is not None
+    assert row["stale"] is True
+
+
+# ── Observability ─────────────────────────────────────────────────────────────
+
+
+def test_recommendation_health_reports_stale_and_missing(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "health.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    scored = _insert_article(db_path, "src", "scored", category="ai")
+    _insert_article(db_path, "src", "unscored", category="ai")
+    _insert_rec(db_path, user_id, scored, stale=True)
+
+    health = recommendation_health(db_path=db_path)
+    assert health["total_scores"] == 1
+    assert health["stale_scores"] == 1
+    assert health["missing_scores"] >= 1
+    assert health["by_model_version"]


### PR DESCRIPTION
Closes #226

## What this does

Adds a background repair path for stale, missing, or superseded recommendation scores, with operator-facing observability. The Today read path stays a cheap LEFT JOIN with a cold-start fallback — it never recomputes the model synchronously.

## Changes

- **Staleness flag**: new `stale` column on `user_article_recommendations`. Any preference change (workflow/star action through `_upsert_uas`) marks that user's scores stale, making them eligible for recalculation.
- **`recommendation_jobs` module**:
  - `find_recalculation_candidates` — users with stale, missing (live today/later candidate without a score), or superseded scores.
  - `recalculate_stale_recommendations` — recomputes those users with **per-user failure isolation** so one transient scoring error never aborts the sweep.
  - `recommendation_health` — diagnostic snapshot (total/stale/outdated/missing counts, per-model-version breakdown, oldest timestamp).
- **Formula/embedding repair path**: a stored `model_version` outside the current set is treated as a repair signal.
- **Out-of-band recalculation** runs after ingest, guarded so scoring failures never fail the ingest run.
- **Observability surfaces**: admin endpoints `GET /api/recommendations/health` and `POST /api/recommendations/recalculate`, plus CLI commands `rec-health` / `rec-recalc`.

## Acceptance criteria

- [x] Background recalculation for stale/missing pairs
- [x] Preference changes mark affected scores stale
- [x] Repair path for scoring-formula/embedding changes (model_version)
- [x] Today loading requires no synchronous full recompute
- [x] Ingestion continues if recalculation/scoring fails
- [x] Operators can diagnose from stored metadata / logs / API output
- [x] Tests cover stale repair, missing repair, failure fallback, no synchronous recompute on Today reads

## Testing

`make lint`, `make typecheck`, and full `make test` (421 backend + 277 frontend) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)