### PR TITLE
fix: expose recommendation score on single-article read path

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -229,12 +229,37 @@ def _merge_user_state(
     return d
 
 
+def _merge_user_recommendation(
+    d: dict[str, Any], conn: Any, article_id: int, user_id: int
+) -> dict[str, Any]:
+    """Overlay the per-user recommendation score/signals onto an article dict.
+
+    Mirrors the recommendation columns ``list_articles`` returns so the
+    single-article read path exposes the same ``recommendation_score`` /
+    ``recommendation_model`` / ``recommendation_signals`` fields. Absent metadata
+    (no stored score yet) leaves the fields ``None`` so the frontend falls back to
+    its cold-start explanation rather than a stale one.
+    """
+    rec_row = conn.execute(
+        "SELECT recommendation_score, model_version, signals"
+        " FROM user_article_recommendations WHERE user_id = %s AND article_id = %s",
+        (user_id, article_id),
+    ).fetchone()
+    rec = row_to_dict(rec_row) if rec_row else None
+    score = rec.get("recommendation_score") if rec else None
+    d["recommendation_score"] = float(score) if score is not None else None
+    d["recommendation_model"] = rec.get("model_version") if rec else None
+    d["recommendation_signals"] = rec.get("signals") if rec else None
+    return d
+
+
 def _article_from_row(row: Any, conn: Any, article_id: int, user_id: int | None) -> dict[str, Any]:
     d = row_to_dict(row)
     d.pop("embedding", None)
     d.pop("fts_vector", None)
     if user_id is not None:
         _merge_user_state(d, conn, article_id, user_id)
+        _merge_user_recommendation(d, conn, article_id, user_id)
     return d
 
 

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -243,6 +243,57 @@ def test_today_stays_intact_when_no_scores_have_been_computed(
             assert item["recommendation_score"] is None
 
 
+# ── Reader path exposes the same score metadata as the Today list ─────────────
+
+
+def test_single_article_read_exposes_recommendation_metadata(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """The single-article endpoint (the reader's "Why recommended" source) must
+    carry the same per-user recommendation_score / signals as the Today list, so
+    a refresh that personalizes scores is reflected on the reader rather than
+    always falling back to "Not personalized yet"."""
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-reader.db")
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "reader", category="ai", importance=70)
+    signals = {"base_score": 50.0, "affinity_adjustment": 12.5}
+    upsert_recommendation_score(user_id, article, 88.0, db_path=db_path, signals=signals)
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            response = client.get(f"/api/articles/{article}")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["recommendation_score"] == pytest.approx(88.0)
+    assert payload["recommendation_signals"] == signals
+
+
+def test_single_article_read_returns_null_score_when_unranked(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """An article with no stored score returns a null score/signals on the reader
+    path so the frontend uses its cold-start explanation, not a stale one."""
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-reader-null.db")
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "unranked", category="ai", importance=70)
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            response = client.get(f"/api/articles/{article}")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["recommendation_score"] is None
+    assert payload["recommendation_signals"] is None
+
+
 # ── Scope guard: ranking only, no hiding / separate feed ──────────────────────
 
 


### PR DESCRIPTION
Fixes #239

## Problem

The article reader's "Why recommended" panel always showed **"Not personalized yet — shown based on general importance"**, even right after a successful refresh reporting `Personalized 1000 articles. Your feed is up to date.`

## Root cause

Two read paths, only one returned recommendation data:

- `list_articles` (`ingest.py`) LEFT JOINs `user_article_recommendations` → returns `recommendation_score` + `recommendation_signals`. ✅ Today list works.
- `get_article` → `_article_from_row` → `_merge_user_state` (`body_fetch.py`) merged only `user_article_state`, never the recommendation table. ❌ The single-article response (`GET /api/articles/{id}`, used by the reader) had `recommendation_score == null` and `recommendation_signals == null`.

With null score and null signals, the frontend `recommendationExplanation` (`frontend/src/lib/recommendation.ts`) falls through to its final fallback branch → "Not personalized yet…". The scores existed in the DB; the reader just never read them.

## Fix

Add `_merge_user_recommendation` so the single-article read path populates `recommendation_score` / `recommendation_model` / `recommendation_signals`, mirroring `list_articles`. Absent metadata leaves the fields `null` so the cold-start explanation still applies for genuinely unranked articles.

## Tests

Added two regression tests in `test_recommendation_contracts.py`:
- scored article → reader exposes the score + signals
- unranked article → reader returns null score/signals

Full gate green locally: 496 backend + 285 frontend tests pass; ruff/mypy/ty/pyrefly/eslint/tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)