### PR TITLE
feat: What's New changelog popup on version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+## 1.15.3
+- Show numeric relevance score on each article card in Today's feed
+- Invalidate article cache after recommendations recalculate
+- Fix analytics Feature usage panel by emitting feature events
+
+## 1.15.2
+- Fix empty summaries for HuggingFace Blog articles
+- Add AI/LLM to cold-start category bonus in recommendation score
+- Make analytics charts respond to 7d/30d/90d time filter
+- Fix activity heatmap width and active-users chart axes
+
+## 1.15.1
+- Fix briefing page bottom navbar overlapping content on mobile
+- Drop returned snoozes from the Later view
+
+## 1.15.0
+- Briefing summarization via custom OpenAI-compatible endpoint
+- Retry briefing generation on transient AI failures
+- Surface upstream errors from the briefing AI endpoint
+
+## 1.14.0
+- Admin user-behavior analytics dashboard
+- Admin page to provision users (Keycloak-aware)
+
+## 1.13.0
+- Expose recommendation score on single-article read path
+- Fix: stop leaking internal DB details from public health endpoint
+
+## 1.12.3
+- Fix coercion of source values in SQLite-to-Postgres migration
+
+## 1.12.0
+- On-demand and daily personalized recommendation refresh
+- Recalculate and observe stale recommendation scores
+- Expose inspectable recommendation explanations ("Why recommended")
+- Show compact recommendation labels in Today's feed
+- Blend novelty and freshness into Today ranking
+- Add semantic similarity to hybrid recommendation score
+- Learn behavioral affinity from workflow actions
+- Rank Today feed by personalized recommendation scores
+
+## 1.11.0
+- In-app update-available notification for all platforms
+- Add 17 AI/ML X (Twitter) accounts via Nitter RSS
+- Navigate back to article list after triage action on article page
+- Fix triage toasts stacking — they now replace each other
+
+## 1.10.0
+- Automatic semantic versioning via Conventional Commits
+
+## 1.9.0
+- Electron desktop app (wraps news.lihor.ro, distributed via GitHub Releases)
+
+## 1.8.0
+- Android APK signed release via GitHub Actions
+- TWA (Trusted Web Activity) native Android wrapper
+- On-demand AI insights require article body text before generating
+- Monochrome icon for Android 13+ themed icons

