### PR TITLE
fix: expose cold-start recommendation score for unscored feed candidates

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -17,6 +17,7 @@ import feedparser
 
 from .db import connect, init_db, insert_article_sql, placeholders, row_to_dict
 from .ingest_events import ingest_events
+from .recommendations import COLD_START_MODEL_VERSION
 from .sources import DEFAULT_SOURCES, SourceDefinition
 
 try:
@@ -706,6 +707,33 @@ _ARTICLE_LIST_COLUMNS = (
 )
 
 
+def _apply_recommendation_fields(d: dict[str, Any]) -> None:
+    """Resolve a feed row's recommendation score/model/signals in place.
+
+    Falls back to the cold-start score the feed already *ranks* by when no
+    personalized row has been persisted yet, so every candidate carries a
+    score/label.  Without this, high-churn sources (e.g. Hacker News AI) whose
+    fresh articles outpace the recompute sweep would show no recommendation
+    insight at all.
+    """
+    rec_score = d.pop("_uar_recommendation_score", None)
+    cold_start = d.pop("_cold_start_score", None)
+    persisted_model = d.pop("_uar_recommendation_model", None)
+    if rec_score is not None:
+        d["recommendation_score"] = float(rec_score)
+        d["recommendation_model"] = persisted_model
+    elif cold_start is not None:
+        d["recommendation_score"] = float(cold_start)
+        d["recommendation_model"] = COLD_START_MODEL_VERSION
+    else:
+        d["recommendation_score"] = None
+        d["recommendation_model"] = persisted_model
+    # The signals JSONB carries the per-factor breakdown (affinity, semantic,
+    # freshness, novelty) used to produce on-demand explanations; absent for
+    # unranked articles.
+    d["recommendation_signals"] = d.pop("_uar_recommendation_signals", None)
+
+
 def _article_list_select(alias: str | None = None) -> str:
     if alias is None:
         return _ARTICLE_LIST_COLUMNS
