### PR TITLE
fix: keep desktop nav rail sticky on scroll

### DIFF
--- a/frontend/src/__tests__/appShellStickyNav.test.ts
+++ b/frontend/src/__tests__/appShellStickyNav.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+// The DesktopRail <aside> uses `position: sticky` to keep the nav fixed while
+// the article list scrolls. `overflow-x: hidden` on an ancestor (`.app-shell`)
+// silently turns it into a scroll container and breaks sticky positioning.
+// `overflow-x: clip` guards against horizontal overflow without that side
+// effect. This guards against regressing back to `hidden`.
+describe('.app-shell horizontal overflow', () => {
+  const css = readFileSync(join(import.meta.dirname, '../globals.css'), 'utf8');
+
+  const appShellBlock = /\.app-shell\s*\{[^}]*\}/.exec(css)?.[0] ?? '';
+
+  it('exists', () => {
+    expect(appShellBlock).toContain('overflow-x');
+  });
+
+  it('uses overflow-x: clip so sticky nav keeps working', () => {
+    expect(appShellBlock).toMatch(/overflow-x:\s*clip/);
+    expect(appShellBlock).not.toMatch(/overflow-x:\s*hidden/);
+  });
+});

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -216,9 +216,10 @@
 
 /* Guard against content (e.g. long unbroken tokens in AI-generated briefings)
    forcing horizontal overflow, which would stretch the fixed bottom nav past
-   the viewport. */
+   the viewport. `clip` (not `hidden`) avoids establishing a scroll container,
+   which would otherwise break `position: sticky` on the desktop nav rail. */
 .app-shell {
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* Neutralise global a { color: ... } from legacy styles.css inside new shell */


### PR DESCRIPTION
Closes #307

## Problem
On the desktop web app the left nav rail scrolled away with the article list. The `DesktopRail` `<aside>` already uses `md:sticky md:top-12 md:self-start`, but `.app-shell { overflow-x: hidden }` made `.app-shell` a scroll container, which silently disables `position: sticky` on descendants.

## Fix
Switch `.app-shell` to `overflow-x: clip`. It still guards against horizontal overflow (long unbroken tokens in briefings) but does not establish a scroll container, so the nav rail now stays fixed while the news list scrolls.

## Test
`frontend/src/__tests__/appShellStickyNav.test.ts` asserts `.app-shell` uses `overflow-x: clip` and not `hidden`, guarding against regressing the sticky behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)