### PR TITLE
feat: admin user-behavior analytics dashboard

### DIFF
--- a/backend/news_dashboard/analytics.py
+++ b/backend/news_dashboard/analytics.py
@@ -1,0 +1,416 @@
+"""User-behavior analytics: ingest client telemetry and aggregate it for admins.
+
+Events are emitted by the frontend tracker (see ``frontend/src/lib/analytics.ts``)
+and stored one row per event in ``user_events``. Time-on-app is reconstructed from
+``heartbeat`` events whose ``duration_ms`` is the active foreground time since the
+previous heartbeat; sessions are derived from gaps between heartbeats at query time.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .db import connect, init_db
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_EVENT_TYPES = frozenset({"heartbeat", "route", "article_open", "article_close", "feature"})
+# Clamp a single heartbeat's reported active time so a misbehaving or malicious
+# client cannot inflate time-on-app. The tracker beats every 15s; 5 min is slack.
+MAX_HEARTBEAT_MS = 5 * 60 * 1000
+# Gap (seconds) of heartbeat silence that ends one session and starts the next.
+SESSION_GAP_SECONDS = 30 * 60
+
+
+def record_events(
+    user_id: int,
+    events: list[dict[str, Any]],
+    db_path: Path | None = None,
+    database_url: str | None = None,
+) -> int:
+    """Bulk-insert validated telemetry events for ``user_id``; return the count stored."""
+    init_db(db_path, database_url=database_url)
+    rows: list[tuple[int, str, str | None, int | None, str | None, int | None]] = []
+    for event in events:
+        event_type = str(event.get("type") or "")
+        if event_type not in ALLOWED_EVENT_TYPES:
+            continue
+        route = _clean_text(event.get("route"))
+        feature = _clean_text(event.get("feature"))
+        article_id = _coerce_int(event.get("article_id"))
+        duration_ms = _coerce_int(event.get("duration_ms"))
+        if duration_ms is not None:
+            duration_ms = max(0, min(duration_ms, MAX_HEARTBEAT_MS))
+        rows.append((user_id, event_type, route, article_id, feature, duration_ms))
+
+    if not rows:
+        return 0
+
+    with connect(db_path, database_url=database_url) as conn:
+        conn.cursor().executemany(
+            """
+            INSERT INTO user_events
+              (user_id, event_type, route, article_id, feature, duration_ms)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            rows,
+        )
+    return len(rows)
+
+
+def admin_analytics(
+    days: int = 30,
+    db_path: Path | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate user consumption and behavior over the trailing ``days`` window."""
+    init_db(db_path, database_url=database_url)
+    days = max(1, min(days, 365))
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(days=days)
+
+    with connect(db_path, database_url=database_url) as conn:
+        return {
+            "range_days": days,
+            "generated_at": now.isoformat(),
+            "summary": _summary(conn, start, now),
+            "active_over_time": _active_over_time(conn, start),
+            "users": _per_user(conn, start),
+            "route_popularity": _route_popularity(conn, start),
+            "feature_usage": _feature_usage(conn, start),
+            "article_dwell": _article_dwell(conn, start),
+            "category_consumption": _category_consumption(conn, start),
+            "source_consumption": _source_consumption(conn, start),
+            "hourly_heatmap": _hourly_heatmap(conn, start),
+            "skip_rate_trend": _skip_rate_trend(conn, start),
+            "recommendation_funnel": _recommendation_funnel(conn, start),
+        }
+
+
+def _summary(conn: Any, start: datetime, now: datetime) -> dict[str, Any]:
+    day_ago = now - timedelta(days=1)
+    week_ago = now - timedelta(days=7)
+    dau = _scalar(
+        conn,
+        "SELECT COUNT(DISTINCT user_id) FROM user_events WHERE created_at >= %s",
+        (day_ago,),
+    )
+    wau = _scalar(
+        conn,
+        "SELECT COUNT(DISTINCT user_id) FROM user_events WHERE created_at >= %s",
+        (week_ago,),
+    )
+    mau = _scalar(
+        conn,
+        "SELECT COUNT(DISTINCT user_id) FROM user_events WHERE created_at >= %s",
+        (start,),
+    )
+    total_ms = _scalar(
+        conn,
+        "SELECT COALESCE(SUM(duration_ms), 0) FROM user_events"
+        " WHERE event_type = 'heartbeat' AND created_at >= %s",
+        (start,),
+    )
+    total_reads = _scalar(
+        conn,
+        "SELECT COUNT(*) FROM user_article_state WHERE state = 'done' AND done_at >= %s",
+        (start,),
+    )
+    total_events = _scalar(
+        conn, "SELECT COUNT(*) FROM user_events WHERE created_at >= %s", (start,)
+    )
+    sessions = _session_stats(conn, start)
+    return {
+        "dau": dau,
+        "wau": wau,
+        "mau": mau,
+        "stickiness": round(dau / mau, 3) if mau else 0.0,
+        "total_minutes": round(total_ms / 60000, 1),
+        "total_sessions": sessions["count"],
+        "avg_session_minutes": sessions["avg_minutes"],
+        "total_reads": total_reads,
+        "total_events": total_events,
+    }
+
+
+def _session_stats(conn: Any, start: datetime) -> dict[str, Any]:
+    """Derive session count and average length from heartbeat gaps per user."""
+    rows = _query(
+        conn,
+        """
+        SELECT user_id, created_at
+        FROM user_events
+        WHERE event_type = 'heartbeat' AND created_at >= %s
+        ORDER BY user_id, created_at
+        """,
+        (start,),
+    )
+    sessions = 0
+    durations: list[float] = []
+    prev_user: int | None = None
+    prev_time: datetime | None = None
+    session_start: datetime | None = None
+    for row in rows:
+        user_id = int(row["user_id"])
+        ts = _as_datetime(row["created_at"])
+        new_session = (
+            user_id != prev_user
+            or prev_time is None
+            or (ts - prev_time).total_seconds() > SESSION_GAP_SECONDS
+        )
+        if new_session:
+            if session_start is not None and prev_time is not None:
+                durations.append((prev_time - session_start).total_seconds())
+            sessions += 1
+            session_start = ts
+        prev_user = user_id
+        prev_time = ts
+    if session_start is not None and prev_time is not None:
+        durations.append((prev_time - session_start).total_seconds())
+
+    avg_minutes = round(sum(durations) / len(durations) / 60, 1) if durations else 0.0
+    return {"count": sessions, "avg_minutes": avg_minutes}
+
+
+def _active_over_time(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT to_char(date_trunc('day', created_at), 'YYYY-MM-DD') AS day,
+               COUNT(DISTINCT user_id) AS active_users,
+               ROUND(COALESCE(SUM(duration_ms) FILTER (WHERE event_type = 'heartbeat'), 0)
+                     / 60000.0, 1) AS minutes
+        FROM user_events
+        WHERE created_at >= %s
+        GROUP BY 1
+        ORDER BY 1
+        """,
+        (start,),
+    )
+
+
+def _per_user(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT u.id AS user_id,
+               u.username,
+               u.last_login_at,
+               ROUND(COALESCE(ev.total_ms, 0) / 60000.0, 1) AS minutes,
+               COALESCE(ev.events, 0) AS events,
+               COALESCE(st.reads, 0) AS reads,
+               COALESCE(st.skips, 0) AS skips,
+               COALESCE(st.starred, 0) AS starred,
+               COALESCE(br.briefings, 0) AS briefings
+        FROM users u
+        LEFT JOIN (
+            SELECT user_id,
+                   COUNT(*) AS events,
+                   SUM(duration_ms) FILTER (WHERE event_type = 'heartbeat') AS total_ms
+            FROM user_events WHERE created_at >= %(start)s GROUP BY user_id
+        ) ev ON ev.user_id = u.id
+        LEFT JOIN (
+            SELECT user_id,
+                   COUNT(*) FILTER (WHERE state = 'done' AND done_at >= %(start)s) AS reads,
+                   COUNT(*) FILTER (WHERE skipped_at >= %(start)s) AS skips,
+                   COUNT(*) FILTER (WHERE starred_at >= %(start)s) AS starred
+            FROM user_article_state GROUP BY user_id
+        ) st ON st.user_id = u.id
+        LEFT JOIN (
+            SELECT user_id, COUNT(*) AS briefings
+            FROM briefings WHERE created_at >= %(start)s GROUP BY user_id
+        ) br ON br.user_id = u.id
+        ORDER BY minutes DESC, reads DESC, u.username
+        """,
+        {"start": start},
+    )
+
+
+def _route_popularity(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT route,
+               COUNT(*) AS views,
+               COUNT(DISTINCT user_id) AS users
+        FROM user_events
+        WHERE event_type = 'route' AND route IS NOT NULL AND created_at >= %s
+        GROUP BY route
+        ORDER BY views DESC
+        LIMIT 30
+        """,
+        (start,),
+    )
+
+
+def _feature_usage(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT feature,
+               COUNT(*) AS count,
+               COUNT(DISTINCT user_id) AS users
+        FROM user_events
+        WHERE event_type = 'feature' AND feature IS NOT NULL AND created_at >= %s
+        GROUP BY feature
+        ORDER BY count DESC
+        LIMIT 30
+        """,
+        (start,),
+    )
+
+
+def _article_dwell(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT e.article_id,
+               a.title,
+               COUNT(*) AS opens,
+               ROUND(AVG(e.duration_ms) / 1000.0, 1) AS avg_dwell_seconds
+        FROM user_events e
+        JOIN articles a ON a.id = e.article_id
+        WHERE e.event_type = 'article_close'
+          AND e.duration_ms IS NOT NULL
+          AND e.created_at >= %s
+        GROUP BY e.article_id, a.title
+        ORDER BY opens DESC, avg_dwell_seconds DESC
+        LIMIT 20
+        """,
+        (start,),
+    )
+
+
+def _category_consumption(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT a.category, COUNT(*) AS reads
+        FROM user_article_state s
+        JOIN articles a ON a.id = s.article_id
+        WHERE s.state = 'done' AND s.done_at >= %s
+        GROUP BY a.category
+        ORDER BY reads DESC
+        """,
+        (start,),
+    )
+
+
+def _source_consumption(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT a.source_name, COUNT(*) AS reads
+        FROM user_article_state s
+        JOIN articles a ON a.id = s.article_id
+        WHERE s.state = 'done' AND s.done_at >= %s
+        GROUP BY a.source_name
+        ORDER BY reads DESC
+        LIMIT 20
+        """,
+        (start,),
+    )
+
+
+def _hourly_heatmap(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT EXTRACT(DOW FROM created_at)::int AS dow,
+               EXTRACT(HOUR FROM created_at)::int AS hour,
+               COUNT(*) AS events
+        FROM user_events
+        WHERE created_at >= %s
+        GROUP BY 1, 2
+        ORDER BY 1, 2
+        """,
+        (start,),
+    )
+
+
+def _skip_rate_trend(conn: Any, start: datetime) -> list[dict[str, Any]]:
+    return _query(
+        conn,
+        """
+        SELECT to_char(date_trunc('day', ts), 'YYYY-MM-DD') AS day,
+               COUNT(*) FILTER (WHERE kind = 'skip') AS skips,
+               COUNT(*) FILTER (WHERE kind = 'read') AS reads
+        FROM (
+            SELECT done_at AS ts, 'read' AS kind FROM user_article_state
+            WHERE state = 'done' AND done_at >= %(start)s
+            UNION ALL
+            SELECT skipped_at AS ts, 'skip' AS kind FROM user_article_state
+            WHERE skipped_at >= %(start)s
+        ) events
+        GROUP BY 1
+        ORDER BY 1
+        """,
+        {"start": start},
+    )
+
+
+def _recommendation_funnel(conn: Any, start: datetime) -> dict[str, Any]:
+    recommended = _scalar(
+        conn,
+        "SELECT COUNT(*) FROM user_article_recommendations WHERE computed_at >= %s",
+        (start,),
+    )
+    read = _scalar(
+        conn,
+        """
+        SELECT COUNT(*) FROM user_article_recommendations r
+        JOIN user_article_state s
+          ON s.user_id = r.user_id AND s.article_id = r.article_id
+        WHERE r.computed_at >= %s AND s.state = 'done'
+        """,
+        (start,),
+    )
+    skipped = _scalar(
+        conn,
+        """
+        SELECT COUNT(*) FROM user_article_recommendations r
+        JOIN user_article_state s
+          ON s.user_id = r.user_id AND s.article_id = r.article_id
+        WHERE r.computed_at >= %s AND s.skipped_at IS NOT NULL
+        """,
+        (start,),
+    )
+    return {"recommended": recommended, "read": read, "skipped": skipped}
+
+
+def _query(conn: Any, sql: str, params: Any) -> list[dict[str, Any]]:
+    cursor = conn.execute(sql, params)
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def _scalar(conn: Any, sql: str, params: Any) -> int:
+    row = conn.execute(sql, params).fetchone()
+    if row is None:
+        return 0
+    value = next(iter(row.values()))
+    return int(value) if value is not None else 0
+
+
+def _as_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(str(value))
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text[:200] if text else None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -330,6 +330,26 @@ POSTGRES_MULTIUSER_SCHEMA = [
     CREATE INDEX IF NOT EXISTS idx_uar_user_stale
       ON user_article_recommendations(user_id) WHERE stale = TRUE
     """,
+    # Behavioral telemetry: every row is one client-emitted event. A single
+    # table covers time-on-app (heartbeat), page popularity (route), per-article
+    # dwell (article_open/article_close), and feature usage (feature). Sessions
+    # are derived at query time from heartbeat gaps rather than stored.
+    """
+    CREATE TABLE IF NOT EXISTS user_events (
+      id          BIGSERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      event_type  TEXT NOT NULL
+                    CHECK(event_type IN ('heartbeat','route','article_open',
+                                         'article_close','feature')),
+      route       TEXT,
+      article_id  BIGINT REFERENCES articles(id) ON DELETE SET NULL,
+      feature     TEXT,
+      duration_ms INTEGER,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_events_user_time ON user_events(user_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_user_events_type_time ON user_events(event_type, created_at)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response as StarletteResponse
 
+from .analytics import admin_analytics, record_events
 from .auth import (
     _session_days,
     authenticate,
@@ -189,6 +190,18 @@ class GenerateUserRequest(BaseModel):
     is_admin: bool = False
 
 
+class AnalyticsEvent(BaseModel):
+    type: str
+    route: str | None = None
+    article_id: int | None = None
+    feature: str | None = None
+    duration_ms: int | None = None
+
+
+class AnalyticsEventsRequest(BaseModel):
+    events: list[AnalyticsEvent]
+
+
 # ── Public auth routes (no session required) ──────────────────────────────────
 
 public_router = APIRouter()
@@ -313,6 +326,16 @@ def version_endpoint() -> dict[str, str]:
 # ── Authenticated API router ─────────────────────────────────────────────────
 
 api = APIRouter(dependencies=[Depends(require_auth)])
+
+
+@api.post("/api/events")
+def ingest_events(
+    payload: AnalyticsEventsRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Store a batch of client telemetry events for the current user."""
+    stored = record_events(current_user["id"], [event.model_dump() for event in payload.events])
+    return {"stored": stored}
 
 
 @api.get("/api/auth/me")
@@ -853,6 +876,11 @@ def summary(
 # ── Admin user-management routes ─────────────────────────────────────────────
 
 admin = APIRouter(prefix="/api/admin", dependencies=[Depends(require_admin)])
+
+
+@admin.get("/analytics")
+def admin_get_analytics(days: Annotated[int, Query(ge=1, le=365)] = 30) -> dict[str, Any]:
+    return admin_analytics(days=days)
 
 
 @admin.get("/users")

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from news_dashboard.analytics import admin_analytics, record_events
+from news_dashboard.db import connect, init_db
+
+
+def _seed(db_path: Path) -> int:
+    """Create one user, source, and article; return the article id."""
+    init_db(db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash, is_admin)"
+            " VALUES (1, 'reader', 'x', FALSE)"
+        )
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind)"
+            " VALUES ('s1', 'Source One', 'https://s1.example', 'tech', 'rss')"
+        )
+        conn.execute(
+            """
+            INSERT INTO articles(id, url, canonical_url, title, source_slug,
+                                 source_name, category, kind)
+            VALUES (10, 'https://s1.example/a', 'https://s1.example/a', 'Hello',
+                    's1', 'Source One', 'tech', 'rss')
+            """
+        )
+    return 10
+
+
+def test_record_events_filters_invalid_and_clamps(tmp_path: Path) -> None:
+    db_path = tmp_path / "a.db"
+    article_id = _seed(db_path)
+
+    stored = record_events(
+        1,
+        [
+            {"type": "heartbeat", "duration_ms": 10_000},
+            {"type": "heartbeat", "duration_ms": 99_999_999},  # clamped
+            {"type": "route", "route": "/today"},
+            {"type": "article_close", "article_id": article_id, "duration_ms": 4_000},
+            {"type": "feature", "feature": "ask"},
+            {"type": "bogus", "route": "/x"},  # dropped
+        ],
+        db_path=db_path,
+    )
+    assert stored == 5
+
+    with connect(db_path) as conn:
+        total = conn.execute(
+            "SELECT COALESCE(SUM(duration_ms), 0) AS s FROM user_events"
+            " WHERE event_type = 'heartbeat'"
+        ).fetchone()["s"]
+    # 10_000 + clamp(99_999_999) == 10_000 + 300_000
+    assert total == 310_000
+
+
+def test_admin_analytics_aggregates_behavior(tmp_path: Path) -> None:
+    db_path = tmp_path / "b.db"
+    article_id = _seed(db_path)
+    now = datetime.now(timezone.utc)
+
+    record_events(
+        1,
+        [
+            {"type": "heartbeat", "duration_ms": 60_000},
+            {"type": "route", "route": "/today"},
+            {"type": "route", "route": "/today"},
+            {"type": "feature", "feature": "ask"},
+            {"type": "article_close", "article_id": article_id, "duration_ms": 30_000},
+        ],
+        db_path=db_path,
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state, done_at)"
+            " VALUES (1, %s, 'done', %s)",
+            (article_id, now - timedelta(hours=1)),
+        )
+
+    result = admin_analytics(days=30, db_path=db_path)
+
+    assert result["summary"]["mau"] == 1
+    assert result["summary"]["total_minutes"] == 1.0
+    assert result["summary"]["total_reads"] == 1
+    assert result["summary"]["total_sessions"] == 1
+
+    routes = {r["route"]: r["views"] for r in result["route_popularity"]}
+    assert routes["/today"] == 2
+
+    features = {f["feature"]: f["count"] for f in result["feature_usage"]}
+    assert features["ask"] == 1
+
+    dwell = {d["article_id"]: d["avg_dwell_seconds"] for d in result["article_dwell"]}
+    assert dwell[article_id] == 30.0
+
+    categories = {c["category"]: c["reads"] for c in result["category_consumption"]}
+    assert categories["tech"] == 1
+
+
+def test_admin_analytics_empty_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "c.db"
+    init_db(db_path)
+    result = admin_analytics(days=7, db_path=db_path)
+    assert result["summary"]["mau"] == 0
+    assert result["summary"]["stickiness"] == 0.0
+    assert result["users"] == []

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -20,6 +20,7 @@ import { ArchivePage } from './pages/ArchivePage';
 import { SettingsPage } from './pages/SettingsPage';
 import { ArticlePage } from './pages/ArticlePage';
 import { AdminPage } from './pages/AdminPage';
