### PR TITLE
fix: surface upstream errors from briefing AI endpoint

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -195,16 +195,26 @@ def _call_openai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]
     )
     user = "Articles:\n\n" + "\n\n".join(article_lines)
 
+    from openai import OpenAIError  # lazy import — optional dep at import time
+
     client = OpenAI(api_key=api_key, base_url=base_url)
-    response = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-        response_format={"type": "json_object"},
-        max_tokens=2048,
-    )
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            response_format={"type": "json_object"},
+            max_tokens=2048,
+        )
+    except OpenAIError as exc:
+        # Connection refused, auth failure, or the model/gateway rejecting the
+        # request (e.g. an endpoint that does not support JSON response_format).
+        # Surface the upstream reason instead of an opaque 500.
+        endpoint = base_url or "the default OpenAI endpoint"
+        msg = f"Briefing AI request to {endpoint} failed: {exc}"
+        raise BriefingGenerationError(msg) from exc
     text = response.choices[0].message.content or "{}"
     try:
         return json.loads(text)  # type: ignore[no-any-return]

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -9,6 +9,7 @@ fixture (started by testcontainers) and are skipped when Docker is unavailable.
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, ClassVar
@@ -726,6 +727,7 @@ def _patch_openai(monkeypatch: pytest.MonkeyPatch, content: str) -> type[_FakeOp
 def test_call_openai_uses_default_base_url_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
     cls = _patch_openai(monkeypatch, "{}")
     _call_openai([{"id": 1, "title": "A"}], model="gpt-x")
     assert cls.last_kwargs["api_key"] == "sk-test"
@@ -754,6 +756,33 @@ def test_call_openai_raises_on_invalid_json(monkeypatch: pytest.MonkeyPatch) -> 
     _patch_openai(monkeypatch, "not json at all")
     with pytest.raises(BriefingGenerationError, match="invalid JSON"):
         _call_openai([{"id": 1, "title": "A"}], model="gpt-x")
+
+
+def test_call_openai_wraps_upstream_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An error from the gateway surfaces as BriefingGenerationError, not a bare 500."""
+    from openai import OpenAIError
+
+    class _UpstreamError(OpenAIError):
+        pass
+
+    def _raise(**_kwargs: Any) -> Any:
+        msg = "Connection error."
+        raise _UpstreamError(msg)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://192.168.0.75:9130/v1")
+    cls = type(
+        "Patched",
+        (_FakeOpenAI,),
+        {
+            "__init__": lambda self, **_kw: setattr(
+                self, "chat", SimpleNamespace(completions=SimpleNamespace(create=_raise))
+            )
+        },
+    )
+    monkeypatch.setattr("openai.OpenAI", cls)
+    with pytest.raises(BriefingGenerationError, match=re.escape("192.168.0.75:9130")):
+        _call_openai([{"id": 1, "title": "A"}], model="auto")
 
 
 # ── generate_briefing (end-to-end with fake AI) ───────────────────────────────


### PR DESCRIPTION
## Problem

Generating a briefing returned a bare **HTTP 500 "Internal Server Error"** (no JSON `detail`). When the OpenAI-compatible gateway call fails — connection refused, auth failure, or the model/gateway rejecting `response_format: json_object` — the OpenAI SDK raises `OpenAIError`, which escaped `_call_openai` uncaught. FastAPI then returns a generic 500 and no failed-briefing record is saved, so the actual cause is invisible.

## Fix

Catch `OpenAIError` in `_call_openai` and re-raise as `BriefingGenerationError`, including the endpoint and the upstream message. The reason now surfaces in the API response and is persisted on the failed briefing (via the existing `_save_failed_briefing` path in `generate_briefing`).

## Testing

- `make lint`, `make typecheck` clean
- `pytest tests/test_briefings_db.py` — 58 passed, incl. new `test_call_openai_wraps_upstream_error`

## Context

Diagnoses the freellmapi briefing rollout (#262, #263). With this in place, the next failed generation will show whether it's reachability (`192.168.0.75:9130` from the pod), auth, or JSON-mode support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)