### PR TITLE
test: cover AppRouter and SettingsPage platform branches (#252)

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Navigate, type RouteObject } from 'react-router-dom';
 import { FocusedArticleProvider } from './contexts/focusedArticle';
 import { AuthProvider } from './contexts/auth';
 import { RequireAuth } from './components/RequireAuth';
@@ -22,7 +22,7 @@ import { ArticlePage } from './pages/ArticlePage';
 import { BriefingsHistoryPage } from './pages/BriefingsHistoryPage';
 import { BriefingDetailPage } from './pages/BriefingDetailPage';
 
-function NotFound() {
+export function NotFound() {
   return (
     <div className="flex min-h-[60vh] items-center justify-center px-4">
       <div className="max-w-md text-center">
@@ -44,7 +44,8 @@ function NotFound() {
   );
 }
 
-const router = createBrowserRouter([
+// eslint-disable-next-line react-refresh/only-export-components
+export const routes: RouteObject[] = [
   {
     path: '/login',
     element: <LoginPage />,
@@ -99,7 +100,9 @@ const router = createBrowserRouter([
       { path: '*', element: <NotFound /> },
     ],
   },
-]);
+];
+
+const router = createBrowserRouter(routes);
 
 export function AppRouter() {
   return (

--- a/frontend/src/__tests__/appRouter.test.tsx
+++ b/frontend/src/__tests__/appRouter.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+
+// Stub every page/shell so the route table can be exercised cheaply without
+// pulling in real data fetching. Each stub renders an identifiable marker.
+const { stub } = vi.hoisted(() => ({
+  stub: (label: string) => () => <div>{label}</div>,
+}));
+
+vi.mock('../components/RequireAuth', () => ({
+  RequireAuth: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../components/AppShell', async () => {
+  const { Outlet } = await import('react-router-dom');
+  return { AppShell: () => <Outlet /> };
+});
+vi.mock('../contexts/auth', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../contexts/focusedArticle', () => ({
+  FocusedArticleProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../pages/LoginPage', () => ({ LoginPage: stub('login-page') }));
+vi.mock('../pages/BriefPage', () => ({ BriefPage: stub('brief-page') }));
+vi.mock('../pages/InboxPage', () => ({ InboxPage: stub('inbox-page') }));
+vi.mock('../pages/LaterPage', () => ({ LaterPage: stub('later-page') }));
+vi.mock('../pages/StarredPage', () => ({ StarredPage: stub('starred-page') }));
+vi.mock('../pages/SearchPage', () => ({ SearchPage: stub('search-page') }));
+vi.mock('../pages/AskPage', () => ({ AskPage: stub('ask-page') }));
+vi.mock('../pages/FeedsPage', async () => {
+  const { Outlet } = await import('react-router-dom');
+  return {
+    FeedsPage: () => (
+      <div>
+        feeds-page
+        <Outlet />
+      </div>
+    ),
+  };
+});
+vi.mock('../pages/SourcesPage', () => ({ SourcesPage: stub('sources-page') }));
+vi.mock('../pages/SchedulerPage', () => ({ SchedulerPage: stub('scheduler-page') }));
+vi.mock('../pages/FeedsRunsPage', () => ({ FeedsRunsPage: stub('runs-page') }));
+vi.mock('../pages/FeedsLogsPage', () => ({ FeedsLogsPage: stub('logs-page') }));
+vi.mock('../pages/StatsPage', () => ({ StatsPage: stub('stats-page') }));
+vi.mock('../pages/ArchivePage', () => ({ ArchivePage: stub('archive-page') }));
+vi.mock('../pages/SettingsPage', () => ({ SettingsPage: stub('settings-page') }));
+vi.mock('../pages/ArticlePage', () => ({ ArticlePage: stub('article-page') }));
+vi.mock('../pages/BriefingsHistoryPage', () => ({ BriefingsHistoryPage: stub('briefs-page') }));
+vi.mock('../pages/BriefingDetailPage', () => ({ BriefingDetailPage: stub('brief-detail-page') }));
+
+import { routes, NotFound, AppRouter } from '../AppRouter';
+
+function renderAt(path: string) {
+  const router = createMemoryRouter(routes, { initialEntries: [path] });
+  return render(<RouterProvider router={router} />);
+}
+
+describe('AppRouter routes', () => {
+  it('renders the login route', async () => {
+    renderAt('/login');
+    expect(await screen.findByText('login-page')).toBeTruthy();
+  });
+
+  it('renders the index brief page', async () => {
+    renderAt('/');
+    expect(await screen.findByText('brief-page')).toBeTruthy();
+  });
+
+  it('renders a nested feeds child route', async () => {
+    renderAt('/feeds/runs');
+    expect(await screen.findByText('runs-page')).toBeTruthy();
+  });
+
+  it('redirects legacy /inbox to /today', async () => {
+    renderAt('/inbox');
+    expect(await screen.findByText('inbox-page')).toBeTruthy();
+  });
+
+  it('redirects legacy /scheduler to the schedule tab', async () => {
+    renderAt('/scheduler');
+    expect(await screen.findByText('scheduler-page')).toBeTruthy();
+  });
+
+  it('renders the 404 page for unknown routes', async () => {
+    renderAt('/no-such-page');
+    expect(await screen.findByText('404')).toBeTruthy();
+  });
+
+  it('mounts the provider tree via AppRouter', async () => {
+    render(<AppRouter />);
+    await waitFor(() => expect(screen.getByText('brief-page')).toBeTruthy());
+  });
+});
+
+describe('NotFound', () => {
+  it('renders a home link', () => {
+    const router = createMemoryRouter([{ path: '/', element: <NotFound /> }]);
+    render(<RouterProvider router={router} />);
+    expect(screen.getByText('Page not found')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Go home' }).getAttribute('href')).toBe('/');
+  });
+});

--- a/frontend/src/__tests__/settingsPlatforms.test.tsx
+++ b/frontend/src/__tests__/settingsPlatforms.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@/api', () => ({ recalculateMyRecommendations: vi.fn() }));
+
+import { SettingsPage } from '../pages/SettingsPage';
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  // Remove the electron shim between tests.
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  sessionStorage.clear();
+});
+
+// ── Electron platform ────────────────────────────────────────────────────────
+
+describe('SettingsPage on Electron', () => {
+  type Cb<T> = (arg: T) => void;
+
+  function installElectron(overrides: Record<string, unknown> = {}) {
+    const handlers: Record<string, Cb<unknown>> = {};
+    const api = {
+      appVersion: '2.3.4',
+      removeUpdateListeners: vi.fn(),
+      onUpdateAvailable: (cb: Cb<{ version: string }>) => (handlers.available = cb as Cb<unknown>),
+      onUpdateNotAvailable: (cb: Cb<void>) => (handlers.notAvailable = cb as Cb<unknown>),
+      onDownloadProgress: (cb: Cb<{ percent: number }>) => (handlers.progress = cb as Cb<unknown>),
+      onUpdateDownloaded: (cb: Cb<void>) => (handlers.downloaded = cb as Cb<unknown>),
+      onUpdateError: (cb: Cb<string>) => (handlers.error = cb as Cb<unknown>),
+      checkForUpdate: vi.fn(),
+      downloadUpdate: vi.fn(),
+      quitAndInstall: vi.fn(),
+      ...overrides,
+    };
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+    return { api, handlers };
+  }
+
+  it('shows the current version and an up-to-date state', async () => {
+    const { handlers } = installElectron();
+    render(<SettingsPage />);
+    expect(screen.getByText('2.3.4')).toBeTruthy();
+    handlers.notAvailable?.(undefined);
+    await waitFor(() => expect(screen.getByText(/latest version/)).toBeTruthy());
+  });
+
+  it('walks the available → download → ready flow', async () => {
+    const { api, handlers } = installElectron();
+    render(<SettingsPage />);
+
+    handlers.available?.({ version: '9.9.9' });
+    const download = await screen.findByText('Download update');
+    fireEvent.click(download);
+    expect(api.downloadUpdate).toHaveBeenCalled();
+
+    handlers.progress?.({ percent: 42 });
+    await waitFor(() => expect(screen.getByText(/42%/)).toBeTruthy());
+
+    handlers.downloaded?.(undefined);
+    const restart = await screen.findByText('Restart and install');
+    fireEvent.click(restart);
+    expect(api.quitAndInstall).toHaveBeenCalled();
+  });
+
+  it('shows an error and allows retry', async () => {
+    const { api, handlers } = installElectron();
+    render(<SettingsPage />);
+    handlers.error?.('update boom');
+    await waitFor(() => expect(screen.getByText('update boom')).toBeTruthy());
+    fireEvent.click(screen.getByText('Try again'));
+    expect(api.checkForUpdate).toHaveBeenCalledTimes(2); // mount + retry
+  });
+});
+
+// ── TWA platform ─────────────────────────────────────────────────────────────
+
+describe('SettingsPage on TWA', () => {
+  beforeEach(() => {
+    sessionStorage.setItem('nd_platform', 'twa');
+  });
+
+  it('checks for updates and offers an APK download', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        if (url.includes('/api/version')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ version: '1.0.0' }) });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                tag_name: 'android-v2.0.0',
+                html_url: 'https://gh/release',
+                assets: [{ name: 'app.apk', browser_download_url: 'https://gh/app.apk' }],
+              },
+            ]),
+        });
+      })
+    );
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByText('Check for updates'));
+    const apk = await screen.findByText('Download APK');
+    expect(apk.getAttribute('href')).toBe('https://gh/app.apk');
+  });
+});


### PR DESCRIPTION
Coverage round 6 (frontend) — closes #252.

- **AppRouter** — exported the `routes` array and `NotFound` so the route table can be exercised via `createMemoryRouter` with stubbed pages: login, index brief, nested `/feeds/runs`, legacy redirects (`/inbox`→`/today`, `/scheduler`→`/feeds/schedule`), the 404 fallback, and a full `<AppRouter />` provider-tree mount. `NotFound` gets its own render test.
- **SettingsPage** — Electron path (version display, up-to-date, available→download→ready install, error+retry) driven through a fake `window.electronAPI`, plus the TWA APK-download path via stubbed GitHub/version fetches.

Frontend line coverage **84.4% → 88.6%** (410 → 422 tests). SettingsPage 73% → 93%. Full frontend suite ~2.6s. Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)