### PR TITLE
fix: populate Most-read articles analytics panel

### DIFF
--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -27,6 +27,7 @@ import type { WorkflowState } from '@/lib/workflowTypes';
 import { formatDate, readingTime, signalLabel } from '@/lib/format';
 import { getReaderList } from '@/lib/readerList';
 import { recommendationExplanation } from '@/lib/recommendation';
+import { trackArticleOpen, trackArticleClose } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
 function renderBody(md: string): string {
@@ -161,6 +162,19 @@ export function ArticlePage() {
     bodyMutation.mutate();
     // Run once per article id; bodyMutation is intentionally omitted from deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  // Per-article dwell telemetry: record an open when the reader mounts (or the
+  // user pages to a different article via prev/next, which swaps the id in
+  // place) and a close on unmount/id change so the close carries dwell time.
+  // This feeds the "Most-read articles" analytics panel via article_close
+  // events; without it that panel stays empty.
+  useEffect(() => {
+    if (!id) return;
+    const articleId = Number(id);
+    if (!Number.isFinite(articleId)) return;
+    trackArticleOpen(articleId);
+    return () => trackArticleClose(articleId);
   }, [id]);
 
   const insightsMutation = useMutation({


### PR DESCRIPTION
Fixes #272

## Problem

The **Most-read articles** panel on Analytics (\"By opens, with average dwell time\") was always empty.

## Root cause

The panel is computed from `article_close` events carrying a `duration_ms` dwell time. The backend query, the ingestion endpoint, and the frontend `trackArticleOpen`/`trackArticleClose` helpers all existed — but the helpers were never called anywhere in the app (only in tests), so no events were ever emitted.

## Fix

Wire the dwell tracking into `ArticlePage` via an effect keyed on the article `id`: records an open on mount (and when paging between articles via prev/next, which swaps the id in place) and a close on unmount/id change, so each close carries the elapsed dwell time.

Note: this collects data going forward; the panel populates as articles are opened in production (telemetry is disabled under the test runner by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)