### PR TITLE
test: cover auth flow, ingest helpers, and admin endpoints (#256)

### DIFF
--- a/backend/tests/test_auth_extra.py
+++ b/backend/tests/test_auth_extra.py
@@ -1,0 +1,234 @@
+"""Additional auth coverage: config helpers, keycloak flow, session edges, admin CRUD."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import news_dashboard.db as db_mod
+from news_dashboard import auth as auth_mod
+from news_dashboard.auth import (
+    create_user,
+    exchange_keycloak_code,
+    keycloak_authorization_url,
+    keycloak_config,
+    keycloak_logout_url,
+    keycloak_token_request_data,
+    verify_session_token,
+)
+from news_dashboard.db import init_db
+from news_dashboard.main import app
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / "test.db"
+    init_db(db)
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    return db
+
+
+def _enable_keycloak(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "true")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://idp.example")
+    monkeypatch.setenv("KEYCLOAK_REALM", "nd")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "nd-client")
+
+
+# ── config helpers ────────────────────────────────────────────────────────────
+
+
+def test_session_days_invalid_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_DAYS", "not-an-int")
+    assert auth_mod._session_days() == 30
+
+
+def test_keycloak_realm_url_properties(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://pub.example/")
+    monkeypatch.setenv("KEYCLOAK_INTERNAL_SERVER_URL", "http://idp:8080")
+    monkeypatch.setenv("KEYCLOAK_REALM", "nd")
+    cfg = keycloak_config()
+    assert cfg.public_realm_url == "https://pub.example/realms/nd"
+    assert cfg.internal_realm_url == "http://idp:8080/realms/nd"
+
+
+def test_keycloak_token_request_data_includes_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    monkeypatch.setenv("KEYCLOAK_CLIENT_SECRET", "s3cret")
+    data = keycloak_token_request_data("the-code")
+    assert data["code"] == "the-code"
+    assert data["client_secret"] == "s3cret"  # noqa: S105 - test fixture value
+    assert data["grant_type"] == "authorization_code"
+
+
+# ── keycloak url builders when disabled/unconfigured ─────────────────────────
+
+
+def test_keycloak_authorization_url_raises_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KEYCLOAK_AUTH_ENABLED", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        keycloak_authorization_url("state")
+    assert exc.value.status_code == 500
+
+
+def test_keycloak_logout_url_disabled_returns_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KEYCLOAK_AUTH_ENABLED", raising=False)
+    assert keycloak_logout_url() == "/login"
+
+
+def test_keycloak_logout_url_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    out = keycloak_logout_url()
+    assert "protocol/openid-connect/logout" in out
+    assert "client_id=nd-client" in out
+
+
+# ── verify_session_token edges ───────────────────────────────────────────────
+
+
+def test_verify_session_token_rejects_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_SESSION_SECRET", "x" * 32)
+    assert verify_session_token("not-a-real-token") is None
+
+
+# ── get_current_user via the real dependency (no override) ───────────────────
+
+
+def test_me_rejects_invalid_session_cookie(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_SESSION_SECRET", "x" * 32)
+    app.dependency_overrides.clear()
+    client = TestClient(app)
+    resp = client.get("/api/auth/me", cookies={"nd_session": "tampered"})
+    assert resp.status_code == 401
+
+
+def test_me_rejects_when_user_missing(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_SESSION_SECRET", "x" * 32)
+    app.dependency_overrides.clear()
+    # Valid signature but a user id that does not exist in the DB.
+    from news_dashboard.auth import create_session_token
+
+    token = create_session_token(999999, is_admin=False)
+    client = TestClient(app)
+    resp = client.get("/api/auth/me", cookies={"nd_session": token})
+    assert resp.status_code == 401
+
+
+# ── exchange_keycloak_code with a faked httpx client ─────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Drives exchange_keycloak_code: first POST = token, then GET = userinfo."""
+
+    token_resp: _FakeResp
+    user_resp: _FakeResp
+
+    def __init__(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *_a: Any) -> None:
+        return None
+
+    async def post(self, *_a: Any, **_k: Any) -> _FakeResp:
+        return type(self).token_resp
+
+    async def get(self, *_a: Any, **_k: Any) -> _FakeResp:
+        return type(self).user_resp
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, token: _FakeResp, user: _FakeResp) -> None:
+    cls = type("Patched", (_FakeAsyncClient,), {"token_resp": token, "user_resp": user})
+    monkeypatch.setattr("news_dashboard.auth.httpx.AsyncClient", cls)
+
+
+def test_exchange_disabled_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KEYCLOAK_AUTH_ENABLED", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(exchange_keycloak_code("code"))
+    assert exc.value.status_code == 400
+
+
+def test_exchange_token_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    _patch_httpx(monkeypatch, _FakeResp(401, {}), _FakeResp(200, {}))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(exchange_keycloak_code("code"))
+    assert exc.value.status_code == 401
+
+
+def test_exchange_no_access_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    _patch_httpx(monkeypatch, _FakeResp(200, {}), _FakeResp(200, {}))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(exchange_keycloak_code("code"))
+    assert exc.value.status_code == 401
+
+
+def test_exchange_userinfo_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    _patch_httpx(monkeypatch, _FakeResp(200, {"access_token": "t"}), _FakeResp(500, {}))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(exchange_keycloak_code("code"))
+    assert exc.value.status_code == 401
+
+
+def test_exchange_success_creates_user(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    _patch_httpx(
+        monkeypatch,
+        _FakeResp(200, {"access_token": "t"}),
+        _FakeResp(200, {"preferred_username": "kc_user", "email": "kc@example.com"}),
+    )
+    user = asyncio.run(exchange_keycloak_code("code"))
+    assert user["username"] == "kc_user"
+    assert user["email"] == "kc@example.com"
+
+
+# ── admin user CRUD endpoints (admin override is autouse) ────────────────────
+
+
+def test_admin_get_user_found_and_missing(tmp_db: Path) -> None:
+    created = create_user("dora", "pw123456", email="dora@example.com")
+    client = TestClient(app)
+    ok = client.get(f"/api/admin/users/{created['id']}")
+    assert ok.status_code == 200
+    assert ok.json()["username"] == "dora"
+    missing = client.get("/api/admin/users/987654")
+    assert missing.status_code == 404
+
+
+def test_admin_update_password_found_and_missing(tmp_db: Path) -> None:
+    created = create_user("evan", "pw123456")
+    client = TestClient(app)
+    ok = client.patch(f"/api/admin/users/{created['id']}/password", json={"password": "newpass123"})
+    assert ok.status_code == 200
+    assert ok.json()["status"] == "updated"
+    missing = client.patch("/api/admin/users/987654/password", json={"password": "newpass123"})
+    assert missing.status_code == 404
+
+
+def test_admin_create_user_conflict_on_duplicate(tmp_db: Path) -> None:
+    client = TestClient(app)
+    first = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
+    assert first.status_code == 200
+    dup = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
+    assert dup.status_code == 409

--- a/backend/tests/test_ingest_helpers.py
+++ b/backend/tests/test_ingest_helpers.py
@@ -1,0 +1,160 @@
+"""Unit tests for pure ingest helpers — no DB or network required."""
+
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard.ingest import (
+    canonicalize_url,
+    clean_html,
+    infer_tags,
+    make_reason,
+    make_summary,
+    parse_date,
+)
+from news_dashboard.sources import SourceDefinition
+
+
+def _src(
+    *,
+    slug: str = "acme",
+    name: str = "Acme",
+    category: str = "ai-llm",
+    kind: str = "rss_feed",
+    priority: int = 50,
+) -> SourceDefinition:
+    return SourceDefinition(
+        slug=slug,
+        name=name,
+        url="https://acme.test/feed",
+        category=category,
+        kind=kind,
+        priority=priority,
+    )
+
+
+# ── clean_html ────────────────────────────────────────────────────────────────
+
+
+def test_clean_html_empty() -> None:
+    assert clean_html(None) == ""
+    assert clean_html("") == ""
+
+
+def test_clean_html_strips_tags_and_entities() -> None:
+    assert clean_html("<p>Hello&amp;  <b>world</b></p>") == "Hello& world"
+
+
+# ── canonicalize_url ──────────────────────────────────────────────────────────
+
+
+def test_canonicalize_url_strips_tracking_and_fragment() -> None:
+    out = canonicalize_url("https://x.test/p?utm_source=rss&id=5#frag")
+    assert "utm_source" not in out
+    assert "id=5" in out
+    assert "#frag" not in out
+
+
+# ── parse_date ────────────────────────────────────────────────────────────────
+
+
+def test_parse_date_rfc822() -> None:
+    out = parse_date({"published": "Mon, 01 Jun 2026 12:00:00 +0000"})
+    assert out is not None
+    assert out.startswith("2026-06-01T12:00:00")
+
+
+def test_parse_date_unparseable_returns_raw() -> None:
+    assert parse_date({"published": "not a date"}) == "not a date"
+
+
+def test_parse_date_none_when_absent() -> None:
+    assert parse_date({"published": None, "updated": None, "created": None}) is None
+
+
+# ── infer_tags ────────────────────────────────────────────────────────────────
+
+
+def test_infer_tags_detects_keywords() -> None:
+    tags = infer_tags("A new LLM agent framework in Python")
+    assert "llm" in tags or "agents" in tags
+    assert "python" in tags
+
+
+def test_infer_tags_empty_for_unrelated_text() -> None:
+    assert infer_tags("the quick brown fox") == []
+
+
+# ── make_reason (first-match-wins rule chain) ────────────────────────────────
+
+
+def test_make_reason_release_with_version() -> None:
+    out = make_reason("Foo v1.2.3 released", _src(kind="github_release_feed"), [])
+    assert "1.2.3" in out
+    assert "New release" in out
+
+
+def test_make_reason_release_without_version() -> None:
+    out = make_reason("Foo released", _src(kind="github_release_feed"), [])
+    assert out == "New release from Acme."
+
+
+def test_make_reason_security() -> None:
+    assert "Security update" in make_reason("x", _src(), ["security"])
+
+
+def test_make_reason_tutorial() -> None:
+    out = make_reason("x", _src(category="ai-llm"), ["tutorial"])
+    assert "How-to" in out
+    assert "ai/llm" in out
+
+
+def test_make_reason_trending_hacker_news() -> None:
+    out = make_reason("x", _src(slug="hacker-news", kind="trending_feed"), [])
+    assert out == "Trending on Hacker News."
+
+
+def test_make_reason_trending_github() -> None:
+    out = make_reason("x", _src(slug="github-trending-python", kind="trending_feed"), [])
+    assert "Trending Python repository" in out
+
+
+def test_make_reason_trending_generic() -> None:
+    out = make_reason("x", _src(slug="other-feed", kind="trending_feed"), [])
+    assert out == "Trending item from Acme."
+
+
+def test_make_reason_llm_then_python_then_infra() -> None:
+    assert "AI/agent" in make_reason("x", _src(), ["llm"])
+    assert "Python ecosystem" in make_reason("x", _src(), ["python"])
+    assert "Cloud/infrastructure" in make_reason("x", _src(), ["infra"])
+
+
+def test_make_reason_fallback() -> None:
+    out = make_reason("x", _src(category="dev-tools"), [])
+    assert out == "Dev Tools — Acme."
+
+
+# ── make_summary ──────────────────────────────────────────────────────────────
+
+
+def test_make_summary_truncates_and_scores() -> None:
+    long = "word " * 100
+    summary, reason, score, tags = make_summary("Python release", long, _src(priority=50))
+    assert summary.endswith("…")
+    assert len(summary) <= 281
+    assert score == 60  # priority 50 + 10 for having tags
+    assert "python" in tags
+    assert reason
+
+
+def test_make_summary_no_tags_no_bonus() -> None:
+    _, _, score, tags = make_summary("zzz", "nothing here", _src(priority=20, category="misc"))
+    assert score == 20
+    assert tags == ""
+
+
+@pytest.mark.parametrize("priority", [95, 100, 120])
+def test_make_summary_score_capped_at_100(priority: int) -> None:
+    _, _, score, _ = make_summary("Python", "llm agent", _src(priority=priority))
+    assert score == 100


### PR DESCRIPTION
Coverage round 6 (backend) — closes #256.

Adds two focused test modules:

**`test_auth_extra.py`** — `auth.py` 79% → **95%**:
- config helpers: `_session_days` invalid-value fallback, realm-URL properties, `keycloak_token_request_data` with client secret
- keycloak URL builders when disabled/unconfigured (`keycloak_authorization_url` raises 500, `keycloak_logout_url` enabled/disabled)
- `verify_session_token` rejecting garbage
- real `get_current_user` 401 paths (tampered cookie, valid signature but missing user) — clears the auth override and drives the live dependency
- full `exchange_keycloak_code` flow via a faked `httpx.AsyncClient`: disabled, token failure, no access token, userinfo failure, and success-creates-user
- admin user CRUD endpoints: get (found/404), update password (found/404), create-duplicate conflict

**`test_ingest_helpers.py`** — `ingest.py` 83% → **86%**:
- pure helpers `clean_html`, `canonicalize_url`, `parse_date` (rfc822 / unparseable / absent), `infer_tags`, `make_reason` (every rule branch), `make_summary` (truncation, tag bonus, score cap)

Backend total **87% → 89%** (578 → 617 tests, full suite ~122s, all green locally). Async coroutine driven with `asyncio.run` (no `pytest-asyncio` dependency added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)