### PR TITLE
feat: attribute all AI usage to users in Langfuse

### DIFF
--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -91,7 +91,7 @@ def _embed(text: str) -> list[float]:
     response = client.embeddings.create(
         model="text-embedding-3-small",
         input=text,
-        **trace_params("article-embedding", tags=["embedding"]),
+        **trace_params("article-embedding", tags=["embedding"], user_id="system"),
     )
     return list(response.data[0].embedding)
 

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -75,6 +75,9 @@ def generate_audio(
 
     client = get_openai_client(api_key=api_key)
     logger.info("Generating TTS audio for article %d (%d chars)", article_id, len(text))
+    # audio/speech does not accept Langfuse trace kwargs, so TTS calls are
+    # intentionally untraced. The wrapped client still routes through the same
+    # factory but no span metadata is attached.
     with client.audio.speech.with_streaming_response.create(
         model=_MODEL, voice=_VOICE, input=text
     ) as response:

--- a/backend/tests/test_user_attribution.py
+++ b/backend/tests/test_user_attribution.py
@@ -1,0 +1,206 @@
+"""Assert that user_id is threaded to Langfuse traces in all AI features.
+
+Each test checks that the relevant ai_client wrapper function (chat_create or
+trace_params) is called with the expected user attribution — either a real user
+id or the "system" label for background / ingest-time calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+_ARTICLE: dict[str, Any] = {
+    "id": 1,
+    "title": "Test Article",
+    "body": "Article body text with enough content to process.",
+    "summary": "Article summary.",
+}
+
+_CANDIDATES: list[dict[str, Any]] = [
+    {
+        "id": 1,
+        "title": "Some Article",
+        "source_name": "Test Source",
+        "category": "tech",
+        "summary": "Some summary",
+    }
+]
+
+
+def _mock_completion(content: str = "• Bullet") -> MagicMock:
+    completion = MagicMock()
+    completion.choices[0].message.content = content
+    return completion
+
+
+def _mock_json_completion(json_text: str) -> MagicMock:
+    completion = MagicMock()
+    completion.choices[0].message.content = json_text
+    return completion
+
+
+# ── insights ──────────────────────────────────────────────────────────────────
+
+
+def test_generate_insights_threads_user_id_to_chat_create() -> None:
+    from news_dashboard.ai_client import ManagedPrompt
+    from news_dashboard.insights import generate_insights
+
+    mock_cc = MagicMock(return_value=_mock_completion())
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.get_prompt", return_value=ManagedPrompt("prompt", None)),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+    ):
+        generate_insights(_ARTICLE, user_id=42)
+
+    assert mock_cc.call_args.kwargs["user_id"] == 42
+
+
+def test_generate_insights_passes_none_user_id_when_no_user() -> None:
+    from news_dashboard.ai_client import ManagedPrompt
+    from news_dashboard.insights import generate_insights
+
+    mock_cc = MagicMock(return_value=_mock_completion())
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.get_prompt", return_value=ManagedPrompt("prompt", None)),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+    ):
+        generate_insights(_ARTICLE)
+
+    assert mock_cc.call_args.kwargs["user_id"] is None
+
+
+# ── embeddings: article embedding tags "system" ────────────────────────────────
+
+
+def test_embed_passes_system_user_id_to_trace_params() -> None:
+    from news_dashboard.embeddings import _embed
+
+    mock_tp = MagicMock(return_value={})
+    mock_response = MagicMock()
+    mock_response.data[0].embedding = [0.1, 0.2, 0.3]
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = mock_response
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.trace_params", new=mock_tp),
+    ):
+        _embed("some text")
+
+    mock_tp.assert_called_once_with("article-embedding", tags=["embedding"], user_id="system")
+
+
+# ── embeddings: ask-ai answer threads real user_id ────────────────────────────
+
+
+def test_answer_threads_user_id_to_chat_create() -> None:
+    from news_dashboard.embeddings import _answer
+
+    mock_cc = MagicMock(return_value=_mock_completion("The answer."))
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+    ):
+        _answer("system prompt", "user prompt", user_id=7)
+
+    assert mock_cc.call_args.kwargs["user_id"] == 7
+
+
+def test_answer_passes_none_user_id_when_absent() -> None:
+    from news_dashboard.embeddings import _answer
+
+    mock_cc = MagicMock(return_value=_mock_completion("The answer."))
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+    ):
+        _answer("system prompt", "user prompt")
+
+    assert mock_cc.call_args.kwargs["user_id"] is None
+
+
+# ── body_fetch: AI body extraction threads user_id ────────────────────────────
+
+
+def test_ai_extract_body_threads_user_id_to_chat_create() -> None:
+    from news_dashboard.body_fetch import _ai_extract_body
+
+    mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
+    mock_http_response = MagicMock()
+    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+        patch("httpx.get", return_value=mock_http_response),
+    ):
+        _ai_extract_body("https://example.com/article", user_id=55)
+
+    assert mock_cc.call_args.kwargs["user_id"] == 55
+
+
+def test_ai_extract_body_passes_none_user_id_by_default() -> None:
+    from news_dashboard.body_fetch import _ai_extract_body
+
+    mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
+    mock_http_response = MagicMock()
+    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+        patch("httpx.get", return_value=mock_http_response),
+    ):
+        _ai_extract_body("https://example.com/article")
+
+    assert mock_cc.call_args.kwargs["user_id"] is None
+
+
+# ── briefings: generation threads user_id ─────────────────────────────────────
+
+
+def test_call_openai_threads_user_id_to_chat_create() -> None:
+    from news_dashboard.ai_client import ManagedPrompt
+    from news_dashboard.briefings import _call_openai
+
+    json_text = '{"title":"T","summary":"S","sections":[],"worth_opening":[]}'
+    mock_cc = MagicMock(return_value=_mock_json_completion(json_text))
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.get_prompt", return_value=ManagedPrompt("system", None)),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+    ):
+        _call_openai(_CANDIDATES, "gpt-4o-mini", user_id=33)
+
+    assert mock_cc.call_args.kwargs["user_id"] == 33
+
+
+def test_call_openai_passes_none_user_id_for_system_briefings() -> None:
+    from news_dashboard.ai_client import ManagedPrompt
+    from news_dashboard.briefings import _call_openai
+
+    json_text = '{"title":"T","summary":"S","sections":[],"worth_opening":[]}'
+    mock_cc = MagicMock(return_value=_mock_json_completion(json_text))
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.get_prompt", return_value=ManagedPrompt("system", None)),
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+    ):
+        _call_openai(_CANDIDATES, "gpt-4o-mini")
+
+    assert mock_cc.call_args.kwargs["user_id"] is None


### PR DESCRIPTION
Closes #313

## Summary

- Tag article embeddings with `user_id="system"` in `trace_params` so background ingest-time traces are bucketed under a system label in Langfuse (previously they had no user attribution at all)
- Document TTS (`audio.speech`) as intentionally untraced — the `with_streaming_response.create` API does not accept extra kwargs for Langfuse metadata; the wrapped client still routes through the factory for consistency
- Add `test_user_attribution.py` with 9 tests asserting that `chat_create` receives the correct `user_id` for every user-facing AI feature (insights, ask-ai, body fetch, briefings) and that `_embed` uses the `"system"` label

## Audit of AI endpoints

All user-facing AI endpoints in `main.py` already thread `current_user["id"]` through to the Langfuse trace:
- `/api/briefings` → `generate_briefing(user_id=current_user["id"])` ✅
- `/api/articles/{id}/insights` → `get_or_generate_insights(article_id, user_id=current_user["id"])` ✅  
- `/api/articles/{id}/body` → `fetch_and_cache_body(article_id, user_id=current_user["id"])` → `_ai_extract_body(url, user_id=user_id)` ✅
- `/api/ask` → `ask(q, user_id=current_user["id"])` → `_answer(..., user_id=user_id)` ✅
- Article embeddings: background/system-level, tagged `user_id="system"` ✅ (this PR)
- TTS: intentionally untraced (documented in code comment) ✅ (this PR)

## Test plan

- [x] `python -m pytest backend/tests/test_user_attribution.py` — 9/9 pass
- [x] `make lint` — clean
- [x] `make typecheck` — mypy ✅, ty ✅, pyrefly ✅
- [ ] CI (local Postgres has a transient DiskFull preventing pre-push hook; CI will validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)