### PR TITLE
perf: CacheFirst caching for woff2 fonts in Service Worker (#331)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,18 @@ export default defineConfig({
         importScripts: ['/push-handler.js'],
         runtimeCaching: [
           {
+            // Font assets: cache-first, 1 year TTL
+            urlPattern: /\.(?:woff2)$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'pwa-fonts',
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365,
+              },
+            },
+          },
+          {
             // Icon/image assets: cache-first, long TTL
             urlPattern: /\/icons\/.+\.(png|svg|webp|ico)$/,
             handler: 'CacheFirst',


### PR DESCRIPTION
## Summary

- Adds a `CacheFirst` Workbox runtime caching rule for `.woff2` font files in `vite.config.ts`
- Uses a dedicated `pwa-fonts` cache with a 1-year TTL and 10-entry cap
- Eliminates FOUT/FOIT under slow networks by serving Inter, JetBrains Mono, and Source Serif 4 directly from the browser cache on repeat visits

Closes #331

## Test plan

- [x] `npm run typecheck` — passes (tsc strict, no errors)
- [x] `npm run lint` — passes (eslint --max-warnings 0)
- [x] `npm run format:check` — passes (prettier)
- [x] `npm run test:frontend` (vitest) — passes (pre-push hook verified)
- [ ] Manual: build app, open in Chrome, check Application → Cache Storage for `pwa-fonts` cache containing `.woff2` entries
- [ ] Manual: test offline mode — fonts render correctly from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)