### PR TITLE
feat: deepen Langfuse integration (feedback, prompts, metrics, auto-improve)

### DIFF
--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     from openai import OpenAI
@@ -26,10 +29,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+ScoreDataType = Literal["NUMERIC", "CATEGORICAL", "BOOLEAN"]
+
 
 def langfuse_enabled() -> bool:
     """Return True when Langfuse tracing credentials are configured."""
     return bool(os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY"))
+
+
+def _client() -> Any:
+    """Return the configured Langfuse client (host normalised).
+
+    Callers must guard with :func:`langfuse_enabled` first; this resolves the
+    SDK dynamically so the module type-checks whether or not langfuse is
+    installed.
+    """
+    _normalise_host_env()
+    langfuse = importlib.import_module("langfuse")
+    return langfuse.get_client()
 
 
 def _normalise_host_env() -> None:
@@ -82,6 +99,7 @@ def chat_create(
     tags: list[str] | None = None,
     user_id: int | str | None = None,
     session_id: str | None = None,
+    prompt: ManagedPrompt | None = None,
     **kwargs: Any,
 ) -> ChatCompletion:
     """Create a (non-streaming) chat completion, traced when Langfuse is on.
@@ -90,8 +108,16 @@ def chat_create(
     clean and the overloaded ``create`` keeps resolving to a non-streaming
     ``ChatCompletion`` (unpacking ``**kwargs`` otherwise widens the return type
     to include ``Stream``).
+
+    When *prompt* is a Langfuse-managed prompt, the generation is linked to its
+    version (via the ``langfuse_prompt`` kwarg the wrapped client understands),
+    so the Langfuse UI shows which prompt version produced each answer. The link
+    is gated on tracing being enabled and on the prompt not being a local
+    fallback, so the plain OpenAI client never receives Langfuse-only kwargs.
     """
     trace = trace_params(name, tags=tags, user_id=user_id, session_id=session_id)
+    if langfuse_enabled() and prompt is not None and prompt.langfuse_prompt is not None:
+        trace["langfuse_prompt"] = prompt.langfuse_prompt
     completion = client.chat.completions.create(**kwargs, **trace)
     return cast("ChatCompletion", completion)
 
@@ -118,6 +144,225 @@ def get_openai_client(*, api_key: str, base_url: str | None = None) -> OpenAI:
     from openai import OpenAI as PlainOpenAI
 
     return PlainOpenAI(**kwargs)
+
+
+# ── Trace context ────────────────────────────────────────────────────────
+
+
+@dataclass
+class TraceHandle:
+    """Handle to the current Langfuse trace, returned by :func:`observe`.
+
+    ``trace_id`` is ``None`` when tracing is disabled, so callers can pass it
+    through to API responses unconditionally (clients simply omit feedback when
+    it is absent).
+    """
+
+    trace_id: str | None = None
+    _span: Any = field(default=None, repr=False)
+
+    def update_output(self, output: Any) -> None:
+        """Attach the final pipeline output to the trace, if tracing is on."""
+        if self._span is not None:
+            try:
+                self._span.update(output=output)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("langfuse span update failed: %s", exc)
+
+
+@contextmanager
+def observe(
+    name: str,
+    *,
+    input: Any = None,  # noqa: A002 - mirrors the Langfuse SDK kwarg name
+) -> Iterator[TraceHandle]:
+    """Group nested AI calls under a single Langfuse trace.
+
+    Any wrapped-client calls made inside the ``with`` block (embeddings, chat
+    completions) attach as child observations of one trace, instead of each
+    creating its own. The yielded :class:`TraceHandle` exposes ``trace_id`` so
+    the caller can return it to the frontend and later attach user feedback as a
+    score. A no-op (``trace_id=None``) when tracing is disabled.
+    """
+    if not langfuse_enabled():
+        yield TraceHandle()
+        return
+    try:
+        client = _client()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("langfuse client unavailable, tracing skipped: %s", exc)
+        yield TraceHandle()
+        return
+    with client.start_as_current_observation(name=name, as_type="span", input=input) as span:
+        yield TraceHandle(trace_id=client.get_current_trace_id(), _span=span)
+
+
+def create_score(
+    trace_id: str,
+    *,
+    name: str,
+    value: float | str,
+    data_type: ScoreDataType = "NUMERIC",
+    comment: str | None = None,
+) -> bool:
+    """Attach a score (e.g. user feedback) to a trace. Returns success.
+
+    No-op returning ``False`` when tracing is disabled or the SDK is
+    unavailable, so feedback endpoints degrade gracefully. Flushes immediately
+    because the API request that triggers feedback is short-lived.
+    """
+    if not langfuse_enabled() or not trace_id:
+        return False
+    try:
+        client = _client()
+        client.create_score(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            data_type=data_type,
+            comment=comment,
+        )
+        client.flush()
+    except Exception as exc:
+        logger.warning("langfuse score creation failed: %s", exc)
+        return False
+    return True
+
+
+def get_trace_url(trace_id: str) -> str | None:
+    """Return the Langfuse UI URL for *trace_id*, or ``None`` if unavailable."""
+    if not langfuse_enabled() or not trace_id:
+        return None
+    try:
+        url = _client().get_trace_url(trace_id=trace_id)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("langfuse trace url lookup failed: %s", exc)
+        return None
+    return cast("str | None", url)
+
+
+# ── Prompt management ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ManagedPrompt:
+    """A prompt resolved from Langfuse, or a local fallback.
+
+    ``text`` is the compiled prompt string ready to use. ``langfuse_prompt`` is
+    the underlying Langfuse prompt object when the prompt was fetched from
+    Langfuse (used to link generations to the prompt version), or ``None`` for
+    the local fallback.
+    """
+
+    text: str
+    langfuse_prompt: Any | None = None
+
+
+def get_prompt(
+    name: str,
+    *,
+    fallback: str,
+    label: str = "production",
+    variables: dict[str, Any] | None = None,
+) -> ManagedPrompt:
+    """Fetch a managed text prompt from Langfuse, falling back to *fallback*.
+
+    Prompts live in Langfuse (type ``text``) so they can be edited and
+    versioned without redeploying. When tracing is disabled, the prompt is
+    missing, or the fetch fails, the hardcoded *fallback* is used so behaviour
+    is never blocked on Langfuse availability. ``{{variable}}`` placeholders are
+    substituted from *variables* (Langfuse's ``compile`` for fetched prompts; a
+    simple local substitution for the fallback).
+    """
+    variables = variables or {}
+    if not langfuse_enabled():
+        return ManagedPrompt(_compile_fallback(fallback, variables))
+    try:
+        client = _client()
+        prompt = client.get_prompt(name, label=label, type="text", fallback=fallback)
+        compiled = prompt.compile(**variables) if variables else prompt.prompt
+        # A fallback-resolved prompt has no real version to link against.
+        is_fallback = getattr(prompt, "is_fallback", False)
+        return ManagedPrompt(str(compiled), None if is_fallback else prompt)
+    except Exception as exc:
+        logger.warning("langfuse get_prompt(%s) failed, using fallback: %s", name, exc)
+        return ManagedPrompt(_compile_fallback(fallback, variables))
+
+
+def _compile_fallback(template: str, variables: dict[str, Any]) -> str:
+    """Substitute ``{{var}}`` placeholders locally (Langfuse-compatible syntax)."""
+    text = template
+    for key, val in variables.items():
+        text = text.replace("{{" + key + "}}", str(val))
+    return text
+
+
+# ── Metrics ────────────────────────────────────────────────────────────────
+
+
+def _metrics_query(query: dict[str, Any]) -> list[dict[str, Any]]:
+    """Run one Langfuse Metrics API query, returning its ``data`` rows."""
+    import json
+
+    response = _client().api.metrics.metrics(query=json.dumps(query))
+    return [dict(row) for row in (response.data or [])]
+
+
+def fetch_metrics(*, days: int = 30) -> dict[str, Any]:
+    """Return aggregate AI usage metrics from Langfuse for the last *days*.
+
+    Surfaces cost, latency and feedback aggregates in-app (e.g. an admin
+    dashboard) so they are visible without opening the Langfuse UI. Degrades
+    gracefully: returns ``{"enabled": False}`` when tracing is off, and
+    per-section ``None`` when a query fails, so the endpoint never errors.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    if not langfuse_enabled():
+        return {"enabled": False}
+
+    to_ts = datetime.now(timezone.utc)
+    from_ts = to_ts - timedelta(days=days)
+    window = {
+        "fromTimestamp": from_ts.isoformat(),
+        "toTimestamp": to_ts.isoformat(),
+        "filters": [],
+        "dimensions": [{"field": "name"}],
+    }
+    result: dict[str, Any] = {"enabled": True, "window_days": days}
+
+    try:
+        result["usage"] = _metrics_query(
+            {
+                "view": "observations",
+                "metrics": [
+                    {"measure": "count", "aggregation": "count"},
+                    {"measure": "totalCost", "aggregation": "sum"},
+                    {"measure": "latency", "aggregation": "avg"},
+                ],
+                **window,
+            }
+        )
+    except Exception as exc:
+        logger.warning("langfuse usage metrics query failed: %s", exc)
+        result["usage"] = None
+
+    try:
+        result["scores"] = _metrics_query(
+            {
+                "view": "scores-numeric",
+                "metrics": [
+                    {"measure": "value", "aggregation": "avg"},
+                    {"measure": "count", "aggregation": "count"},
+                ],
+                **window,
+            }
+        )
+    except Exception as exc:
+        logger.warning("langfuse score metrics query failed: %s", exc)
+        result["scores"] = None
+
+    return result
 
 
 def flush() -> None:

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -28,6 +28,22 @@ CURRENT_DAY_SCOPE = "current_day"
 BRIEFING_MAX_ATTEMPTS = 3
 BRIEFING_RETRY_BASE_DELAY_SECONDS = 0.5
 
+# Local fallback for the briefing system prompt. The live prompt is managed in
+# Langfuse (name "briefing-system", label "production"); this string is used
+# verbatim when Langfuse is disabled or unreachable.
+_BRIEFING_SYSTEM_PROMPT = (
+    "You are a briefing editor. Given a list of news articles (each with a numeric ID), "
+    "produce a JSON object with these exact keys:\n"
+    "  title     — short, punchy headline for the briefing (max 10 words)\n"
+    "  summary   — 1-2 sentence overview of the day's themes\n"
+    "  sections  — array of section objects, each with:\n"
+    "                title     — section heading\n"
+    "                body      — 2-4 sentence narrative\n"
+    "                citations — array of integer article IDs cited in body\n"
+    "  worth_opening — flat array of integer article IDs most worth reading in full\n"
+    "Only use IDs from the provided list. Return valid JSON only, no markdown wrapper."
+)
+
 logger = logging.getLogger(__name__)
 
 # ── Error types ───────────────────────────────────────────────────────────────
@@ -190,23 +206,13 @@ def _call_openai(
             f"({a.get('source_name', '')} / {a.get('category', '')})\n  {snippet}"
         )
 
-    system = (
-        "You are a briefing editor. Given a list of news articles (each with a numeric ID), "
-        "produce a JSON object with these exact keys:\n"
-        "  title     — short, punchy headline for the briefing (max 10 words)\n"
-        "  summary   — 1-2 sentence overview of the day's themes\n"
-        "  sections  — array of section objects, each with:\n"
-        "                title     — section heading\n"
-        "                body      — 2-4 sentence narrative\n"
-        "                citations — array of integer article IDs cited in body\n"
-        "  worth_opening — flat array of integer article IDs most worth reading in full\n"
-        "Only use IDs from the provided list. Return valid JSON only, no markdown wrapper."
-    )
-    user = "Articles:\n\n" + "\n\n".join(article_lines)
-
     from openai import OpenAIError  # lazy import — optional dep at import time
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_openai_client, get_prompt
+
+    prompt = get_prompt("briefing-system", fallback=_BRIEFING_SYSTEM_PROMPT)
+    system = prompt.text
+    user = "Articles:\n\n" + "\n\n".join(article_lines)
 
     client = get_openai_client(api_key=api_key, base_url=base_url)
     try:
@@ -215,6 +221,7 @@ def _call_openai(
             name="briefing-generation",
             tags=["briefing"],
             user_id=user_id,
+            prompt=prompt,
             model=model,
             messages=[
                 {"role": "system", "content": system},

--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -56,5 +56,44 @@ def rec_recalc() -> None:
         typer.echo(f"{key}: {value}")
 
 
+@app.command(name="improve-prompt")
+def improve_prompt(
+    name: str = "ask-system",
+    days: int = 14,
+    max_examples: int = 50,
+) -> None:
+    """Draft an improved prompt version from thumbs-down feedback in Langfuse.
+
+    Fetches recent unhelpful answers, asks an LLM to revise the prompt, and saves
+    the result to Langfuse under the 'candidate' label for human review. Does NOT
+    auto-deploy: promote the candidate to 'production' in the Langfuse UI.
+    """
+    from .embeddings import ASK_SYSTEM_PROMPT
+    from .prompt_optimizer import PromptOptimizerError, optimize_prompt
+
+    fallback = ASK_SYSTEM_PROMPT if name == "ask-system" else ""
+    try:
+        result = optimize_prompt(
+            prompt_name=name,
+            fallback=fallback,
+            days=days,
+            max_examples=max_examples,
+        )
+    except PromptOptimizerError as exc:
+        typer.echo(f"skipped: {exc}")
+        raise typer.Exit(code=0) from exc
+
+    typer.echo(
+        f"proposed candidate for '{result.prompt_name}' "
+        f"(version {result.new_version}, label '{result.candidate_label}') "
+        f"from {result.example_count} thumbs-down examples"
+    )
+    typer.echo("review it in Langfuse and promote to 'production' if it is an improvement.")
+
+    from .ai_client import flush
+
+    flush()
+
+
 if __name__ == "__main__":
     app()

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -10,11 +10,26 @@ from __future__ import annotations
 
 import os
 import struct
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from news_dashboard.ai_client import ManagedPrompt
 
 MIN_ARTICLES = 5  # refuse to answer if fewer than this many articles are embedded
 TOP_K = 8  # articles to include as context
 DEFAULT_ANSWER_MODEL = "gpt-4o-mini"
+
+# Local fallback for the Ask AI system prompt. The live prompt is managed in
+# Langfuse (name "ask-system", label "production"); this string is used verbatim
+# when Langfuse is disabled or unreachable, so behaviour never depends on it.
+ASK_SYSTEM_PROMPT = (
+    "You are a helpful assistant that answers questions based on the user's "
+    "curated news articles. "
+    "Use only the provided article excerpts to answer. "
+    "Cite articles by their bracketed number, e.g. [1], [2]. "
+    "If the articles do not contain enough information, say so clearly. "
+    "Be concise (2-4 sentences unless a longer answer is clearly needed)."
+)
 
 
 class MissingAICredentialsError(RuntimeError):
@@ -81,7 +96,13 @@ def _embed(text: str) -> list[float]:
     return list(response.data[0].embedding)
 
 
-def _answer(system_prompt: str, user_prompt: str, *, user_id: int | None = None) -> str:
+def _answer(
+    system_prompt: str,
+    user_prompt: str,
+    *,
+    user_id: int | None = None,
+    prompt: ManagedPrompt | None = None,
+) -> str:
     """Generate an answer with OpenAI using the same key as embeddings."""
     from news_dashboard.ai_client import chat_create, get_openai_client
 
@@ -91,6 +112,7 @@ def _answer(system_prompt: str, user_prompt: str, *, user_id: int | None = None)
         name="ask-ai",
         tags=["ask-ai"],
         user_id=user_id,
+        prompt=prompt,
         model=os.getenv("OPENAI_ANSWER_MODEL", DEFAULT_ANSWER_MODEL),
         messages=[
             {"role": "system", "content": system_prompt},
@@ -212,11 +234,11 @@ def ask(
     # 2. Load embedded articles
     init_db(db_path)
     with connect(db_path) as conn:
-        query = (
+        sql = (
             "SELECT id, title, url, summary, embedding FROM articles "
             f"WHERE {status_filter} AND embedding IS NOT NULL"
         )
-        rows = conn.execute(query).fetchall()
+        rows = conn.execute(sql).fetchall()
 
     if len(rows) < MIN_ARTICLES:
         return {
@@ -225,9 +247,10 @@ def ask(
                 f"articles to answer questions. You currently have {len(rows)}."
             ),
             "sources": [],
+            "trace_id": None,
         }
 
-    # 3. Embed the query
+    # 3. Embed the user's question
     query_vec = _embed(query)
 
     # 4. Rank by cosine similarity and pick top-k
@@ -243,19 +266,17 @@ def ask(
         )
     context_text = "\n\n".join(context_blocks)
 
-    system_prompt = (
-        "You are a helpful assistant that answers questions based on the user's "
-        "curated news articles. "
-        "Use only the provided article excerpts to answer. "
-        "Cite articles by their bracketed number, e.g. [1], [2]. "
-        "If the articles do not contain enough information, say so clearly. "
-        "Be concise (2-4 sentences unless a longer answer is clearly needed)."
-    )
+    from news_dashboard.ai_client import get_prompt, observe
+
+    prompt = get_prompt("ask-system", fallback=ASK_SYSTEM_PROMPT)
     user_prompt = f"Articles:\n\n{context_text}\n\nQuestion: {query}"
 
-    # 6. Call OpenAI for the answer
-    answer_text = _answer(system_prompt, user_prompt, user_id=user_id)
+    # 6. Call OpenAI for the answer, grouping retrieval + generation under one
+    #    Langfuse trace so its id can carry user feedback (see /api/feedback).
+    with observe("ask-ai", input={"query": query, "include_all": include_all}) as trace:
+        answer_text = _answer(prompt.text, user_prompt, user_id=user_id, prompt=prompt)
+        trace.update_output(answer_text)
 
     # 7. Return answer + deduplicated source list (top-k order)
     sources = [{"id": row["id"], "title": row["title"], "url": row["url"]} for row, _ in top]
-    return {"answer": answer_text, "sources": sources}
+    return {"answer": answer_text, "sources": sources, "trace_id": trace.trace_id}

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -69,17 +69,19 @@ def generate_insights(article: dict[str, Any], *, user_id: int | None = None) ->
     if not text.strip():
         return []
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_openai_client, get_prompt
 
     client = get_openai_client(api_key=api_key)
+    prompt = get_prompt("article-insights", fallback=_PROMPT)
     logger.info("Generating insights for article %s", article.get("id"))
     result = chat_create(
         client,
         name="article-insights",
         tags=["insights"],
         user_id=user_id,
+        prompt=prompt,
         model=_MODEL,
-        messages=[{"role": "user", "content": f"{_PROMPT}\n\n{text}"}],
+        messages=[{"role": "user", "content": f"{prompt.text}\n\n{text}"}],
         max_tokens=512,
     )
     response_text = (result.choices[0].message.content or "").strip()

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -997,6 +997,37 @@ def ask_ai(
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+class FeedbackRequest(BaseModel):
+    trace_id: str
+    helpful: bool
+    comment: str | None = None
+
+
+@api.post("/api/feedback")
+def submit_feedback(
+    payload: FeedbackRequest,
+    _current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Record a user's thumbs up/down on an AI answer as a Langfuse score.
+
+    The Langfuse keys stay server-side: the frontend posts the ``trace_id`` it
+    received from ``/api/ask`` plus a boolean, and we attach a ``user-thumbs``
+    BOOLEAN score to that trace. A no-op (``recorded: False``) when Langfuse is
+    disabled, so feedback never errors for the user.
+    """
+    from .ai_client import create_score
+
+    comment = (payload.comment or "").strip() or None
+    recorded = create_score(
+        payload.trace_id,
+        name="user-thumbs",
+        value=1 if payload.helpful else 0,
+        data_type="BOOLEAN",
+        comment=comment,
+    )
+    return {"recorded": recorded}
+
+
 @api.get("/api/summary")
 def summary(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
@@ -1012,6 +1043,17 @@ admin = APIRouter(prefix="/api/admin", dependencies=[Depends(require_admin)])
 @admin.get("/analytics")
 def admin_get_analytics(days: Annotated[int, Query(ge=1, le=365)] = 30) -> dict[str, Any]:
     return admin_analytics(days=days)
+
+
+@admin.get("/ai/metrics")
+def admin_ai_metrics(days: Annotated[int, Query(ge=1, le=365)] = 30) -> dict[str, Any]:
+    """Aggregate AI usage/cost/feedback metrics from Langfuse for admins.
+
+    Returns ``{"enabled": False}`` when Langfuse tracing is not configured.
+    """
+    from .ai_client import fetch_metrics
+
+    return fetch_metrics(days=days)
 
 
 @admin.get("/users")

--- a/backend/news_dashboard/prompt_optimizer.py
+++ b/backend/news_dashboard/prompt_optimizer.py
@@ -1,0 +1,205 @@
+"""Feedback-driven prompt auto-improvement.
+
+Closes the loop on the user-feedback scores collected via ``/api/feedback``:
+pull the recent thumbs-down answers for a managed prompt from Langfuse, ask an
+LLM to revise that prompt so it would have handled those cases better, and save
+the result back to Langfuse as a **new, non-production prompt version** (label
+``candidate``). A human then reviews the candidate in the Langfuse UI and
+promotes it to ``production`` if it is an improvement — the loop never
+auto-deploys a prompt.
+
+All Langfuse access degrades gracefully: when tracing is disabled or the API is
+unreachable, the entry point raises a clear error instead of silently doing
+nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from .ai_client import _client, chat_create, get_openai_client, langfuse_enabled
+
+logger = logging.getLogger(__name__)
+
+CANDIDATE_LABEL = "candidate"
+DEFAULT_OPTIMIZER_MODEL = "gpt-4o"
+
+_OPTIMIZER_INSTRUCTIONS = (
+    "You are a prompt engineer improving a system prompt for an LLM feature. "
+    "Below is the CURRENT system prompt, followed by real examples where users "
+    "marked the assistant's answer as unhelpful (thumbs down). Rewrite the "
+    "system prompt so it would handle these failure cases better, while "
+    "preserving its original intent, constraints, and output format. Keep it "
+    "concise. Do not invent new capabilities or remove safety constraints. "
+    "Return ONLY the revised system prompt text, with no preamble or commentary."
+)
+
+
+class PromptOptimizerError(Exception):
+    """Raised when prompt optimization cannot proceed."""
+
+
+@dataclass(frozen=True)
+class NegativeExample:
+    """A single thumbs-down answer with the question that produced it."""
+
+    question: str
+    answer: str
+    comment: str | None = None
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    """Outcome of an optimization run."""
+
+    prompt_name: str
+    example_count: int
+    new_version: int | None
+    candidate_label: str
+    proposed_text: str
+
+
+def _score_is_negative(value: Any) -> bool:
+    """True when a ``user-thumbs`` BOOLEAN/NUMERIC score reads as thumbs-down."""
+    try:
+        return float(value) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+def collect_negative_examples(
+    *,
+    score_name: str = "user-thumbs",
+    days: int = 14,
+    limit: int = 50,
+) -> list[NegativeExample]:
+    """Fetch recent thumbs-down answers and their questions from Langfuse."""
+    if not langfuse_enabled():
+        msg = "Langfuse is not configured (LANGFUSE_PUBLIC_KEY/SECRET_KEY missing)."
+        raise PromptOptimizerError(msg)
+
+    api = _client().api
+    from_ts = datetime.now(timezone.utc) - timedelta(days=days)
+    scores = api.scores_v3.get_many_v3(name=score_name, from_timestamp=from_ts, limit=limit)
+
+    examples: list[NegativeExample] = []
+    for score in scores.data or []:
+        if not _score_is_negative(getattr(score, "value", None)):
+            continue
+        trace_id = getattr(score, "trace_id", None)
+        if not trace_id:
+            continue
+        try:
+            trace = api.trace.get(trace_id)
+        except Exception as exc:
+            logger.warning("could not fetch trace %s: %s", trace_id, exc)
+            continue
+        question = _extract_question(trace.input)
+        answer = str(trace.output or "").strip()
+        if question and answer:
+            examples.append(
+                NegativeExample(
+                    question=question,
+                    answer=answer,
+                    comment=getattr(score, "comment", None),
+                )
+            )
+    return examples
+
+
+def _extract_question(trace_input: Any) -> str:
+    """Pull the user question out of a trace input (dict or raw string)."""
+    if isinstance(trace_input, dict):
+        return str(trace_input.get("query") or "").strip()
+    return str(trace_input or "").strip()
+
+
+def build_optimizer_prompt(current_text: str, examples: list[NegativeExample]) -> str:
+    """Build the meta-prompt sent to the optimizing LLM (pure, testable)."""
+    blocks = [f"CURRENT SYSTEM PROMPT:\n{current_text}", "\nUNHELPFUL EXAMPLES:"]
+    for i, ex in enumerate(examples, 1):
+        block = f"\nExample {i}:\nUser question: {ex.question}\nAssistant answer: {ex.answer}"
+        if ex.comment:
+            block += f"\nUser comment: {ex.comment}"
+        blocks.append(block)
+    return "\n".join(blocks)
+
+
+def _propose_revision(current_text: str, examples: list[NegativeExample], *, model: str) -> str:
+    """Call the LLM to draft an improved prompt. Traced like any other call."""
+    client = get_openai_client(api_key=_require_openai_key())
+    response = chat_create(
+        client,
+        name="prompt-optimizer",
+        tags=["prompt-optimizer"],
+        model=model,
+        messages=[
+            {"role": "system", "content": _OPTIMIZER_INSTRUCTIONS},
+            {"role": "user", "content": build_optimizer_prompt(current_text, examples)},
+        ],
+        max_tokens=1024,
+    )
+    return (response.choices[0].message.content or "").strip()
+
+
+def _require_openai_key() -> str:
+    key = os.getenv("OPENAI_API_KEY")
+    if not key:
+        msg = "OPENAI_API_KEY is required to propose prompt improvements."
+        raise PromptOptimizerError(msg)
+    return key
+
+
+def optimize_prompt(
+    *,
+    prompt_name: str,
+    fallback: str = "",
+    score_name: str = "user-thumbs",
+    days: int = 14,
+    max_examples: int = 50,
+    model: str = DEFAULT_OPTIMIZER_MODEL,
+) -> OptimizationResult:
+    """Run one feedback-driven improvement pass for *prompt_name*.
+
+    Fetches the current production prompt, collects recent thumbs-down answers,
+    asks the LLM for a revision, and saves it to Langfuse under the
+    ``candidate`` label for human review. Raises :class:`PromptOptimizerError`
+    when there is nothing to learn from (no negative feedback) or Langfuse is
+    unavailable.
+    """
+    examples = collect_negative_examples(score_name=score_name, days=days, limit=max_examples)
+    if not examples:
+        msg = f"No '{score_name}' thumbs-down feedback in the last {days} days; nothing to do."
+        raise PromptOptimizerError(msg)
+
+    client = _client()
+    try:
+        current = client.get_prompt(prompt_name, label="production", type="text", fallback=fallback)
+        current_text = current.prompt
+    except Exception as exc:
+        msg = f"Could not load current prompt '{prompt_name}': {exc}"
+        raise PromptOptimizerError(msg) from exc
+
+    proposed = _propose_revision(current_text, examples, model=model)
+    if not proposed:
+        msg = "The optimizer model returned an empty prompt."
+        raise PromptOptimizerError(msg)
+
+    created = client.create_prompt(
+        name=prompt_name,
+        prompt=proposed,
+        type="text",
+        labels=[CANDIDATE_LABEL],
+        commit_message=f"Auto-proposed from {len(examples)} thumbs-down examples ({days}d)",
+    )
+    return OptimizationResult(
+        prompt_name=prompt_name,
+        example_count=len(examples),
+        new_version=getattr(created, "version", None),
+        candidate_label=CANDIDATE_LABEL,
+        proposed_text=proposed,
+    )

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -5,10 +5,15 @@ import os
 import pytest
 
 from news_dashboard.ai_client import (
+    _compile_fallback,
     _normalise_host_env,
+    create_score,
     flush,
     get_openai_client,
+    get_prompt,
+    get_trace_url,
     langfuse_enabled,
+    observe,
     trace_params,
 )
 
@@ -54,6 +59,10 @@ def test_base_url_is_forwarded() -> None:
 
 
 def test_returns_langfuse_client_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The wrapped client requires the langfuse SDK; skip when it is not importable
+    # in this interpreter (e.g. a system pytest outside the project venv). It is a
+    # core dependency, so this still runs in CI and any properly-synced env.
+    pytest.importorskip("langfuse.openai")
     monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
     monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
     monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse:3000")
@@ -110,3 +119,41 @@ def test_existing_host_not_overwritten_by_alias(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("LANGFUSE_BASE_URL", "https://alias.example.com")
     _normalise_host_env()
     assert os.environ["LANGFUSE_HOST"] == "https://primary.example.com"
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_observe_is_noop_without_credentials() -> None:
+    # Disabled: yields a handle with no trace id and tolerates update_output.
+    with observe("ask-ai-pipeline", input={"q": "hi"}) as handle:
+        assert handle.trace_id is None
+        handle.update_output("answer")
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_create_score_and_trace_url_noop_without_credentials() -> None:
+    assert create_score("trace-1", name="user-thumbs", value=1, data_type="BOOLEAN") is False
+    assert get_trace_url("trace-1") is None
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_get_prompt_uses_fallback_when_disabled() -> None:
+    prompt = get_prompt(
+        "ask-system",
+        fallback="Answer about {{topic}} clearly.",
+        variables={"topic": "Postgres"},
+    )
+    assert prompt.text == "Answer about Postgres clearly."
+    # No Langfuse prompt object to link against in fallback mode.
+    assert prompt.langfuse_prompt is None
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_fetch_metrics_disabled_returns_enabled_false() -> None:
+    from news_dashboard.ai_client import fetch_metrics
+
+    assert fetch_metrics(days=30) == {"enabled": False}
+
+
+def test_compile_fallback_substitutes_double_brace_vars() -> None:
+    assert _compile_fallback("Hi {{name}}, {{name}}!", {"name": "Sam"}) == "Hi Sam, Sam!"
+    assert _compile_fallback("no vars here", {}) == "no vars here"

--- a/backend/tests/test_feedback_api.py
+++ b/backend/tests/test_feedback_api.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client() -> Any:
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    fake_user = {"id": 7, "username": "feedbackuser", "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def test_feedback_records_score_when_langfuse_enabled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_create_score(trace_id: str, **kwargs: Any) -> bool:
+        captured["trace_id"] = trace_id
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr("news_dashboard.ai_client.create_score", fake_create_score)
+
+    resp = client.post(
+        "/api/feedback",
+        json={"trace_id": "trace-abc", "helpful": True, "comment": "great"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"recorded": True}
+    assert captured["trace_id"] == "trace-abc"
+    assert captured["name"] == "user-thumbs"
+    assert captured["value"] == 1
+    assert captured["data_type"] == "BOOLEAN"
+    assert captured["comment"] == "great"
+
+
+def test_feedback_thumbs_down_sends_zero(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_create_score(trace_id: str, **kwargs: Any) -> bool:
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr("news_dashboard.ai_client.create_score", fake_create_score)
+
+    resp = client.post("/api/feedback", json={"trace_id": "t", "helpful": False})
+
+    assert resp.status_code == 200
+    assert captured["value"] == 0
+    # Empty/omitted comment is normalised to None, not "".
+    assert captured["comment"] is None
+
+
+def test_feedback_noop_returns_recorded_false(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # When Langfuse is disabled create_score returns False; the endpoint surfaces
+    # that without erroring.
+    monkeypatch.setattr("news_dashboard.ai_client.create_score", lambda *_a, **_k: False)
+
+    resp = client.post("/api/feedback", json={"trace_id": "t", "helpful": True})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"recorded": False}

--- a/backend/tests/test_prompt_optimizer.py
+++ b/backend/tests/test_prompt_optimizer.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard.prompt_optimizer import (
+    NegativeExample,
+    PromptOptimizerError,
+    _extract_question,
+    _score_is_negative,
+    build_optimizer_prompt,
+    collect_negative_examples,
+)
+
+
+@pytest.fixture
+def _no_langfuse(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, True), (0.0, True), ("0", True), (1, False), ("1", False), (None, False), ("x", False)],
+)
+def test_score_is_negative(value: object, expected: bool) -> None:
+    assert _score_is_negative(value) is expected
+
+
+def test_extract_question_from_dict_and_string() -> None:
+    assert _extract_question({"query": " hello ", "include_all": False}) == "hello"
+    assert _extract_question("raw question") == "raw question"
+    assert _extract_question(None) == ""
+    assert _extract_question({"other": "x"}) == ""
+
+
+def test_build_optimizer_prompt_includes_current_and_examples() -> None:
+    examples = [
+        NegativeExample(question="Q1", answer="A1", comment="too vague"),
+        NegativeExample(question="Q2", answer="A2"),
+    ]
+    out = build_optimizer_prompt("CURRENT PROMPT TEXT", examples)
+
+    assert "CURRENT PROMPT TEXT" in out
+    assert "Q1" in out
+    assert "A1" in out
+    assert "too vague" in out
+    assert "Q2" in out
+    assert "A2" in out
+    # The example without a comment must not emit a stray "User comment:" line.
+    assert out.count("User comment:") == 1
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_collect_negative_examples_requires_langfuse() -> None:
+    with pytest.raises(PromptOptimizerError, match="not configured"):
+        collect_negative_examples()

--- a/frontend/src/__tests__/ask.test.tsx
+++ b/frontend/src/__tests__/ask.test.tsx
@@ -61,6 +61,7 @@ describe('AskPage — citation click opens reader', () => {
         { id: 42, title: 'Test Article', url: 'https://example.com/test' },
         { id: 99, title: 'Another Article', url: 'https://example.com/other' },
       ],
+      trace_id: null,
     });
   });
 
@@ -131,6 +132,7 @@ describe('AskPage — error states', () => {
       answer:
         'Not enough articles yet — I need at least 5 saved or read articles to answer questions. You currently have 2.',
       sources: [],
+      trace_id: null,
     });
     renderAskPage();
     const ta = screen.getByPlaceholderText(/Postgres/i);
@@ -157,7 +159,9 @@ describe('AskPage — error states', () => {
 
 describe('AskPage — include_all checkbox', () => {
   it('passes include_all=false by default', async () => {
-    const spy = vi.spyOn(api, 'askAI').mockResolvedValue({ answer: 'ok', sources: [] });
+    const spy = vi
+      .spyOn(api, 'askAI')
+      .mockResolvedValue({ answer: 'ok', sources: [], trace_id: null });
     renderAskPage();
     const ta = screen.getByPlaceholderText(/Postgres/i);
     await userEvent.type(ta, 'test');
@@ -166,7 +170,9 @@ describe('AskPage — include_all checkbox', () => {
   });
 
   it('passes include_all=true when checkbox is checked', async () => {
-    const spy = vi.spyOn(api, 'askAI').mockResolvedValue({ answer: 'ok', sources: [] });
+    const spy = vi
+      .spyOn(api, 'askAI')
+      .mockResolvedValue({ answer: 'ok', sources: [], trace_id: null });
     renderAskPage();
     const checkbox = screen.getByRole('checkbox');
     await userEvent.click(checkbox);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -116,6 +116,17 @@ export async function askAI(query: string, includeAll = false): Promise<AskRespo
   });
 }
 
+export async function submitFeedback(
+  traceId: string,
+  helpful: boolean,
+  comment?: string
+): Promise<{ recorded: boolean }> {
+  return requestJson<{ recorded: boolean }>('/api/feedback', {
+    method: 'POST',
+    body: JSON.stringify({ trace_id: traceId, helpful, comment }),
+  });
+}
+
 export async function updateSourceEnabled(slug: string, enabled: boolean): Promise<Source> {
   return requestJson<Source>(`/api/sources/${slug}/enabled`, {
     method: 'PATCH',

--- a/frontend/src/pages/AskPage.tsx
+++ b/frontend/src/pages/AskPage.tsx
@@ -1,9 +1,45 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Sparkles, Loader2, AlertCircle, BookOpen } from 'lucide-react';
-import { askAI } from '@/api';
+import { Sparkles, Loader2, AlertCircle, BookOpen, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { askAI, submitFeedback } from '@/api';
 import type { AskResponse } from '@/types';
 import { cn } from '@/lib/utils';
+
+function AnswerFeedback({ traceId }: { traceId: string }) {
+  const [sent, setSent] = useState<boolean | null>(null);
+
+  function rate(helpful: boolean) {
+    if (sent !== null) return;
+    setSent(helpful);
+    // Fire-and-forget: feedback must never block or error the UI.
+    void submitFeedback(traceId, helpful).catch(() => undefined);
+  }
+
+  if (sent !== null) {
+    return <p className="text-[11px] text-muted-foreground">Thanks for the feedback.</p>;
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-[11px] text-muted-foreground">Was this helpful?</span>
+      <button
+        type="button"
+        aria-label="Helpful"
+        onClick={() => rate(true)}
+        className="rounded p-1 text-muted-foreground hover:bg-surface hover:text-foreground"
+      >
+        <ThumbsUp className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Not helpful"
+        onClick={() => rate(false)}
+        className="rounded p-1 text-muted-foreground hover:bg-surface hover:text-foreground"
+      >
+        <ThumbsDown className="size-3.5" />
+      </button>
+    </div>
+  );
+}
 
 type ErrorKind = 'no_key' | 'not_enough' | 'generation_failed';
 
@@ -155,6 +191,8 @@ export function AskPage() {
       {result && (
         <div className="mt-6 space-y-4">
           <div className="reader-prose text-[15px] leading-relaxed">{result.answer}</div>
+
+          {result.trace_id && <AnswerFeedback traceId={result.trace_id} />}
 
           {noSupportingArticles && (
             <p className="text-sm text-muted-foreground italic">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -142,6 +142,8 @@ export interface AskSource {
 export interface AskResponse {
   answer: string;
   sources: AskSource[];
+  /** Langfuse trace id for this answer; null when tracing is disabled. */
+  trace_id: string | null;
 }
 
 export interface IngestRun {


### PR DESCRIPTION
## Summary

Expands the Langfuse integration from "every LLM call is traced" into a full **observability → feedback → improvement loop**. Installed SDK confirmed as **langfuse v4.12.0**; all calls use its actual API surface. Everything degrades gracefully — when Langfuse keys are unset, behaviour is unchanged.

### What's new

- **`ai_client` foundation** — `observe(name, input=...)` context manager that groups a pipeline under one trace and exposes its `trace_id`; `create_score()`; `get_prompt(name, fallback=..., variables=...)` → `ManagedPrompt` with local fallback and prompt→generation linking via `chat_create(..., prompt=)`; `get_trace_url()`; `fetch_metrics()`.
- **Prompt management** — Ask AI, insights, and briefing system prompts now resolve through Langfuse (`ask-system`, `article-insights`, `briefing-system`, label `production`) with the original text kept as fallback.
- **User feedback** — `/api/ask` returns `trace_id`; new `POST /api/feedback` records a `user-thumbs` BOOLEAN score **server-side** (keys never reach the browser); thumbs up/down UI in `AskPage`.
- **Admin metrics** — `GET /api/admin/ai/metrics?days=` surfaces usage/cost/latency + score aggregates via the Langfuse Metrics API.
- **Feedback-driven auto-improvement** — `prompt_optimizer.py` + CLI `improve-prompt` pulls thumbs-down answers, asks an LLM to revise the prompt, and saves a **`candidate`** version to Langfuse for human review (never auto-promotes to production).

### Bug fix

`embeddings.ask()` shadowed the user `query` with the SQL string before `_embed()`/the prompt, so Ask AI was embedding and answering the **SQL string instead of the question**. Fixed by renaming the SQL local.

## Test plan

- Backend: full suite **712 passed** locally (`source .env && make test`).
- Frontend: **454 passed**.
- `make lint` + `make typecheck` (ruff, mypy, ty, pyrefly, eslint, prettier, tsc) clean.
- New tests: `test_feedback_api.py`, `test_prompt_optimizer.py`, plus `ai_client` no-op/fallback coverage.

## Follow-ups (not in this PR — they mutate the live Langfuse)

- Create the three prompts in Langfuse with `labels=["production"]` so `get_prompt` uses them instead of the fallbacks.
- Optionally schedule `improve-prompt` once feedback has accumulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)