### PR TITLE
fix: retry briefing generation on transient AI failures

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -19,6 +20,12 @@ CANDIDATE_LIMIT = 40
 DEFAULT_BRIEFING_MODEL = "gpt-4o-mini"
 IDEMPOTENCY_WINDOW_MINUTES = 10
 CURRENT_DAY_SCOPE = "current_day"
+
+# Generation retries: transient upstream failures (gateway hiccup, rate limit,
+# a flaky JSON response) often clear on a quick second attempt, so retry the AI
+# call a few times with a short, growing backoff before persisting a failed row.
+BRIEFING_MAX_ATTEMPTS = 3
+BRIEFING_RETRY_BASE_DELAY_SECONDS = 0.5
 
 logger = logging.getLogger(__name__)
 
@@ -427,18 +434,27 @@ def generate_briefing(
     ai_fn: AiFn | None = None,
     idempotency_window_minutes: int = IDEMPOTENCY_WINDOW_MINUTES,
     user_id: int | None = None,
+    max_attempts: int = BRIEFING_MAX_ATTEMPTS,
+    retry_base_delay_seconds: float = BRIEFING_RETRY_BASE_DELAY_SECONDS,
 ) -> dict[str, Any]:
     """Generate and persist a briefing from eligible Today articles.
 
     If a complete briefing already exists within ``idempotency_window_minutes``,
     return it immediately without calling the AI again.
 
+    The AI call is retried up to ``max_attempts`` times on transient
+    ``BriefingGenerationError`` failures, waiting ``retry_base_delay_seconds``
+    after the first failure and doubling the delay on each subsequent retry
+    (short exponential backoff). A missing-API-key error is never retried, and
+    a failed-status row is persisted only once, after the final attempt fails.
+
     Returns the saved briefing dict on success, or ``{"status": "no_candidates"}``
     when no eligible articles are found.
 
     Raises:
         BriefingAINotConfiguredError: OPENAI_API_KEY is not set.
-        BriefingGenerationError: AI returned an invalid or unparseable response.
+        BriefingGenerationError: AI returned an invalid or unparseable response
+            on every attempt.
     """
     recent = _find_recent_briefing(idempotency_window_minutes, database_url, user_id=user_id)
     if recent is not None:
