### PR TITLE
fix: make Kubernetes ingest scheduling single-authority (#336)

### DIFF
--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -25,6 +25,20 @@ def ingest() -> None:
     flush()
 
 
+@app.command(name="scheduled-ingest")
+def scheduled_ingest() -> None:
+    from news_dashboard.scheduler import run_scheduled_ingest
+
+    results = run_scheduled_ingest()
+    for source, count in results.items():
+        typer.echo(f"{source}: {count}")
+    typer.echo(f"inserted: {sum(value for value in results.values() if value > 0)}")
+    # Short-lived process: flush any buffered Langfuse traces before exit.
+    from news_dashboard.ai_client import flush
+
+    flush()
+
+
 @app.command()
 def articles(status: str | None = None, limit: int = 20) -> None:
     for article in list_articles(status=status, limit=limit):

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -71,6 +71,7 @@ from news_dashboard.run_history import get_ingest_run_sources, list_ingest_runs
 from news_dashboard.scheduler import (
     get_interval_minutes,
     get_next_ingest_at,
+    is_ingest_interval_enabled,
     is_paused,
     pause_scheduler,
     resume_scheduler,
@@ -774,12 +775,15 @@ def set_source_enabled(
 
 @api.get("/api/scheduler/status")
 def scheduler_status() -> dict[str, Any]:
+    interval_enabled = is_ingest_interval_enabled()
     next_run = get_next_ingest_at()
-    paused = is_paused()
+    paused = is_paused() if interval_enabled else False
     return {
         "interval_minutes": get_interval_minutes(),
         "paused": paused,
         "next_run_at": next_run,
+        "interval_ingest_enabled": interval_enabled,
+        "ingest_authority": "in_process" if interval_enabled else "external",
     }
 
 

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -16,16 +16,25 @@ class _SchedulerState:
     def __init__(self) -> None:
         self.scheduler: Any = None  # APScheduler BackgroundScheduler instance
         self.interval_minutes: int = 30  # may differ from env var after live update
+        self.ingest_interval_enabled: bool = True
 
 
 _state = _SchedulerState()
 
 
-def _run_ingest() -> None:
+def _env_flag_enabled(name: str, *, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def run_scheduled_ingest() -> dict[str, int]:
     from news_dashboard.body_fetch import prefetch_article_bodies
     from news_dashboard.ingest import ingest_all
 
     logger.info("Scheduled ingest starting…")
+    results: dict[str, int] = {}
     try:
         results = ingest_all()
         total = sum(v for v in results.values() if v > 0)
@@ -37,6 +46,11 @@ def _run_ingest() -> None:
     # Repair stale/missing scores out-of-band.  Guarded separately so a
     # recalculation or scoring failure never fails the ingest run itself.
     _run_recommendation_recalc()
+    return results
+
+
+def _run_ingest() -> None:
+    run_scheduled_ingest()
 
 
 def _run_recommendation_recalc() -> None:
@@ -175,6 +189,9 @@ def start_scheduler() -> None:
     db_interval = get_setting("ingest_interval_minutes")
     interval_minutes = int(db_interval) if db_interval is not None else env_interval
     _state.interval_minutes = interval_minutes
+    _state.ingest_interval_enabled = _env_flag_enabled(
+        "INGEST_INTERVAL_SCHEDULER_ENABLED", default=True
+    )
 
     db_paused = get_setting("scheduler_paused")
     start_paused = db_paused == "true" if db_paused is not None else False
@@ -185,13 +202,16 @@ def start_scheduler() -> None:
 
     scheduler = BackgroundScheduler(timezone="UTC")
 
-    scheduler.add_job(
-        _run_ingest,
-        trigger="interval",
-        minutes=interval_minutes,
-        id="ingest",
-        replace_existing=True,
-    )
+    if _state.ingest_interval_enabled:
+        scheduler.add_job(
+            _run_ingest,
+            trigger="interval",
+            minutes=interval_minutes,
+            id="ingest",
+            replace_existing=True,
+        )
+    else:
+        logger.info("Interval ingest scheduler disabled by INGEST_INTERVAL_SCHEDULER_ENABLED.")
 
     cron_minute, cron_hour = _parse_cron_hm(digest_cron, "0", "8")
     scheduler.add_job(
@@ -234,7 +254,7 @@ def start_scheduler() -> None:
     scheduler.start()
     _state.scheduler = scheduler
 
-    if start_paused:
+    if start_paused and _state.ingest_interval_enabled:
         try:
             scheduler.pause_job("ingest")
             logger.info("Scheduler started (ingest paused per saved settings).")
@@ -252,6 +272,11 @@ def start_scheduler() -> None:
             r_hour.zfill(2),
             r_minute.zfill(2),
         )
+
+
+def is_ingest_interval_enabled() -> bool:
+    """Return whether this process owns the interval ingest job."""
+    return _state.ingest_interval_enabled
 
 
 def stop_scheduler() -> None:
@@ -303,7 +328,7 @@ def set_interval(minutes: int) -> None:
     _state.interval_minutes = minutes
     set_setting("ingest_interval_minutes", str(minutes))
 
-    if _state.scheduler is None:
+    if _state.scheduler is None or not _state.ingest_interval_enabled:
         return
     try:
         _state.scheduler.reschedule_job("ingest", trigger="interval", minutes=minutes)
@@ -317,7 +342,7 @@ def pause_scheduler() -> None:
     from news_dashboard.db import set_setting
 
     set_setting("scheduler_paused", "true")
-    if _state.scheduler is None:
+    if _state.scheduler is None or not _state.ingest_interval_enabled:
         return
     try:
         _state.scheduler.pause_job("ingest")
@@ -331,7 +356,7 @@ def resume_scheduler() -> None:
     from news_dashboard.db import set_setting
 
     set_setting("scheduler_paused", "false")
-    if _state.scheduler is None:
+    if _state.scheduler is None or not _state.ingest_interval_enabled:
         return
     try:
         _state.scheduler.resume_job("ingest")

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -33,6 +33,18 @@ def test_ingest_prints_per_source_counts_and_total() -> None:
     assert "inserted: 5" in result.stdout
 
 
+def test_scheduled_ingest_uses_scheduler_runner() -> None:
+    with patch(
+        "news_dashboard.scheduler.run_scheduled_ingest",
+        return_value={"a": 2, "b": 0, "c": -1},
+    ) as run:
+        result = runner.invoke(app, ["scheduled-ingest"])
+    assert result.exit_code == 0
+    run.assert_called_once_with()
+    assert "a: 2" in result.stdout
+    assert "inserted: 2" in result.stdout
+
+
 def test_articles_lists_rows() -> None:
     fake = [{"id": 7, "status": "new", "title": "Hello", "source_name": "Src"}]
     with patch("news_dashboard.cli.list_articles", return_value=fake) as listed:

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -6,6 +6,7 @@ No APScheduler or database is required; all external dependencies are patched.
 from __future__ import annotations
 
 import logging
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -103,6 +104,17 @@ _INIT_DB_PATH = "news_dashboard.db.init_db"
 _GET_SETTING_PATH = "news_dashboard.db.get_setting"
 
 
+@pytest.fixture(autouse=True)
+def _reset_scheduler_state() -> Generator[None]:
+    from news_dashboard import scheduler
+
+    scheduler._state.scheduler = None
+    scheduler._state.ingest_interval_enabled = True
+    yield
+    scheduler._state.scheduler = None
+    scheduler._state.ingest_interval_enabled = True
+
+
 def _start_with_env(monkeypatch: pytest.MonkeyPatch, briefing_cron: str | None = None) -> MagicMock:
     """Run start_scheduler() with APScheduler mocked; return the mock scheduler."""
     mock_sched = MagicMock()
@@ -184,6 +196,22 @@ def test_run_ingest_prefetches_when_new_articles() -> None:
     ):
         scheduler._run_ingest()
 
+    ingest.assert_called_once()
+    prefetch.assert_called_once()
+    recalc.assert_called_once()
+
+
+def test_run_scheduled_ingest_returns_results_and_runs_maintenance() -> None:
+    from news_dashboard import scheduler
+
+    with (
+        patch("news_dashboard.ingest.ingest_all", return_value={"a": 2, "b": -1}) as ingest,
+        patch("news_dashboard.body_fetch.prefetch_article_bodies") as prefetch,
+        patch.object(scheduler, "_run_recommendation_recalc") as recalc,
+    ):
+        results = scheduler.run_scheduled_ingest()
+
+    assert results == {"a": 2, "b": -1}
     ingest.assert_called_once()
     prefetch.assert_called_once()
     recalc.assert_called_once()
@@ -372,6 +400,44 @@ def test_start_scheduler_uses_db_interval(monkeypatch: pytest.MonkeyPatch) -> No
         c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "ingest"
     )
     assert ingest_call.kwargs["minutes"] == 12
+
+
+def test_start_scheduler_can_disable_only_interval_ingest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INGEST_INTERVAL_SCHEDULER_ENABLED", "false")
+    mock_sched = _start_with_env(monkeypatch)
+
+    ids = [c.kwargs.get("id") for c in mock_sched.add_job.call_args_list]
+    assert "ingest" not in ids
+    assert {"digest", "briefing", "recommendations", "per_user_briefings"} <= set(ids)
+
+    from news_dashboard import scheduler
+
+    assert scheduler.is_ingest_interval_enabled() is False
+
+
+def test_start_scheduler_ignores_saved_pause_when_interval_ingest_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INGEST_INTERVAL_SCHEDULER_ENABLED", "false")
+    mock_sched = MagicMock()
+    mock_sched.get_job.return_value = None
+
+    def get_setting(key: str) -> str | None:
+        return "true" if key == "scheduler_paused" else None
+
+    with (
+        patch(_BGSCHED_PATH, return_value=mock_sched),
+        patch(_INIT_DB_PATH),
+        patch(_GET_SETTING_PATH, side_effect=get_setting),
+    ):
+        from news_dashboard import scheduler
+
+        scheduler._state.scheduler = None
+        scheduler.start_scheduler()
+
+    mock_sched.pause_job.assert_not_called()
 
 
 # ── lifecycle: stop / next-run / pause-state / interval ───────────────────────
@@ -614,3 +680,22 @@ def test_resume_scheduler_suppresses_error() -> None:
             scheduler.resume_scheduler()  # must not raise
         finally:
             scheduler._state.scheduler = None
+
+
+def test_scheduler_status_reports_external_ingest_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard import main
+
+    monkeypatch.setattr(main, "is_ingest_interval_enabled", lambda: False)
+    monkeypatch.setattr(main, "get_interval_minutes", lambda: 30)
+    monkeypatch.setattr(main, "get_next_ingest_at", lambda: None)
+    monkeypatch.setattr(main, "is_paused", lambda: True)
+
+    assert main.scheduler_status() == {
+        "interval_minutes": 30,
+        "paused": False,
+        "next_run_at": None,
+        "interval_ingest_enabled": False,
+        "ingest_authority": "external",
+    }

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -155,6 +155,23 @@ describe('SchedulerPage', () => {
     await waitFor(() => expect(apiMock.pauseScheduler).toHaveBeenCalled());
   });
 
+  it('shows external scheduler state without mutable interval controls', async () => {
+    apiMock.fetchSchedulerStatus.mockResolvedValue({
+      ...running,
+      interval_ingest_enabled: false,
+      ingest_authority: 'external',
+      next_run_at: null,
+    });
+    withProviders(<SchedulerPage />);
+
+    expect(await screen.findByText('External schedule')).toBeTruthy();
+    expect(screen.getByText('External CronJob')).toBeTruthy();
+    fireEvent.click(screen.getByText('⏸ Pause'));
+    fireEvent.click(screen.getByText('1h'));
+    expect(apiMock.pauseScheduler).not.toHaveBeenCalled();
+    expect(apiMock.setSchedulerInterval).not.toHaveBeenCalled();
+  });
+
   it('resumes a paused scheduler', async () => {
     apiMock.fetchSchedulerStatus.mockResolvedValue({ ...running, paused: true });
     apiMock.resumeScheduler.mockResolvedValue({ paused: false, next_run_at: null });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -140,6 +140,8 @@ export interface SchedulerStatus {
   interval_minutes: number;
   paused: boolean;
   next_run_at: string | null;
+  interval_ingest_enabled?: boolean;
+  ingest_authority?: 'in_process' | 'external';
 }
 
 export async function fetchSchedulerStatus(): Promise<SchedulerStatus> {

--- a/frontend/src/pages/SchedulerPage.tsx
+++ b/frontend/src/pages/SchedulerPage.tsx
@@ -47,6 +47,10 @@ export function SchedulerPage() {
 
   useEffect(() => {
     if (!status) return;
+    if (status.interval_ingest_enabled === false) {
+      setCountdown('Externally scheduled');
+      return;
+    }
     if (status.paused) {
       setCountdown('Paused');
       return;
@@ -59,6 +63,7 @@ export function SchedulerPage() {
   }, [status]);
 
   async function handlePreset(minutes: number) {
+    if (status?.interval_ingest_enabled === false) return;
     setActionPending(true);
     try {
       const res = await setSchedulerInterval(minutes);
@@ -85,6 +90,7 @@ export function SchedulerPage() {
 
   async function handleTogglePause() {
     if (!status) return;
+    if (status.interval_ingest_enabled === false) return;
     setActionPending(true);
     try {
       if (status.paused) {
@@ -137,18 +143,36 @@ export function SchedulerPage() {
           Status
         </h3>
         <div className="flex items-center gap-3 mb-2">
-          <Badge variant={status?.paused ? 'secondary' : 'default'}>
-            {status?.paused ? '⏸ Paused' : '▶ Running'}
+          <Badge
+            variant={
+              status?.paused || status?.interval_ingest_enabled === false ? 'secondary' : 'default'
+            }
+          >
+            {status?.interval_ingest_enabled === false
+              ? 'External schedule'
+              : status?.paused
+                ? '⏸ Paused'
+                : '▶ Running'}
           </Badge>
           <span className="text-sm text-muted-foreground">
-            {status?.paused ? 'No runs scheduled' : `Next run in ${countdown}`}
+            {status?.interval_ingest_enabled === false
+              ? 'Interval ingest is managed outside this scheduler'
+              : status?.paused
+                ? 'No runs scheduled'
+                : `Next run in ${countdown}`}
           </span>
         </div>
         <div className="flex gap-2 text-sm mt-2">
           <span className="text-muted-foreground">Interval:</span>
           <span className="font-medium">{status?.interval_minutes ?? '—'} minutes</span>
         </div>
-        {!status?.paused && status?.next_run_at && (
+        {status?.interval_ingest_enabled === false && (
+          <div className="flex gap-2 text-sm mt-1">
+            <span className="text-muted-foreground">Authority:</span>
+            <span className="text-muted-foreground">External CronJob</span>
+          </div>
+        )}
+        {status?.interval_ingest_enabled !== false && !status?.paused && status?.next_run_at && (
           <div className="flex gap-2 text-sm mt-1">
             <span className="text-muted-foreground">Next run at:</span>
             <span className="text-muted-foreground">
@@ -172,7 +196,7 @@ export function SchedulerPage() {
               size="sm"
               variant={status?.interval_minutes === p.value ? 'default' : 'outline'}
               onClick={() => void handlePreset(p.value)}
-              disabled={actionPending}
+              disabled={actionPending || status?.interval_ingest_enabled === false}
             >
               {p.label}
             </Button>
@@ -188,14 +212,14 @@ export function SchedulerPage() {
             onKeyDown={(e) => {
               if (e.key === 'Enter') void handleCustomSave();
             }}
-            disabled={actionPending}
+            disabled={actionPending || status?.interval_ingest_enabled === false}
             className="max-w-[180px] h-9"
             aria-label="Custom interval in minutes"
           />
           <Button
             size="sm"
             onClick={() => void handleCustomSave()}
-            disabled={actionPending || !customMinutes}
+            disabled={actionPending || !customMinutes || status?.interval_ingest_enabled === false}
           >
             Save
           </Button>
@@ -210,7 +234,7 @@ export function SchedulerPage() {
           <Button
             variant={status?.paused ? 'default' : 'secondary'}
             onClick={() => void handleTogglePause()}
-            disabled={actionPending}
+            disabled={actionPending || status?.interval_ingest_enabled === false}
           >
             {status?.paused ? '▶ Resume' : '⏸ Pause'}
           </Button>

--- a/helm/news-dashboard/templates/cronjob.yaml
+++ b/helm/news-dashboard/templates/cronjob.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.ingestCronJob.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "news-dashboard.fullname" . }}-ingest
 spec:
-  schedule: "17 */6 * * *"
+  schedule: {{ .Values.ingestCronJob.schedule | quote }}
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
   jobTemplate:
@@ -25,7 +26,7 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 1000
                 runAsGroup: 1000
-              command: ["news-dashboard", "ingest"]
+              command: ["news-dashboard", "scheduled-ingest"]
               env:
 {{- if .Values.postgresql.enabled }}
                 - name: POSTGRES_HOST
@@ -73,4 +74,5 @@ spec:
   {{- else }}
     {{- fail "External PostgreSQL configuration is required when postgresql.enabled=false. Provide app.postgresExternal or app.databaseUrl." }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
           env:
+            - name: INGEST_INTERVAL_SCHEDULER_ENABLED
+              value: {{ ternary "false" "true" .Values.ingestCronJob.enabled | quote }}
 {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_HOST
               value: {{ printf "%s-postgres" (include "news-dashboard.fullname" .) | quote }}

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -75,6 +75,10 @@ app:
       publicKeyKey: LANGFUSE_PUBLIC_KEY
       secretKeyKey: LANGFUSE_SECRET_KEY
 
+ingestCronJob:
+  enabled: true
+  schedule: "17 */6 * * *"
+
 postgresql:
   enabled: true
   image: postgres:16-alpine


### PR DESCRIPTION
Closes #336

## Summary
- Add `INGEST_INTERVAL_SCHEDULER_ENABLED` so the app can disable only the in-process interval ingest job while keeping digest, briefing, per-user briefing, and recommendation jobs active.
- Add `news-dashboard scheduled-ingest` and point the Helm CronJob at it so CronJob-driven ingest runs the same body prefetch and stale recommendation maintenance as APScheduler ingest.
- Add Helm `ingestCronJob.enabled` / `ingestCronJob.schedule` values and render the deployment env switch so the default chart has a single ingest authority.
- Expose scheduler authority in `/api/scheduler/status` and make the Scheduler page show external CronJob authority without implying pause/resume controls affect it.

## Tests
- `python -m pytest backend/tests/test_scheduler.py backend/tests/test_cli.py`
- `npm run test:frontend -- --run frontend/src/__tests__/feedsPages.test.tsx frontend/src/__tests__/api.test.ts`
- `npm run lint && npm run format:check && npm run typecheck`
- `make lint && make typecheck`
- `npm run test:frontend && npm run build`
- `source .env && make test` (first full run hit a transient PostgreSQL deadlock in existing `test_postgres_types.py`; retry passed: 808 passed, 5 skipped)
- Pre-push hooks passed on retry (first push hit the same transient PostgreSQL deadlock; second push passed backend pytest and frontend vitest)

Helm render note: local `helm` is not installed in this worktree environment, so chart render tests were skipped locally by the existing test suite.
