### PR TITLE
perf: defer off-screen article row rendering (#329)

### DIFF
--- a/frontend/src/__tests__/articleListView.test.tsx
+++ b/frontend/src/__tests__/articleListView.test.tsx
@@ -79,6 +79,15 @@ describe('ArticleListView', () => {
     expect(screen.getByText('All')).toBeTruthy();
   });
 
+  it('marks article rows for deferred off-screen rendering', async () => {
+    renderArticleList(() => Promise.resolve([makeArticle()]));
+
+    await waitFor(() => expect(screen.getByText('Readable article')).toBeTruthy());
+
+    const link = screen.getByRole('link', { name: /readable article/i });
+    expect(link.closest('.content-visibility-auto')).toBeTruthy();
+  });
+
   it('renders the configured empty state after a successful empty response', async () => {
     renderArticleList(() => Promise.resolve([]));
 

--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -34,63 +34,67 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
         : 'text-signal-low';
 
   return (
-    <SwipeableRow
-      onSwipeRight={handleDone}
-      onSwipeLeft={handleSkip}
-      onLongPress={handleStar}
-      disableLeft={article.starred}
-    >
-      <Link
-        to={`/a/${article.id}`}
-        className={cn(
-          'motion-fade-up block px-4 py-3 border-b border-border transition-colors hover:bg-surface md:px-5',
-          focused && 'bg-surface-2 focus-row'
-        )}
+    <div className="content-visibility-auto">
+      <SwipeableRow
+        onSwipeRight={handleDone}
+        onSwipeLeft={handleSkip}
+        onLongPress={handleStar}
+        disableLeft={article.starred}
       >
-        <div className="flex items-baseline justify-between gap-3 mb-1">
-          <div className="flex items-baseline gap-1.5 min-w-0 text-[11px] text-muted-foreground">
-            <span className="truncate font-medium">{article.sourceName}</span>
-            <span>·</span>
-            <span className="shrink-0">{relativeTime(article.publishedAt)}</span>
-            <span>·</span>
-            <span className="truncate">{article.category}</span>
+        <Link
+          to={`/a/${article.id}`}
+          className={cn(
+            'motion-fade-up block px-4 py-3 border-b border-border transition-colors hover:bg-surface md:px-5',
+            focused && 'bg-surface-2 focus-row'
+          )}
+        >
+          <div className="flex items-baseline justify-between gap-3 mb-1">
+            <div className="flex items-baseline gap-1.5 min-w-0 text-[11px] text-muted-foreground">
+              <span className="truncate font-medium">{article.sourceName}</span>
+              <span>·</span>
+              <span className="shrink-0">{relativeTime(article.publishedAt)}</span>
+              <span>·</span>
+              <span className="truncate">{article.category}</span>
+            </div>
+            {article.starred && (
+              <Star className="size-3.5 shrink-0 fill-star text-star" strokeWidth={1.5} />
+            )}
           </div>
-          {article.starred && (
-            <Star className="size-3.5 shrink-0 fill-star text-star" strokeWidth={1.5} />
-          )}
-        </div>
-        <h3 className="text-[15px] leading-snug font-semibold tracking-tight text-foreground mb-1.5">
-          {article.title}
-        </h3>
-        <p className="text-[13px] leading-snug text-foreground/80 line-clamp-1">{article.reason}</p>
-        <div className="mt-1.5 flex items-center gap-2 text-[11px]">
-          <span
-            className={cn('font-medium', labelColor)}
-            data-testid="recommendation-label"
-            data-source={recLabel ? 'recommendation' : 'signal'}
-          >
-            {labelText}
-          </span>
-          {article.recommendationScore != null && (
-            <>
-              <span className="text-subtle">·</span>
-              <span
-                className="text-muted-foreground tabular-nums"
-                data-testid="recommendation-score"
-              >
-                {Math.round(article.recommendationScore)}%
-              </span>
-            </>
-          )}
-          {showLaterUntil && article.later_until && (
-            <>
-              <span className="text-subtle">·</span>
-              <span className="text-subtle">returns {relativeTime(article.later_until)}</span>
-            </>
-          )}
-        </div>
-      </Link>
-    </SwipeableRow>
+          <h3 className="text-[15px] leading-snug font-semibold tracking-tight text-foreground mb-1.5">
+            {article.title}
+          </h3>
+          <p className="text-[13px] leading-snug text-foreground/80 line-clamp-1">
+            {article.reason}
+          </p>
+          <div className="mt-1.5 flex items-center gap-2 text-[11px]">
+            <span
+              className={cn('font-medium', labelColor)}
+              data-testid="recommendation-label"
+              data-source={recLabel ? 'recommendation' : 'signal'}
+            >
+              {labelText}
+            </span>
+            {article.recommendationScore != null && (
+              <>
+                <span className="text-subtle">·</span>
+                <span
+                  className="text-muted-foreground tabular-nums"
+                  data-testid="recommendation-score"
+                >
+                  {Math.round(article.recommendationScore)}%
+                </span>
+              </>
+            )}
+            {showLaterUntil && article.later_until && (
+              <>
+                <span className="text-subtle">·</span>
+                <span className="text-subtle">returns {relativeTime(article.later_until)}</span>
+              </>
+            )}
+          </div>
+        </Link>
+      </SwipeableRow>
+    </div>
   );
 }
 

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -7,6 +7,11 @@
 /* Map Tailwind's dark: variant to [data-theme=dark] */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
+@utility content-visibility-auto {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 100px;
+}
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);


### PR DESCRIPTION
Closes #329

## Summary
- add a Tailwind v4 content-visibility utility for article rows
- wrap each ArticleRow in the utility container so off-screen rows can defer rendering
- add ArticleListView coverage to assert rendered rows include the deferred-rendering wrapper

## Test results
- npm run test:frontend -- frontend/src/__tests__/articleListView.test.tsx
- npm run lint && npm run format:check && npm run typecheck && npm run test:frontend && npm run build
- git push pre-push hooks, including vitest (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)