### PR TITLE
perf: reduce bcrypt work factor in test environment (#340)

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -120,8 +120,21 @@ def _session_days() -> int:
 # --------------------------------------------------------------------------- #
 
 
+def _bcrypt_rounds() -> int:
+    env_val = os.getenv("BCRYPT_ROUNDS")
+    if env_val is not None:
+        try:
+            return int(env_val)
+        except ValueError:
+            pass
+    # Detect test context: TEST_SESSION_SECRET is set by pytest fixtures.
+    if os.getenv("TEST_SESSION_SECRET"):
+        return 4
+    return 12
+
+
 def hash_password(password: str) -> str:
-    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt(_bcrypt_rounds())).decode()
 
 
 def verify_password(password: str, password_hash: str) -> bool:


### PR DESCRIPTION
## Summary

Closes #340

- Added `_bcrypt_rounds()` helper in `backend/news_dashboard/auth.py` that reads `BCRYPT_ROUNDS` env var (explicit override) or falls back to 4 rounds when `TEST_SESSION_SECRET` is set (test context detection), defaulting to 12 in production
- `hash_password()` now calls `bcrypt.gensalt(_bcrypt_rounds())` instead of the default

## Test results

- `test_auth.py`: 37 passed in ~14s (was >3 min)
- `test_auth_extra.py`: 21 passed in ~5s
- `make check`: all lint, typecheck, and full test suite pass cleanly

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes (mypy, ty, pyrefly all green)
- [x] `source .env && pytest backend/tests/test_auth.py` passes quickly
- [x] `source .env && pytest backend/tests/test_auth_extra.py` passes quickly
- [x] Pre-push hook (`make test`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)