### PR TITLE
fix: drop returned snoozes from the Later view

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -905,6 +905,10 @@ def list_articles(  # noqa: PLR0913
                 " OR (state = 'later' AND later_until IS NOT NULL AND later_until <= %s))"
             )
             params.append(now)
+        elif state == "later":
+            # Hide snoozes that have already returned to the today feed.
+            clauses.append("state = 'later' AND (later_until IS NULL OR later_until > %s)")
+            params.append(now)
         else:
             clauses.append("state = %s")
             params.append(state)
@@ -967,6 +971,12 @@ def _list_articles_for_user(  # noqa: PLR0913
                 "(uas.state IS NULL OR uas.state = 'today'"
                 " OR (uas.state = 'later' AND uas.later_until IS NOT NULL"
                 " AND uas.later_until <= %s))"
+            )
+            where_params.append(now)
+        elif state == "later":
+            # Hide snoozes that have already returned to the today feed.
+            art_clauses.append(
+                "uas.state = 'later' AND (uas.later_until IS NULL OR uas.later_until > %s)"
             )
             where_params.append(now)
         else:

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -247,6 +247,31 @@ def test_snooze_returns_to_today_after_expiry(tmp_path: Path) -> None:
     assert any(a["id"] == aid for a in today_arts)
 
 
+def test_snooze_leaves_later_view_after_expiry(tmp_path: Path) -> None:
+    """An expired snooze returns to today and no longer shows in the later view."""
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    send_article_later(aid, days=1, db_path=db, user_id=uid)
+
+    # Still pending: visible in later, not yet in today.
+    assert any(a["id"] == aid for a in list_articles(state="later", db_path=db, user_id=uid))
+    assert not any(a["id"] == aid for a in list_articles(state="today", db_path=db, user_id=uid))
+
+    # Backdate later_until to simulate the snooze expiring.
+    expired_ts = "2020-01-01T00:00:00+00:00"
+    with connect(db) as conn:
+        conn.execute(
+            "UPDATE user_article_state SET later_until = %s WHERE article_id = %s AND user_id = %s",
+            (expired_ts, aid, uid),
+        )
+
+    # Returned: in today, gone from later.
+    assert any(a["id"] == aid for a in list_articles(state="today", db_path=db, user_id=uid))
+    assert not any(a["id"] == aid for a in list_articles(state="later", db_path=db, user_id=uid))
+
+
 # ── search_articles with user_id ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #266

## What
When a user sends an article to **Later** (snooze), it correctly reappears in the **Today** feed once `later_until` passes. But the stored state stays `later`, and the Later view filtered only on `state = 'later'` — so a returned article kept showing in **both** Today and Later at once, contradicting the "returns to Today automatically" promise.

## Change
In the `state == 'later'` branch of both the legacy (`list_articles`) and per-user (`_list_articles_for_user`) listing queries, exclude already-returned items:

```
later_until IS NULL OR later_until > now
```

So a returned snooze cleanly leaves the Later view and shows only in Today.

## Tests
- New `test_snooze_leaves_later_view_after_expiry`: asserts a pending snooze shows in Later (not Today), and after expiry shows in Today (not Later).
- Existing `test_per_user_article_state.py` (18) and `test_workflow_state.py` (29) pass locally against Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)