### PR TITLE
feat: admin page to provision users (Keycloak-aware)

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -31,6 +31,8 @@ class KeycloakConfig:
     client_id: str
     client_secret: str | None
     base_url: str
+    admin_client_id: str
+    admin_client_secret: str | None
 
     @property
     def public_realm_url(self) -> str:
@@ -61,14 +63,17 @@ def _strip_url(value: str | None) -> str:
 def keycloak_config() -> KeycloakConfig:
     public_server = _strip_url(os.getenv("KEYCLOAK_SERVER_URL"))
     internal_server = _strip_url(os.getenv("KEYCLOAK_INTERNAL_SERVER_URL")) or public_server
+    client_id = (os.getenv("KEYCLOAK_CLIENT_ID") or "news-dashboard").strip()
     return KeycloakConfig(
         enabled=_truthy(os.getenv("KEYCLOAK_AUTH_ENABLED")),
         public_server_url=public_server,
         internal_server_url=internal_server,
         realm=(os.getenv("KEYCLOAK_REALM") or "news-dashboard").strip(),
-        client_id=(os.getenv("KEYCLOAK_CLIENT_ID") or "news-dashboard").strip(),
+        client_id=client_id,
         client_secret=(os.getenv("KEYCLOAK_CLIENT_SECRET") or "").strip() or None,
         base_url=_strip_url(os.getenv("NEWS_DASHBOARD_BASE_URL")) or "http://localhost:8080",
+        admin_client_id=(os.getenv("KEYCLOAK_ADMIN_CLIENT_ID") or client_id).strip(),
+        admin_client_secret=(os.getenv("KEYCLOAK_ADMIN_CLIENT_SECRET") or "").strip() or None,
     )
 
 

