### PR TITLE
chore: enforce ready-for-agent label on issues created via tdd-ship

### DIFF
--- a/.claude/skills/tdd-ship/SKILL.md
+++ b/.claude/skills/tdd-ship/SKILL.md
@@ -45,11 +45,18 @@ Capture the intent before writing code, so the change has a tracked rationale.
 
 ```bash
 gh issue create --title "<concise imperative title>" \
-  --body "<what & why; acceptance criteria as a checklist>"
+  --body "<what & why; acceptance criteria as a checklist>" \
+  --label "ready-for-agent"
 ```
 
 Keep the title in the repo's voice (e.g. `fix:`/`feat:` style matches commits).
 Note the issue number — you'll reference it in the branch and the PR.
+
+**Always apply the `ready-for-agent` label** to every issue you open. The body
+must be fully specified — context, file references, and acceptance criteria as a
+checklist — so an agent can pick it up with no further human context. If you add
+the label to an existing issue, use `gh issue edit <issue#> --add-label
+"ready-for-agent"`.
 
 ### 2. Branch off `main`
 


### PR DESCRIPTION
Closes #322

Updates step 1 of the `tdd-ship` skill so every issue it opens is labeled `ready-for-agent` and is fully specified enough for an agent to pick up with no human context. Adds `--label "ready-for-agent"` to the `gh issue create` example, documents the fully-specified-body requirement, and shows `gh issue edit --add-label` for existing issues.

Docs/skill-only change — no behavioral code, so no automated test applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)