### PR TITLE
feat: share articles to other users in-platform

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -364,6 +364,21 @@ POSTGRES_MULTIUSER_SCHEMA = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_push_subs_user ON user_push_subscriptions(user_id)",
+    """
+    CREATE TABLE IF NOT EXISTS article_shares (
+      id            BIGSERIAL PRIMARY KEY,
+      article_id    BIGINT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+      from_user_id  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      to_user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      note          TEXT,
+      created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      read_at       TIMESTAMPTZ
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_article_shares_recipient"
+    " ON article_shares(to_user_id, created_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_article_shares_unread"
+    " ON article_shares(to_user_id) WHERE read_at IS NULL",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -153,6 +153,11 @@ class LaterUpdate(BaseModel):
     days: int = 1
 
 
+class ShareArticleRequest(BaseModel):
+    to_user_id: int
+    note: str | None = None
+
+
 class EnabledUpdate(BaseModel):
     enabled: bool
 
@@ -557,6 +562,86 @@ def snooze_later(
     if not article:
         raise HTTPException(status_code=404, detail="article not found")
     return article
+
+
+@api.get("/api/users")
+def list_shareable_users(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from .shares import shareable_users
+
+    return {"items": shareable_users(current_user["id"])}
+
+
+@api.post("/api/articles/{article_id}/share")
+def share_article_endpoint(
+    article_id: int,
+    payload: ShareArticleRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    background_tasks: BackgroundTasks,
+) -> dict[str, Any]:
+    from .shares import ShareError, share_article
+
+    try:
+        share = share_article(
+            article_id=article_id,
+            from_user_id=current_user["id"],
+            to_user_id=payload.to_user_id,
+            note=payload.note,
+        )
+    except ShareError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    article = get_article(article_id, user_id=current_user["id"])
+    title = article["title"] if article else "an article"
+    background_tasks.add_task(
+        _notify_share_recipient,
+        to_user_id=payload.to_user_id,
+        sender=current_user["username"],
+        article_title=title,
+    )
+    return share
+
+
+def _notify_share_recipient(*, to_user_id: int, sender: str, article_title: str) -> None:
+    from .push import send_push_for_user
+
+    send_push_for_user(
+        to_user_id,
+        f"{sender} shared an article",
+        article_title,
+    )
+
+
+@api.get("/api/shares")
+def list_shares(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from .shares import list_received_shares, unread_share_count
+
+    return {
+        "items": list_received_shares(current_user["id"]),
+        "unread": unread_share_count(current_user["id"]),
+    }
+
+
+@api.get("/api/shares/unread_count")
+def shares_unread_count(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from .shares import unread_share_count
+
+    return {"unread": unread_share_count(current_user["id"])}
+
+
+@api.post("/api/shares/{share_id}/read")
+def mark_share_read_endpoint(
+    share_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from .shares import mark_share_read
+
+    return {"ok": mark_share_read(share_id, current_user["id"])}
 
 
 @api.get("/api/articles/{article_id}/read")

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -1,0 +1,112 @@
+"""In-platform article sharing between users.
+
+Lets a user send a news article to another platform user.  The recipient sees
+the shared article in a "Shared with me" inbox and (optionally) gets a web-push
+notification.
+
+Runtime SQL uses psycopg %s parameter style. No SQLite fallback.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .db import connect, row_to_dict
+
+logger = logging.getLogger(__name__)
+
+
+class ShareError(RuntimeError):
+    """Raised when a share cannot be created (unknown article/recipient)."""
+
+
+def shareable_users(current_user_id: int) -> list[dict[str, Any]]:
+    """Return platform users the current user can share with (everyone else)."""
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT id, username, email FROM users WHERE id <> %s ORDER BY username",
+            (current_user_id,),
+        ).fetchall()
+        return [row_to_dict(r) for r in rows]
+
+
+def share_article(
+    *,
+    article_id: int,
+    from_user_id: int,
+    to_user_id: int,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Create a share row. Returns the inserted record.
+
+    Raises ShareError if the article or recipient does not exist, or if the
+    sender tries to share with themselves.
+    """
+    if from_user_id == to_user_id:
+        msg = "Cannot share an article with yourself"
+        raise ShareError(msg)
+
+    clean_note = (note or "").strip() or None
+    with connect() as conn:
+        if conn.execute("SELECT 1 FROM articles WHERE id = %s", (article_id,)).fetchone() is None:
+            msg = f"Article {article_id} not found"
+            raise ShareError(msg)
+        if conn.execute("SELECT 1 FROM users WHERE id = %s", (to_user_id,)).fetchone() is None:
+            msg = f"Recipient user {to_user_id} not found"
+            raise ShareError(msg)
+        row = conn.execute(
+            """
+            INSERT INTO article_shares (article_id, from_user_id, to_user_id, note)
+            VALUES (%s, %s, %s, %s)
+            RETURNING id, article_id, from_user_id, to_user_id, note, created_at, read_at
+            """,
+            (article_id, from_user_id, to_user_id, clean_note),
+        ).fetchone()
+    return row_to_dict(row)
+
+
+def list_received_shares(user_id: int, *, limit: int = 100) -> list[dict[str, Any]]:
+    """Return shares received by a user, newest first, with article + sender info."""
+    with connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT s.id, s.note, s.created_at, s.read_at,
+                   s.from_user_id, u.username AS from_username,
+                   a.id AS article_id, a.title AS article_title,
+                   a.url AS article_url, a.source_name AS article_source_name,
+                   a.summary AS article_summary
+            FROM article_shares s
+            JOIN users u ON u.id = s.from_user_id
+            JOIN articles a ON a.id = s.article_id
+            WHERE s.to_user_id = %s
+            ORDER BY s.created_at DESC
+            LIMIT %s
+            """,
+            (user_id, limit),
+        ).fetchall()
+        return [row_to_dict(r) for r in rows]
+
+
+def mark_share_read(share_id: int, user_id: int) -> bool:
+    """Mark a received share as read. Returns True if a row was updated."""
+    with connect() as conn:
+        cursor = conn.execute(
+            """
+            UPDATE article_shares
+            SET read_at = NOW()
+            WHERE id = %s AND to_user_id = %s AND read_at IS NULL
+            """,
+            (share_id, user_id),
+        )
+        return bool(cursor.rowcount > 0)
+
+
+def unread_share_count(user_id: int) -> int:
+    """Return the number of unread shares for a user."""
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM article_shares WHERE to_user_id = %s AND read_at IS NULL",
+            (user_id,),
+        ).fetchone()
+        return int(row_to_dict(row)["n"])

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -1,0 +1,114 @@
+"""Tests for in-platform article sharing (shares.py)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import news_dashboard.db as db_mod
+from news_dashboard.auth import create_user
+from news_dashboard.db import connect
+from news_dashboard.ingest import sync_sources
+from news_dashboard.shares import (
+    ShareError,
+    list_received_shares,
+    mark_share_read,
+    share_article,
+    shareable_users,
+    unread_share_count,
+)
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Iterator[Path]:
+    """A test schema with sources synced and DB_PATH patched for share helpers."""
+    path = tmp_path / "shares.db"
+    sync_sources(path)
+    orig = db_mod.DB_PATH
+    db_mod.DB_PATH = path
+    try:
+        yield path
+    finally:
+        db_mod.DB_PATH = orig
+
+
+def _make_user(username: str) -> int:
+    return int(create_user(username, "password123")["id"])
+
+
+def _insert_article(db_path: Path, suffix: str = "1") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug,
+              source_name, category, kind, state)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/art{suffix}",
+                f"https://example.com/art{suffix}",
+                f"Article {suffix}",
+                "python-insider",
+                "Python Insider",
+                "python",
+                "rss_feed",
+                "today",
+            ),
+        ).fetchone()
+    return int(row["id"])
+
+
+def test_share_and_list(db: Path) -> None:
+    alice = _make_user("alice")
+    bob = _make_user("bob")
+    article_id = _insert_article(db)
+
+    share_article(article_id=article_id, from_user_id=alice, to_user_id=bob, note="  read this  ")
+
+    received = list_received_shares(bob)
+    assert len(received) == 1
+    assert received[0]["from_username"] == "alice"
+    assert received[0]["article_title"] == "Article 1"
+    assert received[0]["note"] == "read this"
+    assert received[0]["read_at"] is None
+    assert unread_share_count(bob) == 1
+    # Sender sees nothing in their own inbox.
+    assert list_received_shares(alice) == []
+
+
+def test_mark_read(db: Path) -> None:
+    alice = _make_user("alice")
+    bob = _make_user("bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+
+    assert mark_share_read(int(share["id"]), bob) is True
+    assert unread_share_count(bob) == 0
+    # Idempotent: already-read share returns False.
+    assert mark_share_read(int(share["id"]), bob) is False
+    # Other users cannot mark someone else's share.
+    assert mark_share_read(int(share["id"]), alice) is False
+
+
+def test_shareable_users_excludes_self(db: Path) -> None:
+    alice = _make_user("alice")
+    _make_user("bob")
+    usernames = {u["username"] for u in shareable_users(alice)}
+    assert usernames == {"bob"}
+
+
+def test_cannot_share_with_self(db: Path) -> None:
+    alice = _make_user("alice")
+    article_id = _insert_article(db)
+    with pytest.raises(ShareError):
+        share_article(article_id=article_id, from_user_id=alice, to_user_id=alice)
+
+
+def test_share_unknown_article_raises(db: Path) -> None:
+    alice = _make_user("alice")
+    bob = _make_user("bob")
+    with pytest.raises(ShareError):
+        share_article(article_id=999999, from_user_id=alice, to_user_id=bob)

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -6,6 +6,7 @@ import { AppShell } from './components/AppShell';
 import { LoginPage } from './pages/LoginPage';
 import { BriefPage } from './pages/BriefPage';
 import { InboxPage } from './pages/InboxPage';
+import { SharedPage } from './pages/SharedPage';
 import { LaterPage } from './pages/LaterPage';
 import { StarredPage } from './pages/StarredPage';
 import { SearchPage } from './pages/SearchPage';
@@ -72,6 +73,7 @@ export const routes: RouteObject[] = [
       { path: 'today', element: <InboxPage /> },
       { path: 'later', element: <LaterPage /> },
       { path: 'starred', element: <StarredPage /> },
+      { path: 'shared', element: <SharedPage /> },
       { path: 'search', element: <SearchPage /> },
       { path: 'ask', element: <AskPage /> },
       {

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -541,7 +541,9 @@ describe('ArticlePage — Share button', () => {
 
     renderReader();
     await waitFor(() => screen.getByText('Test Article Title'));
+    // Open the share dialog, then pick the external option.
     await userEvent.click(screen.getByRole('button', { name: /share/i }));
+    await userEvent.click(await screen.findByText('Share externally'));
 
     expect(shareMock).toHaveBeenCalledWith({
       title: 'Test Article Title',
@@ -560,6 +562,7 @@ describe('ArticlePage — Share button', () => {
     renderReader();
     await waitFor(() => screen.getByText('Test Article Title'));
     await userEvent.click(screen.getByRole('button', { name: /share/i }));
+    await userEvent.click(await screen.findByText('Share externally'));
 
     expect(clipboardMock).toHaveBeenCalledWith('https://example.com/article');
   });

--- a/frontend/src/__tests__/shareDialog.test.tsx
+++ b/frontend/src/__tests__/shareDialog.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ShareDialog } from '../components/ShareDialog';
+import * as api from '../api';
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderDialog(onOpenChange = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <ShareDialog
+        open
+        onOpenChange={onOpenChange}
+        article={{ id: 7, title: 'Big News', url: 'https://example.com/x' }}
+      />
+    </QueryClientProvider>
+  );
+  return { onOpenChange };
+}
+
+describe('ShareDialog', () => {
+  it('offers internal and external choices', () => {
+    renderDialog();
+    expect(screen.getByText('Send inside the platform')).toBeTruthy();
+    expect(screen.getByText('Share externally')).toBeTruthy();
+  });
+
+  it('lists users and shares to the chosen recipient', async () => {
+    vi.spyOn(api, 'fetchShareableUsers').mockResolvedValue([
+      { id: 2, username: 'alice', email: 'alice@example.com' },
+      { id: 3, username: 'bob', email: null },
+    ]);
+    const shareSpy = vi.spyOn(api, 'shareArticle').mockResolvedValue();
+    const { onOpenChange } = renderDialog();
+
+    await userEvent.click(screen.getByText('Send inside the platform'));
+    await waitFor(() => expect(screen.getByText('alice')).toBeTruthy());
+
+    await userEvent.click(screen.getByText('alice'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalledWith(7, 2, ''));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('uses the Web Share API for external sharing when available', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+    renderDialog();
+
+    await userEvent.click(screen.getByText('Share externally'));
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({ title: 'Big News', url: 'https://example.com/x' })
+    );
+    Reflect.deleteProperty(navigator, 'share');
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,6 +13,8 @@ import type {
   NotificationSettings,
   NotificationSettingsUpdate,
   PushSubscribeRequest,
+  ReceivedShare,
+  ShareableUser,
   Source,
   SourceHealth,
   SourceQualityRow,
@@ -347,4 +349,38 @@ export async function subscribePush(
 
 export async function unsubscribePush(): Promise<{ unsubscribed: boolean }> {
   return requestJson('/api/notifications/subscribe', { method: 'DELETE' });
+}
+
+// ─── In-platform sharing ──────────────────────────────────────────────────────
+
+export async function fetchShareableUsers(): Promise<ShareableUser[]> {
+  const data = await requestJson<{ items: ShareableUser[] }>('/api/users');
+  return data.items;
+}
+
+export async function shareArticle(
+  articleId: number,
+  toUserId: number,
+  note?: string
+): Promise<void> {
+  await requestJson(`/api/articles/${articleId}/share`, {
+    method: 'POST',
+    body: JSON.stringify({ to_user_id: toUserId, note: note ?? null }),
+  });
+}
+
+export async function fetchReceivedShares(): Promise<{
+  items: ReceivedShare[];
+  unread: number;
+}> {
+  return requestJson('/api/shares');
+}
+
+export async function fetchSharesUnreadCount(): Promise<number> {
+  const data = await requestJson<{ unread: number }>('/api/shares/unread_count');
+  return data.unread;
+}
+
+export async function markShareRead(shareId: number): Promise<void> {
+  await requestJson(`/api/shares/${shareId}/read`, { method: 'POST' });
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -8,7 +8,7 @@ import { ShortcutOverlay } from './ShortcutOverlay';
 import { WhatsNewDialog } from './WhatsNewDialog';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
 import { cn } from '@/lib/utils';
-import { fetchSummary, logoutUser } from '@/api';
+import { fetchSummary, fetchSharesUnreadCount, logoutUser } from '@/api';
 import { startAnalytics, stopAnalytics, trackRoute } from '@/lib/analytics';
 import { useAuth } from '@/contexts/auth';
 import {
@@ -28,9 +28,15 @@ function useNavCounts() {
     staleTime: 30_000,
     refetchOnWindowFocus: false,
   });
+  const { data: sharesUnread } = useQuery({
+    queryKey: ['shares-unread'],
+    queryFn: fetchSharesUnreadCount,
+    staleTime: 30_000,
+  });
   return {
     today: data?.byStatus?.new ?? null,
     starred: data?.byStatus?.saved ?? null,
+    shared: sharesUnread ?? null,
   };
 }
 
@@ -39,7 +45,13 @@ function DesktopRail({ pathname }: { pathname: string }) {
   const { user, setUser } = useAuth();
   const navigate = useNavigate();
   const countFor = (item: NavigationItem): number | null =>
-    item.to === '/today' ? counts.today : item.to === '/starred' ? counts.starred : null;
+    item.to === '/today'
+      ? counts.today
+      : item.to === '/starred'
+        ? counts.starred
+        : item.to === '/shared'
+          ? counts.shared
+          : null;
 
   async function handleLogout() {
     await logoutUser();

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Send, Share, Users, Loader2, Search } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { fetchShareableUsers, shareArticle } from '@/api';
+
+export interface ShareTarget {
+  id: number;
+  title: string;
+  url: string;
+}
+
+interface ShareDialogProps {
+  article: ShareTarget | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type Mode = 'choose' | 'internal';
+
+/**
+ * Two-step share flow:
+ *   1. Choose between sharing to another platform user (internal) or via the
+ *      OS share sheet / clipboard (external).
+ *   2. For internal, pick a recipient and optionally add a note.
+ */
+export function ShareDialog({ article, open, onOpenChange }: ShareDialogProps) {
+  const [mode, setMode] = useState<Mode>('choose');
+  const [query, setQuery] = useState('');
+  const [note, setNote] = useState('');
+  const [sendingTo, setSendingTo] = useState<number | null>(null);
+
+  function reset() {
+    setMode('choose');
+    setQuery('');
+    setNote('');
+    setSendingTo(null);
+  }
+
+  function close() {
+    onOpenChange(false);
+  }
+
+  const usersQuery = useQuery({
+    queryKey: ['shareable-users'],
+    queryFn: fetchShareableUsers,
+    enabled: open && mode === 'internal',
+    staleTime: 60_000,
+  });
+
+  async function handleExternal() {
+    if (!article) return;
+    const shareData = { title: article.title, url: article.url };
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+      } catch (err) {
+        // User cancelling the share sheet rejects with AbortError — stay quiet.
+        if ((err as Error).name !== 'AbortError') {
+          toast.error('Could not open the share sheet');
+        }
+        return;
+      }
+    } else {
+      await navigator.clipboard.writeText(article.url);
+      toast('Link copied!');
+    }
+    close();
+  }
+
+  async function handleSendTo(userId: number, username: string) {
+    if (!article) return;
+    setSendingTo(userId);
+    try {
+      await shareArticle(article.id, userId, note);
+      toast.success(`Sent to ${username}`);
+      close();
+    } catch {
+      toast.error('Could not share the article');
+    } finally {
+      setSendingTo(null);
+    }
+  }
+
+  const users = usersQuery.data ?? [];
+  const filtered = query
+    ? users.filter((u) => u.username.toLowerCase().includes(query.toLowerCase()))
+    : users;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) reset();
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Share article</DialogTitle>
+          <DialogDescription className="line-clamp-2">{article?.title}</DialogDescription>
+        </DialogHeader>
+
+        {mode === 'choose' ? (
+          <div className="mt-1 flex flex-col gap-2">
+            <Button
+              variant="outline"
+              className="h-auto justify-start gap-3 py-3"
+              onClick={() => setMode('internal')}
+            >
+              <Users className="h-5 w-5 shrink-0" />
+              <span className="flex flex-col items-start text-left">
+                <span className="font-medium">Send inside the platform</span>
+                <span className="text-xs text-muted-foreground">
+                  Deliver to another user's inbox
+                </span>
+              </span>
+            </Button>
+            <Button
+              variant="outline"
+              className="h-auto justify-start gap-3 py-3"
+              onClick={() => void handleExternal()}
+            >
+              <Share className="h-5 w-5 shrink-0" />
+              <span className="flex flex-col items-start text-left">
+                <span className="font-medium">Share externally</span>
+                <span className="text-xs text-muted-foreground">
+                  Open your apps, or copy the link
+                </span>
+              </span>
+            </Button>
+          </div>
+        ) : (
+          <div className="mt-1 flex flex-col gap-3">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                autoFocus
+                placeholder="Search people…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="pl-8"
+              />
+            </div>
+            <Input
+              placeholder="Add a note (optional)"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              maxLength={500}
+            />
+            <div className="max-h-56 overflow-y-auto rounded-md border border-border">
+              {usersQuery.isLoading ? (
+                <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Loading people…
+                </div>
+              ) : filtered.length === 0 ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">
+                  {users.length === 0 ? 'No other users yet.' : 'No matches.'}
+                </div>
+              ) : (
+                <ul className="divide-y divide-border">
+                  {filtered.map((u) => (
+                    <li key={u.id}>
+                      <button
+                        type="button"
+                        disabled={sendingTo !== null}
+                        onClick={() => void handleSendTo(u.id, u.username)}
+                        className="flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left text-sm hover:bg-accent disabled:opacity-50"
+                      >
+                        <span className="flex min-w-0 flex-col">
+                          <span className="truncate font-medium">{u.username}</span>
+                          {u.email ? (
+                            <span className="truncate text-xs text-muted-foreground">
+                              {u.email}
+                            </span>
+                          ) : null}
+                        </span>
+                        {sendingTo === u.id ? (
+                          <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                        ) : (
+                          <Send className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="self-start"
+              onClick={() => setMode('choose')}
+            >
+              ← Back
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -8,6 +8,7 @@ import {
   Newspaper,
   Radio,
   Search,
+  Send,
   Settings,
   Sparkles,
   Star,
@@ -28,6 +29,7 @@ export const primaryNavigationItems: NavigationItem[] = [
   { to: '/today', label: 'Today', icon: Inbox, shortcut: 't' },
   { to: '/later', label: 'Later', icon: Clock, shortcut: 'l' },
   { to: '/starred', label: 'Starred', icon: Star, shortcut: 's' },
+  { to: '/shared', label: 'Shared', icon: Send },
   { to: '/search', label: 'Search', icon: Search },
   { to: '/ask', label: 'Ask', commandLabel: 'Ask AI', icon: Sparkles, shortcut: 'a' },
 ];
@@ -52,7 +54,12 @@ export function secondaryNavigationItemsFor(isAdmin: boolean): NavigationItem[] 
     : secondaryNavigationItems;
 }
 
-export const mobileNavigationItems = primaryNavigationItems.slice(0, 5);
+// The mobile bottom bar is a fixed 5-column grid. Keep the five most-used
+// destinations here explicitly so adding desktop-only items (e.g. Shared) does
+// not silently push one off the bar.
+export const mobileNavigationItems = primaryNavigationItems.filter((item) =>
+  ['/', '/today', '/later', '/starred', '/search'].includes(item.to)
+);
 
 export const commandNavigationItems = [...primaryNavigationItems, ...secondaryNavigationItems].map(
   (item) => ({
@@ -90,6 +97,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname === '/today') return 'Today';
   if (pathname.startsWith('/later')) return 'Later';
   if (pathname.startsWith('/starred')) return 'Starred';
+  if (pathname.startsWith('/shared')) return 'Shared';
   if (pathname.startsWith('/search')) return 'Search';
   if (pathname.startsWith('/ask')) return 'Ask AI';
   if (pathname.startsWith('/briefs')) return 'Briefs';

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -29,6 +29,7 @@ import { getReaderList } from '@/lib/readerList';
 import { recommendationExplanation } from '@/lib/recommendation';
 import { trackArticleOpen, trackArticleClose } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
+import { ShareDialog } from '@/components/ShareDialog';
 
 function renderBody(md: string): string {
   const escape = (s: string) =>
@@ -280,14 +281,11 @@ export function ArticlePage() {
     audioMutation.mutate();
   }
 
-  async function handleShare() {
+  const [shareOpen, setShareOpen] = useState(false);
+
+  function handleShare() {
     if (!article) return;
-    if (navigator.share) {
-      await navigator.share({ title: article.title, url: article.url });
-    } else {
-      await navigator.clipboard.writeText(article.url);
-      toast('Link copied!');
-    }
+    setShareOpen(true);
   }
 
   // On-demand recommendation explanation — kept collapsed by default so the
@@ -642,6 +640,11 @@ export function ArticlePage() {
         </div>,
         document.body
       )}
+      <ShareDialog
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+        article={{ id: Number(article.id), title: article.title, url: article.url }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/SharedPage.tsx
+++ b/frontend/src/pages/SharedPage.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Send, ExternalLink } from 'lucide-react';
+import { EmptyState } from '@/components/EmptyState';
+import { fetchReceivedShares, markShareRead } from '@/api';
+import { relativeTime } from '@/lib/format';
+import { cn } from '@/lib/utils';
+
+const SHARES_KEY = ['shares'];
+
+export function SharedPage() {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: SHARES_KEY,
+    queryFn: fetchReceivedShares,
+    staleTime: 15_000,
+  });
+
+  const shares = data?.items ?? [];
+
+  // Opening the page clears the unread badge: mark every unread share as read
+  // once, then refresh the badge query other surfaces rely on.
+  useEffect(() => {
+    const unread = shares.filter((s) => !s.read_at);
+    if (unread.length === 0) return;
+    let cancelled = false;
+    void Promise.all(unread.map((s) => markShareRead(s.id))).then(() => {
+      if (cancelled) return;
+      void queryClient.invalidateQueries({ queryKey: ['shares-unread'] });
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Run when the set of unread ids changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shares.map((s) => (s.read_at ? '' : s.id)).join(',')]);
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-6">
+      <div className="mb-4">
+        <h1 className="text-lg font-semibold text-foreground">Shared with me</h1>
+        <p className="text-sm text-muted-foreground">
+          {isLoading ? '…' : `${shares.length} article${shares.length === 1 ? '' : 's'}`} sent to
+          you by other people
+        </p>
+      </div>
+
+      {!isLoading && shares.length === 0 ? (
+        <EmptyState
+          icon={Send}
+          title="Nothing shared yet"
+          subtitle="When someone sends you an article, it shows up here."
+        />
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {shares.map((s) => (
+            <li
+              key={s.id}
+              className={cn('rounded-lg border border-border p-3', !s.read_at && 'bg-surface')}
+            >
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                {!s.read_at && (
+                  <span className="size-2 shrink-0 rounded-full bg-signal-high" aria-hidden />
+                )}
+                <span className="font-medium text-foreground">{s.from_username}</span>
+                <span>shared · {relativeTime(s.created_at)}</span>
+              </div>
+
+              <Link
+                to={`/a/${s.article_id}`}
+                className="mt-1 block font-medium text-foreground hover:underline"
+              >
+                {s.article_title}
+              </Link>
+              <div className="mt-0.5 text-xs text-muted-foreground">{s.article_source_name}</div>
+
+              {s.note ? (
+                <div className="mt-2 rounded-md bg-surface-2 px-2.5 py-1.5 text-sm text-foreground">
+                  “{s.note}”
+                </div>
+              ) : null}
+
+              <div className="mt-2 flex items-center gap-3 text-xs">
+                <Link to={`/a/${s.article_id}`} className="text-accent-foreground hover:underline">
+                  Read
+                </Link>
+                <a
+                  href={s.article_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                >
+                  Original <ExternalLink className="size-3" />
+                </a>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -45,6 +45,26 @@ export interface User {
   is_admin: boolean;
 }
 
+export interface ShareableUser {
+  id: number;
+  username: string;
+  email?: string | null;
+}
+
+export interface ReceivedShare {
+  id: number;
+  note?: string | null;
+  created_at: string;
+  read_at?: string | null;
+  from_user_id: number;
+  from_username: string;
+  article_id: number;
+  article_title: string;
+  article_url: string;
+  article_source_name: string;
+  article_summary?: string | null;
+}
+
 export interface Source {
   slug: string;
   name: string;


### PR DESCRIPTION
Closes #301

## What
Adds in-platform article sharing alongside the existing external share. Tapping **Share** on an article now opens a chooser dialog:

- **Send inside the platform** — search/pick a user, optional note → delivered to their "Shared with me" inbox + a web-push notification.
- **Share externally** — `navigator.share()` (OS share sheet) with clipboard fallback. Preserves prior behavior, now behind the chooser.

Recipients get a **Shared** nav entry with an unread badge and a page listing received shares (sender, note, links to read in-app or open the original). Opening the page clears the badge.

## Backend
- `article_shares` table + indexes (`db.py`)
- `shares.py` — share / list / mark-read / unread-count / user-picker helpers
- Endpoints: `GET /api/users`, `POST /api/articles/{id}/share` (fires push in a background task), `GET /api/shares`, `GET /api/shares/unread_count`, `POST /api/shares/{id}/read`

## Frontend
- `ShareDialog` (internal/external) wired into the article reader
- `SharedPage` + `/shared` route + unread nav badge in `AppShell`
- api + types wiring

## Tests
- Backend: `test_article_shares.py` — share/list, mark-read idempotency + authorization, self-share guard, unknown-article guard (5 tests)
- Frontend: `shareDialog.test.tsx` (3 tests) + updated the two existing reader share tests for the new chooser step
- Verified locally with env: 34 backend tests (shares + workflow_state) green, 457 frontend tests green; ruff/mypy/pyrefly/eslint/tsc/prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)