--- a/backend/news_dashboard/keycloak_admin.py
+++ b/backend/news_dashboard/keycloak_admin.py
@@ -1,0 +1,106 @@
+"""Keycloak Admin REST API helpers for provisioning users from the admin page.
+
+When the dashboard runs behind Keycloak, local username/password login is
+disabled, so a user created only in the local ``users`` table can never log in.
+To actually onboard someone, the account must exist in Keycloak. This module
+uses a service-account (client-credentials) token to call the Keycloak Admin
+REST API and create the user, returning a one-time temporary password.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from fastapi import HTTPException
+
+from .auth import keycloak_config
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10.0
+
+
+async def _admin_token(client: httpx.AsyncClient) -> str:
+    config = keycloak_config()
+    if not config.admin_client_secret:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Keycloak admin provisioning is not configured. Set "
+                "KEYCLOAK_ADMIN_CLIENT_SECRET (and optionally KEYCLOAK_ADMIN_CLIENT_ID) "
+                "for a client with the realm-management manage-users role."
+            ),
+        )
+    token_url = f"{config.internal_realm_url}/protocol/openid-connect/token"
+    response = await client.post(
+        token_url,
+        data={
+            "grant_type": "client_credentials",
+            "client_id": config.admin_client_id,
+            "client_secret": config.admin_client_secret,
+        },
+        headers={"Accept": "application/json"},
+    )
+    if response.status_code >= 400:
+        logger.error("Keycloak admin token request failed: %s", response.status_code)
+        raise HTTPException(status_code=502, detail="Keycloak admin authentication failed")
+    token = response.json().get("access_token")
+    if not token:
+        raise HTTPException(
+            status_code=502,
+            detail="Keycloak admin token response had no access token",
+        )
+    return str(token)
+
+
+def _user_id_from_location(location: str) -> str | None:
+    return location.rstrip("/").rsplit("/", 1)[-1] if location else None
+
+
+async def create_keycloak_user(
+    username: str,
+    password: str,
+    *,
+    email: str | None = None,
+    temporary: bool = True,
+) -> dict[str, Any]:
+    """Create a realm user with a (temporary) password via the Admin REST API.
+
+    Returns the new Keycloak user id, username, and email. The plaintext
+    ``password`` itself is supplied by the caller and returned to the admin once.
+    """
+    config = keycloak_config()
+    if not config.enabled:
+        raise HTTPException(status_code=400, detail="Keycloak authentication is disabled")
+    users_url = f"{config.internal_server_url}/admin/realms/{config.realm}/users"
+    body: dict[str, Any] = {
+        "username": username,
+        "enabled": True,
+        "credentials": [{"type": "password", "value": password, "temporary": temporary}],
+    }
+    if email:
+        body["email"] = email
+        body["emailVerified"] = False
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        token = await _admin_token(client)
+        response = await client.post(
+            users_url,
+            json=body,
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        )
+
+    if response.status_code == 409:
+        raise HTTPException(status_code=409, detail="A user with that username already exists")
+    if response.status_code >= 400:
+        logger.error("Keycloak user creation failed: %s %s", response.status_code, response.text)
+        raise HTTPException(status_code=502, detail="Keycloak user creation failed")
+
+    return {
+        "id": _user_id_from_location(response.headers.get("Location", "")),
+        "username": username,
+        "email": email,
+        "temporary": temporary,
+    }

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -183,6 +183,12 @@ class UpdatePasswordRequest(BaseModel):
     password: str
 
 
+class GenerateUserRequest(BaseModel):
+    username: str
+    email: str | None = None
+    is_admin: bool = False
+
+
 # ── Public auth routes (no session required) ──────────────────────────────────
 
 public_router = APIRouter()
@@ -865,6 +871,41 @@ def admin_create_user(payload: CreateUserRequest) -> dict[str, Any]:
         )
     except Exception as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@admin.post("/users/generate")
+async def admin_generate_user(payload: GenerateUserRequest) -> dict[str, Any]:
+    """Create a user with a server-generated password and return the credentials.
+
+    The plaintext password is returned exactly once here so the admin can hand it
+    to the new user; it is never stored or retrievable afterwards.
+
+    When Keycloak SSO is enabled, local password login is disabled, so the user
+    must be created in Keycloak (with a one-time temporary password) for the
+    credentials to actually work. Otherwise the user is created in the local
+    ``users`` table.
+    """
+    username = payload.username.strip()
+    if not username:
+        raise HTTPException(status_code=422, detail="username is required")
+    password = secrets.token_urlsafe(12)
+
+    if keycloak_config().enabled:
+        from .keycloak_admin import create_keycloak_user
+
+        result = await create_keycloak_user(username, password, email=payload.email)
+        return {**result, "password": password, "provider": "keycloak"}
+
+    try:
+        user = create_user(
+            username,
+            password,
+            email=payload.email,
+            is_admin=payload.is_admin,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return {**user, "password": password, "provider": "password", "temporary": False}
 
 
 @admin.get("/users/{user_id}")

--- a/backend/tests/test_auth_extra.py
+++ b/backend/tests/test_auth_extra.py
@@ -232,3 +232,59 @@ def test_admin_create_user_conflict_on_duplicate(tmp_db: Path) -> None:
     assert first.status_code == 200
     dup = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
     assert dup.status_code == 409
+
+
+def test_admin_generate_user_returns_credentials(tmp_db: Path) -> None:
+    client = TestClient(app)
+    resp = client.post("/api/admin/users/generate", json={"username": "grace"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["username"] == "grace"
+    assert body["is_admin"] is False
+    # The generated password is returned once and must actually log the user in.
+    assert isinstance(body["password"], str)
+    assert len(body["password"]) >= 12
+    login = client.post(
+        "/api/auth/login",
+        json={"username": "grace", "password": body["password"]},
+    )
+    assert login.status_code == 200
+
+
+def test_admin_generate_user_rejects_blank_username(tmp_db: Path) -> None:
+    client = TestClient(app)
+    resp = client.post("/api/admin/users/generate", json={"username": "   "})
+    assert resp.status_code == 422
+
+
+def test_admin_generate_user_conflict_on_duplicate(tmp_db: Path) -> None:
+    client = TestClient(app)
+    first = client.post("/api/admin/users/generate", json={"username": "heidi"})
+    assert first.status_code == 200
+    dup = client.post("/api/admin/users/generate", json={"username": "heidi"})
+    assert dup.status_code == 409
+
+
+def test_admin_generate_user_uses_keycloak_when_enabled(
+    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_keycloak(monkeypatch)
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "admin-secret")
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(username: str, password: str, **kwargs: Any) -> dict[str, Any]:
+        captured["username"] = username
+        captured["password"] = password
+        return {"id": "kc-1", "username": username, "email": None, "temporary": True}
+
+    monkeypatch.setattr("news_dashboard.keycloak_admin.create_keycloak_user", fake_create)
+    client = TestClient(app)
+    resp = client.post("/api/admin/users/generate", json={"username": "ivan"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "keycloak"
+    assert body["id"] == "kc-1"
+    assert body["temporary"] is True
+    assert body["password"] == captured["password"]
+    assert captured["username"] == "ivan"

--- a/backend/tests/test_auth_extra.py
+++ b/backend/tests/test_auth_extra.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import secrets
 from pathlib import Path
 from typing import Any
 
@@ -269,7 +270,7 @@ def test_admin_generate_user_uses_keycloak_when_enabled(
     tmp_db: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _enable_keycloak(monkeypatch)
-    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "admin-secret")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", secrets.token_hex(8))
 
     captured: dict[str, Any] = {}
 

--- a/backend/tests/test_keycloak_admin.py
+++ b/backend/tests/test_keycloak_admin.py
@@ -1,0 +1,110 @@
+"""Coverage for Keycloak Admin REST user provisioning."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from news_dashboard.keycloak_admin import create_keycloak_user
+
+
+def _enable_keycloak(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "true")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://idp.example")
+    monkeypatch.setenv("KEYCLOAK_REALM", "nd")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "nd-client")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "admin-secret")
+
+
+class _FakeResp:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """First POST = admin token, second POST = user creation."""
+
+    token_resp: _FakeResp
+    create_resp: _FakeResp
+
+    def __init__(self, *_a: Any, **_k: Any) -> None:
+        self._calls = 0
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *_a: Any) -> None:
+        return None
+
+    async def post(self, *_a: Any, **_k: Any) -> _FakeResp:
+        self._calls += 1
+        return type(self).token_resp if self._calls == 1 else type(self).create_resp
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, token: _FakeResp, create: _FakeResp) -> None:
+    cls = type("Patched", (_FakeAsyncClient,), {"token_resp": token, "create_resp": create})
+    monkeypatch.setattr("news_dashboard.keycloak_admin.httpx.AsyncClient", cls)
+
+
+def test_create_disabled_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KEYCLOAK_AUTH_ENABLED", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(create_keycloak_user("alice", "pw"))
+    assert exc.value.status_code == 400
+
+
+def test_create_requires_admin_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    monkeypatch.delenv("KEYCLOAK_ADMIN_CLIENT_SECRET", raising=False)
+    _patch_httpx(monkeypatch, _FakeResp(200, {"access_token": "t"}), _FakeResp(201))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(create_keycloak_user("alice", "pw"))
+    assert exc.value.status_code == 500
+
+
+def test_create_token_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    _patch_httpx(monkeypatch, _FakeResp(401, {}), _FakeResp(201))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(create_keycloak_user("alice", "pw"))
+    assert exc.value.status_code == 502
+
+
+def test_create_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    _patch_httpx(monkeypatch, _FakeResp(200, {"access_token": "t"}), _FakeResp(409))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(create_keycloak_user("alice", "pw"))
+    assert exc.value.status_code == 409
+
+
+def test_create_success_returns_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_keycloak(monkeypatch)
+    _patch_httpx(
+        monkeypatch,
+        _FakeResp(200, {"access_token": "t"}),
+        _FakeResp(
+            201,
+            headers={"Location": "https://idp.example/admin/realms/nd/users/abc-123"},
+        ),
+    )
+    result = asyncio.run(create_keycloak_user("alice", "pw", email="a@example.com"))
+    assert result["id"] == "abc-123"
+    assert result["username"] == "alice"
+    assert result["email"] == "a@example.com"
+    assert result["temporary"] is True

