### PR TITLE
chore: sync Codex skills with Claude skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,8 @@
 - Before starting work, fetch and rebase on `origin/main`.
 - Keep working branches fast-forwardable with `origin/main`; resolve divergence by rebasing rather than merging.
 - Do not use `git push --no-verify` when pushing changes.
+
+## Agent Skills
+
+- Keep Claude and Codex skill access synchronized at all times.
+- `.agents/skills` must point at `.claude/skills` so Codex agents see the same project skills without maintaining duplicate copies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ ignore = [
   "S101",    # asserts are the point of tests
   "PT009",   # plain assert is preferred over self.assertEqual here
 ]
+"scripts/test_agent_skill_sync.py" = [
+  "S101",    # asserts are the point of tests
+]
 
 [tool.ruff.lint.pylint]
 max-args = 7

--- a/scripts/test_agent_skill_sync.py
+++ b/scripts/test_agent_skill_sync.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_codex_agent_skills_link_to_claude_skills() -> None:
+    agents_skills = ROOT / ".agents" / "skills"
+    claude_skills = ROOT / ".claude" / "skills"
+
+    assert agents_skills.is_symlink()
+    assert agents_skills.readlink() == Path("../.claude/skills")
+    assert agents_skills.resolve() == claude_skills.resolve()
+
+    claude_skill_names = sorted(path.parent.name for path in claude_skills.glob("*/SKILL.md"))
+    agents_skill_names = sorted(path.parent.name for path in agents_skills.glob("*/SKILL.md"))
+
+    assert agents_skill_names == claude_skill_names
+    assert agents_skill_names
+
+
+def test_agent_notes_document_skill_sync_contract() -> None:
+    agent_notes = (ROOT / "AGENTS.md").read_text()
+
+    assert "Keep Claude and Codex skill access synchronized at all times." in agent_notes
+    assert "`.agents/skills` must point at `.claude/skills`" in agent_notes


### PR DESCRIPTION
Closes #324

## Summary
- expose `.claude/skills` to Codex through `.agents/skills` as a symlink
- document the Claude/Codex skill sync contract in `AGENTS.md`
- add a regression test for the symlink and documentation contract

## Tests
- `pytest scripts/test_agent_skill_sync.py`
- `ruff check scripts/test_agent_skill_sync.py pyproject.toml`
- `ruff format --check scripts/test_agent_skill_sync.py`
- pre-push hooks, including backend pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)