### PR TITLE
ci: derive version at build time so releases aren't one version behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,11 @@ env:
 
 # Minimum permissions. packages:write is only exercised by the publish job;
 # GitHub scopes GITHUB_TOKEN to the individual job automatically.
+# models:read lets the publish job summarize the changelog via GitHub Models.
 permissions:
   contents: read
   packages: write
+  models: read
 
 jobs:
   # ── 1. LINT ────────────────────────────────────────────────────────────────
@@ -115,6 +117,74 @@ jobs:
       image_tag: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # tags + history for version computation
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      # Derive the release version from tags + commits and bake it into the
+      # image, so /api/version and /api/changelog match the deployed code.
+      # release.yml computes the same value from the same script and tags it.
+      - name: Compute version
+        id: version
+        run: bash scripts/next_version.sh >> "$GITHUB_OUTPUT"
+
+      - name: Collect commits since last tag
+        id: log
+        run: |
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          RANGE="HEAD"
+          [ -n "$LAST_TAG" ] && RANGE="${LAST_TAG}..HEAD"
+          {
+            echo "commits<<COMMITS_EOF"
+            git log --no-merges --pretty=format:'- %s' "$RANGE"
+            echo
+            echo "COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog entry (GitHub Models)
+        id: ai
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o
+          system-prompt: |
+            You write the "What's new" notes that everyday users of a news
+            dashboard app see in an in-app popup after the app updates. Your
+            readers are NOT developers — write for them, not for engineers.
+
+            Given raw git commit subjects, output ONLY markdown "- " bullet
+            lines. Rules:
+            - Describe the benefit to the user — what they can now do, see, or
+              no longer have to deal with — not the technical change that
+              delivered it.
+            - Write in plain, friendly language. Address the user as "you" /
+              "your" where natural.
+            - NO jargon, internal names, file paths, config keys, library or
+              service names (e.g. Helm, Langfuse, cache, endpoint, API, schema,
+              migration), version numbers, or ticket/PR references.
+            - Merge related commits into a single user-facing bullet.
+            - Omit anything with no visible effect for users — chore, ci, test,
+              refactor, docs, deploy/infra, observability, and other internal
+              work. If a release is entirely internal, summarize it as a single
+              bullet like "Stability and performance improvements."
+            Output no headings, no version number, and no preamble — bullets only.
+          prompt: |
+            Commits for release ${{ steps.version.outputs.tag }}:
+            ${{ steps.log.outputs.commits }}
+
+      - name: Bake version + changelog into the build context
+        env:
+          V: ${{ steps.version.outputs.version }}
+          NOTES: ${{ steps.ai.outputs.response }}
+          COMMITS: ${{ steps.log.outputs.commits }}
+        run: |
+          echo "$V" > VERSION
+          # Fall back to raw commit subjects if inference returned nothing.
+          BODY="$NOTES"
+          [ -z "$(printf '%s' "$BODY" | tr -d '[:space:]')" ] && BODY="$COMMITS"
+          printf '%s\n' "$BODY" | python3 scripts/update_changelog.py --version "$V"
 
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,20 @@
 name: Release
 
-# Automatic semantic version bump + build on every push to main.
+# Tags each release and builds the downloadable Android / Desktop artifacts.
 #
-# Job graph:
-#   version  →  android   (ubuntu, ~5 min)
-#            ↘  desktop   (macos,  ~10 min)
+# The version itself is NOT committed to git — it is derived from the latest v*
+# tag plus the Conventional Commits since it (see scripts/next_version.sh), and
+# baked into the Docker image by ci.yml at build time. That keeps the deployed
+# app's /api/version and /api/changelog in step with the code on every push,
+# instead of trailing a separate post-merge bump commit by one release.
 #
-# version job:
-#   1. Reads commits since the last v* tag (Conventional Commits)
-#   2. Determines bump: feat → minor, fix/perf → patch, BREAKING → major
-#   3. Updates VERSION, android/app/build.gradle, android/twa-manifest.json,
-#      desktop/package.json, commits "chore: bump version to vX.Y.Z", pushes tag
+# This workflow only ever pushes a *tag* ref — never the protected main branch —
+# so it can't hit branch-protection (GH006).
 #
-# android / desktop jobs build only when a bump occurred.
-# GITHUB_TOKEN pushes never re-trigger workflows — no infinite loop risk.
+# Job graph (push to main):
+#   release  →  android   (ubuntu)
+#            ↘  desktop   (macos)
+# android / desktop run only when a new tag was created.
 
 on:
   push:
@@ -25,19 +26,17 @@ permissions:
   models: read # GitHub Models inference for the changelog entry
 
 jobs:
-  # ── 1. Compute bump and update version files ─────────────────────────────────
+  # ── 1. Compute version, create the tag, summarize the changelog ──────────────
 
-  version:
-    name: Compute & bump version
+  release:
+    name: Tag release
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]'
     outputs:
