### PR TITLE
fix: keep minutes line inside the Active users & time chart (#270)

### DIFF
--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -134,6 +134,16 @@ export function AnalyticsPage() {
                 axisLine={false}
               />
               <YAxis
+                yAxisId="users"
+                allowDecimals={false}
+                tick={{ fontSize: 10, fill: AXIS_FILL }}
+                tickLine={false}
+                axisLine={false}
+                width={28}
+              />
+              <YAxis
+                yAxisId="minutes"
+                orientation="right"
                 allowDecimals={false}
                 tick={{ fontSize: 10, fill: AXIS_FILL }}
                 tickLine={false}
@@ -142,6 +152,7 @@ export function AnalyticsPage() {
               />
               <Tooltip contentStyle={TOOLTIP_STYLE} />
               <Area
+                yAxisId="users"
                 type="monotone"
                 dataKey="active_users"
                 stroke={CHART_COLORS[0]}
@@ -151,6 +162,7 @@ export function AnalyticsPage() {
                 name="active users"
               />
               <Area
+                yAxisId="minutes"
                 type="monotone"
                 dataKey="minutes"
                 stroke={CHART_COLORS[1]}


### PR DESCRIPTION
## Summary
The "Active users & time" chart on the Analytics page plotted `active_users` and `minutes` on a single shared Y axis. Minutes' much larger magnitude dominated the axis, so the minutes area rode the top edge of the panel (cut off / unreadable) while active users was flattened to the bottom.

Each series now has its own Y axis (active users left, minutes right), so both scale independently and stay within the panel.

Fixes #270

## Test
- `npm run lint` — clean
- `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)