### PR TITLE
feat: route article embeddings through gateway

### DIFF
--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 MIN_ARTICLES = 5  # refuse to answer if fewer than this many articles are embedded
 TOP_K = 8  # articles to include as context
 DEFAULT_ANSWER_MODEL = "gpt-4o-mini"
+DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 
 # Local fallback for the Ask AI system prompt. The live prompt is managed in
 # Langfuse (name "ask-system", label "production"); this string is used verbatim
@@ -79,16 +80,17 @@ def embedding_text(
     return " ".join(parts)
 
 
-# ── OpenAI embedding ───────────────────────────────────────────────────────
+# ── OpenAI-compatible embedding ────────────────────────────────────────────
 
 
-def _embeddings_ai_config() -> tuple[str, str | None]:
+def _embeddings_ai_config() -> tuple[str, str | None, str]:
     """Resolve the (api_key, base_url) for embedding generation.
 
     Embeddings can target any OpenAI-compatible endpoint (e.g. a self-hosted
     gateway) via ``OPENAI_EMBEDDINGS_BASE_URL`` / ``OPENAI_EMBEDDINGS_API_KEY``,
-    falling back to the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The
-    base URL is optional; when unset the official OpenAI endpoint is used.
+    falling back to the briefing gateway and then the shared
+    ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The base URL is optional; when
+    unset the official OpenAI endpoint is used.
     """
     api_key = os.getenv("OPENAI_EMBEDDINGS_API_KEY") or os.getenv("OPENAI_API_KEY")
     if not api_key:
@@ -97,18 +99,24 @@ def _embeddings_ai_config() -> tuple[str, str | None]:
             "generate article embeddings. Set it in the app environment."
         )
         raise MissingAICredentialsError(msg)
-    base_url = os.getenv("OPENAI_EMBEDDINGS_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
-    return api_key, base_url
+    base_url = (
+        os.getenv("OPENAI_EMBEDDINGS_BASE_URL")
+        or os.getenv("OPENAI_BRIEFING_BASE_URL")
+        or os.getenv("OPENAI_BASE_URL")
+        or None
+    )
+    model = os.getenv("OPENAI_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+    return api_key, base_url, model
 
 
 def _embed(text: str) -> list[float]:
-    """Embed *text* with text-embedding-3-small via the OpenAI SDK."""
+    """Embed *text* via the configured OpenAI-compatible endpoint."""
     from news_dashboard.ai_client import get_openai_client, trace_params
 
-    api_key, base_url = _embeddings_ai_config()
+    api_key, base_url, model = _embeddings_ai_config()
     client = get_openai_client(api_key=api_key, base_url=base_url)
     response = client.embeddings.create(
-        model="text-embedding-3-small",
+        model=model,
         input=text,
         **trace_params("article-embedding", tags=["embedding"], user_id="system"),
     )

--- a/backend/tests/test_ai_credentials.py
+++ b/backend/tests/test_ai_credentials.py
@@ -84,9 +84,10 @@ def test_embeddings_ai_config_uses_embeddings_specific_key(
     monkeypatch.setenv("OPENAI_EMBEDDINGS_API_KEY", "embed-key")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
-    api_key, base_url = _embeddings_ai_config()
+    api_key, base_url, _model = _embeddings_ai_config()
 
     assert api_key == "embed-key"
     assert base_url is None
@@ -98,9 +99,10 @@ def test_embeddings_ai_config_falls_back_to_shared_api_key(
     monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "shared-key")
     monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
-    api_key, base_url = _embeddings_ai_config()
+    api_key, base_url, _model = _embeddings_ai_config()
 
     assert api_key == "shared-key"
     assert base_url is None
@@ -111,9 +113,10 @@ def test_embeddings_ai_config_uses_embeddings_specific_base_url(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "key")
     monkeypatch.setenv("OPENAI_EMBEDDINGS_BASE_URL", "http://gateway:9130/v1")
+    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
-    _, base_url = _embeddings_ai_config()
+    _, base_url, _model = _embeddings_ai_config()
 
     assert base_url == "http://gateway:9130/v1"
 
@@ -123,9 +126,10 @@ def test_embeddings_ai_config_falls_back_to_shared_base_url(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "key")
     monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway:9130/v1")
 
-    _, base_url = _embeddings_ai_config()
+    _, base_url, _model = _embeddings_ai_config()
 
     assert base_url == "http://shared-gateway:9130/v1"
 
@@ -135,8 +139,33 @@ def test_embeddings_ai_config_specific_base_url_takes_precedence_over_shared(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "key")
     monkeypatch.setenv("OPENAI_EMBEDDINGS_BASE_URL", "http://embed-gateway/v1")
+    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gateway/v1")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway/v1")
 
-    _, base_url = _embeddings_ai_config()
+    _, base_url, _model = _embeddings_ai_config()
 
     assert base_url == "http://embed-gateway/v1"
+
+
+def test_embeddings_ai_config_falls_back_to_briefing_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gateway/v1")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway/v1")
+
+    _, base_url, _model = _embeddings_ai_config()
+
+    assert base_url == "http://briefing-gateway/v1"
+
+
+def test_embeddings_ai_config_uses_model_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "gateway-embedding-model")
+
+    _, _, model = _embeddings_ai_config()
+
+    assert model == "gateway-embedding-model"