@@ -457,14 +473,39 @@ def generate_briefing(
 
     candidate_ids = {int(a["id"]) for a in candidates}
     call_ai: AiFn = ai_fn if ai_fn is not None else _call_openai
-    try:
-        raw_content = call_ai(candidates, resolved_model)
-        content = _validate_content(raw_content, candidate_ids)
-    except (BriefingAINotConfiguredError, BriefingGenerationError) as exc:
-        _save_failed_briefing(
-            since_at, until_at, exc, resolved_model, database_url, user_id=user_id
-        )
-        raise
+    attempts = max(1, max_attempts)
+    content: dict[str, Any] | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            raw_content = call_ai(candidates, resolved_model)
+            content = _validate_content(raw_content, candidate_ids)
+            break
+        except BriefingAINotConfiguredError as exc:
+            # Misconfiguration won't fix itself on retry — fail fast.
+            _save_failed_briefing(
+                since_at, until_at, exc, resolved_model, database_url, user_id=user_id
+            )
+            raise
+        except BriefingGenerationError as exc:
+            if attempt >= attempts:
+                _save_failed_briefing(
+                    since_at, until_at, exc, resolved_model, database_url, user_id=user_id
+                )
+                raise
+            delay = retry_base_delay_seconds * (2 ** (attempt - 1))
+            logger.warning(
+                "Briefing generation attempt %d/%d failed (%s); retrying in %.2fs",
+                attempt,
+                attempts,
+                exc,
+                delay,
+            )
+            if delay > 0:
+                time.sleep(delay)
+
+    if content is None:  # pragma: no cover — loop either breaks or raises
+        msg = "Briefing generation produced no content"
+        raise BriefingGenerationError(msg)
     return _save_briefing(
         since_at, until_at, content, candidate_ids, resolved_model, database_url, user_id=user_id
     )

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -1043,3 +1043,90 @@ def test_generate_briefing_ignores_failed_rows_in_idempotency_check(pg_clean: st
     )
     assert result["status"] == "complete"
     assert result["title"] == "Recovery Brief"
+
+
+# ── Generation retries ────────────────────────────────────────────────────────
+
+
+def test_generate_briefing_retries_then_succeeds(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    a1 = _seed_article(pg_clean, url="https://example.com/r1", title="R1", state="today")
+
+    calls = {"n": 0}
+
+    def _flaky_ai(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            msg = "transient gateway hiccup"
+            raise BriefingGenerationError(msg)
+        return {
+            "title": "Recovered Brief",
+            "summary": "S",
+            "sections": [{"title": "S", "body": "B", "citations": [a1]}],
+            "worth_opening": [],
+        }
+
+    result = generate_briefing(
+        database_url=pg_clean,
+        ai_fn=_flaky_ai,
+        idempotency_window_minutes=0,
+        retry_base_delay_seconds=0,
+    )
+
+    assert calls["n"] == 2
+    assert result["status"] == "complete"
+    assert result["title"] == "Recovered Brief"
+    # The transient first failure must not leave a failed-status row behind.
+    assert [b["status"] for b in list_briefings(database_url=pg_clean)] == ["complete"]
+
+
+def test_generate_briefing_exhausts_retries_and_persists_single_failed_row(
+    pg_clean: str,
+) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/r2", title="R2", state="today")
+
+    calls = {"n": 0}
+
+    def _always_fail(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        calls["n"] += 1
+        msg = "still failing"
+        raise BriefingGenerationError(msg)
+
+    with pytest.raises(BriefingGenerationError, match="still failing"):
+        generate_briefing(
+            database_url=pg_clean,
+            ai_fn=_always_fail,
+            idempotency_window_minutes=0,
+            max_attempts=3,
+            retry_base_delay_seconds=0,
+        )
+
+    assert calls["n"] == 3
+    briefings = list_briefings(database_url=pg_clean)
+    assert len(briefings) == 1
+    assert briefings[0]["status"] == "failed"
+
+
+def test_generate_briefing_does_not_retry_when_ai_not_configured(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/r3", title="R3", state="today")
+
+    calls = {"n": 0}
+
+    def _not_configured(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        calls["n"] += 1
+        msg = "OPENAI_API_KEY missing"
+        raise BriefingAINotConfiguredError(msg)
+
+    with pytest.raises(BriefingAINotConfiguredError):
+        generate_briefing(
+            database_url=pg_clean,
+            ai_fn=_not_configured,
+            idempotency_window_minutes=0,
+            max_attempts=3,
+            retry_base_delay_seconds=0,
+        )
+
+    # Misconfiguration fails fast — no retries.
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
Briefing generation previously failed permanently on the first AI error. This adds a short retry loop so transient upstream failures (gateway hiccups, rate limits, flaky JSON responses) get a second/third chance before the briefing is marked failed.

- Retries the AI call up to **3 attempts** with a short exponential backoff (0.5s → 1s).
- Misconfiguration (`BriefingAINotConfiguredError`, e.g. missing API key) **fails fast** — no retries.
- Only a **single** failed-status row is persisted, after the final attempt fails.
- Tunable via `generate_briefing(max_attempts=..., retry_base_delay_seconds=...)` and the `BRIEFING_MAX_ATTEMPTS` / `BRIEFING_RETRY_BASE_DELAY_SECONDS` module constants.

## Tests
Added coverage in `backend/tests/test_briefings_db.py`:
- retries then succeeds (no stray failed row)
- exhausts retries → raises + persists exactly one failed row
- does not retry on misconfiguration

Full suite green locally: 641 backend + 430 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)