### PR TITLE
feat: on-demand and daily personalized recommendation refresh

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -696,6 +696,23 @@ def recommendations_recalculate_endpoint() -> dict[str, Any]:
     return recalculate_stale_recommendations().as_dict()
 
 
+@api.post("/api/recommendations/recalculate-mine")
+def recommendations_recalculate_mine_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, int]:
+    """Recompute the calling user's own recommendation scores on demand.
+
+    Lets any authenticated user personalize their feed from the UI without the
+    admin-only stale sweep above. Returns the number of articles scored so the
+    client can tell the user whether personalization has anything to learn from
+    yet (zero means no interaction history exists).
+    """
+    from .recommendations import recompute_user_recommendations
+
+    scored = recompute_user_recommendations(current_user["id"])
+    return {"scored": scored}
+
+
 @api.get("/api/stats/overview", dependencies=_admin_dep)
 def stats_overview_endpoint(
     from_: Annotated[str, Query(alias="from")],

--- a/backend/news_dashboard/recommendation_jobs.py
+++ b/backend/news_dashboard/recommendation_jobs.py
@@ -159,6 +159,61 @@ def recalculate_stale_recommendations(
     return summary
 
 
+def _all_user_ids(*, db_path: Path | None = None, database_url: str | None = None) -> list[int]:
+    """Return every user id, ordered, for an unconditional recompute sweep."""
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute("SELECT id FROM users ORDER BY id").fetchall()
+    return [int(row_to_dict(row)["id"]) for row in rows]
+
+
+def recalculate_all_recommendations(
+    *,
+    db_path: Path | None = None,
+    database_url: str | None = None,
+    limit_per_user: int = 1000,
+) -> RecalculationSummary:
+    """Recompute scores for *every* user, regardless of staleness.
+
+    Unlike :func:`recalculate_stale_recommendations`, this refreshes users whose
+    stored scores are neither stale nor missing — needed for the daily sweep
+    because the freshness factor decays with article age, so scores drift over
+    time even when a user's preferences and the model version are unchanged.
+    Per-user failures are isolated so one bad user never aborts the sweep.
+    """
+    user_ids = _all_user_ids(db_path=db_path, database_url=database_url)
+    recalculated = 0
+    failed = 0
+    scores = 0
+    for user_id in user_ids:
+        try:
+            scores += recompute_user_recommendations(
+                user_id,
+                db_path=db_path,
+                database_url=database_url,
+                limit=limit_per_user,
+            )
+            recalculated += 1
+        except Exception:
+            failed += 1
+            logger.exception("Daily recommendation recalculation failed for user %s", user_id)
+    summary = RecalculationSummary(
+        users_considered=len(user_ids),
+        users_recalculated=recalculated,
+        users_failed=failed,
+        scores_written=scores,
+    )
+    logger.info(
+        "Daily recommendation recalculation complete: "
+        "considered=%d recalculated=%d failed=%d written=%d",
+        summary.users_considered,
+        summary.users_recalculated,
+        summary.users_failed,
+        summary.scores_written,
+    )
+    return summary
+
+
 def recommendation_health(
     *,
     db_path: Path | None = None,

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -49,6 +49,17 @@ def _run_recommendation_recalc() -> None:
         logger.exception("Recommendation recalculation failed")
 
 
+def _run_daily_recommendation_recalc() -> None:
+    from .recommendation_jobs import recalculate_all_recommendations
+
+    logger.info("Daily recommendation recalculation starting…")
+    try:
+        summary = recalculate_all_recommendations()
+        logger.info("Daily recommendation recalculation: %s", summary.as_dict())
+    except Exception:
+        logger.exception("Daily recommendation recalculation failed")
+
+
 def _run_briefing() -> None:
     from .briefings import (
         BriefingAINotConfiguredError,
@@ -85,6 +96,21 @@ def _run_digest() -> None:
         logger.exception("Daily digest failed")
 
 
+def _parse_cron_hm(cron: str, default_minute: str, default_hour: str) -> tuple[str, str]:
+    """Extract (minute, hour) from a cron string, falling back to defaults.
+
+    Only the first two fields matter for our daily jobs; a malformed value
+    degrades to the supplied defaults rather than failing scheduler startup.
+    """
+    try:
+        parts = cron.strip().split()
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+    except Exception:
+        logger.debug("Could not parse cron %r; using defaults", cron, exc_info=True)
+    return default_minute, default_hour
+
+
 def start_scheduler() -> None:
     try:
         from apscheduler.schedulers.background import BackgroundScheduler
@@ -107,6 +133,7 @@ def start_scheduler() -> None:
 
     digest_cron = os.getenv("DIGEST_CRON", "0 8 * * *")
     briefing_cron = os.getenv("BRIEFING_CRON", "0 9 * * *")
+    recommendations_cron = os.getenv("RECOMMENDATIONS_CRON", "30 7 * * *")
 
     scheduler = BackgroundScheduler(timezone="UTC")
 
@@ -118,16 +145,7 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
-    try:
-        parts = digest_cron.strip().split()
-        if len(parts) >= 2:
-            cron_minute = parts[0]
-            cron_hour = parts[1]
-        else:
-            cron_minute, cron_hour = "0", "8"
-    except Exception:
-        cron_minute, cron_hour = "0", "8"
-
+    cron_minute, cron_hour = _parse_cron_hm(digest_cron, "0", "8")
     scheduler.add_job(
         _run_digest,
         trigger="cron",
@@ -137,22 +155,23 @@ def start_scheduler() -> None:
         replace_existing=True,
     )
 
-    try:
-        b_parts = briefing_cron.strip().split()
-        if len(b_parts) >= 2:
-            b_minute = b_parts[0]
-            b_hour = b_parts[1]
-        else:
-            b_minute, b_hour = "0", "9"
-    except Exception:
-        b_minute, b_hour = "0", "9"
-
+    b_minute, b_hour = _parse_cron_hm(briefing_cron, "0", "9")
     scheduler.add_job(
         _run_briefing,
         trigger="cron",
         hour=b_hour,
         minute=b_minute,
         id="briefing",
+        replace_existing=True,
+    )
+
+    r_minute, r_hour = _parse_cron_hm(recommendations_cron, "30", "7")
+    scheduler.add_job(
+        _run_daily_recommendation_recalc,
+        trigger="cron",
+        hour=r_hour,
+        minute=r_minute,
+        id="recommendations",
         replace_existing=True,
     )
 
@@ -167,12 +186,15 @@ def start_scheduler() -> None:
             logger.exception("Failed to pause ingest job on startup")
     else:
         logger.info(
-            "Scheduler started: ingest every %d min, digest at %s:%s UTC, briefing at %s:%s UTC",
+            "Scheduler started: ingest every %d min, digest at %s:%s UTC, "
+            "briefing at %s:%s UTC, recommendations at %s:%s UTC",
             interval_minutes,
             cron_hour.zfill(2),
             cron_minute.zfill(2),
             b_hour.zfill(2),
             b_minute.zfill(2),
+            r_hour.zfill(2),
+            r_minute.zfill(2),
         )
 
 

--- a/backend/tests/test_recommendation_recalc.py
+++ b/backend/tests/test_recommendation_recalc.py
@@ -11,6 +11,7 @@ from news_dashboard.db import connect, init_db
 from news_dashboard.ingest import list_articles, transition_article_state
 from news_dashboard.recommendation_jobs import (
     find_recalculation_candidates,
+    recalculate_all_recommendations,
     recalculate_stale_recommendations,
     recommendation_health,
 )
@@ -264,3 +265,28 @@ def test_recommendation_health_reports_stale_and_missing(
     assert health["stale_scores"] == 1
     assert health["missing_scores"] >= 1
     assert health["by_model_version"]
+
+
+# ── Daily full sweep ───────────────────────────────────────────────────────────
+
+
+def test_recalculate_all_refreshes_non_stale_current_scores(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "daily.db")
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "a", category="ai")
+    # A score that is neither stale nor missing nor outdated — the stale sweep
+    # would skip it, but the daily full sweep must still recompute it.
+    _insert_rec(db_path, user_id, article, score=1.0, stale=False)
+
+    assert user_id not in find_recalculation_candidates(db_path=db_path)
+
+    summary = recalculate_all_recommendations(db_path=db_path)
+    assert summary.users_considered == 1
+    assert summary.users_recalculated == 1
+
+    row = _rec_row(db_path, user_id, article)
+    assert row is not None
+    assert row["recommendation_score"] != pytest.approx(1.0)

--- a/backend/tests/test_today_recommendations.py
+++ b/backend/tests/test_today_recommendations.py
@@ -221,3 +221,23 @@ def test_today_endpoint_uses_cold_start_fallback_for_missing_scores(
         app.dependency_overrides.pop(require_auth, None)
 
     assert ids[:3] == [recent_topic_match, older_important, old_low_signal]
+
+
+def test_recalculate_mine_scores_callers_own_feed(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "recalc-mine.db")
+    _insert_source(db_path, "hot-ai-source", category="ai", priority=95)
+    user_id = _make_user(db_path, "alice")
+
+    _insert_article(db_path, "hot-ai-source", "a", category="ai", importance=80)
+    _insert_article(db_path, "hot-ai-source", "b", category="ai", importance=70)
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            response = client.post("/api/recommendations/recalculate-mine")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json()["scored"] == 2

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -265,3 +265,14 @@ export async function toggleSourceSubscription(
     body: JSON.stringify({ enabled }),
   });
 }
+
+/**
+ * Recompute the current user's personalized recommendation scores on demand.
+ * Returns how many articles were scored — zero means there's no interaction
+ * history (starred/done/skipped) to learn from yet.
+ */
+export async function recalculateMyRecommendations(): Promise<{ scored: number }> {
+  return requestJson<{ scored: number }>('/api/recommendations/recalculate-mine', {
+    method: 'POST',
+  });
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,9 +1,19 @@
-import { useEffect } from 'react';
-import { Sun, Moon, Monitor, RefreshCw, Download, RotateCcw, ExternalLink } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import {
+  Sun,
+  Moon,
+  Monitor,
+  RefreshCw,
+  Download,
+  RotateCcw,
+  ExternalLink,
+  Sparkles,
+} from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { cn } from '@/lib/utils';
 import type { Theme } from '@/lib/theme';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
+import { recalculateMyRecommendations } from '@/api';
 
 const THEME_OPTS: { v: Theme; label: string; Icon: React.ComponentType<{ className?: string }> }[] =
   [
@@ -260,6 +270,67 @@ function UpdatesSection() {
   );
 }
 
+type RecalcState =
+  | { status: 'idle' }
+  | { status: 'running' }
+  | { status: 'done'; scored: number }
+  | { status: 'error' };
+
+function PersonalizationSection() {
+  const [state, setState] = useState<RecalcState>({ status: 'idle' });
+
+  const recalculate = async () => {
+    setState({ status: 'running' });
+    try {
+      const { scored } = await recalculateMyRecommendations();
+      setState({ status: 'done', scored });
+    } catch {
+      setState({ status: 'error' });
+    }
+  };
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        Personalization
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Recommendations are learned from articles you star, read, or skip. Refresh to recompute
+          your personalized scores now.
+        </p>
+        <button
+          onClick={() => void recalculate()}
+          disabled={state.status === 'running'}
+          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-60"
+        >
+          {state.status === 'running' ? (
+            <RefreshCw className="size-3 animate-spin" />
+          ) : (
+            <Sparkles className="size-3" />
+          )}
+          {state.status === 'running' ? 'Refreshing…' : 'Refresh recommendations'}
+        </button>
+
+        {state.status === 'done' && state.scored > 0 && (
+          <p className="text-xs text-green-600 dark:text-green-400">
+            Personalized {state.scored} {state.scored === 1 ? 'article' : 'articles'}. Your feed is
+            up to date.
+          </p>
+        )}
+        {state.status === 'done' && state.scored === 0 && (
+          <p className="text-xs text-muted-foreground">
+            Nothing to personalize yet — star, read, or skip a few articles first, then refresh.
+          </p>
+        )}
+        {state.status === 'error' && (
+          <p className="text-xs text-destructive">Couldn't refresh recommendations. Try again.</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
 export function SettingsPage() {
   const { theme, setTheme } = useTheme();
 
@@ -294,6 +365,8 @@ export function SettingsPage() {
           })}
         </div>
       </section>
+
+      <PersonalizationSection />
 
       <UpdatesSection />
 


### PR DESCRIPTION
## Summary

Lets users personalize their recommendation feed from the UI on demand, and adds a daily scheduler sweep so scores stay fresh automatically.

Motivated by the "Not personalized yet" state: scores are computed per user, out of band, and were only recalculable via CLI or the admin-only stale sweep.

### Changes
- **`POST /api/recommendations/recalculate-mine`** — recomputes the *calling* user's own scores (the existing `/recalculate` is admin-only and sweeps all stale users). Returns `{scored: N}`.
- **Settings → Personalization** — a "Refresh recommendations" button with scored / nothing-to-personalize / error states.
- **`recalculate_all_recommendations()`** — recomputes *every* user regardless of staleness, wired to a daily cron job (`RECOMMENDATIONS_CRON`, default `07:30 UTC`). The existing post-ingest sweep only touches stale/missing/superseded scores; a full daily pass is needed because the freshness factor decays with article age, so scores drift even when preferences are unchanged.
- Extracted `_parse_cron_hm()` to de-duplicate scheduler cron parsing.

### Tests
- `test_recalculate_mine_scores_callers_own_feed` (API endpoint)
- `test_recalculate_all_refreshes_non_stale_current_scores` (daily sweep recomputes scores the stale sweep would skip)

### Verification
- backend: 493 passed · frontend: 285 passed · build ✅
- ruff / mypy / ty / pyrefly / eslint / prettier / tsc all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)