### PR TITLE
test: raise coverage for scheduler, db, oauth, frontend hooks/pages

### DIFF
--- a/backend/tests/test_database_config.py
+++ b/backend/tests/test_database_config.py
@@ -6,6 +6,9 @@ from news_dashboard.db import (
     active_database_url,
     describe_database,
     insert_article_sql,
+    placeholders,
+    row_to_dict,
+    search_articles_sql,
 )
 
 
@@ -52,3 +55,70 @@ def test_article_insert_sql_is_postgres_only() -> None:
     assert "ON CONFLICT (url) DO NOTHING" in sql
     assert "%s" in sql
     assert "INSERT OR IGNORE" not in sql
+
+
+def test_active_database_url_builds_from_postgres_parts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_HOST", "db.internal")
+    monkeypatch.setenv("POSTGRES_USER", "alice")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "pw")
+    monkeypatch.setenv("POSTGRES_DB", "mydb")
+    monkeypatch.setenv("POSTGRES_PORT", "6543")
+
+    assert active_database_url() == "postgresql://alice:pw@db.internal:6543/mydb"
+
+
+def test_describe_database_passes_through_url_without_password() -> None:
+    dsn = "postgresql://news_dashboard@postgres:5432/news_dashboard"
+    assert describe_database(database_url=dsn) == dsn
+
+
+# ── row_to_dict ───────────────────────────────────────────────────────────────
+
+
+def test_row_to_dict_from_mapping() -> None:
+    assert row_to_dict({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+
+
+def test_row_to_dict_from_iterable_keys() -> None:
+    class _Row:
+        def __init__(self) -> None:
+            self._d = {"x": 10, "y": 20}
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            return iter(self._d)
+
+        def __getitem__(self, key: str) -> int:
+            return self._d[key]
+
+    assert row_to_dict(_Row()) == {"x": 10, "y": 20}
+
+
+# ── placeholders ──────────────────────────────────────────────────────────────
+
+
+def test_placeholders_builds_one_per_value() -> None:
+    assert placeholders([1, 2, 3]) == "%s, %s, %s"
+
+
+def test_placeholders_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="at least one value"):
+        placeholders([])
+
+
+# ── search_articles_sql ───────────────────────────────────────────────────────
+
+
+def test_search_articles_sql_no_terms_orders_by_recency() -> None:
+    sql, params = search_articles_sql([], 25)
+    assert "ORDER BY discovered_at DESC" in sql
+    assert params == [25]
+
+
+def test_search_articles_sql_builds_ilike_clauses_per_term() -> None:
+    sql, params = search_articles_sql(["ai", "gpu"], 10)
+    assert sql.count("title ILIKE %s") == 2
+    assert " AND " in sql
+    # Five ILIKE params per term, plus the trailing limit.
+    assert params == ["%ai%"] * 5 + ["%gpu%"] * 5 + [10]
+    assert "ORDER BY importance_score DESC" in sql

--- a/backend/tests/test_main_oauth.py
+++ b/backend/tests/test_main_oauth.py
@@ -1,0 +1,135 @@
+"""Tests for the public OAuth / Keycloak endpoints and the version endpoint.
+
+These routes live in main.py and were previously uncovered. Keycloak helpers
+are patched so no real identity provider is contacted; the TestClient is built
+without auth overrides because every route here is public.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import app
+
+
+def _client() -> TestClient:
+    app.dependency_overrides.clear()
+    # follow_redirects=False so we can assert on the 3xx responses themselves.
+    return TestClient(app, follow_redirects=False)
+
+
+# ── /auth/login ───────────────────────────────────────────────────────────────
+
+
+def test_keycloak_login_redirects_to_local_login_when_disabled() -> None:
+    with patch("news_dashboard.main.keycloak_config", return_value=SimpleNamespace(enabled=False)):
+        resp = _client().get("/auth/login")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/login"
+
+
+def test_keycloak_login_redirects_to_provider_and_sets_state_cookie() -> None:
+    with (
+        patch("news_dashboard.main.keycloak_config", return_value=SimpleNamespace(enabled=True)),
+        patch(
+            "news_dashboard.main.keycloak_authorization_url",
+            return_value="https://idp.example/auth?state=x",
+        ),
+    ):
+        resp = _client().get("/auth/login")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "https://idp.example/auth?state=x"
+    assert "nd_oauth_state" in resp.cookies
+
+
+# ── /auth/callback ────────────────────────────────────────────────────────────
+
+
+def test_keycloak_callback_rejects_missing_state() -> None:
+    resp = _client().get("/auth/callback?code=abc")
+    assert resp.status_code == 400
+    assert "state" in resp.json()["detail"].lower()
+
+
+def test_keycloak_callback_rejects_mismatched_state() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "expected")
+    resp = client.get("/auth/callback?state=different&code=abc")
+    assert resp.status_code == 400
+
+
+def test_keycloak_callback_rejects_missing_code() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "match")
+    resp = client.get("/auth/callback?state=match")
+    assert resp.status_code == 400
+    assert "code" in resp.json()["detail"].lower()
+
+
+def test_keycloak_callback_success_sets_session_and_redirects() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "match")
+    with (
+        patch(
+            "news_dashboard.main.exchange_keycloak_code",
+            new=AsyncMock(return_value={"id": 7, "is_admin": False}),
+        ),
+        patch("news_dashboard.main.create_session_token", return_value="sess-token"),
+    ):
+        resp = client.get("/auth/callback?state=match&code=good")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/"
+    assert resp.cookies.get("nd_session") == "sess-token"
+
+
+# ── /auth/logout ──────────────────────────────────────────────────────────────
+
+
+def test_keycloak_logout_redirects_to_provider_logout() -> None:
+    with patch(
+        "news_dashboard.main.keycloak_logout_url", return_value="https://idp.example/logout"
+    ):
+        resp = _client().get("/auth/logout")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "https://idp.example/logout"
+
+
+# ── /api/auth/login conflict when Keycloak is enabled ─────────────────────────
+
+
+def test_password_login_returns_409_when_keycloak_enabled() -> None:
+    with patch("news_dashboard.main.keycloak_config", return_value=SimpleNamespace(enabled=True)):
+        resp = _client().post("/api/auth/login", json={"username": "u", "password": "p"})
+    assert resp.status_code == 409
+
+
+# ── /api/auth/config ──────────────────────────────────────────────────────────
+
+
+def test_auth_config_returns_metadata() -> None:
+    with patch("news_dashboard.main.keycloak_auth_metadata", return_value={"provider": "password"}):
+        resp = _client().get("/api/auth/config")
+    assert resp.status_code == 200
+    assert resp.json() == {"provider": "password"}
+
+
+# ── /api/version ──────────────────────────────────────────────────────────────
+
+
+def test_version_endpoint_reads_version_file() -> None:
+    with patch("news_dashboard.main._VERSION_FILE") as vf:
+        vf.read_text.return_value = "9.9.9\n"
+        resp = _client().get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "9.9.9"}
+
+
+def test_version_endpoint_falls_back_to_unknown_on_oserror() -> None:
+    with patch("news_dashboard.main._VERSION_FILE") as vf:
+        vf.read_text.side_effect = OSError("missing")
+        resp = _client().get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "unknown"}

--- a/backend/tests/test_migrate_multi_user.py
+++ b/backend/tests/test_migrate_multi_user.py
@@ -45,6 +45,25 @@ def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "done"
 # ── _row_count helper ─────────────────────────────────────────────────────────
 
 
+def test_sqlite_to_postgres_requires_postgres_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    src = tmp_path / "old.sqlite"
+    src.touch()
+    result = runner.invoke(app, ["sqlite-to-postgres", str(src)])
+    assert result.exit_code != 0
+    assert "POSTGRES" in result.output or "DATABASE_URL" in result.output
+
+
+def test_sqlite_to_postgres_rejects_missing_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    result = runner.invoke(app, ["sqlite-to-postgres", "/no/such/file.sqlite"])
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
 def test_row_count_postgres_style() -> None:
     # Simulate a psycopg dict_row with 'count' key (lowercase)
     assert _row_count({"count": 3}) == 3

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -169,3 +169,448 @@ def test_start_scheduler_briefing_fn_is_run_briefing(monkeypatch: pytest.MonkeyP
         c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "briefing"
     )
     assert briefing_call.args[0] is expected_fn
+
+
+# ── _run_ingest ───────────────────────────────────────────────────────────────
+
+
+def test_run_ingest_prefetches_when_new_articles() -> None:
+    from news_dashboard import scheduler
+
+    with (
+        patch("news_dashboard.ingest.ingest_all", return_value={"a": 2, "b": -1}) as ingest,
+        patch("news_dashboard.body_fetch.prefetch_article_bodies") as prefetch,
+        patch.object(scheduler, "_run_recommendation_recalc") as recalc,
+    ):
+        scheduler._run_ingest()
+
+    ingest.assert_called_once()
+    prefetch.assert_called_once()
+    recalc.assert_called_once()
+
+
+def test_run_ingest_skips_prefetch_when_no_new_articles() -> None:
+    from news_dashboard import scheduler
+
+    with (
+        patch("news_dashboard.ingest.ingest_all", return_value={"a": 0}),
+        patch("news_dashboard.body_fetch.prefetch_article_bodies") as prefetch,
+        patch.object(scheduler, "_run_recommendation_recalc"),
+    ):
+        scheduler._run_ingest()
+
+    prefetch.assert_not_called()
+
+
+def test_run_ingest_suppresses_ingest_failure_but_still_recalcs() -> None:
+    from news_dashboard import scheduler
+
+    with (
+        patch("news_dashboard.ingest.ingest_all", side_effect=RuntimeError("boom")),
+        patch("news_dashboard.body_fetch.prefetch_article_bodies") as prefetch,
+        patch.object(scheduler, "_run_recommendation_recalc") as recalc,
+    ):
+        scheduler._run_ingest()  # must not raise
+
+    prefetch.assert_not_called()
+    recalc.assert_called_once()
+
+
+# ── recommendation recalc jobs ────────────────────────────────────────────────
+
+
+def test_run_recommendation_recalc_logs_summary() -> None:
+    from news_dashboard import scheduler
+
+    summary = MagicMock()
+    summary.as_dict.return_value = {"recomputed": 3}
+    with patch(
+        "news_dashboard.recommendation_jobs.recalculate_stale_recommendations",
+        return_value=summary,
+    ):
+        scheduler._run_recommendation_recalc()
+    summary.as_dict.assert_called_once()
+
+
+def test_run_recommendation_recalc_suppresses_errors() -> None:
+    from news_dashboard import scheduler
+
+    with patch(
+        "news_dashboard.recommendation_jobs.recalculate_stale_recommendations",
+        side_effect=RuntimeError("nope"),
+    ):
+        scheduler._run_recommendation_recalc()  # must not raise
+
+
+def test_run_daily_recommendation_recalc_logs_summary() -> None:
+    from news_dashboard import scheduler
+
+    summary = MagicMock()
+    summary.as_dict.return_value = {"recomputed": 9}
+    with patch(
+        "news_dashboard.recommendation_jobs.recalculate_all_recommendations",
+        return_value=summary,
+    ):
+        scheduler._run_daily_recommendation_recalc()
+    summary.as_dict.assert_called_once()
+
+
+def test_run_daily_recommendation_recalc_suppresses_errors() -> None:
+    from news_dashboard import scheduler
+
+    with patch(
+        "news_dashboard.recommendation_jobs.recalculate_all_recommendations",
+        side_effect=RuntimeError("nope"),
+    ):
+        scheduler._run_daily_recommendation_recalc()  # must not raise
+
+
+# ── _run_digest ───────────────────────────────────────────────────────────────
+
+
+def test_run_digest_logs_sent(caplog: pytest.LogCaptureFixture) -> None:
+    from news_dashboard import scheduler
+
+    with (
+        caplog.at_level(logging.INFO, logger="news_dashboard.scheduler"),
+        patch("news_dashboard.digest.send_digest", return_value=True),
+    ):
+        scheduler._run_digest()
+    assert any("sent" in r.message.lower() for r in caplog.records)
+
+
+def test_run_digest_logs_skip(caplog: pytest.LogCaptureFixture) -> None:
+    from news_dashboard import scheduler
+
+    with (
+        caplog.at_level(logging.INFO, logger="news_dashboard.scheduler"),
+        patch("news_dashboard.digest.send_digest", return_value=False),
+    ):
+        scheduler._run_digest()
+    assert any("skipped" in r.message.lower() for r in caplog.records)
+
+
+def test_run_digest_suppresses_errors() -> None:
+    from news_dashboard import scheduler
+
+    with patch("news_dashboard.digest.send_digest", side_effect=RuntimeError("smtp down")):
+        scheduler._run_digest()  # must not raise
+
+
+# ── _parse_cron_hm ────────────────────────────────────────────────────────────
+
+
+def test_parse_cron_hm_extracts_fields() -> None:
+    from news_dashboard.scheduler import _parse_cron_hm
+
+    assert _parse_cron_hm("15 6 * * *", "0", "8") == ("15", "6")
+
+
+def test_parse_cron_hm_falls_back_on_short_input() -> None:
+    from news_dashboard.scheduler import _parse_cron_hm
+
+    assert _parse_cron_hm("nonsense", "0", "8") == ("0", "8")
+
+
+# ── start_scheduler — extra branches ──────────────────────────────────────────
+
+
+def test_start_scheduler_handles_missing_apscheduler(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from news_dashboard import scheduler
+
+    # Setting the submodule to None in sys.modules makes the lazy
+    # `from apscheduler.schedulers.background import ...` raise ImportError.
+    with (
+        caplog.at_level(logging.WARNING, logger="news_dashboard.scheduler"),
+        patch.dict("sys.modules", {"apscheduler.schedulers.background": None}),
+    ):
+        scheduler.start_scheduler()
+    assert any("APScheduler not installed" in r.message for r in caplog.records)
+
+
+def test_start_scheduler_pauses_when_db_flag_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = None
+
+    def get_setting(key: str) -> str | None:
+        return "true" if key == "scheduler_paused" else None
+
+    with (
+        patch(_BGSCHED_PATH, return_value=mock_sched),
+        patch(_INIT_DB_PATH),
+        patch(_GET_SETTING_PATH, side_effect=get_setting),
+    ):
+        from news_dashboard import scheduler
+
+        scheduler._state.scheduler = None
+        scheduler.start_scheduler()
+
+    mock_sched.pause_job.assert_called_once_with("ingest")
+
+
+def test_start_scheduler_uses_db_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = None
+
+    def get_setting(key: str) -> str | None:
+        return "12" if key == "ingest_interval_minutes" else None
+
+    with (
+        patch(_BGSCHED_PATH, return_value=mock_sched),
+        patch(_INIT_DB_PATH),
+        patch(_GET_SETTING_PATH, side_effect=get_setting),
+    ):
+        from news_dashboard import scheduler
+
+        scheduler._state.scheduler = None
+        scheduler.start_scheduler()
+
+    assert scheduler.get_interval_minutes() == 12
+    ingest_call = next(
+        c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "ingest"
+    )
+    assert ingest_call.kwargs["minutes"] == 12
+
+
+# ── lifecycle: stop / next-run / pause-state / interval ───────────────────────
+
+
+def test_stop_scheduler_shuts_down_and_clears() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    scheduler._state.scheduler = mock_sched
+    scheduler.stop_scheduler()
+    mock_sched.shutdown.assert_called_once_with(wait=False)
+    assert scheduler._state.scheduler is None
+
+
+def test_stop_scheduler_noop_when_not_running() -> None:
+    from news_dashboard import scheduler
+
+    scheduler._state.scheduler = None
+    scheduler.stop_scheduler()  # must not raise
+
+
+def test_get_next_ingest_at_none_when_not_running() -> None:
+    from news_dashboard import scheduler
+
+    scheduler._state.scheduler = None
+    assert scheduler.get_next_ingest_at() is None
+
+
+def test_get_next_ingest_at_returns_iso() -> None:
+    from datetime import datetime, timezone
+
+    from news_dashboard import scheduler
+
+    job = MagicMock()
+    job.next_run_time = datetime(2026, 6, 23, 8, 0, 0, tzinfo=timezone.utc)
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = job
+    scheduler._state.scheduler = mock_sched
+    try:
+        result = scheduler.get_next_ingest_at()
+    finally:
+        scheduler._state.scheduler = None
+    assert result == "2026-06-23T08:00:00+00:00"
+
+
+def test_is_paused_false_when_not_running() -> None:
+    from news_dashboard import scheduler
+
+    scheduler._state.scheduler = None
+    assert scheduler.is_paused() is False
+
+
+def test_is_paused_true_when_no_next_run() -> None:
+    from news_dashboard import scheduler
+
+    job = MagicMock()
+    job.next_run_time = None
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = job
+    scheduler._state.scheduler = mock_sched
+    try:
+        assert scheduler.is_paused() is True
+    finally:
+        scheduler._state.scheduler = None
+
+
+def test_is_paused_false_when_job_missing() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = None
+    scheduler._state.scheduler = mock_sched
+    try:
+        assert scheduler.is_paused() is False
+    finally:
+        scheduler._state.scheduler = None
+
+
+def test_set_interval_persists_and_reschedules() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    scheduler._state.scheduler = mock_sched
+    with patch("news_dashboard.db.set_setting") as set_setting:
+        try:
+            scheduler.set_interval(45)
+        finally:
+            scheduler._state.scheduler = None
+    set_setting.assert_called_once_with("ingest_interval_minutes", "45")
+    mock_sched.reschedule_job.assert_called_once()
+    assert scheduler.get_interval_minutes() == 45
+
+
+def test_set_interval_persists_when_scheduler_stopped() -> None:
+    from news_dashboard import scheduler
+
+    scheduler._state.scheduler = None
+    with patch("news_dashboard.db.set_setting") as set_setting:
+        scheduler.set_interval(60)
+    set_setting.assert_called_once_with("ingest_interval_minutes", "60")
+
+
+def test_pause_scheduler_persists_and_pauses() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    scheduler._state.scheduler = mock_sched
+    with patch("news_dashboard.db.set_setting") as set_setting:
+        try:
+            scheduler.pause_scheduler()
+        finally:
+            scheduler._state.scheduler = None
+    set_setting.assert_called_once_with("scheduler_paused", "true")
+    mock_sched.pause_job.assert_called_once_with("ingest")
+
+
+def test_pause_scheduler_persists_when_stopped() -> None:
+    from news_dashboard import scheduler
+
+    scheduler._state.scheduler = None
+    with patch("news_dashboard.db.set_setting") as set_setting:
+        scheduler.pause_scheduler()
+    set_setting.assert_called_once_with("scheduler_paused", "true")
+
+
+def test_resume_scheduler_persists_and_resumes() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    scheduler._state.scheduler = mock_sched
+    with patch("news_dashboard.db.set_setting") as set_setting:
+        try:
+            scheduler.resume_scheduler()
+        finally:
+            scheduler._state.scheduler = None
+    set_setting.assert_called_once_with("scheduler_paused", "false")
+    mock_sched.resume_job.assert_called_once_with("ingest")
+
+
+def test_resume_scheduler_persists_when_stopped() -> None:
+    from news_dashboard import scheduler
+
+    scheduler._state.scheduler = None
+    with patch("news_dashboard.db.set_setting") as set_setting:
+        scheduler.resume_scheduler()
+    set_setting.assert_called_once_with("scheduler_paused", "false")
+
+
+# ── error-handler branches (advisory state must never propagate) ──────────────
+
+
+def test_start_scheduler_pause_failure_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = None
+    mock_sched.pause_job.side_effect = RuntimeError("cannot pause")
+
+    def get_setting(key: str) -> str | None:
+        return "true" if key == "scheduler_paused" else None
+
+    with (
+        patch(_BGSCHED_PATH, return_value=mock_sched),
+        patch(_INIT_DB_PATH),
+        patch(_GET_SETTING_PATH, side_effect=get_setting),
+    ):
+        from news_dashboard import scheduler
+
+        scheduler._state.scheduler = None
+        scheduler.start_scheduler()  # must not raise
+
+
+def test_stop_scheduler_suppresses_shutdown_error() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    mock_sched.shutdown.side_effect = RuntimeError("already down")
+    scheduler._state.scheduler = mock_sched
+    scheduler.stop_scheduler()  # must not raise
+    assert scheduler._state.scheduler is None
+
+
+def test_get_next_ingest_at_suppresses_error() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    mock_sched.get_job.side_effect = RuntimeError("boom")
+    scheduler._state.scheduler = mock_sched
+    try:
+        assert scheduler.get_next_ingest_at() is None
+    finally:
+        scheduler._state.scheduler = None
+
+
+def test_is_paused_suppresses_error() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    mock_sched.get_job.side_effect = RuntimeError("boom")
+    scheduler._state.scheduler = mock_sched
+    try:
+        assert scheduler.is_paused() is False
+    finally:
+        scheduler._state.scheduler = None
+
+
+def test_set_interval_suppresses_reschedule_error() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    mock_sched.reschedule_job.side_effect = RuntimeError("boom")
+    scheduler._state.scheduler = mock_sched
+    with patch("news_dashboard.db.set_setting"):
+        try:
+            scheduler.set_interval(15)  # must not raise
+        finally:
+            scheduler._state.scheduler = None
+
+
+def test_pause_scheduler_suppresses_error() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    mock_sched.pause_job.side_effect = RuntimeError("boom")
+    scheduler._state.scheduler = mock_sched
+    with patch("news_dashboard.db.set_setting"):
+        try:
+            scheduler.pause_scheduler()  # must not raise
+        finally:
+            scheduler._state.scheduler = None
+
+
+def test_resume_scheduler_suppresses_error() -> None:
+    from news_dashboard import scheduler
+
+    mock_sched = MagicMock()
+    mock_sched.resume_job.side_effect = RuntimeError("boom")
+    scheduler._state.scheduler = mock_sched
+    with patch("news_dashboard.db.set_setting"):
+        try:
+            scheduler.resume_scheduler()  # must not raise
+        finally:
+            scheduler._state.scheduler = None

--- a/frontend/src/__tests__/hooks.test.tsx
+++ b/frontend/src/__tests__/hooks.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useIsMobile } from '../hooks/use-mobile';
+import { useTheme } from '../hooks/useTheme';
+
+// ── matchMedia harness ──────────────────────────────────────────────────────
+// happy-dom ships a minimal matchMedia; we replace it with a controllable mock
+// so we can drive change events deterministically.
+
+type Listener = () => void;
+
+function installMatchMedia(matches: boolean) {
+  const listeners = new Set<Listener>();
+  const mql = {
+    matches,
+    media: '',
+    addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+    removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+    dispatch: () => listeners.forEach((cb) => cb()),
+  };
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => mql)
+  );
+  return mql;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ── useIsMobile ─────────────────────────────────────────────────────────────
+
+describe('useIsMobile', () => {
+  it('reports true below the mobile breakpoint', async () => {
+    installMatchMedia(true);
+    vi.stubGlobal('innerWidth', 500);
+    const { result } = renderHook(() => useIsMobile());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('reports false at desktop width', async () => {
+    installMatchMedia(false);
+    vi.stubGlobal('innerWidth', 1200);
+    const { result } = renderHook(() => useIsMobile());
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('re-evaluates when the media query fires a change', async () => {
+    const mql = installMatchMedia(false);
+    vi.stubGlobal('innerWidth', 1200);
+    const { result } = renderHook(() => useIsMobile());
+    await waitFor(() => expect(result.current).toBe(false));
+
+    vi.stubGlobal('innerWidth', 400);
+    act(() => mql.dispatch());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+});
+
+// ── useTheme ────────────────────────────────────────────────────────────────
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('initialises from stored preference', () => {
+    installMatchMedia(false);
+    localStorage.setItem('theme', 'dark');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('dark');
+  });
+
+  it('setTheme persists and applies the new theme', () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.setTheme('light'));
+    expect(result.current.theme).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('re-applies system theme when OS preference changes', () => {
+    const mql = installMatchMedia(true);
+    localStorage.setItem('theme', 'system');
+    renderHook(() => useTheme());
+    act(() => mql.dispatch());
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});

--- a/frontend/src/__tests__/themeSwitcher.test.tsx
+++ b/frontend/src/__tests__/themeSwitcher.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeSwitcher } from '../components/ThemeSwitcher';
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ThemeSwitcher', () => {
+  it('renders one toggle button per theme option', () => {
+    render(<ThemeSwitcher />);
+    expect(screen.getByLabelText('Light')).toBeTruthy();
+    expect(screen.getByLabelText('System')).toBeTruthy();
+    expect(screen.getByLabelText('Dark')).toBeTruthy();
+  });
+
+  it('marks the active theme as pressed and switches on click', () => {
+    render(<ThemeSwitcher />);
+    const dark = screen.getByLabelText('Dark');
+    expect(dark.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(dark);
+
+    expect(dark.getAttribute('aria-pressed')).toBe('true');
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});

--- a/frontend/src/__tests__/triagePages.test.tsx
+++ b/frontend/src/__tests__/triagePages.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import type { WorkflowArticle } from '../lib/workflowTypes';
+import { InboxPage } from '../pages/InboxPage';
+import { LaterPage } from '../pages/LaterPage';
+import { StarredPage } from '../pages/StarredPage';
+import { ArchivePage } from '../pages/ArchivePage';
+
+// Pin the data layer: each page only differs in title/sort/config wiring, so we
+// stub fetchTriageArticles and assert the page renders its heading + rows.
+const fetchTriageArticles = vi.fn<(...args: unknown[]) => Promise<WorkflowArticle[]>>();
+vi.mock('@/api/workflowApi', () => ({
+  fetchTriageArticles: (...args: unknown[]) => fetchTriageArticles(...args),
+}));
+vi.mock('@/hooks/useTriageMutations', () => ({
+  useTriageMutations: () => ({ setState: vi.fn(), toggleStar: vi.fn(), sendLater: vi.fn() }),
+  ARTICLES_KEY: 'articles',
+}));
+
+function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
+  return {
+    id: '1',
+    title: 'An article',
+    sourceId: 'source',
+    sourceName: 'Source',
+    category: 'ai-llm',
+    url: 'https://example.com/a',
+    publishedAt: '2026-06-16T10:00:00Z',
+    ingestedAt: '2026-06-16T11:00:00Z',
+    reason: 'why',
+    summary: 'summary',
+    signal: 'high',
+    tags: ['ai'],
+    bodyStatus: 'missing',
+    state: 'today',
+    starred: false,
+    ...overrides,
+  };
+}
+
+function renderPage(ui: React.ReactElement, route = '/') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FocusedArticleProvider>
+        <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+      </FocusedArticleProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('triage wrapper pages', () => {
+  it('InboxPage renders the Today heading and forwards the category filter', async () => {
+    fetchTriageArticles.mockResolvedValueOnce([makeArticle()]);
+    renderPage(<InboxPage />, '/today?category=ai-llm');
+    expect(await screen.findByRole('heading', { name: 'Today' })).toBeTruthy();
+    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('today', 'ai-llm'));
+  });
+
+  it('LaterPage renders snoozed articles sorted by return date', async () => {
+    fetchTriageArticles.mockResolvedValueOnce([
+      makeArticle({ id: '1', title: 'Returns later', later_until: '2026-07-01T00:00:00Z' }),
+      makeArticle({ id: '2', title: 'Returns sooner', later_until: '2026-06-25T00:00:00Z' }),
+    ]);
+    renderPage(<LaterPage />, '/later');
+    expect(await screen.findByRole('heading', { name: 'Later' })).toBeTruthy();
+    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('later'));
+  });
+
+  it('StarredPage renders the Starred heading', async () => {
+    fetchTriageArticles.mockResolvedValueOnce([
+      makeArticle({ starred: true, starred_at: '2026-06-20T00:00:00Z' }),
+    ]);
+    renderPage(<StarredPage />, '/starred');
+    expect(await screen.findByRole('heading', { name: 'Starred' })).toBeTruthy();
+    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('starred', undefined));
+  });
+
+  it('ArchivePage renders the Archive heading', async () => {
+    fetchTriageArticles.mockResolvedValueOnce([
+      makeArticle({ archived_at: '2026-06-19T00:00:00Z' }),
+    ]);
+    renderPage(<ArchivePage />, '/archive');
+    expect(await screen.findByRole('heading', { name: 'Archive' })).toBeTruthy();
+    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('archived', undefined));
+  });
+
+  it('ArchivePage shows the empty state when there are no rows', async () => {
+    fetchTriageArticles.mockResolvedValueOnce([]);
+    renderPage(<ArchivePage />, '/archive');
+    expect(await screen.findByText('Archive empty')).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/useUpdateCheck.test.tsx
+++ b/frontend/src/__tests__/useUpdateCheck.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useUpdateCheck } from '../hooks/useUpdateCheck';
+
+// detectPlatform reads navigator/window; default (no electronAPI, no TWA) is 'web',
+// which maps to the 'desktop-v' release prefix.
+
+function mockFetch(handlers: Record<string, unknown>) {
+  return vi.fn((url: string) => {
+    const key = Object.keys(handlers).find((k) => url.includes(k));
+    if (!key) return Promise.resolve({ ok: false, status: 404 });
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(handlers[key]) });
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useUpdateCheck — web/GitHub flow', () => {
+  it('reports an available update when the latest tag is newer', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/api/version': { version: '1.0.0' },
+        '/releases': [
+          { tag_name: 'desktop-v2.0.0', html_url: 'https://gh/r/2', assets: [] },
+          { tag_name: 'android-v9.0.0', html_url: 'https://gh/r/a', assets: [] },
+        ],
+      })
+    );
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.check();
+    });
+    expect(result.current.info?.updateAvailable).toBe(true);
+    expect(result.current.info?.latestVersion).toBe('2.0.0');
+    expect(result.current.info?.releaseUrl).toBe('https://gh/r/2');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('reports no update when there is no matching release', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/api/version': { version: '1.0.0' },
+        '/releases': [{ tag_name: 'android-v9.0.0', html_url: 'https://gh/r/a', assets: [] }],
+      })
+    );
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.check();
+    });
+    expect(result.current.info?.updateAvailable).toBe(false);
+    expect(result.current.info?.latestVersion).toBe('1.0.0');
+  });
+
+  it('records an error when the version API fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: false, status: 500 }))
+    );
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.check();
+    });
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe('useUpdateCheck — Electron IPC flow', () => {
+  type Cb<T> = (arg: T) => void;
+  let listeners: Record<string, Cb<unknown>>;
+
+  beforeEach(() => {
+    listeners = {};
+    const api = {
+      removeUpdateListeners: vi.fn(),
+      onUpdateAvailable: vi.fn((cb: Cb<{ version: string }>) => {
+        listeners.available = cb as Cb<unknown>;
+      }),
+      onUpdateNotAvailable: vi.fn((cb: Cb<void>) => {
+        listeners.notAvailable = cb as Cb<unknown>;
+      }),
+      onDownloadProgress: vi.fn((cb: Cb<{ percent: number }>) => {
+        listeners.progress = cb as Cb<unknown>;
+      }),
+      onUpdateDownloaded: vi.fn((cb: Cb<void>) => {
+        listeners.downloaded = cb as Cb<unknown>;
+      }),
+      onUpdateError: vi.fn((cb: Cb<string>) => {
+        listeners.error = cb as Cb<unknown>;
+      }),
+      checkForUpdate: vi.fn(),
+      downloadUpdate: vi.fn(),
+      quitAndInstall: vi.fn(),
+    };
+    vi.stubGlobal('electronAPI', api);
+    (window as unknown as { electronAPI: typeof api }).electronAPI = api;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it('drives stage transitions from IPC events', () => {
+    const { result } = renderHook(() => useUpdateCheck());
+
+    act(() => result.current.checkElectron());
+    expect(result.current.electronStage).toBe('checking');
+
+    act(() => listeners.available({ version: '3.1.0' }));
+    expect(result.current.electronStage).toBe('available');
+    expect(result.current.electronLatestVersion).toBe('3.1.0');
+
+    act(() => (listeners.progress as Cb<{ percent: number }>)({ percent: 42.6 }));
+    expect(result.current.electronStage).toBe('downloading');
+    expect(result.current.downloadPercent).toBe(43);
+
+    act(() => listeners.downloaded(undefined));
+    expect(result.current.electronStage).toBe('ready');
+
+    act(() => (listeners.error as Cb<string>)('boom'));
+    expect(result.current.electronStage).toBe('error');
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('forwards download and install actions to the Electron API', () => {
+    const { result } = renderHook(() => useUpdateCheck());
+    const api = (
+      window as unknown as {
+        electronAPI: { downloadUpdate: () => void; quitAndInstall: () => void };
+      }
+    ).electronAPI;
+
+    act(() => result.current.downloadElectronUpdate());
+    expect(api.downloadUpdate).toHaveBeenCalled();
+    expect(result.current.electronStage).toBe('downloading');
+
+    act(() => result.current.installElectronUpdate());
+    expect(api.quitAndInstall).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #244.

Second coverage round, continuing toward ~100% across backend and frontend.

## Backend (83% → 87%)
- **scheduler.py 43% → 99%** — job runners (`_run_ingest` w/ prefetch + failure suppression, recommendation recalc, digest), `_parse_cron_hm`, and the full lifecycle API (start/stop/pause/resume/set_interval/next-run/is-paused) including every error-handler branch.
- **db.py 79% → 96%** — `active_database_url` built from POSTGRES_* parts, `describe_database` passthrough, `row_to_dict`, `placeholders`, `search_articles_sql`.
- **main.py 67% → 73%** — public Keycloak OAuth endpoints (`/auth/login`, `/auth/callback` incl. state/code validation, `/auth/logout`), password-login 409 when Keycloak enabled, `/api/auth/config`, `/api/version` (incl. OSError fallback).
- **migrate.py** — `sqlite-to-postgres` env/file guard branches.

## Frontend (55.8% → 62.6%)
- Hooks: `useIsMobile`, `useTheme`, `useUpdateCheck` (GitHub release flow + Electron IPC stage machine).
- `ThemeSwitcher` component.
- Thin triage pages: Inbox / Later / Starred / Archive.

## Verification
- Backend: 569 passed, coverage 87%.
- Frontend: 319 passed, coverage 62.6%.
- `make lint typecheck` clean (ruff, mypy, ty, pyrefly, eslint, prettier, tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)