### PR TITLE
feat: route insights through LLM gateway (#318)

### DIFF
--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -1,6 +1,6 @@
 """AI-generated 'Why it matters' bullet points for articles.
 
-Calls gpt-4o-mini with the article text and caches the result in
+Calls an OpenAI-compatible chat model with the article text and caches the result in
 articles.insights (JSON) so the AI is invoked at most once per article.
 """
 
@@ -16,7 +16,7 @@ from news_dashboard.db import connect, init_db
 
 logger = logging.getLogger(__name__)
 
-_MODEL = "gpt-4o-mini"
+DEFAULT_INSIGHTS_MODEL = "gpt-4o-mini"
 _MAX_CHARS = 8_000
 _PROMPT = (
     "You are analyzing a news article. Based ONLY on the information explicitly stated in the "
@@ -54,16 +54,30 @@ def _parse_bullets(response_text: str) -> list[str]:
     return bullets
 
 
+def _insights_ai_config() -> tuple[str, str | None, str]:
+    """Resolve the (api_key, base_url, model) for article insight generation.
+
+    Insights can target any OpenAI-compatible endpoint via
+    ``OPENAI_INSIGHTS_BASE_URL`` / ``OPENAI_INSIGHTS_API_KEY``, falling back to
+    the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The base URL is
+    optional; when unset the official OpenAI endpoint is used.
+    """
+    api_key = os.getenv("OPENAI_INSIGHTS_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = "OPENAI_API_KEY is not configured"
+        raise InsightsNotConfiguredError(msg)
+    base_url = os.getenv("OPENAI_INSIGHTS_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    model = os.getenv("OPENAI_INSIGHTS_MODEL", DEFAULT_INSIGHTS_MODEL)
+    return api_key, base_url, model
+
+
 def generate_insights(article: dict[str, Any], *, user_id: int | None = None) -> list[str]:
     """Call OpenAI and return a list of bullet-point strings.
 
     Raises InsightsNotConfiguredError when OPENAI_API_KEY is absent.
     Raises RuntimeError on API failure.
     """
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        msg = "OPENAI_API_KEY is not configured"
-        raise InsightsNotConfiguredError(msg)
+    api_key, base_url, model = _insights_ai_config()
 
     text = _build_text(article)
     if not text.strip():
@@ -71,7 +85,7 @@ def generate_insights(article: dict[str, Any], *, user_id: int | None = None) ->
 
     from news_dashboard.ai_client import chat_create, get_openai_client, get_prompt
 
-    client = get_openai_client(api_key=api_key)
+    client = get_openai_client(api_key=api_key, base_url=base_url)
     prompt = get_prompt("article-insights", fallback=_PROMPT)
     logger.info("Generating insights for article %s", article.get("id"))
     result = chat_create(
@@ -80,7 +94,7 @@ def generate_insights(article: dict[str, Any], *, user_id: int | None = None) ->
         tags=["insights"],
         user_id=user_id,
         prompt=prompt,
-        model=_MODEL,
+        model=model,
         messages=[{"role": "user", "content": f"{prompt.text}\n\n{text}"}],
         max_tokens=512,
     )

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -14,8 +14,10 @@ import pytest
 
 from news_dashboard.db import connect
 from news_dashboard.insights import (
+    DEFAULT_INSIGHTS_MODEL,
     InsightsNotConfiguredError,
     _build_text,
+    _insights_ai_config,
     _parse_bullets,
     generate_insights,
     get_or_generate_insights,
@@ -129,9 +131,53 @@ def test_generate_insights_raises_without_api_key() -> None:
     with patch.dict("os.environ", {}, clear=False):
         import os
 
+        os.environ.pop("OPENAI_INSIGHTS_API_KEY", None)
         os.environ.pop("OPENAI_API_KEY", None)
         with pytest.raises(InsightsNotConfiguredError):
             generate_insights(_ARTICLE)
+
+
+def test_insights_ai_config_uses_gateway_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway:9130/v1")
+
+    api_key, base_url, model = _insights_ai_config()
+
+    assert api_key == "sk-openai"
+    assert base_url == "http://shared-gateway:9130/v1"
+    assert model == DEFAULT_INSIGHTS_MODEL
+
+
+def test_insights_ai_config_prefers_insights_gateway_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway/v1")
+    monkeypatch.setenv("OPENAI_INSIGHTS_API_KEY", "freellmapi-key")
+    monkeypatch.setenv("OPENAI_INSIGHTS_BASE_URL", "http://insights-gateway/v1")
+    monkeypatch.setenv("OPENAI_INSIGHTS_MODEL", "gateway-chat-model")
+
+    api_key, base_url, model = _insights_ai_config()
+
+    assert api_key == "freellmapi-key"
+    assert base_url == "http://insights-gateway/v1"
+    assert model == "gateway-chat-model"
+
+
+def test_insights_ai_config_falls_back_to_openai_when_gateway_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_INSIGHTS_BASE_URL", raising=False)
+
+    api_key, base_url, model = _insights_ai_config()
+
+    assert api_key == "sk-openai"
+    assert base_url is None
+    assert model == DEFAULT_INSIGHTS_MODEL
 
 
 def test_generate_insights_returns_parsed_bullets() -> None:
@@ -143,7 +189,14 @@ def test_generate_insights_returns_parsed_bullets() -> None:
     mock_client.chat.completions.create.return_value = mock_completion
 
     with (
-        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "sk-test",
+                "OPENAI_BASE_URL": "http://shared-gateway:9130/v1",
+                "OPENAI_INSIGHTS_MODEL": "gateway-chat-model",
+            },
+        ),
         patch("openai.OpenAI", return_value=mock_client),
     ):
         bullets = generate_insights(_ARTICLE)
@@ -151,7 +204,7 @@ def test_generate_insights_returns_parsed_bullets() -> None:
     assert bullets == ["First bullet point", "Second bullet point", "Third bullet point"]
     mock_client.chat.completions.create.assert_called_once()
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-    assert call_kwargs["model"] == "gpt-4o-mini"
+    assert call_kwargs["model"] == "gateway-chat-model"
     assert "Test Headline" in call_kwargs["messages"][0]["content"]
 
 


### PR DESCRIPTION
Closes #318

## Summary
- routes article insights chat completions through `OPENAI_INSIGHTS_BASE_URL` or shared `OPENAI_BASE_URL` when configured
- adds `OPENAI_INSIGHTS_API_KEY` and `OPENAI_INSIGHTS_MODEL` overrides while preserving OpenAI fallback
- covers gateway, model, and fallback selection in insights tests

## Tests
- `pytest backend/tests/test_insights.py -q`
- `make lint`
- `make typecheck`
- `npm run test:frontend --silent`
- `npm run build --silent`
- pre-push hook: backend pytest passed during `git push`

Note: one manual `source .env && make test` run earlier reported two unrelated briefing test failures, but the required pre-push backend pytest hook passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)