-      bumped: ${{ steps.compute.outputs.bumped }}
-      version: ${{ steps.compute.outputs.version }}
-      code: ${{ steps.compute.outputs.code }}
-      tag: ${{ steps.compute.outputs.tag }}
+      released: ${{ steps.tag.outputs.released }}
+      version: ${{ steps.version.outputs.version }}
+      code: ${{ steps.version.outputs.code }}
+      tag: ${{ steps.version.outputs.tag }}
       notes: ${{ steps.ai.outputs.response }}
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,53 +47,42 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Run bump script
-        id: compute
+      - name: Compute version
+        id: version
+        run: bash scripts/next_version.sh >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag (tag ref only)
+        id: tag
         run: |
-          CURRENT=$(cat VERSION)
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
-
-          if [ -z "$LAST_TAG" ]; then
-            echo "No v* tags found — bootstrapping from all commits"
-            RESULT=$(python3 scripts/bump_version.py --current "$CURRENT")
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists — nothing to release."
+            echo "released=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Computing bump since $LAST_TAG"
-            RESULT=$(python3 scripts/bump_version.py --current "$CURRENT" --since-tag "$LAST_TAG")
+            echo "Tagging $TAG"
+            git tag "$TAG"
+            git push origin "refs/tags/$TAG"
+            echo "released=true" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "$RESULT"
-          BUMP=$(echo "$RESULT" | grep '^bump=' | cut -d= -f2)
-          NEXT=$(echo "$RESULT" | grep '^next=' | cut -d= -f2)
-          CODE=$(echo "$RESULT" | grep '^code=' | cut -d= -f2)
+      # ── Changelog notes for the GitHub Releases (GITHUB_TOKEN only) ──
 