--- a/backend/tests/test_user_attribution.py
+++ b/backend/tests/test_user_attribution.py
@@ -97,6 +97,86 @@ def test_embed_passes_system_user_id_to_trace_params() -> None:
     mock_tp.assert_called_once_with("article-embedding", tags=["embedding"], user_id="system")
 
 
+def test_embed_uses_briefing_gateway_base_url_when_configured() -> None:
+    from news_dashboard.embeddings import _embed
+
+    mock_response = MagicMock()
+    mock_response.data[0].embedding = [0.1, 0.2, 0.3]
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = mock_response
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "sk-test",
+                "OPENAI_BRIEFING_BASE_URL": "http://127.0.0.1:9130/v1",
+            },
+            clear=True,
+        ),
+        patch(
+            "news_dashboard.ai_client.get_openai_client",
+            return_value=mock_client,
+        ) as mock_client_factory,
+    ):
+        _embed("some text")
+
+    mock_client_factory.assert_called_once_with(
+        api_key="sk-test",
+        base_url="http://127.0.0.1:9130/v1",
+    )
+
+
+def test_embed_uses_shared_openai_base_url_when_briefing_gateway_missing() -> None:
+    from news_dashboard.embeddings import _embed
+
+    mock_response = MagicMock()
+    mock_response.data[0].embedding = [0.1, 0.2, 0.3]
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = mock_response
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "sk-test",
+                "OPENAI_BASE_URL": "http://shared-gateway:9130/v1",
+            },
+            clear=True,
+        ),
+        patch(
+            "news_dashboard.ai_client.get_openai_client",
+            return_value=mock_client,
+        ) as mock_client_factory,
+    ):
+        _embed("some text")
+
+    mock_client_factory.assert_called_once_with(
+        api_key="sk-test",
+        base_url="http://shared-gateway:9130/v1",
+    )
+
+
+def test_embed_falls_back_to_openai_when_no_gateway_configured() -> None:
+    from news_dashboard.embeddings import _embed
+
+    mock_response = MagicMock()
+    mock_response.data[0].embedding = [0.1, 0.2, 0.3]
+    mock_client = MagicMock()
+    mock_client.embeddings.create.return_value = mock_response
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=True),
+        patch(
+            "news_dashboard.ai_client.get_openai_client",
+            return_value=mock_client,
+        ) as mock_client_factory,
+    ):
+        _embed("some text")
+
+    mock_client_factory.assert_called_once_with(api_key="sk-test", base_url=None)
+
+
 # ── embeddings: ask-ai answer threads real user_id ────────────────────────────
 
 


### PR DESCRIPTION
Closes #316

## Summary
- Route article embedding clients through `OPENAI_BRIEFING_BASE_URL` first, then shared `OPENAI_BASE_URL`, falling back to OpenAI when no gateway is configured.
- Add `OPENAI_EMBEDDING_MODEL` override while keeping `text-embedding-3-small` as the default.
- Cover gateway, shared base URL, and no-gateway fallback behavior in embedding tests.

## Verification
- `make lint`
- `make typecheck`
- `source .env && uv run pytest backend/tests/test_user_attribution.py -k embed -q`
- `source .env && make test` via pre-push hook
- `make build`

## Gateway model check
- Local `.env` has a gateway base URL configured, but `/models` was unreachable from this environment (`ConnectError`), so model availability needs to be verified in the deployed network. Runtime supports `OPENAI_EMBEDDING_MODEL` when the gateway exposes a different embeddings model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)