### PR TITLE
fix: add ai-llm to cold-start recommendation category bonus

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -702,6 +702,7 @@ _COLD_START_RECOMMENDATION_SCORE_SQL = """
       + CASE lower(COALESCE(a.category, ''))
           WHEN 'ai' THEN 8.0
           WHEN 'ai-ml' THEN 8.0
+          WHEN 'ai-llm' THEN 8.0
           WHEN 'python' THEN 7.0
           WHEN 'security' THEN 6.0
           WHEN 'devtools' THEN 5.0

--- a/backend/tests/test_today_recommendations.py
+++ b/backend/tests/test_today_recommendations.py
@@ -241,3 +241,48 @@ def test_recalculate_mine_scores_callers_own_feed(
 
     assert response.status_code == 200
     assert response.json()["scored"] == 2
+
+
+def test_cold_start_ai_llm_category_ranks_above_generic_tech(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """Regression: ai-llm category must receive the same 8-point bonus as ai/ai-ml.
+
+    Before the fix, `ai-llm` fell through to ELSE 2.0, silently demoting every
+    Google AI Blog / HuggingFace / Anthropic / OpenAI article in cold-start rank.
+    """
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "ai-llm-category.db")
+    sync_sources(db_path)
+    _insert_source(db_path, "google-ai-test", category="ai-llm", priority=75)
+    _insert_source(db_path, "generic-tech", category="tech", priority=75)
+    user_id = _make_user(db_path, "alice")
+
+    # Both articles: identical priority, importance, no tags, same freshness.
+    # The only difference is the source category — ai-llm vs tech.
+    tech_article = _insert_article(
+        db_path,
+        "generic-tech",
+        "tech-piece",
+        category="tech",
+        importance=70,
+        tags="",
+        discovered_at="2026-06-21T10:00:00+00:00",
+    )
+    ai_llm_article = _insert_article(
+        db_path,
+        "google-ai-test",
+        "google-ai-piece",
+        category="ai-llm",
+        importance=70,
+        tags="",
+        discovered_at="2026-06-21T10:00:00+00:00",
+    )
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            ids = _today_ids(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    # ai-llm should rank above tech when all other factors are equal
+    assert ids.index(ai_llm_article) < ids.index(tech_article)


### PR DESCRIPTION
## Summary

- The `_COLD_START_RECOMMENDATION_SCORE_SQL` CASE expression had `WHEN 'ai-ml' THEN 8.0` but the dominant AI/LLM category in DEFAULT_SOURCES is `'ai-llm'`, used by Google AI Blog, Hugging Face Blog, Anthropic News, OpenAI Blog, Simon Willison, Augment Code, Latent Space, and Import AI — all of these fell through to `ELSE 2.0` instead of getting the 8-point AI bonus, silently suppressing them in cold-start ranking.
- Adds `WHEN 'ai-llm' THEN 8.0` to the formula.
- Adds a regression test that inserts equal-priority `ai-llm` and `tech` articles and asserts the AI article ranks first.

Closes #278.

## Test plan

- [x] `make lint` — green
- [x] `make typecheck` — green (mypy strict + ty + pyrefly)
- [x] `source .env && python -m pytest backend/tests/test_today_recommendations.py -v` — 5/5 passed including new regression test
- [x] `source .env && python -m pytest backend/tests/ --ignore=backend/tests/test_hf_blog_ingest.py` — 643 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)