-          if [ "$BUMP" = "none" ]; then
-            echo "No version bump needed (only ci/docs/test/chore commits)"
-            echo "bumped=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Bump: $BUMP  |  $CURRENT → $NEXT  (versionCode $CODE)"
-            echo "bumped=true"  >> "$GITHUB_OUTPUT"
-            echo "version=$NEXT" >> "$GITHUB_OUTPUT"
-            echo "code=$CODE"    >> "$GITHUB_OUTPUT"
-            echo "tag=v$NEXT"   >> "$GITHUB_OUTPUT"
-          fi
-
-      # ── Changelog: summarize commits with GitHub Models (GITHUB_TOKEN only) ──
-      # Single-shot inference via actions/ai-inference — no external API key.
-
-      - name: Collect commits since last tag
-        if: steps.compute.outputs.bumped == 'true'
+      - name: Collect commits since previous tag
+        if: steps.tag.outputs.released == 'true'
         id: log
         run: |
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -vx "${{ steps.version.outputs.tag }}" | head -1)
+          RANGE="HEAD"
+          [ -n "$PREV_TAG" ] && RANGE="${PREV_TAG}..HEAD"
           {
             echo "commits<<COMMITS_EOF"
-            git log --no-merges --pretty=format:'- %s' "${LAST_TAG}..HEAD"
+            git log --no-merges --pretty=format:'- %s' "$RANGE"
             echo
             echo "COMMITS_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate changelog entry (GitHub Models)
-        if: steps.compute.outputs.bumped == 'true'
+        if: steps.tag.outputs.released == 'true'
         id: ai
         uses: actions/ai-inference@v1
         with:
@@ -121,71 +109,35 @@ jobs:
               bullet like "Stability and performance improvements."
             Output no headings, no version number, and no preamble — bullets only.
           prompt: |
-            Commits for release ${{ steps.compute.outputs.tag }}:
+            Commits for release ${{ steps.version.outputs.tag }}:
             ${{ steps.log.outputs.commits }}
-
-      - name: Prepend entry to CHANGELOG.md
-        if: steps.compute.outputs.bumped == 'true'
-        env:
-          V: ${{ steps.compute.outputs.version }}
-          BODY: ${{ steps.ai.outputs.response }}
-        run: |
-          python3 - <<'PY'
-          import os, pathlib
-          v = os.environ["V"]
-          body = os.environ["BODY"].strip()
-          # Fallback to raw commit subjects if inference returned nothing.
-          if not body:
-              body = """${{ steps.log.outputs.commits }}""".strip()
-          path = pathlib.Path("CHANGELOG.md")
-          text = path.read_text() if path.exists() else "# Changelog\n"
-          head, _, rest = text.partition("\n")
-          path.write_text(f"{head}\n\n## {v}\n{body}\n\n{rest.lstrip()}")
-          PY
-
-      - name: Update version files and push tag
-        if: steps.compute.outputs.bumped == 'true'
-        run: |
-          V="${{ steps.compute.outputs.version }}"
-          CODE="${{ steps.compute.outputs.code }}"
-          TAG="${{ steps.compute.outputs.tag }}"
-
-          # Primary source of truth
-          echo "$V" > VERSION
-
-          # Android Gradle build file — patterns require at least one digit to
-          # avoid matching empty strings (POSIX BRE: [0-9][0-9]* = one or more)
-          sed -i "s/versionCode [0-9][0-9]*/versionCode $CODE/" android/app/build.gradle
-          sed -i "s/versionName \"[0-9][^\"]*\"/versionName \"$V\"/" android/app/build.gradle
-
-          # android/twa-manifest.json
-          jq --arg v "$V" --argjson c "$CODE" \
-            '.appVersionName = $v | .appVersionCode = $c' \
-            android/twa-manifest.json > /tmp/twa.json
-          mv /tmp/twa.json android/twa-manifest.json
-
-          # desktop/package.json
-          jq --arg v "$V" '.version = $v' \
-            desktop/package.json > /tmp/pkg.json
-          mv /tmp/pkg.json desktop/package.json
-
-          git add VERSION CHANGELOG.md android/app/build.gradle android/twa-manifest.json desktop/package.json
-          git commit -m "chore: bump version to $TAG"
-          git tag "$TAG"
-          git push origin HEAD:main --tags
 
   # ── 2a. Build and sign Android APK ───────────────────────────────────────────
 
   android:
     name: Android APK
-    needs: version
-    if: needs.version.outputs.bumped == 'true'
+    needs: release
+    if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Inject version (not committed — only for this build)
+        env:
+          V: ${{ needs.release.outputs.version }}
+          CODE: ${{ needs.release.outputs.code }}
+        run: |
+          # Patterns require at least one digit to avoid matching empty strings
+          # (POSIX BRE: [0-9][0-9]* = one or more).
+          sed -i "s/versionCode [0-9][0-9]*/versionCode $CODE/" android/app/build.gradle
+          sed -i "s/versionName \"[0-9][^\"]*\"/versionName \"$V\"/" android/app/build.gradle
+          jq --arg v "$V" --argjson c "$CODE" \
+            '.appVersionName = $v | .appVersionCode = $c' \
+            android/twa-manifest.json > /tmp/twa.json
+          mv /tmp/twa.json android/twa-manifest.json
 
       - uses: actions/setup-java@v4
         with:
@@ -211,7 +163,7 @@ jobs:
         id: apk
         run: |
           APK=$(find android/app/build/outputs/apk/release -name "*.apk" | head -1)
-          V="${{ needs.version.outputs.version }}"
+          V="${{ needs.release.outputs.version }}"
           DEST="news-dashboard-android-v${V}.apk"
           cp "$APK" "$DEST"
           echo "path=$DEST" >> "$GITHUB_OUTPUT"
@@ -219,15 +171,15 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          CHANGELOG: ${{ needs.version.outputs.notes }}
+          CHANGELOG: ${{ needs.release.outputs.notes }}
         run: |
-          V="${{ needs.version.outputs.version }}"
+          V="${{ needs.release.outputs.version }}"
           NOTES_FILE="$RUNNER_TEMP/android-notes.md"
           {
             if [ -n "$CHANGELOG" ]; then
               printf "## What's new\n\n%s\n\n---\n\n" "$CHANGELOG"
             fi
-            echo "Signed APK built from ${{ needs.version.outputs.tag }}."
+            echo "Signed APK built from ${{ needs.release.outputs.tag }}."
           } > "$NOTES_FILE"
           gh release create "android-v$V" \
             "${{ steps.apk.outputs.path }}" \
@@ -245,14 +197,22 @@ jobs:
 
   desktop:
     name: Desktop DMG
-    needs: version
-    if: needs.version.outputs.bumped == 'true'
+    needs: release
+    if: needs.release.outputs.released == 'true'
     runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Inject version (not committed — only for this build)
+        env:
+          V: ${{ needs.release.outputs.version }}
+        run: |
+          jq --arg v "$V" '.version = $v' \
+            desktop/package.json > /tmp/pkg.json
+          mv /tmp/pkg.json desktop/package.json
 
       - uses: actions/setup-node@v4
         with:
@@ -286,15 +246,15 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          CHANGELOG: ${{ needs.version.outputs.notes }}
+          CHANGELOG: ${{ needs.release.outputs.notes }}
         run: |
-          V="${{ needs.version.outputs.version }}"
+          V="${{ needs.release.outputs.version }}"
           NOTES="Unsigned macOS DMG (universal — Intel + Apple Silicon).
 
           First launch: right-click News Dashboard.app in Finder → Open → Open
           Or in Terminal: xattr -cr \"/Applications/News Dashboard.app\"
 
-          Built from ${{ needs.version.outputs.tag }}."
+          Built from ${{ needs.release.outputs.tag }}."
           if [ -n "$CHANGELOG" ]; then
             NOTES="## What's new
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ packages = ["backend/news_dashboard"]
 # ── pytest ───────────────────────────────────────────────────────────────────
 [tool.pytest.ini_options]
 pythonpath = ["backend"]
-testpaths = ["backend/tests"]
+testpaths = ["backend/tests", "scripts"]
 addopts = "-ra --strict-markers --strict-config"
 filterwarnings = ["error::DeprecationWarning:news_dashboard.*"]
 
@@ -125,6 +125,10 @@ ignore = [
   "T201",    # print is the intended CLI output for shell consumption
 ]
 "scripts/test_bump_version.py" = [
+  "S101",    # asserts are the point of tests
+  "PT009",   # plain assert is preferred over self.assertEqual here
+]
+"scripts/test_update_changelog.py" = [
   "S101",    # asserts are the point of tests
   "PT009",   # plain assert is preferred over self.assertEqual here
 ]

--- a/scripts/next_version.sh
+++ b/scripts/next_version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Single source of truth for "what version is this build?", shared by ci.yml
+# (bakes it into the image) and release.yml (tags + builds artifacts).
+#
+# Computes the next semantic version from the latest v* tag plus the
+# Conventional Commits since it, falling back to the VERSION file when no tags
+# exist. Stateless: nothing is committed — the version lives in git tags.
+#
+# Prints KEY=VALUE lines to stdout:
+#   version=1.2.3
+#   code=1002003
+#   tag=v1.2.3
+#   bumped=true|false   # false = only ci/docs/test/chore commits since last tag
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+if [ -z "$LAST_TAG" ]; then
+  BASE=$(cat VERSION)
+  RESULT=$(python3 scripts/bump_version.py --current "$BASE")
+else
+  BASE="${LAST_TAG#v}"
+  RESULT=$(python3 scripts/bump_version.py --current "$BASE" --since-tag "$LAST_TAG")
+fi
+
+BUMP=$(printf '%s\n' "$RESULT" | sed -n 's/^bump=//p')
+NEXT=$(printf '%s\n' "$RESULT" | sed -n 's/^next=//p')
+CODE=$(printf '%s\n' "$RESULT" | sed -n 's/^code=//p')
+
+if [ "$BUMP" = "none" ]; then BUMPED=false; else BUMPED=true; fi
+
+echo "version=$NEXT"
+echo "code=$CODE"
+echo "tag=v$NEXT"
+echo "bumped=$BUMPED"

--- a/scripts/test_update_changelog.py
+++ b/scripts/test_update_changelog.py
@@ -1,0 +1,75 @@
+"""Unit tests for update_changelog.py — stdlib only, no pytest required.
+
+Run:  python3 -m unittest scripts/test_update_changelog.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from update_changelog import update_changelog
+
+_EXISTING = """# Changelog
+
+## 1.21.0
+- You can now share articles with other users directly within the platform!
+
+## 1.20.0
+- Smarter recommendations.
+"""
+
+
+class TestUpdateChangelog(unittest.TestCase):
+    def test_prepends_new_version(self):
+        out = update_changelog(_EXISTING, "1.22.0", "- A shiny new feature.")
+        # New entry sits at the top, right after the header.
+        self.assertTrue(out.startswith("# Changelog\n\n## 1.22.0\n- A shiny new feature."))
+        # Older entries are preserved.
+        self.assertIn("## 1.21.0", out)
+        self.assertIn("## 1.20.0", out)
+        # Header appears exactly once.
+        self.assertEqual(out.count("# Changelog"), 1)
+
+    def test_idempotent_same_inputs(self):
+        once = update_changelog(_EXISTING, "1.22.0", "- A shiny new feature.")
+        twice = update_changelog(once, "1.22.0", "- A shiny new feature.")
+        self.assertEqual(once, twice)
+        # Version heading appears exactly once after re-applying.
+        self.assertEqual(twice.count("## 1.22.0"), 1)
+
+    def test_replaces_existing_version_body(self):
+        first = update_changelog(_EXISTING, "1.22.0", "- Draft note.")
+        updated = update_changelog(first, "1.22.0", "- Final note.")
+        self.assertEqual(updated.count("## 1.22.0"), 1)
+        self.assertIn("- Final note.", updated)
+        self.assertNotIn("- Draft note.", updated)
+
+    def test_replaces_top_version_in_place(self):
+        # Re-bumping the newest version must not duplicate it.
+        updated = update_changelog(_EXISTING, "1.21.0", "- Revised wording.")
+        self.assertEqual(updated.count("## 1.21.0"), 1)
+        self.assertTrue(updated.startswith("# Changelog\n\n## 1.21.0\n- Revised wording."))
+        self.assertIn("## 1.20.0", updated)
+
+    def test_bootstraps_empty_changelog(self):
+        out = update_changelog("", "1.0.0", "- First release.")
+        self.assertEqual(out, "# Changelog\n\n## 1.0.0\n- First release.\n")
+
+    def test_bootstraps_header_only(self):
+        out = update_changelog("# Changelog\n", "1.0.0", "- First release.")
+        self.assertEqual(out, "# Changelog\n\n## 1.0.0\n- First release.\n")
+
+    def test_multiline_body(self):
+        body = "- First bullet.\n- Second bullet."
+        out = update_changelog(_EXISTING, "1.22.0", body)
+        self.assertIn("## 1.22.0\n- First bullet.\n- Second bullet.\n", out)
+
+    def test_trailing_newline_normalized(self):
+        out = update_changelog(_EXISTING, "1.22.0", "- Note.\n\n")
+        self.assertTrue(out.endswith("\n"))
+        self.assertFalse(out.endswith("\n\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Idempotently insert or replace a version entry in CHANGELOG.md.
+
+The PR-time release job re-runs on every push to a pull request, so this must be
+safe to apply repeatedly: re-applying the same version + body is a no-op, and a
+changed body for an existing version replaces it rather than duplicating it.
+
+CLI usage:
+    python3 scripts/update_changelog.py --version 1.2.3 --body-file notes.md
+    echo "- A bullet" | python3 scripts/update_changelog.py --version 1.2.3
+
+Reads the body from --body-file, else stdin. Writes the result back to the file
+named by --file (default: CHANGELOG.md).
+"""
+
+from __future__ import annotations
+
+_HEADER = "# Changelog"
+
+
+def update_changelog(text: str, version: str, body: str) -> str:
+    """Return CHANGELOG text with ``version`` placed at the top.
+
+    Any pre-existing section for ``version`` is removed first, so the result is
+    stable under repeated application (idempotent for identical inputs).
+    """
+    body = body.strip()
+    lines = text.splitlines()
+
+    # Split off the header: everything before the first "## " section heading.
+    i = 0
+    header_lines: list[str] = []
+    while i < len(lines) and not lines[i].startswith("## "):
+        header_lines.append(lines[i])
+        i += 1
+
+    # Group the remaining lines into sections, each starting at a "## " heading.
+    sections: list[list[str]] = []
+    current: list[str] | None = None
+    for line in lines[i:]:
+        if line.startswith("## "):
+            current = [line]
+            sections.append(current)
+        elif current is not None:
+            current.append(line)
+
+    # Drop any existing section for this version, then prepend the fresh one.
+    target = f"## {version}"
+    sections = [s for s in sections if s[0].strip() != target]
+    sections.insert(0, [target, *body.splitlines()])
+
+    header = "\n".join(header_lines).rstrip() or _HEADER
+    rendered = "\n\n".join("\n".join(s).rstrip() for s in sections)
+    return f"{header}\n\n{rendered}\n"
+
+
+def main() -> None:
+    import argparse
+    import pathlib
+    import sys
+
+    parser = argparse.ArgumentParser(description="Insert/replace a CHANGELOG entry")
+    parser.add_argument("--version", required=True, help="Version, e.g. 1.2.3")
+    parser.add_argument("--body-file", help="File with the entry body; else stdin")
+    parser.add_argument("--file", default="CHANGELOG.md", help="Changelog path")
+    args = parser.parse_args()
+
+    body = pathlib.Path(args.body_file).read_text() if args.body_file else sys.stdin.read()
+
+    path = pathlib.Path(args.file)
+    text = path.read_text() if path.exists() else ""
+    path.write_text(update_changelog(text, args.version, body))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #309

## Problem

`release.yml` ran on push to `main` and pushed a `chore: bump version` commit **directly to the protected `main` branch** — branch protection rejects this (`GH006: Protected branch update failed`), leaving a tag with no matching bump commit. It also ran in parallel with `ci.yml`, which builds & deploys the Docker image from the **pre-bump** merge commit. Since `/api/version` and `/api/changelog` are served from the in-repo `VERSION`/`CHANGELOG.md`, the deployed app always trailed the code by one release.

## Fix — derive the version at build time (no commit, no branch push)

The version is now computed from the latest `v*` tag plus the Conventional Commits since it (`scripts/next_version.sh`, shared by both workflows) and **baked into the image at build time** instead of committed:

- **`ci.yml`** (publish job): computes the version, summarizes the changelog via GitHub Models, writes `VERSION` + prepends `CHANGELOG.md` into the build context before the image build — so the running app reports the correct version and "what's new".
- **`release.yml`**: now push-triggered only; creates and pushes the **tag ref only** (never the protected branch → no `GH006`) and builds the Android/Desktop artifacts, injecting the version ephemerally at build time.
- **`scripts/update_changelog.py`**: idempotent insert/replace of a version's changelog entry (safe to re-run every build), with unit tests. `scripts/` is now collected by pytest so these run in CI.

## Tests

- `scripts/test_update_changelog.py` — 8 cases covering prepend, idempotency, in-place replace, bootstrap, multiline bodies.
- Verified `scripts/next_version.sh` output and the `update_changelog.py` CLI round-trip locally; full pytest collection is clean (765 tests).

## Notes

- The deployed app's version no longer lives in git — it is owned by tags + GitHub Releases (intentional trade-off chosen for this fix).
- Pre-existing dangling tags `v1.21.1`/`v1.22.0` from the failed runs are left in place per request; the next release computes forward from `v1.22.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)