### PR TITLE
fix: stretch activity heatmap to fill panel width (#273)

### DIFF
--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -196,16 +196,16 @@ export function AnalyticsPage() {
 
       <ChartSection title="Activity heatmap" sub="Events by day of week and hour">
         <div className="overflow-x-auto -mx-1">
-          <table className="border-separate border-spacing-[2px]">
+          <table className="w-full min-w-[480px] table-fixed border-separate border-spacing-[2px]">
             <tbody>
               {heatmap.map((row, dow) => (
                 <tr key={dow}>
-                  <td className="pr-2 text-[10px] text-subtle text-right">{DOW[dow]}</td>
+                  <td className="w-7 pr-2 text-[10px] text-subtle text-right">{DOW[dow]}</td>
                   {row.map((value, hour) => (
                     <td key={hour}>
                       <div
                         title={`${DOW[dow]} ${hour}:00 — ${value} events`}
-                        className="h-3 w-3 rounded-[2px]"
+                        className="h-3 w-full rounded-[2px]"
                         style={{
                           background:
                             value === 0


### PR DESCRIPTION
## Summary
The Activity heatmap on the Analytics page rendered its cells at a fixed 12px width, so the 24-hour grid only filled about a third of the panel band, leaving the rest of the div empty.

This makes the heatmap table `w-full table-fixed` so the hour columns divide the available width evenly and stretch each cell, with a `min-w-[480px]` fallback (the existing `overflow-x-auto` scrolls on narrow screens). The day-label column is pinned to a fixed width.

Closes #273

## Verification
Ran the Vite dev server and screenshotted the Analytics page with mocked analytics data — the heatmap now spans the full panel width, matching the other charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)