--- a/backend/tests/test_changelog_endpoint.py
+++ b/backend/tests/test_changelog_endpoint.py
@@ -1,0 +1,101 @@
+"""Tests for the /api/changelog endpoint."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import _parse_changelog, app
+
+
+def _client() -> TestClient:
+    app.dependency_overrides.clear()
+    return TestClient(app, follow_redirects=False)
+
+
+# ── _parse_changelog unit tests ───────────────────────────────────────────────
+
+
+def test_parse_changelog_returns_entries() -> None:
+    md = dedent("""\
+        # Changelog
+
+        ## 1.2.0
+        - Feature A
+        - Feature B
+
+        ## 1.1.0
+        - Bug fix C
+    """)
+    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+        cf.read_text.return_value = md
+        entries = _parse_changelog()
+    assert len(entries) == 2
+    assert entries[0] == {"version": "1.2.0", "items": ["Feature A", "Feature B"]}
+    assert entries[1] == {"version": "1.1.0", "items": ["Bug fix C"]}
+
+
+def test_parse_changelog_returns_empty_on_oserror() -> None:
+    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+        cf.read_text.side_effect = OSError("missing")
+        entries = _parse_changelog()
+    assert entries == []
+
+
+def test_parse_changelog_ignores_non_bullet_lines() -> None:
+    md = dedent("""\
+        ## 2.0.0
+        Some intro text.
+        - Real item
+    """)
+    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+        cf.read_text.return_value = md
+        entries = _parse_changelog()
+    assert entries == [{"version": "2.0.0", "items": ["Real item"]}]
+
+
+# ── /api/changelog endpoint ───────────────────────────────────────────────────
+
+
+def test_changelog_endpoint_returns_version_and_entries() -> None:
+    md = dedent("""\
+        ## 9.9.9
+        - New thing
+    """)
+    with (
+        patch("news_dashboard.main._VERSION_FILE") as vf,
+        patch("news_dashboard.main._CHANGELOG_FILE") as cf,
+    ):
+        vf.read_text.return_value = "9.9.9\n"
+        cf.read_text.return_value = md
+        resp = _client().get("/api/changelog")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == "9.9.9"
+    assert body["entries"] == [{"version": "9.9.9", "items": ["New thing"]}]
+
+
+def test_changelog_endpoint_version_falls_back_to_unknown() -> None:
+    with (
+        patch("news_dashboard.main._VERSION_FILE") as vf,
+        patch("news_dashboard.main._CHANGELOG_FILE") as cf,
+    ):
+        vf.read_text.side_effect = OSError("missing")
+        cf.read_text.return_value = "## 1.0.0\n- item\n"
+        resp = _client().get("/api/changelog")
+    assert resp.status_code == 200
+    assert resp.json()["version"] == "unknown"
+
+
+def test_changelog_endpoint_entries_empty_on_missing_file() -> None:
+    with (
+        patch("news_dashboard.main._VERSION_FILE") as vf,
+        patch("news_dashboard.main._CHANGELOG_FILE") as cf,
+    ):
+        vf.read_text.return_value = "1.0.0\n"
+        cf.read_text.side_effect = OSError("missing")
+        resp = _client().get("/api/changelog")
+    assert resp.status_code == 200
+    assert resp.json()["entries"] == []

--- a/frontend/src/__tests__/whatsNew.test.tsx
+++ b/frontend/src/__tests__/whatsNew.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor, render, screen, fireEvent } from '@testing-library/react';
+import { useWhatsNew } from '../hooks/useWhatsNew';
+import { WhatsNewDialog } from '../components/WhatsNewDialog';
+
+const STORAGE_KEY = 'lastSeenVersion';
+
+const MOCK_RESPONSE = {
+  version: '1.15.3',
+  entries: [
+    { version: '1.15.3', items: ['Show relevance score', 'Invalidate cache'] },
+    { version: '1.15.2', items: ['Fix HuggingFace snippets'] },
+  ],
+};
+
+function mockFetch(payload: unknown) {
+  return vi.fn(() =>
+    Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(payload) })
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+// ── useWhatsNew ──────────────────────────────────────────────────────────────
+
+describe('useWhatsNew', () => {
+  it('opens when version differs from lastSeenVersion', async () => {
+    vi.stubGlobal('fetch', mockFetch(MOCK_RESPONSE));
+    localStorage.setItem(STORAGE_KEY, '1.15.2');
+    const { result } = renderHook(() => useWhatsNew());
+    await waitFor(() => expect(result.current.open).toBe(true));
+    expect(result.current.version).toBe('1.15.3');
+    expect(result.current.items).toEqual(['Show relevance score', 'Invalidate cache']);
+  });
+
+  it('stays closed when version matches lastSeenVersion', async () => {
+    vi.stubGlobal('fetch', mockFetch(MOCK_RESPONSE));
+    localStorage.setItem(STORAGE_KEY, '1.15.3');
+    const { result } = renderHook(() => useWhatsNew());
+    // give the hook time to resolve; open must stay false
+    await waitFor(() => expect(result.current.version).toBe(''));
+    expect(result.current.open).toBe(false);
+  });
+
+  it('opens with empty items when current version has no changelog entry', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({ version: '9.9.9', entries: [{ version: '1.0.0', items: ['old'] }] })
+    );
+    const { result } = renderHook(() => useWhatsNew());
+    await waitFor(() => expect(result.current.open).toBe(true));
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('opens when no lastSeenVersion is stored', async () => {
+    vi.stubGlobal('fetch', mockFetch({ version: 'unknown', entries: [] }));
+    const { result } = renderHook(() => useWhatsNew());
+    await waitFor(() => expect(result.current.open).toBe(true));
+  });
+
+  it('dismiss saves version to localStorage and closes', async () => {
+    vi.stubGlobal('fetch', mockFetch(MOCK_RESPONSE));
+    const { result } = renderHook(() => useWhatsNew());
+    await waitFor(() => expect(result.current.open).toBe(true));
+    act(() => result.current.dismiss());
+    expect(result.current.open).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('1.15.3');
+  });
+
+  it('stays closed on fetch error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('network')))
+    );
+    const { result } = renderHook(() => useWhatsNew());
+    // let the rejected promise settle; open must stay false
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.open).toBe(false);
+  });
+});
+
+// ── WhatsNewDialog ───────────────────────────────────────────────────────────
+
+describe('WhatsNewDialog', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+      }
+    );
+  });
+
+  function makeState(overrides?: Partial<ReturnType<typeof useWhatsNew>>) {
+    return {
+      open: true,
+      version: '1.15.3',
+      items: ['Show relevance score', 'Invalidate cache'],
+      dismiss: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it('renders version and items when open', () => {
+    render(<WhatsNewDialog state={makeState()} />);
+    expect(screen.getByText("What's new in v1.15.3")).toBeTruthy();
+    expect(screen.getByText('Show relevance score')).toBeTruthy();
+    expect(screen.getByText('Invalidate cache')).toBeTruthy();
+  });
+
+  it('calls dismiss when Got it is clicked', () => {
+    const dismiss = vi.fn();
+    render(<WhatsNewDialog state={makeState({ dismiss })} />);
+    fireEvent.click(screen.getByRole('button', { name: /got it/i }));
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+
+  it('renders nothing when open is false', () => {
+    render(<WhatsNewDialog state={makeState({ open: false })} />);
+    expect(screen.queryByText("What's new in v1.15.3")).toBeNull();
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -5,6 +5,8 @@ import { LogOut, MoreHorizontal, Search } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { CommandPalette } from './CommandPalette';
 import { ShortcutOverlay } from './ShortcutOverlay';
+import { WhatsNewDialog } from './WhatsNewDialog';
+import { useWhatsNew } from '@/hooks/useWhatsNew';
 import { cn } from '@/lib/utils';
 import { fetchSummary, logoutUser } from '@/api';
 import { startAnalytics, stopAnalytics, trackRoute } from '@/lib/analytics';
@@ -119,6 +121,7 @@ export function AppShell() {
   const [moreOpen, setMoreOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const whatsNew = useWhatsNew();
 
   async function handleLogout() {
     await logoutUser();
@@ -298,6 +301,7 @@ export function AppShell() {
         }}
       />
       <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+      <WhatsNewDialog state={whatsNew} />
     </div>
   );
 }

--- a/frontend/src/components/WhatsNewDialog.tsx
+++ b/frontend/src/components/WhatsNewDialog.tsx
@@ -1,0 +1,44 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { WhatsNewState } from '@/hooks/useWhatsNew';
+
+interface WhatsNewDialogProps {
+  state: WhatsNewState;
+}
+
+export function WhatsNewDialog({ state }: WhatsNewDialogProps) {
+  const { open, version, items, dismiss } = state;
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) dismiss();
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>What's new in v{version}</DialogTitle>
+        </DialogHeader>
+        <ul className="mt-1 space-y-1.5 text-sm text-foreground">
+          {items.map((item) => (
+            <li key={item} className="flex gap-2">
+              <span className="mt-0.5 text-muted-foreground select-none">•</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        <DialogFooter>
+          <Button size="sm" onClick={dismiss}>
+            Got it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useWhatsNew.ts
+++ b/frontend/src/hooks/useWhatsNew.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from 'react';
+import { requestJson } from '@/api';
+
+const STORAGE_KEY = 'lastSeenVersion';
+
+interface ChangelogEntry {
+  version: string;
+  items: string[];
+}
+
+interface ChangelogResponse {
+  version: string;
+  entries: ChangelogEntry[];
+}
+
+export interface WhatsNewState {
+  open: boolean;
+  version: string;
+  items: string[];
+  dismiss: () => void;
+}
+
+export function useWhatsNew(): WhatsNewState {
+  const [open, setOpen] = useState(false);
+  const [version, setVersion] = useState('');
+  const [items, setItems] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    requestJson<ChangelogResponse>('/api/changelog')
+      .then((data) => {
+        if (cancelled) return;
+        const { version: current, entries } = data;
+        const lastSeen = localStorage.getItem(STORAGE_KEY);
+        if (lastSeen === current) return;
+        const entry = entries.find((e) => e.version === current);
+        setVersion(current);
+        setItems(entry?.items ?? []);
+        setOpen(true);
+      })
+      .catch(() => {
+        // silently ignore — changelog is non-critical
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    if (version) {
+      localStorage.setItem(STORAGE_KEY, version);
+    }
+    setOpen(false);
+  }, [version]);
+
+  return { open, version, items, dismiss };
+}


### PR DESCRIPTION
Closes #288

## Summary
- Add `CHANGELOG.md` at repo root with entries for v1.8.0 → v1.15.3
- Add `GET /api/changelog` endpoint (no auth) that parses the file and returns `{version, entries: [{version, items}]}`
- Add `useWhatsNew` hook: on app load, fetches `/api/changelog`, compares current version against `localStorage.lastSeenVersion`; if different, exposes `open=true` + the bullet list for that version
- Add `WhatsNewDialog` component (Radix Dialog) with version title, bullet list, and "Got it" dismiss button
- Mount `WhatsNewDialog` in `AppShell`; dismissing persists the version so the modal only shows once per upgrade

## Tests
- **Backend** (`test_changelog_endpoint.py`): `_parse_changelog` unit tests (entries, OSError, non-bullet lines) + `/api/changelog` endpoint integration tests (version, fallback to unknown, missing file)
- **Frontend** (`whatsNew.test.tsx`): `useWhatsNew` hook (opens on new version, stays closed on same version, no entry for version, no lastSeen, dismiss saves/closes, fetch error) + `WhatsNewDialog` rendering (renders items, Got it closes, closed state)

## Test plan
- [ ] Deploy and open app fresh → no popup (lastSeenVersion matches)
- [ ] Clear `localStorage.lastSeenVersion` → popup appears with current version's changes
- [ ] Click "Got it" → popup gone, `localStorage.lastSeenVersion` updated, no popup on next load
- [ ] Backend: `GET /api/changelog` returns correct JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)