--- a/backend/tests/test_keycloak_admin.py
+++ b/backend/tests/test_keycloak_admin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import secrets
 from typing import Any
 
 import pytest
@@ -16,7 +17,8 @@ def _enable_keycloak(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://idp.example")
     monkeypatch.setenv("KEYCLOAK_REALM", "nd")
     monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "nd-client")
-    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "admin-secret")
+    # Generated at runtime so no credential literal lives in the source.
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", secrets.token_hex(8))
 
 
 class _FakeResp:

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -19,6 +19,7 @@ import { StatsPage } from './pages/StatsPage';
 import { ArchivePage } from './pages/ArchivePage';
 import { SettingsPage } from './pages/SettingsPage';
 import { ArticlePage } from './pages/ArticlePage';
+import { AdminPage } from './pages/AdminPage';
 import { BriefingsHistoryPage } from './pages/BriefingsHistoryPage';
 import { BriefingDetailPage } from './pages/BriefingDetailPage';
 
@@ -87,6 +88,7 @@ export const routes: RouteObject[] = [
       { path: 'stats', element: <StatsPage /> },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'settings', element: <SettingsPage /> },
+      { path: 'admin', element: <AdminPage /> },
 
       /* Legacy route redirects — remove when each migration slice lands */
       { path: 'inbox', element: <Navigate to="/today" replace /> },

