### PR TITLE
fix: populate analytics Feature usage panel (#283)

### DIFF
--- a/frontend/src/__tests__/useTriageMutations.test.tsx
+++ b/frontend/src/__tests__/useTriageMutations.test.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 import * as workflowApi from '../api/workflowApi';
 import { useTriageMutations, ARTICLES_KEY } from '../hooks/useTriageMutations';
+import { trackFeature } from '../lib/analytics';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -17,6 +18,10 @@ vi.mock('sonner', () => ({
     loading: vi.fn(),
     dismiss: vi.fn(),
   }),
+}));
+
+vi.mock('../lib/analytics', () => ({
+  trackFeature: vi.fn(),
 }));
 
 let patchArticleStatePromise: Promise<unknown> = Promise.resolve({});
@@ -136,6 +141,26 @@ describe('useTriageMutations — undo calls the API to revert server state', () 
     });
 
     expect(workflowApi.patchArticleStar).toHaveBeenCalledWith('42', false);
+  });
+
+  it('emits feature events for triage actions so the analytics panel is populated', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+
+    act(() => {
+      result.current.setState(makeArticle(), 'done', 'Marked as read');
+    });
+    expect(trackFeature).toHaveBeenCalledWith('triage_done');
+
+    act(() => {
+      result.current.toggleStar(makeArticle({ starred: false }));
+    });
+    expect(trackFeature).toHaveBeenCalledWith('star');
+
+    act(() => {
+      result.current.sendLater(makeArticle(), 1);
+    });
+    expect(trackFeature).toHaveBeenCalledWith('snooze');
   });
 
   it('sendLater undo calls patchArticleState with original state', () => {

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -22,6 +22,7 @@ import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { useFocusedArticle } from '@/contexts/focusedArticle';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
 import { commandNavigationItems } from '@/lib/navigation';
+import { trackFeature } from '@/lib/analytics';
 
 interface Props {
   open: boolean;
@@ -60,6 +61,7 @@ export function CommandPalette({ open, onOpenChange, onShortcuts }: Props) {
     }
     const doSearch = async () => {
       setSearching(true);
+      trackFeature('search');
       try {
         const raw = await searchArticles(q.trim(), 6);
         setSearchResults(raw.map(adaptArticle));
@@ -86,6 +88,7 @@ export function CommandPalette({ open, onOpenChange, onShortcuts }: Props) {
 
   async function handleIngest() {
     close();
+    trackFeature('ingest_now');
     const id = toast.loading('Refreshing feeds…');
     try {
       const result = await ingestNow();

--- a/frontend/src/hooks/useTriageMutations.ts
+++ b/frontend/src/hooks/useTriageMutations.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 // Single shared ID so every triage toast replaces the previous one rather than
 // stacking — rapid actions (read, skip, star) should show only the latest.
 const TRIAGE_TOAST_ID = 'triage';
+import { trackFeature } from '../lib/analytics';
 import type { WorkflowArticle, WorkflowState } from '../lib/workflowTypes';
 import {
   patchArticleState,
@@ -196,6 +197,7 @@ export function useTriageMutations() {
     }
     const snap = snapshot(article);
     const querySnapshots = snapshotArticleQueries(queryClient, article.id);
+    trackFeature(`triage_${newState}`);
     setStateMutation.mutate({ article, newState });
     toast(label, {
       id: TRIAGE_TOAST_ID,
@@ -217,6 +219,7 @@ export function useTriageMutations() {
     const nextStarred = !article.starred;
     const snap = snapshot(article);
     const querySnapshots = snapshotArticleQueries(queryClient, article.id);
+    trackFeature(nextStarred ? 'star' : 'unstar');
     starMutation.mutate({ article, starred: nextStarred });
     toast(nextStarred ? 'Starred' : 'Unstarred', {
       id: TRIAGE_TOAST_ID,
@@ -235,6 +238,7 @@ export function useTriageMutations() {
   function sendLater(article: WorkflowArticle, days = 1) {
     const snap = snapshot(article);
     const querySnapshots = snapshotArticleQueries(queryClient, article.id);
+    trackFeature('snooze');
     sendLaterMutation.mutate({ article, days });
     toast('Snoozed to tomorrow', {
       id: TRIAGE_TOAST_ID,

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -5,6 +5,7 @@ import { Newspaper, RefreshCw, AlertCircle, Inbox, History } from 'lucide-react'
 import { Button } from '@/components/ui/button';
 import { fetchLatestBriefing, createBriefing } from '@/api';
 import { BriefingView, BriefSkeleton } from '@/components/BriefingView';
+import { trackFeature } from '@/lib/analytics';
 
 // ── Main page ─────────────────────────────────────────────────────────────────
 
@@ -32,6 +33,7 @@ export function BriefPage() {
   }
 
   async function handleGenerate() {
+    trackFeature('generate_briefing');
     setIsGenerating(true);
     setGenerateError(null);
     setNoCandidates({ shown: false });


### PR DESCRIPTION
## Problem

The **Feature usage** panel on the User Analytics page was always empty.

## Root cause

`trackFeature()` in [`frontend/src/lib/analytics.ts`](frontend/src/lib/analytics.ts) was exported but **never called** anywhere in the app. No `feature`-type events were ever sent to `POST /api/events`, so the backend `_feature_usage()` query returned an empty list and the chart rendered blank.

## Fix

Wire `trackFeature()` into the main user-facing actions:

- **Triage** (`useTriageMutations.ts`): `star`/`unstar`, `triage_<state>` (read/skip/archive), `snooze`
- **Briefing** (`BriefPage.tsx`): `generate_briefing`
- **Command palette** (`CommandPalette.tsx`): `search`, `ingest_now`

Added a regression test asserting triage actions emit the corresponding feature events.

## Verification

`npm run lint`, `format:check`, `typecheck`, `test:frontend` (431 passed), and `build` all green.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)