@@ -1056,7 +1084,8 @@ def _list_articles_for_user(  # noqa: PLR0913
           uas.restored_at AS _uas_restored_at,
           uar.recommendation_score AS _uar_recommendation_score,
           uar.model_version        AS _uar_recommendation_model,
-          uar.signals              AS _uar_recommendation_signals
+          uar.signals              AS _uar_recommendation_signals,
+          {_COLD_START_RECOMMENDATION_SCORE_SQL} AS _cold_start_score
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
         LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
@@ -1085,13 +1114,7 @@ def _list_articles_for_user(  # noqa: PLR0913
             d["archived_at"] = d.pop("_uas_archived_at", None)
             d["later_until"] = d.pop("_uas_later_until", None)
             d["restored_at"] = d.pop("_uas_restored_at", None)
-            rec_score = d.pop("_uar_recommendation_score", None)
-            d["recommendation_score"] = float(rec_score) if rec_score is not None else None
-            d["recommendation_model"] = d.pop("_uar_recommendation_model", None)
-            # The signals JSONB carries the per-factor breakdown (affinity,
-            # semantic, freshness, novelty) used to produce on-demand
-            # explanations; absent for unranked articles.
-            d["recommendation_signals"] = d.pop("_uar_recommendation_signals", None)
+            _apply_recommendation_fields(d)
             articles.append(d)
         _attach_also_from(conn, articles)
         return articles

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from .db import connect, init_db, row_to_dict
 
+COLD_START_MODEL_VERSION = "cold-start-v1"
 BEHAVIORAL_MODEL_VERSION = "behavioral-affinity-v1"
 SEMANTIC_MODEL_VERSION = "semantic-hybrid-v1"
 NOVELTY_MODEL_VERSION = "novelty-freshness-v1"
@@ -289,7 +290,7 @@ def upsert_recommendation_score(  # noqa: PLR0913
     database_url: str | None = None,
     cold_start_score: float | None = None,
     signals: dict[str, Any] | None = None,
-    model_version: str = "cold-start-v1",
+    model_version: str = COLD_START_MODEL_VERSION,
 ) -> None:
     """Persist recommendation metadata for one user/article pair."""
     init_db(db_path, database_url=database_url)

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -404,10 +404,16 @@ def test_api_articles_includes_recommendation_score(
         app.dependency_overrides.pop(require_auth, None)
 
 
-def test_api_articles_recommendation_score_null_when_unranked(
+def test_api_articles_recommendation_score_falls_back_to_cold_start_when_unranked(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """GET /api/articles?state=today returns null recommendation_score for unranked articles."""
+    """GET /api/articles?state=today exposes the cold-start score for unranked articles.
+
+    The feed already *ranks* unranked articles by their cold-start score, so it
+    surfaces that same score (not ``null``) and labels the model cold-start —
+    otherwise high-churn sources whose fresh items outpace the recompute sweep
+    would show no recommendation insight at all.
+    """
     db = tmp_path / "rec-score-null.db"
     monkeypatch.setattr(db_mod, "DB_PATH", db)
     sync_sources(db)
@@ -430,6 +436,8 @@ def test_api_articles_recommendation_score_null_when_unranked(
             items = resp.json()["items"]
             article = next((a for a in items if a["id"] == aid), None)
             assert article is not None
-            assert article["recommendation_score"] is None
+            assert article["recommendation_score"] is not None
+            assert article["recommendation_score"] > 0
+            assert article["recommendation_model"] == "cold-start-v1"
     finally:
         app.dependency_overrides.pop(require_auth, None)

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -211,10 +211,13 @@ def test_pg_list_articles_exposes_recommendation_metadata(pg_env: str) -> None:
     assert scored["recommendation_signals"]["semantic_adjustment"] == pytest.approx(12.0)
     assert scored["recommendation_signals"]["affinity_adjustment"] == pytest.approx(8.0)
 
-    # Articles without recommendation metadata degrade gracefully to None.
+    # Articles without a persisted personalized row fall back to the cold-start
+    # score the feed already ranks by, so every candidate carries a score/label.
+    # The per-factor signal breakdown stays None (no personalized factors yet).
     unscored = by_id[aid_unscored]
-    assert unscored["recommendation_score"] is None
-    assert unscored["recommendation_model"] is None
+    assert unscored["recommendation_score"] is not None
+    assert unscored["recommendation_score"] > 0
+    assert unscored["recommendation_model"] == "cold-start-v1"
     assert unscored["recommendation_signals"] is None
 
 

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -237,10 +237,13 @@ def test_today_stays_intact_when_no_scores_have_been_computed(
 
     ids = {int(item["id"]) for item in items}
     assert {first, second} <= ids
-    # Unscored articles surface a null score rather than erroring.
+    # Unscored articles surface the cold-start score the feed already ranks by,
+    # so every candidate carries a score/label rather than showing no insight.
     for item in items:
         if int(item["id"]) in {first, second}:
-            assert item["recommendation_score"] is None
+            assert item["recommendation_score"] is not None
+            assert item["recommendation_score"] > 0
+            assert item["recommendation_model"] == "cold-start-v1"
 
 
 # ── Reader path exposes the same score metadata as the Today list ─────────────

--- a/backend/tests/test_today_recommendations.py
+++ b/backend/tests/test_today_recommendations.py
@@ -105,6 +105,74 @@ def _today_ids(client: TestClient) -> list[int]:
     return [int(item["id"]) for item in response.json()["items"]]
 
 
+def _today_items_by_id(client: TestClient) -> dict[int, dict[str, Any]]:
+    response = client.get("/api/articles", params={"state": "today", "limit": 20})
+    assert response.status_code == 200
+    return {int(item["id"]): item for item in response.json()["items"]}
+
+
+def test_today_endpoint_exposes_cold_start_score_for_unscored_candidate(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """Every feed candidate must carry a score/label, even with no persisted row.
+
+    A high-churn source (e.g. Hacker News AI) constantly ingests fresh articles
+    that outpace the recompute sweep, so they have no ``user_article_recommendations``
+    row.  The feed still ranks them by the cold-start score, so it must expose
+    that same score (not ``null``) — otherwise the UI shows "no recommendation
+    insight" for them.
+    """
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "cold-start-expose.db")
+    _insert_source(db_path, "hacker-news-ai", category="ai", priority=95)
+    user_id = _make_user(db_path, "alice")
+
+    unscored = _insert_article(
+        db_path,
+        "hacker-news-ai",
+        "fresh-ai",
+        category="ai",
+        importance=80,
+        tags="agents,llm",
+        discovered_at="2026-06-21T12:00:00+00:00",
+    )
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            items = _today_items_by_id(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert unscored in items
+    item = items[unscored]
+    assert item["recommendation_score"] is not None
+    assert item["recommendation_score"] > 0
+    assert item["recommendation_model"] == "cold-start-v1"
+
+
+def test_today_endpoint_keeps_persisted_score_over_cold_start(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """A persisted personalized score must win over the cold-start fallback."""
+    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "persisted-wins.db")
+    _insert_source(db_path, "quiet-source", category="misc", priority=1)
+    user_id = _make_user(db_path, "alice")
+    scored = _insert_article(db_path, "quiet-source", "scored", category="misc", importance=1)
+
+    upsert_recommendation_score(
+        user_id, scored, 42.0, db_path=db_path, model_version="behavioral-affinity-v1"
+    )
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            items = _today_items_by_id(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    item = items[scored]
+    assert item["recommendation_score"] == 42.0
+    assert item["recommendation_model"] == "behavioral-affinity-v1"
+
+
 def test_today_endpoint_orders_by_persisted_scores_and_keeps_missing_visible(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:


### PR DESCRIPTION
Closes #311

## Problem

Articles from high-churn / freshly-ingested sources — most visibly **Hacker News AI** (`hacker-news-ai`, the `hnrss.org/newest?q=AI` search feed) — showed **no recommendation insight/label** in the Today feed.

## Root cause

The user feed query in `backend/news_dashboard/ingest.py` **ranks** results by `COALESCE(uar.recommendation_score, _COLD_START_RECOMMENDATION_SCORE_SQL)`, but the value it **exposed** to the frontend was the raw `uar.recommendation_score`, which is `NULL` whenever no personalized recommendation row has been persisted yet. The frontend's `recommendationLabel(null)` then returns `null`, so no band (Recommended / Relevant / Low) is rendered.

Hacker News AI is the most visible victim because its newest-search feed constantly ingests fresh articles that outpace the background recompute sweep, so those articles never have a persisted score.

## Fix

Expose the cold-start score (the same value already used for ranking) as the `recommendation_score` fallback when no personalized row exists, reporting `recommendation_model` as `cold-start-v1` in that case. Now **every feed candidate is scored and labeled**. Persisted personalized scores are unchanged, and the per-factor `recommendation_signals` breakdown stays `null` on fallback (there are no personalized factors yet, so the frontend uses its cold-start explanation).

The per-row resolution was extracted into a small `_apply_recommendation_fields` helper to keep `_list_articles_for_user` within the statement-count limit.

Scope note: this changes the **Today list** path only. The single-article reader endpoint keeps its existing "null when unranked" contract (it has its own cold-start explanation on the client).

## Tests (TDD)

- `test_today_recommendations.py`: new tests that an unscored candidate exposes a non-null cold-start score + `cold-start-v1` model, and that a persisted personalized score still wins.
- Updated `test_per_user_article_state.py`, `test_postgres_types.py`, and `test_recommendation_contracts.py`, which previously asserted the old "null when unranked" list behavior, to the new cold-start-fallback spec.

Verified locally (Postgres on :55432): ruff, mypy, pyrefly clean; affected suites pass (51 passed across the recommendation suites). The `ty` and pre-push hooks fail only on local-env gaps (`testcontainers` not installed / `DATABASE_URL` not exported into the hook env) unrelated to this change — CI runs both with the dependency and DB available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
