### PR TITLE
feat: briefing summarization via custom OpenAI-compatible endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Runtime storage is PostgreSQL only. Set `DATABASE_URL` or the split
 | `SESSION_SECRET` | Signed session key. Generate with `python -c "import secrets; print(secrets.token_hex(32))"`. |
 | `BOOTSTRAP_ADMIN_USERNAME`, `BOOTSTRAP_ADMIN_PASSWORD` | First local admin account. Used only when no users exist. |
 | `OPENAI_API_KEY` | Enables embeddings, Ask AI, and briefings. |
+| `OPENAI_BRIEFING_BASE_URL`, `OPENAI_BRIEFING_API_KEY` | Point briefing generation at an OpenAI-compatible endpoint (e.g. a self-hosted gateway). Optional; falls back to `OPENAI_BASE_URL` / `OPENAI_API_KEY`. Pair with `OPENAI_BRIEFING_MODEL` (use `auto` for a routing gateway). |
 | `KEYCLOAK_AUTH_ENABLED`, `KEYCLOAK_SERVER_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET` | Enables Keycloak. See [docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md). |
 | `CORS_ORIGINS` | Comma-separated browser dev origins. |
 

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -147,14 +147,31 @@ def _current_day_since_at(until_at: datetime) -> datetime:
     return until_at - timedelta(hours=24)
 
 
+def _briefing_ai_config() -> tuple[str, str | None]:
+    """Resolve the (api_key, base_url) for briefing generation.
+
+    Briefings can target any OpenAI-compatible endpoint (e.g. a self-hosted
+    gateway) via ``OPENAI_BRIEFING_BASE_URL`` / ``OPENAI_BRIEFING_API_KEY``,
+    falling back to the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` used by
+    the rest of the app. The base URL is optional; when unset the official
+    OpenAI endpoint is used.
+    """
+    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = (
+            "Briefing generation requires an API key. Set OPENAI_BRIEFING_API_KEY "
+            "(or OPENAI_API_KEY) in the app environment."
+        )
+        raise BriefingAINotConfiguredError(msg)
+    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    return api_key, base_url
+
+
 def _call_openai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
-    """Call OpenAI to generate structured briefing JSON from a candidate article list."""
+    """Call an OpenAI-compatible API to generate structured briefing JSON."""
     from openai import OpenAI  # lazy import — optional dep at import time
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        msg = "Briefing generation requires OPENAI_API_KEY. Set it in the app environment."
-        raise BriefingAINotConfiguredError(msg)
+    api_key, base_url = _briefing_ai_config()
 
     article_lines = []
     for a in candidates:
@@ -178,7 +195,7 @@ def _call_openai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]
     )
     user = "Articles:\n\n" + "\n\n".join(article_lines)
 
-    client = OpenAI(api_key=api_key)
+    client = OpenAI(api_key=api_key, base_url=base_url)
     response = client.chat.completions.create(
         model=model,
         messages=[

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 
 import psycopg
 import pytest
@@ -697,6 +697,7 @@ def test_current_day_since_at_subtracts_24_hours() -> None:
 
 def test_call_openai_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
     with pytest.raises(BriefingAINotConfiguredError, match="OPENAI_API_KEY"):
         _call_openai([], model="gpt-x")
 
@@ -705,19 +706,39 @@ class _FakeOpenAI:
     """Stand-in for ``openai.OpenAI`` whose completion returns a fixed string."""
 
     content = "{}"
+    last_kwargs: ClassVar[dict[str, Any]] = {}
 
-    def __init__(self, api_key: str) -> None:
-        self.api_key = api_key
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).last_kwargs = kwargs
         message = SimpleNamespace(content=type(self).content)
         choice = SimpleNamespace(message=message)
         response = SimpleNamespace(choices=[choice])
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=lambda **_kwargs: response))
 
 
-def _patch_openai(monkeypatch: pytest.MonkeyPatch, content: str) -> None:
+def _patch_openai(monkeypatch: pytest.MonkeyPatch, content: str) -> type[_FakeOpenAI]:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     cls = type("Patched", (_FakeOpenAI,), {"content": content})
     monkeypatch.setattr("openai.OpenAI", cls)
+    return cls
+
+
+def test_call_openai_uses_default_base_url_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+    cls = _patch_openai(monkeypatch, "{}")
+    _call_openai([{"id": 1, "title": "A"}], model="gpt-x")
+    assert cls.last_kwargs["api_key"] == "sk-test"
+    assert cls.last_kwargs["base_url"] is None
+
+
+def test_call_openai_uses_briefing_endpoint_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    cls = _patch_openai(monkeypatch, "{}")
+    monkeypatch.setenv("OPENAI_BRIEFING_API_KEY", "freellmapi-key")
+    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://127.0.0.1:9130/v1")
+    _call_openai([{"id": 1, "title": "A"}], model="auto")
+    assert cls.last_kwargs["api_key"] == "freellmapi-key"
+    assert cls.last_kwargs["base_url"] == "http://127.0.0.1:9130/v1"
 
 
 def test_call_openai_parses_valid_json(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Lets briefing generation target any OpenAI-compatible API (e.g. a self-hosted routing gateway) instead of being hardwired to the official OpenAI endpoint.

`_call_openai` now resolves credentials via `_briefing_ai_config()`:

- `OPENAI_BRIEFING_BASE_URL` → fallback `OPENAI_BASE_URL` → unset (official OpenAI)
- `OPENAI_BRIEFING_API_KEY` → fallback `OPENAI_API_KEY`

The resolved `base_url` is passed to the `OpenAI` client. Model is still chosen via `OPENAI_BRIEFING_MODEL` (use `auto` for a routing gateway). Other AI features (embeddings, Ask AI, TTS) are unchanged.

No secrets are committed — endpoint and key are supplied through the gitignored environment.

## Testing

- `make lint`, `make typecheck` — clean
- `pytest tests/test_briefings_db.py` — 57 passed, including new coverage for the default (no base_url) and override paths

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)