--- a/frontend/src/__tests__/adminPage.test.tsx
+++ b/frontend/src/__tests__/adminPage.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const apiMock = vi.hoisted(() => ({
+  fetchAdminUsers: vi.fn(),
+  generateAdminUser: vi.fn(),
+  deleteAdminUser: vi.fn(),
+  fetchAuthConfig: vi.fn(),
+}));
+vi.mock('@/api', () => apiMock);
+
+import { AdminPage } from '../pages/AdminPage';
+import { AuthProvider, useAuth } from '../contexts/auth';
+import type { User } from '../types';
+
+function SetUser({ user, children }: { user: User | null; children: ReactNode }) {
+  const { setUser } = useAuth();
+  useEffect(() => setUser(user), [user, setUser]);
+  return <>{children}</>;
+}
+
+function renderWithUser(user: User | null) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <AuthProvider>
+        <SetUser user={user}>
+          <AdminPage />
+        </SetUser>
+      </AuthProvider>
+    </QueryClientProvider>
+  );
+}
+
+const admin: User = { id: 1, username: 'joaquim', is_admin: true };
+
+beforeEach(() => {
+  apiMock.fetchAdminUsers.mockResolvedValue([admin]);
+  apiMock.fetchAuthConfig.mockResolvedValue({ provider: 'password' });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AdminPage', () => {
+  it('blocks non-admin users', () => {
+    renderWithUser({ id: 2, username: 'bob', is_admin: false });
+    expect(screen.getByText('Admins only')).toBeTruthy();
+    expect(apiMock.fetchAdminUsers).not.toHaveBeenCalled();
+  });
+
+  it('creates a user and shows the generated credentials', async () => {
+    apiMock.generateAdminUser.mockResolvedValue({
+      id: 3,
+      username: 'maria',
+      is_admin: false,
+      password: 'sup3r-secret-pw',
+      provider: 'password',
+    });
+    renderWithUser(admin);
+
+    await userEvent.type(screen.getByLabelText('Username'), 'maria');
+    await userEvent.click(screen.getByRole('button', { name: /create user/i }));
+
+    await waitFor(() =>
+      expect(apiMock.generateAdminUser).toHaveBeenCalledWith('maria', { is_admin: false })
+    );
+    expect(await screen.findByText('sup3r-secret-pw')).toBeTruthy();
+  });
+
+  it('hides the admin checkbox under Keycloak and notes the temporary password', async () => {
+    apiMock.fetchAuthConfig.mockResolvedValue({ provider: 'keycloak' });
+    apiMock.generateAdminUser.mockResolvedValue({
+      id: 'kc-1',
+      username: 'maria',
+      password: 'temp-pw-123456',
+      provider: 'keycloak',
+      temporary: true,
+    });
+    renderWithUser(admin);
+
+    await waitFor(() => expect(screen.queryByText('Grant administrator access')).toBeNull());
+
+    await userEvent.type(screen.getByLabelText('Username'), 'maria');
+    await userEvent.click(screen.getByRole('button', { name: /create user/i }));
+
+    expect(await screen.findByText('temp-pw-123456')).toBeTruthy();
+    expect(screen.getByText(/set a new password the first time/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -247,6 +247,42 @@ export async function loginUser(username: string, password: string): Promise<Use
   });
 }
 
+export interface GeneratedUser {
+  id: number | string | null;
+  username: string;
+  email?: string | null;
+  is_admin?: boolean;
+  password: string;
+  provider: 'keycloak' | 'password';
+  temporary?: boolean;
+  created_at?: string | null;
+}
+
+export async function fetchAdminUsers(): Promise<User[]> {
+  const data = await requestJson<{ items: User[] }>('/api/admin/users');
+  return data.items;
+}
+
+export async function generateAdminUser(
+  username: string,
+  options?: { email?: string | null; is_admin?: boolean }
+): Promise<GeneratedUser> {
+  return requestJson<GeneratedUser>('/api/admin/users/generate', {
+    method: 'POST',
+    body: JSON.stringify({
+      username,
+      email: options?.email ?? null,
+      is_admin: options?.is_admin ?? false,
+    }),
+  });
+}
+
+export async function deleteAdminUser(userId: number): Promise<void> {
+  await requestJson<{ status: string }>(`/api/admin/users/${userId}`, {
+    method: 'DELETE',
+  });
+}
+
 export async function logoutUser(): Promise<void> {
   const config = await fetchAuthConfig().catch(() => null);
   if (config?.provider === 'keycloak' && config.logout_url) {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -14,7 +14,7 @@ import {
   isNavigationItemActive,
   mobileNavigationItems,
   primaryNavigationItems,
-  secondaryNavigationItems,
+  secondaryNavigationItemsFor,
   type NavigationItem,
 } from '@/lib/navigation';
 
@@ -75,7 +75,7 @@ function DesktopRail({ pathname }: { pathname: string }) {
       </nav>
       <div className="mx-2 my-2 h-px bg-border" />
       <nav className="flex flex-col p-2 gap-0.5">
-        {secondaryNavigationItems.map((m) => {
+        {secondaryNavigationItemsFor(Boolean(user?.is_admin)).map((m) => {
           const Icon = m.icon;
           const active = isNavigationItemActive(m.to, pathname);
           return (
@@ -212,7 +212,7 @@ export function AppShell() {
                   )}
                 </SheetHeader>
                 <nav className="p-2">
-                  {secondaryNavigationItems.map((m) => {
+                  {secondaryNavigationItemsFor(Boolean(user?.is_admin)).map((m) => {
                     const Icon = m.icon;
                     const active = isNavigationItemActive(m.to, pathname);
                     return (

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -10,6 +10,7 @@ import {
   Settings,
   Sparkles,
   Star,
+  Users,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -37,6 +38,17 @@ export const secondaryNavigationItems: NavigationItem[] = [
   { to: '/archive', label: 'Archive', icon: Archive },
   { to: '/settings', label: 'Settings', icon: Settings },
 ];
+
+// Shown in the secondary nav only for admin users.
+export const adminNavigationItem: NavigationItem = {
+  to: '/admin',
+  label: 'Users',
+  icon: Users,
+};
+
+export function secondaryNavigationItemsFor(isAdmin: boolean): NavigationItem[] {
+  return isAdmin ? [...secondaryNavigationItems, adminNavigationItem] : secondaryNavigationItems;
+}
 
 export const mobileNavigationItems = primaryNavigationItems.slice(0, 5);
 
@@ -83,5 +95,6 @@ export function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/stats')) return 'Stats';
   if (pathname.startsWith('/archive')) return 'Archive';
   if (pathname.startsWith('/settings')) return 'Settings';
+  if (pathname.startsWith('/admin')) return 'Users';
   return 'Radar';
 }

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Check, Copy, ShieldAlert, Trash2, UserPlus } from 'lucide-react';
+import {
+  deleteAdminUser,
+  fetchAdminUsers,
+  fetchAuthConfig,
+  generateAdminUser,
+  type GeneratedUser,
+} from '@/api';
+import { useAuth } from '@/contexts/auth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+      className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      aria-label={`Copy ${label}`}
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+}
+
+function CredentialsCard({ user }: { user: GeneratedUser }) {
+  return (
+    <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-4 space-y-3">
+      <div className="text-sm font-medium text-foreground">
+        User <span className="font-semibold">{user.username}</span> created
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Copy these credentials now — the password is shown only once and cannot be retrieved later.
+        {user.temporary
+          ? ' The user will be asked to set a new password the first time they sign in.'
+          : ''}
+      </p>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3 rounded-md bg-background px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-wider text-subtle">Username</div>
+            <div className="truncate font-mono text-sm text-foreground">{user.username}</div>
+          </div>
+          <CopyButton value={user.username} label="username" />
+        </div>
+        <div className="flex items-center justify-between gap-3 rounded-md bg-background px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-wider text-subtle">Password</div>
+            <div className="truncate font-mono text-sm text-foreground">{user.password}</div>
+          </div>
+          <CopyButton value={user.password} label="password" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AdminPage() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const [username, setUsername] = useState('');
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [created, setCreated] = useState<GeneratedUser | null>(null);
+
+  const usersQuery = useQuery({
+    queryKey: ['admin', 'users'],
+    queryFn: fetchAdminUsers,
+    enabled: Boolean(user?.is_admin),
+  });
+
+  const authConfigQuery = useQuery({
+    queryKey: ['auth', 'config'],
+    queryFn: fetchAuthConfig,
+    enabled: Boolean(user?.is_admin),
+  });
+  const isKeycloak = authConfigQuery.data?.provider === 'keycloak';
+
+  const createMutation = useMutation({
+    mutationFn: (name: string) => generateAdminUser(name, { is_admin: isAdmin }),
+    onSuccess: (newUser) => {
+      setCreated(newUser);
+      setUsername('');
+      setIsAdmin(false);
+      void queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteAdminUser(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+    },
+  });
+
+  if (!user?.is_admin) {
+    return (
+      <div className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center gap-3 text-center">
+        <ShieldAlert className="size-8 text-muted-foreground" />
+        <h1 className="text-lg font-semibold text-foreground">Admins only</h1>
+        <p className="text-sm text-muted-foreground">
+          You need an administrator account to manage users.
+        </p>
+      </div>
+    );
+  }
+
+  const trimmed = username.trim();
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-8 p-4">
+      <header>
+        <h1 className="text-xl font-semibold text-foreground">User management</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Create a new user account. A secure password is generated automatically and shown once.
+        </p>
+        {isKeycloak && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            This deployment uses Keycloak for sign-in, so the account is created in Keycloak with a
+            temporary password. Administrator access is managed via the configured Keycloak admin
+            usernames, not here.
+          </p>
+        )}
+      </header>
+
+      <section className="space-y-4">
+        <form
+          className="space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmed) createMutation.mutate(trimmed);
+          }}
+        >
+          <div className="space-y-1">
+            <label htmlFor="new-username" className="text-sm font-medium text-foreground">
+              Username
+            </label>
+            <Input
+              id="new-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="e.g. maria"
+              autoComplete="off"
+            />
+          </div>
+          {!isKeycloak && (
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input
+                type="checkbox"
+                checked={isAdmin}
+                onChange={(e) => setIsAdmin(e.target.checked)}
+                className="size-4 rounded border-input"
+              />
+              Grant administrator access
+            </label>
+          )}
+          <Button type="submit" disabled={!trimmed || createMutation.isPending}>
+            <UserPlus className="size-4" />
+            {createMutation.isPending ? 'Creating…' : 'Create user'}
+          </Button>
+          {createMutation.isError && (
+            <p className="text-sm text-destructive">
+              Could not create user: {createMutation.error.message}
+            </p>
+          )}
+        </form>
+
+        {created && <CredentialsCard user={created} />}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-medium text-foreground">Existing users</h2>
+        {isKeycloak && (
+          <p className="text-xs text-muted-foreground">
+            Shows app users who have signed in at least once. Newly created Keycloak users appear
+            here after their first login. Manage Keycloak accounts in the Keycloak admin console.
+          </p>
+        )}
+        {usersQuery.isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+        {usersQuery.data && (
+          <ul className="divide-y divide-border rounded-lg border border-border">
+            {usersQuery.data.map((u) => (
+              <li key={u.id} className="flex items-center justify-between gap-3 px-3 py-2">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm text-foreground">{u.username}</span>
+                    {u.is_admin && (
+                      <span className="rounded bg-secondary px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-secondary-foreground">
+                        Admin
+                      </span>
+                    )}
+                  </div>
+                  {u.email && (
+                    <div className="truncate text-xs text-muted-foreground">{u.email}</div>
+                  )}
+                </div>
+                {!isKeycloak && u.id !== user.id && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Delete ${u.username}`}
+                    disabled={deleteMutation.isPending}
+                    onClick={() => {
+                      if (window.confirm(`Delete user "${u.username}"? This cannot be undone.`)) {
+                        deleteMutation.mutate(u.id);
+                      }
+                    }}
+                  >
+                    <Trash2 className="size-4 text-destructive" />
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/helm/news-dashboard/templates/auth-secret.yaml
+++ b/helm/news-dashboard/templates/auth-secret.yaml
@@ -10,4 +10,5 @@ type: Opaque
 stringData:
   SESSION_SECRET: {{ required "app.auth.sessionSecret is required when app.auth.enabled=true" .Values.app.auth.sessionSecret | quote }}
   KEYCLOAK_CLIENT_SECRET: {{ .Values.app.auth.clientSecret | quote }}
+  KEYCLOAK_ADMIN_CLIENT_SECRET: {{ .Values.app.auth.adminClientSecret | quote }}
 {{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -84,6 +84,13 @@ spec:
                   key: KEYCLOAK_CLIENT_SECRET
             - name: KEYCLOAK_ADMIN_USERNAMES
               value: {{ .Values.app.auth.adminUsernames | quote }}
+            - name: KEYCLOAK_ADMIN_CLIENT_ID
+              value: {{ .Values.app.auth.adminClientId | quote }}
+            - name: KEYCLOAK_ADMIN_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "news-dashboard.fullname" . }}-auth
+                  key: KEYCLOAK_ADMIN_CLIENT_SECRET
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -41,6 +41,13 @@ app:
     clientSecret: ""
     # Comma-separated usernames that become app admins when first seen from Keycloak.
     adminUsernames: ioachim
+    # Optional. Confidential client (service account) used by the in-app admin
+    # page to create users via the Keycloak Admin REST API. The client needs the
+    # realm-management "manage-users" role. Defaults to clientId when unset.
+    adminClientId: ""
+    # Service-account secret for adminClientId. Leave empty to disable in-app
+    # user creation (the admin page then reports it is not configured).
+    adminClientSecret: ""
     # Override in CI/local deploy with a long random string.
     sessionSecret: ""
   ai:


### PR DESCRIPTION
## Summary

Adds an admin-only **User management** page (`/admin`, gated to admins in the sidebar) where an admin enters a username and the backend creates the account with a server-generated password, returning the credentials **once**.

The app runs behind **Keycloak** in production, where local username/password login is disabled — so a user created only in the local `users` table could never log in. The new endpoint is therefore provider-aware:

- **Keycloak enabled:** creates the user in Keycloak via the Admin REST API with a one-time **temporary** password (user is prompted to set their own at first login).
- **Password mode:** creates the user in the local `users` table (with optional admin flag).

The page adapts its copy/controls to the active provider (hides the admin checkbox under Keycloak, shows the temporary-password note, and clarifies that the user list reflects accounts that have signed in at least once).

## Changes
- **Backend:** `POST /api/admin/users/generate`; new `keycloak_admin.py` using a confidential service-account client (client-credentials → Admin REST API) with the realm-management `manage-users` role.
- **Config:** `KEYCLOAK_ADMIN_CLIENT_ID` / `KEYCLOAK_ADMIN_CLIENT_SECRET`, wired through the Helm chart (`values.yaml`, auth secret, deployment env).
- **Frontend:** `AdminPage`, API helpers, route, and admin-gated nav entry.
- **Tests:** backend coverage for the Keycloak admin flow (token/conflict/success/config-missing) and the endpoint branch; frontend tests for non-admin block, password-mode create, and Keycloak-mode behavior.

## Deployment note
In-app user creation only activates once a Keycloak confidential client with `manage-users` is configured and `app.auth.adminClientSecret` is set. Until then the endpoint reports it is not configured (users can still be managed in the Keycloak console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)