### PR TITLE
fix: coerce source values in sqlite-to-postgres migration (#254)

### DIFF
--- a/backend/news_dashboard/migrate.py
+++ b/backend/news_dashboard/migrate.py
@@ -49,6 +49,23 @@ ARTICLE_COLUMNS = [
 ]
 
 
+def _coerce_source_value(column: str, row: sqlite3.Row) -> Any:
+    """Map a SQLite source column to a PostgreSQL-compatible value.
+
+    Older dumps lack the newer health columns; the NOT NULL count columns must
+    fall back to 0, and SQLite stores ``enabled`` as an integer 0/1 which
+    PostgreSQL's boolean column rejects.
+    """
+    not_null_counts = {"last_fetched_count", "last_inserted_count"}
+    present = column in row.keys()  # noqa: SIM118 - sqlite3.Row is not a Mapping
+    value = row[column] if present else None
+    if column == "enabled":
+        return None if value is None else bool(value)
+    if column in not_null_counts and value is None:
+        return 0
+    return value
+
+
 def sqlite_rows(path: Path, table: str) -> list[sqlite3.Row]:
     sqlite = sqlite3.connect(path)
     sqlite.row_factory = sqlite3.Row
@@ -75,10 +92,7 @@ def sqlite_to_postgres(
     with connect() as conn:
         for row in sources:
             # Gracefully handle older SQLite dumps that lack new health columns
-            source_values = tuple(
-                row[c] if c in row.keys() else None  # noqa: SIM118 - sqlite3.Row is not a Mapping
-                for c in SOURCE_COLUMNS
-            )
+            source_values = tuple(_coerce_source_value(c, row) for c in SOURCE_COLUMNS)
             conn.execute(
                 """
                 INSERT INTO sources(

--- a/backend/tests/test_migrate_multi_user.py
+++ b/backend/tests/test_migrate_multi_user.py
@@ -73,11 +73,17 @@ def test_sqlite_to_postgres_migrates_rows(
     # exercise the graceful-degradation path, articles carries all columns.
     src = tmp_path / "legacy.sqlite"
     sqlite = sqlite3.connect(src)
-    # Empty sources table: exercises the sources loop (zero iterations) without
-    # tripping the enabled-column boolean adaptation limitation.
+    # Sources lacks the newer health columns (graceful degradation) and stores
+    # enabled as an integer 0/1 — the migrator must coerce it to a PG boolean.
     sqlite.execute(
         "CREATE TABLE sources(slug TEXT, name TEXT, url TEXT, category TEXT,"
         " kind TEXT, priority INTEGER, enabled INTEGER)"
+    )
+    sqlite.execute(
+        "INSERT INTO sources VALUES('acme', 'Acme', 'https://acme.test', 'tech', 'rss_feed', 1, 1)"
+    )
+    sqlite.execute(
+        "INSERT INTO sources VALUES('off', 'Off', 'https://off.test', 'tech', 'rss_feed', 1, 0)"
     )
     sqlite.execute(
         "CREATE TABLE articles(url TEXT, canonical_url TEXT, title TEXT, source_slug TEXT,"
@@ -98,21 +104,22 @@ def test_sqlite_to_postgres_migrates_rows(
     monkeypatch.setenv("DATABASE_URL", pg_url)
     monkeypatch.setattr(db_mod, "DB_PATH", schema_path)
 
-    # Pre-seed the parent source so the migrated article satisfies its FK.
+    # The migrator seeds sources before articles, so the article's FK to 'acme'
+    # is satisfied within the same run — no pre-seeding needed.
     init_db(schema_path)
-    with connect(schema_path) as conn:
-        conn.execute(
-            "INSERT INTO sources(slug, name, url, category, kind)"
-            " VALUES ('acme', 'Acme', 'https://acme.test', 'tech', 'rss_feed')"
-        )
 
     result = runner.invoke(app, ["sqlite-to-postgres", str(src)])
     assert result.exit_code == 0, result.output
-    assert "Migrated 0 source(s) and 1 article(s)" in result.output
+    assert "Migrated 2 source(s) and 1 article(s)" in result.output
 
     with connect(schema_path) as conn:
         articles = conn.execute("SELECT url, title FROM articles").fetchall()
+        sources = conn.execute("SELECT slug, enabled FROM sources ORDER BY slug").fetchall()
     assert articles[0]["title"] == "Hello"
+    # enabled integers are coerced to booleans
+    enabled_by_slug = {s["slug"]: s["enabled"] for s in sources}
+    assert enabled_by_slug["acme"] is True
+    assert enabled_by_slug["off"] is False
 
 
 def test_row_count_postgres_style() -> None:


### PR DESCRIPTION
Closes #254.

The `sqlite-to-postgres` migration crashed on legacy SQLite dumps for two reasons:

1. **`enabled` int → PG boolean** — SQLite stores `enabled` as `0`/`1`; the PostgreSQL column is `boolean`, so the insert raised `DatatypeMismatch`.
2. **Missing NOT NULL health columns** — older dumps omit `last_fetched_count` / `last_inserted_count`, so inserting `NULL` violated the NOT NULL constraint.

### Fix
New `_coerce_source_value(column, row)` helper:
- casts `enabled` to `bool` (preserving `NULL`),
- defaults the NOT NULL count columns to `0` when absent,
- otherwise returns the value, still gracefully handling absent columns.

The migration test now seeds real `sources` rows (`enabled` = 1 and 0) and asserts both are migrated with `enabled` coerced to `True`/`False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)