+import { AnalyticsPage } from './pages/AnalyticsPage';
 import { BriefingsHistoryPage } from './pages/BriefingsHistoryPage';
 import { BriefingDetailPage } from './pages/BriefingDetailPage';
 
@@ -89,6 +90,7 @@ export const routes: RouteObject[] = [
       { path: 'archive', element: <ArchivePage /> },
       { path: 'settings', element: <SettingsPage /> },
       { path: 'admin', element: <AdminPage /> },
+      { path: 'analytics', element: <AnalyticsPage /> },
 
       /* Legacy route redirects — remove when each migration slice lands */
       { path: 'inbox', element: <Navigate to="/today" replace /> },

--- a/frontend/src/__tests__/analytics.test.ts
+++ b/frontend/src/__tests__/analytics.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  flush,
+  trackArticleClose,
+  trackArticleOpen,
+  trackFeature,
+  trackRoute,
+} from '../lib/analytics';
+import { secondaryNavigationItemsFor } from '../lib/navigation';
+
+describe('analytics tracker', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    flush(); // drain any leftover queue
+    vi.unstubAllGlobals();
+  });
+
+  type FetchCall = [string, RequestInit];
+
+  function calls(): FetchCall[] {
+    return fetchMock.mock.calls as FetchCall[];
+  }
+
+  function lastBody(): { events: { type: string; [k: string]: unknown }[] } {
+    const init = calls().at(-1)?.[1];
+    return JSON.parse(init?.body as string) as {
+      events: { type: string; [k: string]: unknown }[];
+    };
+  }
+
+  it('posts queued events to /api/events on flush', () => {
+    trackRoute('/today');
+    trackFeature('ask');
+    flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = calls()[0];
+    expect(url).toBe('/api/events');
+    expect(init.method).toBe('POST');
+    const { events } = lastBody();
+    expect(events).toEqual([
+      { type: 'route', route: '/today' },
+      { type: 'feature', feature: 'ask' },
+    ]);
+  });
+
+  it('does not call fetch when the queue is empty', () => {
+    flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('emits article_close with a dwell duration after open', () => {
+    trackArticleOpen(42);
+    trackArticleClose(42);
+    flush();
+
+    const { events } = lastBody();
+    const close = events.find((e) => e.type === 'article_close');
+    expect(close?.article_id).toBe(42);
+    expect(typeof close?.duration_ms).toBe('number');
+  });
+
+  it('ignores a close for an article that was never opened', () => {
+    trackArticleClose(999);
+    flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('analytics navigation', () => {
+  it('exposes the analytics route to admins only', () => {
+    const adminRoutes = secondaryNavigationItemsFor(true).map((i) => i.to);
+    const userRoutes = secondaryNavigationItemsFor(false).map((i) => i.to);
+    expect(adminRoutes).toContain('/analytics');
+    expect(userRoutes).not.toContain('/analytics');
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AdminAnalytics,
   Article,
   ArticleCountsResult,
   ArticleStatus,
@@ -238,6 +239,10 @@ export async function fetchAuthConfig(): Promise<AuthConfig> {
 
 export async function fetchMe(): Promise<User> {
   return requestJson<User>('/api/auth/me');
+}
+
+export async function fetchAdminAnalytics(days = 30): Promise<AdminAnalytics> {
+  return requestJson<AdminAnalytics>(`/api/admin/analytics?days=${days}`);
 }
 
 export async function loginUser(username: string, password: string): Promise<User> {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import { CommandPalette } from './CommandPalette';
 import { ShortcutOverlay } from './ShortcutOverlay';
 import { cn } from '@/lib/utils';
 import { fetchSummary, logoutUser } from '@/api';
+import { startAnalytics, stopAnalytics, trackRoute } from '@/lib/analytics';
 import { useAuth } from '@/contexts/auth';
 import {
   getPageTitle,
@@ -124,6 +125,15 @@ export function AppShell() {
     setUser(null);
     navigate('/login', { replace: true });
   }
+
+  useEffect(() => {
+    startAnalytics();
+    return () => stopAnalytics();
+  }, []);
+
+  useEffect(() => {
+    trackRoute(pathname);
+  }, [pathname]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,0 +1,127 @@
+// Lightweight client telemetry: batches user-behavior events and ships them to
+// POST /api/events. Captures time-on-app (foreground heartbeats), route views,
+// per-article dwell, and feature usage. No third-party deps; flushes on a timer
+// and on page hide via sendBeacon so events survive tab close.
+
+export type AnalyticsEventType =
+  | 'heartbeat'
+  | 'route'
+  | 'article_open'
+  | 'article_close'
+  | 'feature';
+
+export interface AnalyticsEvent {
+  type: AnalyticsEventType;
+  route?: string;
+  article_id?: number;
+  feature?: string;
+  duration_ms?: number;
+}
+
+const HEARTBEAT_MS = 15_000;
+const FLUSH_MS = 30_000;
+const ENDPOINT = '/api/events';
+
+let queue: AnalyticsEvent[] = [];
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+let lastBeatAt = Date.now();
+let started = false;
+
+// Open articles mapped to the timestamp they were opened, for dwell on close.
+const openArticles = new Map<number, number>();
+
+function enqueue(event: AnalyticsEvent): void {
+  queue.push(event);
+  if (queue.length >= 50) flush();
+}
+
+function isVisible(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible';
+}
+
+function beat(): void {
+  const now = Date.now();
+  if (isVisible()) {
+    enqueue({ type: 'heartbeat', duration_ms: now - lastBeatAt });
+  }
+  lastBeatAt = now;
+}
+
+export function trackRoute(route: string): void {
+  enqueue({ type: 'route', route });
+}
+
+export function trackFeature(feature: string): void {
+  enqueue({ type: 'feature', feature });
+}
+
+export function trackArticleOpen(articleId: number): void {
+  openArticles.set(articleId, Date.now());
+  enqueue({ type: 'article_open', article_id: articleId });
+}
+
+export function trackArticleClose(articleId: number): void {
+  const openedAt = openArticles.get(articleId);
+  if (openedAt === undefined) return;
+  openArticles.delete(articleId);
+  enqueue({
+    type: 'article_close',
+    article_id: articleId,
+    duration_ms: Date.now() - openedAt,
+  });
+}
+
+export function flush(useBeacon = false): void {
+  if (queue.length === 0) return;
+  const events = queue;
+  queue = [];
+  const body = JSON.stringify({ events });
+
+  if (useBeacon && typeof navigator !== 'undefined' && navigator.sendBeacon) {
+    navigator.sendBeacon(ENDPOINT, new Blob([body], { type: 'application/json' }));
+    return;
+  }
+
+  void fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // Telemetry is best-effort; drop on failure rather than disrupt the app.
+  });
+}
+
+function handleVisibility(): void {
+  if (isVisible()) {
+    lastBeatAt = Date.now();
+  } else {
+    beat();
+    flush(true);
+  }
+}
+
+export function startAnalytics(): void {
+  // Never emit telemetry under the test runner — it would issue real network
+  // calls from any component test that mounts the app shell.
+  if (started || typeof window === 'undefined' || import.meta.env.MODE === 'test') return;
+  started = true;
+  lastBeatAt = Date.now();
+  heartbeatTimer = setInterval(beat, HEARTBEAT_MS);
+  flushTimer = setInterval(() => flush(), FLUSH_MS);
+  document.addEventListener('visibilitychange', handleVisibility);
+  window.addEventListener('pagehide', () => flush(true));
+}
+
+export function stopAnalytics(): void {
+  if (!started) return;
+  started = false;
+  if (heartbeatTimer) clearInterval(heartbeatTimer);
+  if (flushTimer) clearInterval(flushTimer);
+  heartbeatTimer = null;
+  flushTimer = null;
+  document.removeEventListener('visibilitychange', handleVisibility);
+  flush(true);
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,4 +1,5 @@
 import {
+  Activity,
   Archive,
   BarChart3,
   Clock,
@@ -40,14 +41,15 @@ export const secondaryNavigationItems: NavigationItem[] = [
 ];
 
 // Shown in the secondary nav only for admin users.
-export const adminNavigationItem: NavigationItem = {
-  to: '/admin',
-  label: 'Users',
-  icon: Users,
-};
+export const adminNavigationItems: NavigationItem[] = [
+  { to: '/analytics', label: 'Analytics', icon: Activity },
+  { to: '/admin', label: 'Users', icon: Users },
+];
 
 export function secondaryNavigationItemsFor(isAdmin: boolean): NavigationItem[] {
-  return isAdmin ? [...secondaryNavigationItems, adminNavigationItem] : secondaryNavigationItems;
+  return isAdmin
+    ? [...secondaryNavigationItems, ...adminNavigationItems]
+    : secondaryNavigationItems;
 }
 
 export const mobileNavigationItems = primaryNavigationItems.slice(0, 5);
@@ -95,6 +97,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/stats')) return 'Stats';
   if (pathname.startsWith('/archive')) return 'Archive';
   if (pathname.startsWith('/settings')) return 'Settings';
+  if (pathname.startsWith('/analytics')) return 'Analytics';
   if (pathname.startsWith('/admin')) return 'Users';
   return 'Radar';
 }

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,407 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { fetchAdminAnalytics } from '../api';
+import type { AdminAnalytics } from '../types';
+
+const CHART_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+  'var(--color-chart-5)',
+];
+const TOOLTIP_STYLE = {
+  background: 'var(--color-popover)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 6,
+  fontSize: 12,
+  color: 'var(--color-foreground)',
+};
+const GRID_STROKE = 'var(--color-border)';
+const AXIS_FILL = 'var(--color-subtle)';
+const RANGES = [7, 30, 90];
+const DOW = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export function AnalyticsPage() {
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState<AdminAnalytics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchAdminAnalytics(days)
+      .then((result) => {
+        if (!cancelled) {
+          setData(result);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load analytics');
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  const s = data?.summary;
+  const activeLabelled = useMemo(
+    () =>
+      (data?.active_over_time ?? []).map((d) => ({
+        ...d,
+        label: new Date(d.day + 'T00:00:00Z').toLocaleDateString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          timeZone: 'UTC',
+        }),
+      })),
+    [data]
+  );
+  const heatmap = useMemo(() => buildHeatmap(data?.hourly_heatmap ?? []), [data]);
+
+  return (
+    <div className="p-4 md:p-5 space-y-6 max-w-5xl">
+      <section className="flex items-end justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-[22px] font-semibold tracking-tight">User Analytics</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Consumption, engagement, and time spent across all users
+          </p>
+        </div>
+        <div className="flex gap-1">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setDays(r)}
+              className={`rounded-md border px-2.5 py-1 text-xs ${
+                days === r
+                  ? 'border-foreground bg-foreground text-background'
+                  : 'border-border bg-card text-muted-foreground'
+              }`}
+            >
+              {r}d
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        <Stat label="DAU" value={fmt(s?.dau, loading)} />
+        <Stat label="WAU" value={fmt(s?.wau, loading)} />
+        <Stat label="MAU" value={fmt(s?.mau, loading)} accent />
+        <Stat
+          label="Stickiness"
+          value={loading || !s ? '…' : `${Math.round(s.stickiness * 100)}%`}
+        />
+        <Stat label="Minutes spent" value={fmt(s?.total_minutes, loading)} />
+        <Stat label="Sessions" value={fmt(s?.total_sessions, loading)} />
+        <Stat label="Avg session" value={loading || !s ? '…' : `${s.avg_session_minutes}m`} />
+        <Stat label="Articles read" value={fmt(s?.total_reads, loading)} />
+      </section>
+
+      <ChartSection title="Active users & time" sub="Daily active users and minutes spent">
+        <div className="h-56 -mx-2">
+          <ResponsiveContainer>
+            <AreaChart data={activeLabelled} margin={{ left: 0, right: 8, top: 4, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="2 3" stroke={GRID_STROKE} />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 10, fill: AXIS_FILL }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 10, fill: AXIS_FILL }}
+                tickLine={false}
+                axisLine={false}
+                width={28}
+              />
+              <Tooltip contentStyle={TOOLTIP_STYLE} />
+              <Area
+                type="monotone"
+                dataKey="active_users"
+                stroke={CHART_COLORS[0]}
+                fill={CHART_COLORS[0]}
+                fillOpacity={0.15}
+                strokeWidth={1.5}
+                name="active users"
+              />
+              <Area
+                type="monotone"
+                dataKey="minutes"
+                stroke={CHART_COLORS[1]}
+                fill={CHART_COLORS[1]}
+                fillOpacity={0.1}
+                strokeWidth={1.5}
+                name="minutes"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </ChartSection>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <ChartSection title="Page popularity" sub="Route views in range">
+          <SimpleBar data={(data?.route_popularity ?? []).slice(0, 8)} xKey="route" yKey="views" />
+        </ChartSection>
+        <ChartSection title="Feature usage" sub="Feature events in range">
+          <SimpleBar
+            data={(data?.feature_usage ?? []).slice(0, 8)}
+            xKey="feature"
+            yKey="count"
+            color={CHART_COLORS[2]}
+          />
+        </ChartSection>
+        <ChartSection title="Top categories read" sub="Completed reads by category">
+          <SimpleBar
+            data={(data?.category_consumption ?? []).slice(0, 8)}
+            xKey="category"
+            yKey="reads"
+            color={CHART_COLORS[3]}
+          />
+        </ChartSection>
+        <ChartSection title="Top sources read" sub="Completed reads by source">
+          <SimpleBar
+            data={(data?.source_consumption ?? []).slice(0, 8)}
+            xKey="source_name"
+            yKey="reads"
+            color={CHART_COLORS[4]}
+          />
+        </ChartSection>
+      </div>
+
+      <ChartSection title="Activity heatmap" sub="Events by day of week and hour">
+        <div className="overflow-x-auto -mx-1">
+          <table className="border-separate border-spacing-[2px]">
+            <tbody>
+              {heatmap.map((row, dow) => (
+                <tr key={dow}>
+                  <td className="pr-2 text-[10px] text-subtle text-right">{DOW[dow]}</td>
+                  {row.map((value, hour) => (
+                    <td key={hour}>
+                      <div
+                        title={`${DOW[dow]} ${hour}:00 — ${value} events`}
+                        className="h-3 w-3 rounded-[2px]"
+                        style={{
+                          background:
+                            value === 0
+                              ? 'var(--color-border)'
+                              : `color-mix(in srgb, var(--color-chart-1) ${heatIntensity(value, heatmap)}%, transparent)`,
+                        }}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </ChartSection>
+
+      <ChartSection title="Per-user engagement" sub="Sorted by time spent">
+        <div className="overflow-x-auto -mx-2">
+          <table className="w-full text-sm min-w-[560px]">
+            <thead>
+              <tr className="text-left text-[10px] uppercase tracking-wider text-subtle border-b border-border">
+                <th className="px-3 py-2 font-medium">User</th>
+                <th className="px-3 py-2 font-medium text-right">Minutes</th>
+                <th className="px-3 py-2 font-medium text-right">Reads</th>
+                <th className="px-3 py-2 font-medium text-right">Skips</th>
+                <th className="px-3 py-2 font-medium text-right">Starred</th>
+                <th className="px-3 py-2 font-medium text-right">Briefings</th>
+                <th className="px-3 py-2 font-medium text-right">Events</th>
+              </tr>
+            </thead>
+            <tbody>
+              {!loading && (data?.users.length ?? 0) === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-3 py-4 text-center text-muted-foreground text-xs">
+                    No activity yet
+                  </td>
+                </tr>
+              )}
+              {(data?.users ?? []).map((u) => (
+                <tr key={u.user_id} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2">{u.username}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-star">{u.minutes}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{u.reads}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                    {u.skips}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">{u.starred}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{u.briefings}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                    {u.events}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </ChartSection>
+
+      <ChartSection title="Most-read articles" sub="By opens, with average dwell time">
+        <div className="overflow-x-auto -mx-2">
+          <table className="w-full text-sm min-w-[480px]">
+            <thead>
+              <tr className="text-left text-[10px] uppercase tracking-wider text-subtle border-b border-border">
+                <th className="px-3 py-2 font-medium">Article</th>
+                <th className="px-3 py-2 font-medium text-right">Opens</th>
+                <th className="px-3 py-2 font-medium text-right">Avg dwell</th>
+              </tr>
+            </thead>
+            <tbody>
+              {!loading && (data?.article_dwell.length ?? 0) === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-3 py-4 text-center text-muted-foreground text-xs">
+                    No reads tracked yet
+                  </td>
+                </tr>
+              )}
+              {(data?.article_dwell ?? []).map((a) => (
+                <tr key={a.article_id} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 truncate max-w-[320px]">{a.title}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{a.opens}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                    {a.avg_dwell_seconds}s
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </ChartSection>
+
+      {data && (
+        <section className="grid grid-cols-3 gap-2">
+          <Stat label="Recommended" value={data.recommendation_funnel.recommended} />
+          <Stat label="Recs read" value={data.recommendation_funnel.read} accent />
+          <Stat label="Recs skipped" value={data.recommendation_funnel.skipped} />
+        </section>
+      )}
+    </div>
+  );
+}
+
+function fmt(value: number | undefined, loading: boolean): number | string {
+  if (loading) return '…';
+  return value ?? 0;
+}
+
+function buildHeatmap(points: { dow: number; hour: number; events: number }[]): number[][] {
+  const grid: number[][] = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0));
+  for (const p of points) {
+    if (p.dow >= 0 && p.dow < 7 && p.hour >= 0 && p.hour < 24) {
+      grid[p.dow][p.hour] = p.events;
+    }
+  }
+  return grid;
+}
+
+function heatIntensity(value: number, grid: number[][]): number {
+  const max = Math.max(1, ...grid.flat());
+  return Math.round((value / max) * 90) + 10;
+}
+
+function Stat({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number | string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium">{label}</div>
+      <div className={`text-xl font-semibold mt-1 tabular-nums ${accent ? 'text-star' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SimpleBar({
+  data,
+  xKey,
+  yKey,
+  color = CHART_COLORS[0],
+}: {
+  data: Record<string, unknown>[];
+  xKey: string;
+  yKey: string;
+  color?: string;
+}) {
+  return (
+    <div className="h-56 -mx-2">
+      <ResponsiveContainer>
+        <BarChart data={data} margin={{ left: 0, right: 8, top: 8, bottom: 40 }}>
+          <CartesianGrid strokeDasharray="2 3" stroke={GRID_STROKE} />
+          <XAxis
+            dataKey={xKey}
+            tick={{ fontSize: 10, fill: AXIS_FILL }}
+            angle={-30}
+            textAnchor="end"
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v: string) => String(v).slice(0, 16)}
+          />
+          <YAxis
+            allowDecimals={false}
+            tick={{ fontSize: 10, fill: AXIS_FILL }}
+            tickLine={false}
+            axisLine={false}
+            width={28}
+          />
+          <Tooltip contentStyle={TOOLTIP_STYLE} />
+          <Bar dataKey={yKey} fill={color} radius={[3, 3, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function ChartSection({
+  title,
+  sub,
+  children,
+}: {
+  title: string;
+  sub?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="mb-2">
+        <div className="text-sm font-semibold">{title}</div>
+        {sub && <div className="text-[11px] text-subtle">{sub}</div>}
+      </div>
+      <div className="rounded-lg border border-border bg-card p-3">{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -212,3 +212,48 @@ export interface Briefing {
 
 export type BriefingLatestResponse = Briefing | { status: 'empty' };
 export type BriefingCreateResponse = Briefing | { status: 'no_candidates' };
+
+export interface AnalyticsSummary {
+  dau: number;
+  wau: number;
+  mau: number;
+  stickiness: number;
+  total_minutes: number;
+  total_sessions: number;
+  avg_session_minutes: number;
+  total_reads: number;
+  total_events: number;
+}
+
+export interface AnalyticsUserRow {
+  user_id: number;
+  username: string;
+  last_login_at: string | null;
+  minutes: number;
+  events: number;
+  reads: number;
+  skips: number;
+  starred: number;
+  briefings: number;
+}
+
+export interface AdminAnalytics {
+  range_days: number;
+  generated_at: string;
+  summary: AnalyticsSummary;
+  active_over_time: { day: string; active_users: number; minutes: number }[];
+  users: AnalyticsUserRow[];
+  route_popularity: { route: string; views: number; users: number }[];
+  feature_usage: { feature: string; count: number; users: number }[];
+  article_dwell: {
+    article_id: number;
+    title: string;
+    opens: number;
+    avg_dwell_seconds: number;
+  }[];
+  category_consumption: { category: string; reads: number }[];
+  source_consumption: { source_name: string; reads: number }[];
+  hourly_heatmap: { dow: number; hour: number; events: number }[];
+  skip_rate_trend: { day: string; skips: number; reads: number }[];
+  recommendation_funnel: { recommended: number; read: number; skipped: number };
+}


### PR DESCRIPTION
Closes #259

## What
Adds behavioral telemetry and an **admin-only Analytics dashboard** that answers "what are my users looking at, and how much time do they spend?"

### Backend
- **`user_events`** table: one row per client event (`heartbeat`, `route`, `article_open`, `article_close`, `feature`) + indexes.
- **`analytics.py`**:
  - `record_events()` — validates/clamps and bulk-inserts a batch.
  - `admin_analytics(days)` — aggregates DAU/WAU/MAU + stickiness, time-on-app & sessions (derived from heartbeat gaps), route popularity, feature usage, per-article dwell, category/source consumption, hourly heatmap, skip-rate trend, recommendation funnel, and a per-user engagement table.
- Endpoints: `POST /api/events` (authenticated beacon) and `GET /api/admin/analytics` (admin-only).

### Frontend
- **`lib/analytics.ts`** — dependency-free tracker: foreground heartbeats (visibility-aware), route changes, article open/close dwell, and a `trackFeature()` hook. Batches and flushes via `sendBeacon`/`fetch`; **no-ops under the test runner**. Wired into `AppShell`.
- **Analytics page** (recharts): summary cards, active-users/time area chart, page-popularity & feature-usage bars, category/source bars, day×hour heatmap, per-user table, most-read articles with dwell, and the recommendation funnel. Range selector (7/30/90 days).
- Admin-only nav entry + `/analytics` route.

### Tests
- Backend `test_analytics.py`: event ingest (filtering + clamping) and aggregation.
- Frontend `analytics.test.ts`: tracker batching/flush, dwell, and admin-only nav exposure.

## Privacy
Behavioral telemetry, admin-gated. Section D in #259 notes retention policy as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)