### PR TITLE
ci: wire briefing OpenAI-compatible endpoint into k8s deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,9 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BRIEFING_API_KEY: ${{ secrets.OPENAI_BRIEFING_API_KEY }}
+          OPENAI_BRIEFING_BASE_URL: ${{ vars.OPENAI_BRIEFING_BASE_URL }}
+          OPENAI_BRIEFING_MODEL: ${{ vars.OPENAI_BRIEFING_MODEL }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
         run: |
           set -euo pipefail
@@ -203,6 +206,9 @@ jobs:
           if [ -n "$OPENAI_API_KEY" ]; then
             ai_secret_args+=(--from-literal=OPENAI_API_KEY="$OPENAI_API_KEY")
           fi
+          if [ -n "$OPENAI_BRIEFING_API_KEY" ]; then
+            ai_secret_args+=(--from-literal=OPENAI_BRIEFING_API_KEY="$OPENAI_BRIEFING_API_KEY")
+          fi
 
           ai_helm_args=()
           if [ ${#ai_secret_args[@]} -gt 0 ]; then
@@ -210,6 +216,12 @@ jobs:
               "${ai_secret_args[@]}" \
               --dry-run=client -o yaml | kubectl apply -f -
             ai_helm_args+=(--set app.ai.existingSecret=news-dashboard-ai)
+          fi
+          if [ -n "$OPENAI_BRIEFING_BASE_URL" ]; then
+            ai_helm_args+=(--set-string "app.ai.briefingBaseUrl=$OPENAI_BRIEFING_BASE_URL")
+          fi
+          if [ -n "$OPENAI_BRIEFING_MODEL" ]; then
+            ai_helm_args+=(--set-string "app.ai.briefingModel=$OPENAI_BRIEFING_MODEL")
           fi
 
           # Sync Helm chart changes from main. Avoid relying on the deploy

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -63,6 +63,20 @@ spec:
                   name: {{ .Values.app.ai.existingSecret | quote }}
                   key: {{ .Values.app.ai.openaiApiKeyKey | quote }}
                   optional: true
+            - name: OPENAI_BRIEFING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.ai.existingSecret | quote }}
+                  key: {{ .Values.app.ai.briefingApiKeyKey | quote }}
+                  optional: true
+{{- end }}
+{{- if .Values.app.ai.briefingBaseUrl }}
+            - name: OPENAI_BRIEFING_BASE_URL
+              value: {{ .Values.app.ai.briefingBaseUrl | quote }}
+{{- end }}
+{{- if .Values.app.ai.briefingModel }}
+            - name: OPENAI_BRIEFING_MODEL
+              value: {{ .Values.app.ai.briefingModel | quote }}
 {{- end }}
 {{- if .Values.app.auth.enabled }}
             - name: KEYCLOAK_AUTH_ENABLED

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -54,6 +54,13 @@ app:
     # Optional: pre-existing Secret with OPENAI_API_KEY.
     existingSecret: ""
     openaiApiKeyKey: OPENAI_API_KEY
+    # Briefing summarization can target a separate OpenAI-compatible endpoint
+    # (e.g. a self-hosted freellmapi gateway) instead of OpenAI. Leave the
+    # base URL empty to keep using OpenAI for briefings too.
+    briefingBaseUrl: ""
+    briefingModel: ""
+    # Key within `existingSecret` holding the briefing endpoint's API key.
+    briefingApiKeyKey: OPENAI_BRIEFING_API_KEY
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## What

Follow-up to #262. Wires the new briefing endpoint env vars through the Helm chart and deploy job so the production pod actually targets the self-hosted freellmapi gateway for briefing summarization, while keeping OpenAI for embeddings / Ask AI / TTS.

## Changes

- **values.yaml** — new `app.ai.briefingBaseUrl`, `app.ai.briefingModel`, `app.ai.briefingApiKeyKey` (defaults empty → no behavior change for other users).
- **deployment.yaml** — pod gets `OPENAI_BRIEFING_API_KEY` (from the existing `news-dashboard-ai` secret), plus `OPENAI_BRIEFING_BASE_URL` / `OPENAI_BRIEFING_MODEL` when set.
- **ci.yml** — adds `OPENAI_BRIEFING_API_KEY` into the `news-dashboard-ai` secret and `--set` the base URL + model from Actions secret/vars.

## Config (already set in repo settings)

- Secret `OPENAI_BRIEFING_API_KEY` — the freellmapi key (separate from `OPENAI_API_KEY`).
- Var `OPENAI_BRIEFING_BASE_URL` = `http://192.168.0.75:9130/v1` (mini-PC LAN IP; pod can't use `127.0.0.1`).
- Var `OPENAI_BRIEFING_MODEL` = `auto`.

## Notes

- Separate key path: briefings → freellmapi, other AI features → OpenAI, no cross-misrouting.
- Gateway must be reachable from the pod at the mini-PC host IP on port 9130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)