### PR TITLE
feat: route prompt optimizer through free LLM gateway (#321)

### DIFF
--- a/backend/news_dashboard/prompt_optimizer.py
+++ b/backend/news_dashboard/prompt_optimizer.py
@@ -129,9 +129,38 @@ def build_optimizer_prompt(current_text: str, examples: list[NegativeExample]) -
     return "\n".join(blocks)
 
 
+def _optimizer_ai_config() -> tuple[str, str | None]:
+    """Resolve (api_key, base_url) for prompt optimization.
+
+    Targets the free LLM gateway via ``OPENAI_OPTIMIZER_BASE_URL`` /
+    ``OPENAI_OPTIMIZER_API_KEY``, falling back to the briefing gateway config
+    and then the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The base URL
+    is optional; when unset the official OpenAI endpoint is used.
+    """
+    api_key = (
+        os.getenv("OPENAI_OPTIMIZER_API_KEY")
+        or os.getenv("OPENAI_BRIEFING_API_KEY")
+        or os.getenv("OPENAI_API_KEY")
+    )
+    if not api_key:
+        msg = (
+            "Prompt optimization requires an API key. Set OPENAI_OPTIMIZER_API_KEY "
+            "(or OPENAI_API_KEY) in the app environment."
+        )
+        raise PromptOptimizerError(msg)
+    base_url = (
+        os.getenv("OPENAI_OPTIMIZER_BASE_URL")
+        or os.getenv("OPENAI_BRIEFING_BASE_URL")
+        or os.getenv("OPENAI_BASE_URL")
+        or None
+    )
+    return api_key, base_url
+
+
 def _propose_revision(current_text: str, examples: list[NegativeExample], *, model: str) -> str:
     """Call the LLM to draft an improved prompt. Traced like any other call."""
-    client = get_openai_client(api_key=_require_openai_key())
+    api_key, base_url = _optimizer_ai_config()
+    client = get_openai_client(api_key=api_key, base_url=base_url)
     response = chat_create(
         client,
         name="prompt-optimizer",
@@ -146,14 +175,6 @@ def _propose_revision(current_text: str, examples: list[NegativeExample], *, mod
     return (response.choices[0].message.content or "").strip()
 
 
-def _require_openai_key() -> str:
-    key = os.getenv("OPENAI_API_KEY")
-    if not key:
-        msg = "OPENAI_API_KEY is required to propose prompt improvements."
-        raise PromptOptimizerError(msg)
-    return key
-
-
 def optimize_prompt(
     *,
     prompt_name: str,
@@ -161,7 +182,7 @@ def optimize_prompt(
     score_name: str = "user-thumbs",
     days: int = 14,
     max_examples: int = 50,
-    model: str = DEFAULT_OPTIMIZER_MODEL,
+    model: str | None = None,
 ) -> OptimizationResult:
     """Run one feedback-driven improvement pass for *prompt_name*.
 
@@ -171,6 +192,9 @@ def optimize_prompt(
     when there is nothing to learn from (no negative feedback) or Langfuse is
     unavailable.
     """
+    resolved_model = (
+        model if model is not None else os.getenv("OPENAI_OPTIMIZER_MODEL", DEFAULT_OPTIMIZER_MODEL)
+    )
     examples = collect_negative_examples(score_name=score_name, days=days, limit=max_examples)
     if not examples:
         msg = f"No '{score_name}' thumbs-down feedback in the last {days} days; nothing to do."
@@ -184,7 +208,7 @@ def optimize_prompt(
         msg = f"Could not load current prompt '{prompt_name}': {exc}"
         raise PromptOptimizerError(msg) from exc
 
-    proposed = _propose_revision(current_text, examples, model=model)
+    proposed = _propose_revision(current_text, examples, model=resolved_model)
     if not proposed:
         msg = "The optimizer model returned an empty prompt."
         raise PromptOptimizerError(msg)

--- a/backend/tests/test_prompt_optimizer.py
+++ b/backend/tests/test_prompt_optimizer.py
@@ -6,6 +6,7 @@ from news_dashboard.prompt_optimizer import (
     NegativeExample,
     PromptOptimizerError,
     _extract_question,
+    _optimizer_ai_config,
     _score_is_negative,
     build_optimizer_prompt,
     collect_negative_examples,
@@ -54,3 +55,62 @@ def test_build_optimizer_prompt_includes_current_and_examples() -> None:
 def test_collect_negative_examples_requires_langfuse() -> None:
     with pytest.raises(PromptOptimizerError, match="not configured"):
         collect_negative_examples()
+
+
+def test_optimizer_ai_config_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("OPENAI_OPTIMIZER_API_KEY", "OPENAI_BRIEFING_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(PromptOptimizerError, match="API key"):
+        _optimizer_ai_config()
+
+
+def test_optimizer_ai_config_uses_optimizer_key_and_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_OPTIMIZER_API_KEY", "opt-key")
+    monkeypatch.setenv("OPENAI_OPTIMIZER_BASE_URL", "http://optimizer-gw/v1")
+    for var in (
+        "OPENAI_BRIEFING_API_KEY",
+        "OPENAI_BRIEFING_BASE_URL",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    api_key, base_url = _optimizer_ai_config()
+
+    assert api_key == "opt-key"
+    assert base_url == "http://optimizer-gw/v1"
+
+
+def test_optimizer_ai_config_falls_back_to_briefing_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("OPENAI_OPTIMIZER_API_KEY", "OPENAI_OPTIMIZER_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENAI_BRIEFING_API_KEY", "briefing-key")
+    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gw/v1")
+    for var in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    api_key, base_url = _optimizer_ai_config()
+
+    assert api_key == "briefing-key"
+    assert base_url == "http://briefing-gw/v1"
+
+
+def test_optimizer_ai_config_falls_back_to_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "OPENAI_OPTIMIZER_API_KEY",
+        "OPENAI_OPTIMIZER_BASE_URL",
+        "OPENAI_BRIEFING_API_KEY",
+        "OPENAI_BRIEFING_BASE_URL",
+        "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "plain-key")
+
+    api_key, base_url = _optimizer_ai_config()
+
+    assert api_key == "plain-key"
+    assert base_url is None


### PR DESCRIPTION
## Summary

Closes #321

- Replaces `_require_openai_key()` with `_optimizer_ai_config()` that resolves `(api_key, base_url)` following the same three-tier fallback pattern used by briefings and embeddings: `OPENAI_OPTIMIZER_*` → `OPENAI_BRIEFING_*` → `OPENAI_*`
- Prompt-optimizer chat completions are now sent to the free LLM gateway when `OPENAI_OPTIMIZER_BASE_URL` (or `OPENAI_BRIEFING_BASE_URL`) is configured
- Falls back gracefully to the official OpenAI endpoint when no gateway is configured (no base URL)
- Adds `OPENAI_OPTIMIZER_MODEL` env var for model override at runtime
- `model` param to `optimize_prompt()` is now optional (`None` → env var → `DEFAULT_OPTIMIZER_MODEL`)

## Test results

Added 4 new tests for `_optimizer_ai_config` covering:
- Missing API key raises `PromptOptimizerError`
- `OPENAI_OPTIMIZER_*` env vars take priority
- Falls back to briefing gateway config
- Falls back to plain OpenAI (no base URL)

All 14 prompt-optimizer tests pass. Full backend suite (796 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)