### PR TITLE
chore: enforce and use absolute imports in backend codebase (closes #315)

### DIFF
--- a/backend/news_dashboard/analytics.py
+++ b/backend/news_dashboard/analytics.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db
+from news_dashboard.db import connect, init_db
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -14,7 +14,7 @@ import httpx
 from fastapi import Depends, HTTPException, Request
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 
-from .db import connect, init_db, row_to_dict
+from news_dashboard.db import connect, init_db, row_to_dict
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -15,8 +15,8 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db, row_to_dict
-from .scraper import TIMEOUT_SECS, USER_AGENT
+from news_dashboard.db import connect, init_db, row_to_dict
+from news_dashboard.scraper import TIMEOUT_SECS, USER_AGENT
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -15,7 +15,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
-from .db import connect, row_to_dict
+from news_dashboard.db import connect, row_to_dict
 
 CANDIDATE_LIMIT = 40
 DEFAULT_BRIEFING_MODEL = "gpt-4o-mini"

--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typer
 
-from .ingest import ingest_all, list_articles, sync_sources
+from news_dashboard.ingest import ingest_all, list_articles, sync_sources
 
 app = typer.Typer(help="News dashboard maintenance CLI")
 
@@ -20,7 +20,7 @@ def ingest() -> None:
         typer.echo(f"{source}: {count}")
     typer.echo(f"inserted: {sum(value for value in results.values() if value > 0)}")
     # Short-lived process: flush any buffered Langfuse traces before exit.
-    from .ai_client import flush
+    from news_dashboard.ai_client import flush
 
     flush()
 
@@ -36,7 +36,7 @@ def articles(status: str | None = None, limit: int = 20) -> None:
 @app.command(name="rec-health")
 def rec_health() -> None:
     """Print a diagnostic snapshot of stale/missing recommendation scores."""
-    from .recommendation_jobs import recommendation_health
+    from news_dashboard.recommendation_jobs import recommendation_health
 
     health = recommendation_health()
     for key in ("total_scores", "stale_scores", "outdated_scores", "missing_scores"):
@@ -49,7 +49,7 @@ def rec_health() -> None:
 @app.command(name="rec-recalc")
 def rec_recalc() -> None:
     """Recalculate stale, missing, or superseded recommendation scores."""
-    from .recommendation_jobs import recalculate_stale_recommendations
+    from news_dashboard.recommendation_jobs import recalculate_stale_recommendations
 
     summary = recalculate_stale_recommendations()
     for key, value in summary.as_dict().items():
@@ -68,8 +68,8 @@ def improve_prompt(
     the result to Langfuse under the 'candidate' label for human review. Does NOT
     auto-deploy: promote the candidate to 'production' in the Langfuse UI.
     """
-    from .embeddings import ASK_SYSTEM_PROMPT
-    from .prompt_optimizer import PromptOptimizerError, optimize_prompt
+    from news_dashboard.embeddings import ASK_SYSTEM_PROMPT
+    from news_dashboard.prompt_optimizer import PromptOptimizerError, optimize_prompt
 
     fallback = ASK_SYSTEM_PROMPT if name == "ask-system" else ""
     try:
@@ -90,7 +90,7 @@ def improve_prompt(
     )
     typer.echo("review it in Langfuse and promote to 'production' if it is an improvement.")
 
-    from .ai_client import flush
+    from news_dashboard.ai_client import flush
 
     flush()
 

--- a/backend/news_dashboard/digest.py
+++ b/backend/news_dashboard/digest.py
@@ -13,7 +13,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
 
-from .db import connect, init_db, row_to_dict
+from news_dashboard.db import connect, init_db, row_to_dict
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -82,12 +82,31 @@ def embedding_text(
 # ── OpenAI embedding ───────────────────────────────────────────────────────
 
 
+def _embeddings_ai_config() -> tuple[str, str | None]:
+    """Resolve the (api_key, base_url) for embedding generation.
+
+    Embeddings can target any OpenAI-compatible endpoint (e.g. a self-hosted
+    gateway) via ``OPENAI_EMBEDDINGS_BASE_URL`` / ``OPENAI_EMBEDDINGS_API_KEY``,
+    falling back to the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The
+    base URL is optional; when unset the official OpenAI endpoint is used.
+    """
+    api_key = os.getenv("OPENAI_EMBEDDINGS_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = (
+            "Ask AI requires OPENAI_EMBEDDINGS_API_KEY (or OPENAI_API_KEY) to "
+            "generate article embeddings. Set it in the app environment."
+        )
+        raise MissingAICredentialsError(msg)
+    base_url = os.getenv("OPENAI_EMBEDDINGS_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    return api_key, base_url
+
+
 def _embed(text: str) -> list[float]:
     """Embed *text* with text-embedding-3-small via the OpenAI SDK."""
     from news_dashboard.ai_client import get_openai_client, trace_params
 
-    api_key = _require_env("OPENAI_API_KEY", "generate article embeddings")
-    client = get_openai_client(api_key=api_key)
+    api_key, base_url = _embeddings_ai_config()
+    client = get_openai_client(api_key=api_key, base_url=base_url)
     response = client.embeddings.create(
         model="text-embedding-3-small",
         input=text,
@@ -145,7 +164,7 @@ def cosine_similarity(a: list[float], b: list[float]) -> float:
 
 def ensure_article_embedded(article_id: int, db_path: Any = None) -> None:
     """Generate and persist an embedding for *article_id* if not already set."""
-    from .db import connect, init_db
+    from news_dashboard.db import connect, init_db
 
     init_db(db_path)
     with connect(db_path) as conn:
@@ -172,7 +191,7 @@ def embed_all_eligible(db_path: Any = None, *, include_all: bool = False) -> int
     Called lazily on the first /api/ask request to backfill existing articles.
     Returns the number of articles newly embedded.
     """
-    from .db import connect, init_db
+    from news_dashboard.db import connect, init_db
 
     status_filter = "status != 'archived'" if include_all else "status IN ('saved', 'read')"
     init_db(db_path)
@@ -190,7 +209,7 @@ def embed_all_eligible(db_path: Any = None, *, include_all: bool = False) -> int
             continue
         vector = _embed(text)
         blob = _pack(vector)
-        from .db import connect as _connect
+        from news_dashboard.db import connect as _connect
 
         with _connect(db_path) as conn:
             conn.execute(
@@ -224,7 +243,7 @@ def ask(
           "sources": [{"id": int, "title": str, "url": str}, ...]
         }
     """
-    from .db import connect, init_db
+    from news_dashboard.db import connect, init_db
 
     # 1. Backfill embeddings for any eligible articles not yet embedded
     embed_all_eligible(db_path, include_all=include_all)

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -15,10 +15,10 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import feedparser
 
-from .db import connect, init_db, insert_article_sql, placeholders, row_to_dict
-from .ingest_events import ingest_events
-from .recommendations import COLD_START_MODEL_VERSION
-from .sources import DEFAULT_SOURCES, SourceDefinition
+from news_dashboard.db import connect, init_db, insert_article_sql, placeholders, row_to_dict
+from news_dashboard.ingest_events import ingest_events
+from news_dashboard.recommendations import COLD_START_MODEL_VERSION
+from news_dashboard.sources import DEFAULT_SOURCES, SourceDefinition
 
 try:
     from rapidfuzz.distance import Levenshtein
@@ -298,7 +298,7 @@ def _fetch_article_snippet(url: str) -> str:
     can treat a missing snippet as a no-op rather than an error.
     """
     try:
-        from .body_fetch import extract_body  # lazy — optional dep
+        from news_dashboard.body_fetch import extract_body  # lazy — optional dep
 
         text, status = extract_body(url)
         if status == "ok" and text:
@@ -422,7 +422,7 @@ def _fetch_nitter_feed(source: SourceDefinition) -> list[dict[str, Any]]:
 
 def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> SourceIngestOutcome:
     """Fetch and insert articles for a single source. Returns count inserted."""
-    from .scraper import scrape_source
+    from news_dashboard.scraper import scrape_source
 
     checked_at = now_iso()
     inserted = 0
@@ -920,7 +920,7 @@ def _upsert_uas(  # noqa: PLR0913
     # A workflow/star change reshapes this user's affinity + semantic profile, so
     # every stored score derived from it is now stale and eligible for a
     # background recalculation (see recommendation_jobs.recalculate_stale_recommendations).
-    from .recommendation_jobs import mark_user_recommendations_stale
+    from news_dashboard.recommendation_jobs import mark_user_recommendations_stale
 
     mark_user_recommendations_stale(conn, user_id)
 
@@ -1366,7 +1366,7 @@ def set_article_status(
     # Lazily embed articles when they become saved/read (fire-and-forget; ignore errors)
     if result and status in {"saved", "read"}:
         try:
-            from .embeddings import ensure_article_embedded
+            from news_dashboard.embeddings import ensure_article_embedded
 
             ensure_article_embedded(article_id, db_path)
         except Exception:  # embedding is optional — don't break the status update

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -11,8 +11,8 @@ import logging
 import os
 from typing import Any
 
-from .body_fetch import get_article
-from .db import connect, init_db
+from news_dashboard.body_fetch import get_article
+from news_dashboard.db import connect, init_db
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/keycloak_admin.py
+++ b/backend/news_dashboard/keycloak_admin.py
@@ -15,7 +15,7 @@ from typing import Any
 import httpx
 from fastapi import HTTPException
 
-from .auth import keycloak_config
+from news_dashboard.auth import keycloak_config
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -26,8 +26,8 @@ from pydantic import BaseModel
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response as StarletteResponse
 
-from .analytics import admin_analytics, record_events
-from .auth import (
+from news_dashboard.analytics import admin_analytics, record_events
+from news_dashboard.auth import (
     _session_days,
     authenticate,
     create_session_token,
@@ -45,8 +45,8 @@ from .auth import (
     require_auth,
     update_password,
 )
-from .body_fetch import fetch_and_cache_body, get_article, prefetch_article_bodies
-from .briefings import (
+from news_dashboard.body_fetch import fetch_and_cache_body, get_article, prefetch_article_bodies
+from news_dashboard.briefings import (
     BriefingAINotConfiguredError,
     BriefingGenerationError,
     generate_briefing,
@@ -54,8 +54,8 @@ from .briefings import (
     get_latest_briefing,
     list_briefings,
 )
-from .db import connect, describe_database, init_db, row_to_dict
-from .ingest import (
+from news_dashboard.db import connect, describe_database, init_db, row_to_dict
+from news_dashboard.ingest import (
     get_user_summary,
     ingest_all,
     list_articles,
@@ -66,9 +66,9 @@ from .ingest import (
     sync_sources,
     transition_article_state,
 )
-from .ingest_events import stream_ingest_events
-from .run_history import get_ingest_run_sources, list_ingest_runs
-from .scheduler import (
+from news_dashboard.ingest_events import stream_ingest_events
+from news_dashboard.run_history import get_ingest_run_sources, list_ingest_runs
+from news_dashboard.scheduler import (
     get_interval_minutes,
     get_next_ingest_at,
     is_paused,
@@ -78,8 +78,8 @@ from .scheduler import (
     start_scheduler,
     stop_scheduler,
 )
-from .source_health import list_source_health
-from .stats import (
+from news_dashboard.source_health import list_source_health
+from news_dashboard.stats import (
     article_counts,
     articles_over_time,
     category_mix,
@@ -306,7 +306,7 @@ app.include_router(public_router)
 def _embed_article_background(article_id: int) -> None:
     """Background task: generate embedding for a 'done' article, silently skipping on errors."""
     try:
-        from .embeddings import ensure_article_embedded
+        from news_dashboard.embeddings import ensure_article_embedded
 
         ensure_article_embedded(article_id)
     except Exception:
@@ -476,7 +476,7 @@ def article_audio(
     article_id: int,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> FileResponse:
-    from .tts import TTSNotConfiguredError, generate_audio
+    from news_dashboard.tts import TTSNotConfiguredError, generate_audio
 
     article = get_article(article_id, user_id=current_user["id"])
     if not article:
@@ -495,7 +495,7 @@ def article_insights(
     article_id: int,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .insights import InsightsNotConfiguredError, get_or_generate_insights
+    from news_dashboard.insights import InsightsNotConfiguredError, get_or_generate_insights
 
     try:
         bullets = get_or_generate_insights(article_id, user_id=current_user["id"])
@@ -568,7 +568,7 @@ def snooze_later(
 def list_shareable_users(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .shares import shareable_users
+    from news_dashboard.shares import shareable_users
 
     return {"items": shareable_users(current_user["id"])}
 
@@ -580,7 +580,7 @@ def share_article_endpoint(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
     background_tasks: BackgroundTasks,
 ) -> dict[str, Any]:
-    from .shares import ShareError, share_article
+    from news_dashboard.shares import ShareError, share_article
 
     try:
         share = share_article(
@@ -604,7 +604,7 @@ def share_article_endpoint(
 
 
 def _notify_share_recipient(*, to_user_id: int, sender: str, article_title: str) -> None:
-    from .push import send_push_for_user
+    from news_dashboard.push import send_push_for_user
 
     send_push_for_user(
         to_user_id,
@@ -617,7 +617,7 @@ def _notify_share_recipient(*, to_user_id: int, sender: str, article_title: str)
 def list_shares(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .shares import list_received_shares, unread_share_count
+    from news_dashboard.shares import list_received_shares, unread_share_count
 
     return {
         "items": list_received_shares(current_user["id"]),
@@ -629,7 +629,7 @@ def list_shares(
 def shares_unread_count(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .shares import unread_share_count
+    from news_dashboard.shares import unread_share_count
 
     return {"unread": unread_share_count(current_user["id"])}
 
@@ -639,14 +639,14 @@ def mark_share_read_endpoint(
     share_id: int,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .shares import mark_share_read
+    from news_dashboard.shares import mark_share_read
 
     return {"ok": mark_share_read(share_id, current_user["id"])}
 
 
 @api.get("/api/articles/{article_id}/read")
 def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict[str, Any]:
-    from .digest import verify_read_token
+    from news_dashboard.digest import verify_read_token
 
     if not verify_read_token(article_id, token):
         raise HTTPException(status_code=403, detail="invalid or expired token")
@@ -836,14 +836,14 @@ def health_details() -> dict[str, Any]:
 
 @api.get("/api/recommendations/health", dependencies=_admin_dep)
 def recommendations_health_endpoint() -> dict[str, Any]:
-    from .recommendation_jobs import recommendation_health
+    from news_dashboard.recommendation_jobs import recommendation_health
 
     return recommendation_health()
 
 
 @api.post("/api/recommendations/recalculate", dependencies=_admin_dep)
 def recommendations_recalculate_endpoint() -> dict[str, Any]:
-    from .recommendation_jobs import recalculate_stale_recommendations
+    from news_dashboard.recommendation_jobs import recalculate_stale_recommendations
 
     return recalculate_stale_recommendations().as_dict()
 
@@ -859,7 +859,7 @@ def recommendations_recalculate_mine_endpoint(
     client can tell the user whether personalization has anything to learn from
     yet (zero means no interaction history exists).
     """
-    from .recommendations import recompute_user_recommendations
+    from news_dashboard.recommendations import recompute_user_recommendations
 
     scored = recompute_user_recommendations(current_user["id"])
     return {"scored": scored}
@@ -985,7 +985,7 @@ class PushSubscribeRequest(BaseModel):
 def get_notification_settings(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .push import get_vapid_public_key
+    from news_dashboard.push import get_vapid_public_key
 
     uid = current_user["id"]
     with connect() as conn:
@@ -1040,7 +1040,7 @@ def push_subscribe(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
     payload: PushSubscribeRequest,
 ) -> dict[str, Any]:
-    from .push import save_push_subscription
+    from news_dashboard.push import save_push_subscription
 
     save_push_subscription(
         current_user["id"],
@@ -1055,7 +1055,7 @@ def push_subscribe(
 def push_unsubscribe(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .push import delete_push_subscriptions
+    from news_dashboard.push import delete_push_subscriptions
 
     delete_push_subscriptions(current_user["id"])
     return {"unsubscribed": True}
@@ -1071,7 +1071,7 @@ def ask_ai(
     payload: AskRequest,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from .embeddings import ask
+    from news_dashboard.embeddings import ask
 
     q = payload.query.strip()
     if not q:
@@ -1100,7 +1100,7 @@ def submit_feedback(
     BOOLEAN score to that trace. A no-op (``recorded: False``) when Langfuse is
     disabled, so feedback never errors for the user.
     """
-    from .ai_client import create_score
+    from news_dashboard.ai_client import create_score
 
     comment = (payload.comment or "").strip() or None
     recorded = create_score(
@@ -1136,7 +1136,7 @@ def admin_ai_metrics(days: Annotated[int, Query(ge=1, le=365)] = 30) -> dict[str
 
     Returns ``{"enabled": False}`` when Langfuse tracing is not configured.
     """
-    from .ai_client import fetch_metrics
+    from news_dashboard.ai_client import fetch_metrics
 
     return fetch_metrics(days=days)
 
@@ -1177,7 +1177,7 @@ async def admin_generate_user(payload: GenerateUserRequest) -> dict[str, Any]:
     password = secrets.token_urlsafe(12)
 
     if keycloak_config().enabled:
-        from .keycloak_admin import create_keycloak_user
+        from news_dashboard.keycloak_admin import create_keycloak_user
 
         result = await create_keycloak_user(username, password, email=payload.email)
         return {**result, "password": password, "provider": "keycloak"}

--- a/backend/news_dashboard/migrate.py
+++ b/backend/news_dashboard/migrate.py
@@ -7,8 +7,8 @@ from typing import Annotated, Any
 
 import typer
 
-from .auth import hash_password
-from .db import connect, init_db, row_to_dict
+from news_dashboard.auth import hash_password
+from news_dashboard.db import connect, init_db, row_to_dict
 
 app = typer.Typer(help="Migration helpers for news-dashboard")
 

--- a/backend/news_dashboard/prompt_optimizer.py
+++ b/backend/news_dashboard/prompt_optimizer.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from .ai_client import _client, chat_create, get_openai_client, langfuse_enabled
+from news_dashboard.ai_client import _client, chat_create, get_openai_client, langfuse_enabled
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -69,7 +69,7 @@ def save_push_subscription(
     database_url: str | None = None,
 ) -> None:
     """Upsert a push subscription for a user."""
-    from .db import connect
+    from news_dashboard.db import connect
 
     with connect(database_url=database_url) as conn:
         conn.execute(
@@ -92,7 +92,7 @@ def delete_push_subscriptions(
     database_url: str | None = None,
 ) -> None:
     """Remove push subscriptions for a user.  Deletes all if endpoint is None."""
-    from .db import connect
+    from news_dashboard.db import connect
 
     with connect(database_url=database_url) as conn:
         if endpoint is not None:
@@ -113,7 +113,7 @@ def get_user_push_subscriptions(
     database_url: str | None = None,
 ) -> list[dict[str, Any]]:
     """Return all push subscriptions for a user."""
-    from .db import connect, row_to_dict
+    from news_dashboard.db import connect, row_to_dict
 
     with connect(database_url=database_url) as conn:
         rows = conn.execute(

--- a/backend/news_dashboard/recommendation_jobs.py
+++ b/backend/news_dashboard/recommendation_jobs.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db, row_to_dict
-from .recommendations import CURRENT_MODEL_VERSIONS, recompute_user_recommendations
+from news_dashboard.db import connect, init_db, row_to_dict
+from news_dashboard.recommendations import CURRENT_MODEL_VERSIONS, recompute_user_recommendations
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db, row_to_dict
+from news_dashboard.db import connect, init_db, row_to_dict
 
 COLD_START_MODEL_VERSION = "cold-start-v1"
 BEHAVIORAL_MODEL_VERSION = "behavioral-affinity-v1"
@@ -234,7 +234,7 @@ def semantic_adjustment(
         return 0.0
     if len(candidate_vector) != len(profile_vector):
         return 0.0
-    from .embeddings import cosine_similarity
+    from news_dashboard.embeddings import cosine_similarity
 
     similarity = cosine_similarity(candidate_vector, profile_vector)
     return _clamp(similarity, -1.0, 1.0) * SEMANTIC_SCORE_SPAN
@@ -272,7 +272,7 @@ def novelty_adjustment(
         return 0.0
     if len(candidate_vector) != len(profile_vector):
         return 0.0
-    from .embeddings import cosine_similarity
+    from news_dashboard.embeddings import cosine_similarity
 
     similarity = cosine_similarity(candidate_vector, profile_vector)
     # Map similarity [-1, 1] onto a dissimilarity factor [0, 1]: the further the
@@ -358,7 +358,7 @@ def _load_user_history_vectors(conn: Any, user_id: int) -> list[list[float]]:
     Articles without an embedding are skipped, so an empty list means "no
     embedded history" and semantic scoring stays disabled for this user.
     """
-    from .embeddings import decode_embedding
+    from news_dashboard.embeddings import decode_embedding
 
     rows = conn.execute(
         """
@@ -381,7 +381,7 @@ def _load_user_history_vectors(conn: Any, user_id: int) -> list[list[float]]:
 
 def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]]:
     """Read today/later-eligible articles with their cold-start base score."""
-    from .ingest import _COLD_START_RECOMMENDATION_SCORE_SQL
+    from news_dashboard.ingest import _COLD_START_RECOMMENDATION_SCORE_SQL
 
     rows = conn.execute(
         f"""
@@ -476,6 +476,6 @@ def _decode_candidate_embedding(blob: Any) -> list[float] | None:
     """Best-effort decode of a candidate's stored embedding, ``None`` if absent."""
     if blob is None:
         return None
-    from .embeddings import decode_embedding
+    from news_dashboard.embeddings import decode_embedding
 
     return decode_embedding(bytes(blob))

--- a/backend/news_dashboard/run_history.py
+++ b/backend/news_dashboard/run_history.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db, row_to_dict
+from news_dashboard.db import connect, init_db, row_to_dict
 
 
 def _iso(value: datetime | str | None) -> str | None:

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -22,8 +22,8 @@ _state = _SchedulerState()
 
 
 def _run_ingest() -> None:
-    from .body_fetch import prefetch_article_bodies
-    from .ingest import ingest_all
+    from news_dashboard.body_fetch import prefetch_article_bodies
+    from news_dashboard.ingest import ingest_all
 
     logger.info("Scheduled ingest starting…")
     try:
@@ -40,7 +40,7 @@ def _run_ingest() -> None:
 
 
 def _run_recommendation_recalc() -> None:
-    from .recommendation_jobs import recalculate_stale_recommendations
+    from news_dashboard.recommendation_jobs import recalculate_stale_recommendations
 
     try:
         summary = recalculate_stale_recommendations()
@@ -50,7 +50,7 @@ def _run_recommendation_recalc() -> None:
 
 
 def _run_daily_recommendation_recalc() -> None:
-    from .recommendation_jobs import recalculate_all_recommendations
+    from news_dashboard.recommendation_jobs import recalculate_all_recommendations
 
     logger.info("Daily recommendation recalculation starting…")
     try:
@@ -61,7 +61,7 @@ def _run_daily_recommendation_recalc() -> None:
 
 
 def _run_briefing() -> None:
-    from .briefings import (
+    from news_dashboard.briefings import (
         BriefingAINotConfiguredError,
         BriefingGenerationError,
         generate_briefing,
@@ -84,13 +84,13 @@ def _run_briefing() -> None:
 
 def _run_per_user_briefings() -> None:
     """Generate briefings for users whose scheduled time matches the current UTC HH:MM."""
-    from .briefings import (
+    from news_dashboard.briefings import (
         BriefingAINotConfiguredError,
         BriefingGenerationError,
         generate_briefing,
     )
-    from .db import connect, row_to_dict
-    from .push import send_push_for_user
+    from news_dashboard.db import connect, row_to_dict
+    from news_dashboard.push import send_push_for_user
 
     now = datetime.now(timezone.utc)
     current_hm = now.strftime("%H:%M")
@@ -131,7 +131,7 @@ def _run_per_user_briefings() -> None:
 
 
 def _run_digest() -> None:
-    from .digest import send_digest
+    from news_dashboard.digest import send_digest
 
     logger.info("Sending daily digest…")
     try:
@@ -167,7 +167,7 @@ def start_scheduler() -> None:
         return
 
     # Read settings from DB (overrides env var)
-    from .db import get_setting, init_db
+    from news_dashboard.db import get_setting, init_db
 
     init_db()
 
@@ -298,7 +298,7 @@ def get_interval_minutes() -> int:
 
 def set_interval(minutes: int) -> None:
     """Reschedule the ingest job with a new interval and persist it."""
-    from .db import set_setting
+    from news_dashboard.db import set_setting
 
     _state.interval_minutes = minutes
     set_setting("ingest_interval_minutes", str(minutes))
@@ -314,7 +314,7 @@ def set_interval(minutes: int) -> None:
 
 def pause_scheduler() -> None:
     """Pause the ingest job and persist state."""
-    from .db import set_setting
+    from news_dashboard.db import set_setting
 
     set_setting("scheduler_paused", "true")
     if _state.scheduler is None:
@@ -328,7 +328,7 @@ def pause_scheduler() -> None:
 
 def resume_scheduler() -> None:
     """Resume the ingest job and persist state."""
-    from .db import set_setting
+    from news_dashboard.db import set_setting
 
     set_setting("scheduler_paused", "false")
     if _state.scheduler is None:

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .db import connect, row_to_dict
+from news_dashboard.db import connect, row_to_dict
 
 logger = logging.getLogger(__name__)
 

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db, row_to_dict
+from news_dashboard.db import connect, init_db, row_to_dict
 
 
 def _clean_error(value: Any) -> str | None:

--- a/backend/news_dashboard/stats.py
+++ b/backend/news_dashboard/stats.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from .db import connect, init_db, placeholders, row_to_dict
+from news_dashboard.db import connect, init_db, placeholders, row_to_dict
 
 
 def parse_range(from_value: str, to_value: str) -> tuple[datetime, datetime]:

--- a/backend/tests/test_ai_credentials.py
+++ b/backend/tests/test_ai_credentials.py
@@ -6,6 +6,7 @@ from news_dashboard.embeddings import (
     DEFAULT_ANSWER_MODEL,
     MissingAICredentialsError,
     _answer,
+    _embeddings_ai_config,
     _require_env,
 )
 
@@ -62,3 +63,80 @@ def test_answer_uses_openai_api_key_and_default_model(
     assert _answer("system", "user") == "answer text"
     assert calls[0] == {"api_key": "test-key"}
     assert calls[1]["model"] == DEFAULT_ANSWER_MODEL
+
+
+# ── _embeddings_ai_config tests ───────────────────────────────────────────────
+
+
+def test_embeddings_ai_config_raises_when_no_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(MissingAICredentialsError, match="OPENAI_EMBEDDINGS_API_KEY"):
+        _embeddings_ai_config()
+
+
+def test_embeddings_ai_config_uses_embeddings_specific_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_EMBEDDINGS_API_KEY", "embed-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    api_key, base_url = _embeddings_ai_config()
+
+    assert api_key == "embed-key"
+    assert base_url is None
+
+
+def test_embeddings_ai_config_falls_back_to_shared_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "shared-key")
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    api_key, base_url = _embeddings_ai_config()
+
+    assert api_key == "shared-key"
+    assert base_url is None
+
+
+def test_embeddings_ai_config_uses_embeddings_specific_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("OPENAI_EMBEDDINGS_BASE_URL", "http://gateway:9130/v1")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    _, base_url = _embeddings_ai_config()
+
+    assert base_url == "http://gateway:9130/v1"
+
+
+def test_embeddings_ai_config_falls_back_to_shared_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway:9130/v1")
+
+    _, base_url = _embeddings_ai_config()
+
+    assert base_url == "http://shared-gateway:9130/v1"
+
+
+def test_embeddings_ai_config_specific_base_url_takes_precedence_over_shared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("OPENAI_EMBEDDINGS_BASE_URL", "http://embed-gateway/v1")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway/v1")
+
+    _, base_url = _embeddings_ai_config()
+
+    assert base_url == "http://embed-gateway/v1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ select = [
   "PL",         # pylint
   "RUF",        # ruff-specific
   "TRY",        # tryceratops
+  "TID",        # flake8-tidy-imports
 ]
 ignore = [
   "UP017",   # keep `timezone.utc`: identical semantics, broader tooling compat
@@ -113,6 +114,9 @@ ignore = [
   "ISC001",  # conflicts with the ruff formatter
   "PLC0415", # lazy imports are deliberate (optional deps, startup cost, cycles)
 ]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
 
 [tool.ruff.lint.per-file-ignores]
 "backend/tests/*" = [


### PR DESCRIPTION
Closes #315. Configures Ruff to select the TID rule group and set ban-relative-imports to 'all', then converts relative imports to absolute imports across the Python files in the backend.