### PR TITLE
test: refactor DB_PATH test routing (#339)

### DIFF
--- a/backend/news_dashboard/analytics.py
+++ b/backend/news_dashboard/analytics.py
@@ -28,7 +28,7 @@ SESSION_GAP_SECONDS = 30 * 60
 def record_events(
     user_id: int,
     events: list[dict[str, Any]],
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
 ) -> int:
     """Bulk-insert validated telemetry events for ``user_id``; return the count stored."""
@@ -63,7 +63,7 @@ def record_events(
 
 def admin_analytics(
     days: int = 30,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
 ) -> dict[str, Any]:
     """Aggregate user consumption and behavior over the trailing ``days`` window."""

--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -6,6 +6,7 @@ import logging
 import os
 import secrets
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Annotated, Any
 from urllib.parse import urlencode
 
@@ -205,9 +206,11 @@ def create_user(
     *,
     email: str | None = None,
     is_admin: bool = False,
+    db_path: Path | str | None = None,
 ) -> dict[str, Any]:
     password_hash = hash_password(password)
-    with connect() as conn:
+    connection = connect(db_path) if db_path is not None else connect()
+    with connection as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash, email, is_admin)"
             " VALUES(%s, %s, %s, %s) RETURNING id, username, email, is_admin, created_at",

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -269,7 +269,7 @@ def _article_from_row(row: Any, conn: Any, article_id: int, user_id: int | None)
 
 def get_article(
     article_id: int,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Fetch a single article by ID, stripping internal columns.
@@ -288,7 +288,7 @@ def get_article(
 
 def fetch_and_cache_body(
     article_id: int,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Fetch and store body for an article. Returns the updated article dict or None if not found.
@@ -320,7 +320,7 @@ def fetch_and_cache_body(
     return get_article(article_id, db_path=db_path, user_id=user_id)
 
 
-def prefetch_article_bodies(limit: int = 20, db_path: Path | None = None) -> int:
+def prefetch_article_bodies(limit: int = 20, db_path: Path | str | None = None) -> int:
     """Fetch and cache bodies for recently ingested articles that are still missing a body.
 
     Called as a background task after each ingest run to warm the body cache

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -527,7 +527,7 @@ def generate_briefing(
 
 
 def get_latest_briefing(
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
     user_id: int | None = None,
 ) -> dict[str, Any] | None:
@@ -568,7 +568,7 @@ def get_latest_briefing(
 def list_briefings(
     limit: int = 50,
     offset: int = 0,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
     user_id: int | None = None,
 ) -> list[dict[str, Any]]:
@@ -603,7 +603,7 @@ def list_briefings(
 
 def get_briefing(
     briefing_id: int,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
     user_id: int | None = None,
 ) -> dict[str, Any] | None:

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -15,7 +15,6 @@ from psycopg import sql
 from psycopg.rows import dict_row
 
 POSTGRES_PREFIXES = ("postgres:" + "//", "postgresql:" + "//")
-DB_PATH: Path | None = None
 
 logger = logging.getLogger(__name__)
 _INIT_DB_LOCK = threading.Lock()
@@ -407,7 +406,7 @@ def active_database_url(database_url: str | None = None) -> str:
     return f"postgresql://{user}:{password}@{host}:{port}/{database}"
 
 
-def describe_database(_db_path: Path | None = None, database_url: str | None = None) -> str:
+def describe_database(database_url: str | None = None) -> str:
     url = active_database_url(database_url)
     parts = urlsplit(url)
     if parts.password:
@@ -421,17 +420,19 @@ def describe_database(_db_path: Path | None = None, database_url: str | None = N
 
 @contextmanager
 def connect(
-    _db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
 ) -> Iterator[Any]:
     """Open a PostgreSQL connection using psycopg-native SQL and parameters."""
+    if isinstance(db_path, str) and db_path.startswith(POSTGRES_PREFIXES):
+        database_url = db_path
+        db_path = None
     # ty mis-resolves psycopg's overloaded connect() and infers the default
     # tuple row_factory; mypy and pyrefly both accept dict_row here.
     conn = psycopg.connect(active_database_url(database_url), row_factory=dict_row)  # ty: ignore[invalid-argument-type]
-    schema_token = _db_path or DB_PATH
     try:
-        if schema_token is not None:
-            schema = _schema_name(schema_token)
+        if isinstance(db_path, Path):
+            schema = _schema_name(db_path)
             conn.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(schema)))
             conn.execute(sql.SQL("SET search_path TO {}").format(sql.Identifier(schema)))
         yield conn
@@ -443,7 +444,10 @@ def connect(
         conn.close()
 
 
-def init_db(_db_path: Path | None = None, database_url: str | None = None) -> None:
+def init_db(db_path: Path | str | None = None, database_url: str | None = None) -> None:
+    if isinstance(db_path, str) and db_path.startswith(POSTGRES_PREFIXES):
+        database_url = db_path
+        db_path = None
     schema_fingerprint = sha256(
         "\0".join(POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA).encode("utf-8")
     ).hexdigest()
@@ -460,7 +464,7 @@ def init_db(_db_path: Path | None = None, database_url: str | None = None) -> No
         )
     )
     cache_key = (
-        str(_db_path or DB_PATH or ""),
+        str(db_path or ""),
         env_key,
         schema_fingerprint,
     )
@@ -473,7 +477,7 @@ def init_db(_db_path: Path | None = None, database_url: str | None = None) -> No
     applied = 0
     for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
         try:
-            with connect(_db_path, database_url=database_url) as conn:
+            with connect(db_path, database_url=database_url) as conn:
                 conn.execute(statement)
                 applied += 1
         except Exception:  # idempotent best-effort schema statements

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -340,7 +340,7 @@ def _find_canonical(conn: Any, canonical_url: str, title: str) -> int | None:
     return None
 
 
-def sync_sources(db_path: Path | None = None) -> None:
+def sync_sources(db_path: Path | str | None = None) -> None:
     init_db(db_path)
     with connect(db_path) as conn:
         for source in DEFAULT_SOURCES:
@@ -420,7 +420,9 @@ def _fetch_nitter_feed(source: SourceDefinition) -> list[dict[str, Any]]:
     raise FeedFetchError(msg) from last_exc
 
 
-def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> SourceIngestOutcome:
+def _ingest_source(
+    source: SourceDefinition, db_path: Path | str | None = None
+) -> SourceIngestOutcome:
     """Fetch and insert articles for a single source. Returns count inserted."""
     from news_dashboard.scraper import scrape_source
 
@@ -567,7 +569,7 @@ def _ingest_source(source: SourceDefinition, db_path: Path | None = None) -> Sou
     )
 
 
-def ingest_source(source: SourceDefinition, db_path: Path | None = None) -> int:
+def ingest_source(source: SourceDefinition, db_path: Path | str | None = None) -> int:
     """Fetch and insert articles for a single source. Returns count inserted."""
     outcome = _ingest_source(source, db_path)
     if outcome.error_message is not None:
@@ -584,7 +586,7 @@ def _row_value(row: Any, key: str, index: int) -> Any:
         return row[index]
 
 
-def _create_ingest_run(db_path: Path | None, started_at: str) -> int:
+def _create_ingest_run(db_path: Path | str | None, started_at: str) -> int:
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
@@ -594,7 +596,9 @@ def _create_ingest_run(db_path: Path | None, started_at: str) -> int:
     return int(_row_value(row, "id", 0))
 
 
-def _record_ingest_source(run_id: int, outcome: SourceIngestOutcome, db_path: Path | None) -> None:
+def _record_ingest_source(
+    run_id: int, outcome: SourceIngestOutcome, db_path: Path | str | None
+) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -615,7 +619,7 @@ def _record_ingest_source(run_id: int, outcome: SourceIngestOutcome, db_path: Pa
 
 def _finish_ingest_run(
     run_id: int,
-    db_path: Path | None,
+    db_path: Path | str | None,
     finished_at: str,
     duration_ms: int,
     total_new: int,
@@ -642,7 +646,7 @@ def _format_source_log(outcome: SourceIngestOutcome) -> str:
     )
 
 
-def ingest_all(db_path: Path | None = None) -> dict[str, int]:
+def ingest_all(db_path: Path | str | None = None) -> dict[str, int]:
     with _INGEST_RUN_LOCK:
         sync_sources(db_path)
         run_started_at = now_iso()
@@ -932,7 +936,7 @@ def list_articles(  # noqa: PLR0913
     starred: bool | None = None,
     limit: int = 100,
     offset: int = 0,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     user_id: int | None = None,
 ) -> list[dict[str, Any]]:
     init_db(db_path)
@@ -1013,7 +1017,7 @@ def _list_articles_for_user(  # noqa: PLR0913
     starred: bool | None,
     limit: int,
     offset: int,
-    db_path: Path | None,
+    db_path: Path | str | None,
     now: str,
 ) -> list[dict[str, Any]]:
     """Article listing scoped to a specific user via user_article_state."""
@@ -1144,7 +1148,7 @@ def _attach_also_from(conn: Any, articles: list[dict[str, Any]]) -> None:
 def search_articles(  # noqa: PLR0912, PLR0913
     q: str = "",
     limit: int = 50,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     states: list[str] | None = None,
     categories: list[str] | None = None,
     sources: list[str] | None = None,
@@ -1245,7 +1249,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     user_id: int,
     q: str,
     limit: int,
-    db_path: Path | None,
+    db_path: Path | str | None,
     states: list[str] | None,
     categories: list[str] | None,
     sources: list[str] | None,
@@ -1354,7 +1358,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
 
 
 def set_article_status(
-    article_id: int, status: str, db_path: Path | None = None
+    article_id: int, status: str, db_path: Path | str | None = None
 ) -> dict[str, Any] | None:
     if status not in VALID_STATUSES:
         message = f"invalid status: {status!r} (expected one of {sorted(VALID_STATUSES)})"
@@ -1400,7 +1404,7 @@ def _get_article_row(conn: Any, article_id: int) -> dict[str, Any] | None:
 def transition_article_state(  # noqa: PLR0912
     article_id: int,
     new_state: str,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Apply a state transition, enforcing allowed-transition rules.
@@ -1491,7 +1495,7 @@ def transition_article_state(  # noqa: PLR0912
 def set_article_starred(
     article_id: int,
     starred: bool,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Set the starred flag on an article. Raises ValueError if starring a skipped article."""
@@ -1537,7 +1541,7 @@ def set_article_starred(
 def send_article_later(
     article_id: int,
     days: int = 1,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     user_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Snooze an article to Later with an expiry of `days` days from now.
@@ -1591,7 +1595,7 @@ def send_article_later(
         return _get_article_row(conn, article_id)
 
 
-def get_user_summary(user_id: int, db_path: Path | None = None) -> dict[str, Any]:
+def get_user_summary(user_id: int, db_path: Path | str | None = None) -> dict[str, Any]:
     """Return per-user article counts by status and category.
 
     Maps the new (state, starred) model back to the legacy status keys the

--- a/backend/news_dashboard/recommendation_jobs.py
+++ b/backend/news_dashboard/recommendation_jobs.py
@@ -74,7 +74,7 @@ def mark_user_recommendations_stale(
 
 def find_recalculation_candidates(
     *,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
 ) -> list[int]:
     """Return ids of users with stale, missing, or superseded scores.
@@ -117,7 +117,7 @@ def find_recalculation_candidates(
 
 def recalculate_stale_recommendations(
     *,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
     limit_per_user: int = 1000,
 ) -> RecalculationSummary:
@@ -159,7 +159,9 @@ def recalculate_stale_recommendations(
     return summary
 
 
-def _all_user_ids(*, db_path: Path | None = None, database_url: str | None = None) -> list[int]:
+def _all_user_ids(
+    *, db_path: Path | str | None = None, database_url: str | None = None
+) -> list[int]:
     """Return every user id, ordered, for an unconditional recompute sweep."""
     init_db(db_path, database_url=database_url)
     with connect(db_path, database_url=database_url) as conn:
@@ -169,7 +171,7 @@ def _all_user_ids(*, db_path: Path | None = None, database_url: str | None = Non
 
 def recalculate_all_recommendations(
     *,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
     limit_per_user: int = 1000,
 ) -> RecalculationSummary:
@@ -216,7 +218,7 @@ def recalculate_all_recommendations(
 
 def recommendation_health(
     *,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
 ) -> dict[str, Any]:
     """Diagnostic snapshot of stored recommendation freshness.

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -286,7 +286,7 @@ def upsert_recommendation_score(  # noqa: PLR0913
     article_id: int,
     recommendation_score: float,
     *,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
     cold_start_score: float | None = None,
     signals: dict[str, Any] | None = None,
@@ -407,7 +407,7 @@ def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]
 def recompute_user_recommendations(
     user_id: int,
     *,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
     database_url: str | None = None,
     limit: int = 1000,
 ) -> int:

--- a/backend/news_dashboard/run_history.py
+++ b/backend/news_dashboard/run_history.py
@@ -61,7 +61,7 @@ def list_ingest_runs(
     to: datetime | str | None = None,
     page: int = 1,
     per_page: int = 20,
-    db_path: Path | None = None,
+    db_path: Path | str | None = None,
 ) -> dict[str, Any]:
     init_db(db_path)
     filters = ["finished_at IS NOT NULL"]
@@ -128,7 +128,7 @@ def list_ingest_runs(
 
 
 def get_ingest_run_sources(
-    run_id: int, *, db_path: Path | None = None
+    run_id: int, *, db_path: Path | str | None = None
 ) -> list[dict[str, Any]] | None:
     init_db(db_path)
     with connect(db_path) as conn:

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -43,7 +43,7 @@ def _as_int(value: Any, default: int = 0) -> int:
         return default
 
 
-def list_source_health(db_path: Path | None = None) -> list[dict[str, Any]]:
+def list_source_health(db_path: Path | str | None = None) -> list[dict[str, Any]]:
     init_db(db_path)
     with connect(db_path) as conn:
         source_rows = conn.execute(

--- a/backend/news_dashboard/stats.py
+++ b/backend/news_dashboard/stats.py
@@ -17,7 +17,9 @@ def parse_range(from_value: str, to_value: str) -> tuple[datetime, datetime]:
     return start, end
 
 
-def stats_overview(from_value: str, to_value: str, db_path: Path | None = None) -> dict[str, Any]:
+def stats_overview(
+    from_value: str, to_value: str, db_path: Path | str | None = None
+) -> dict[str, Any]:
     start, end = parse_range(from_value, to_value)
     runs, source_rows = _load_stats_rows(start, end, db_path)
 
@@ -57,7 +59,7 @@ def stats_overview(from_value: str, to_value: str, db_path: Path | None = None) 
 
 
 def articles_over_time(
-    from_value: str, to_value: str, db_path: Path | None = None
+    from_value: str, to_value: str, db_path: Path | str | None = None
 ) -> list[dict[str, Any]]:
     start, end = parse_range(from_value, to_value)
     runs, _ = _load_stats_rows(start, end, db_path)
@@ -80,7 +82,7 @@ def articles_over_time(
 
 
 def sources_volume(
-    from_value: str, to_value: str, db_path: Path | None = None
+    from_value: str, to_value: str, db_path: Path | str | None = None
 ) -> list[dict[str, Any]]:
     start, end = parse_range(from_value, to_value)
     _, source_rows = _load_stats_rows(start, end, db_path)
@@ -95,7 +97,7 @@ def sources_volume(
     ]
 
 
-def ingested_vs_handled(db_path: Path | None = None, days: int = 14) -> list[dict[str, Any]]:
+def ingested_vs_handled(db_path: Path | str | None = None, days: int = 14) -> list[dict[str, Any]]:
     """Return per-day ingested and handled article counts for the last `days` days."""
     since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
     init_db(db_path)
@@ -146,7 +148,7 @@ def ingested_vs_handled(db_path: Path | None = None, days: int = 14) -> list[dic
     ]
 
 
-def article_counts(db_path: Path | None = None) -> dict[str, int]:
+def article_counts(db_path: Path | str | None = None) -> dict[str, int]:
     """Return total article count per status across all time.
 
     Reads from user_article_state (the live state machine table) rather than
@@ -186,7 +188,7 @@ def article_counts(db_path: Path | None = None) -> dict[str, int]:
     }
 
 
-def triage_metrics(db_path: Path | None = None) -> dict[str, Any]:
+def triage_metrics(db_path: Path | str | None = None) -> dict[str, Any]:
     """Return habit metrics for articles discovered in the last 7 days.
 
     All counts read from user_article_state rather than the legacy
@@ -270,7 +272,7 @@ def triage_metrics(db_path: Path | None = None) -> dict[str, Any]:
     }
 
 
-def source_quality(db_path: Path | None = None) -> list[dict[str, Any]]:
+def source_quality(db_path: Path | str | None = None) -> list[dict[str, Any]]:
     """Return per-source quality stats computed from the articles table."""
     init_db(db_path)
     with connect(db_path) as conn:
@@ -331,7 +333,7 @@ def source_quality(db_path: Path | None = None) -> list[dict[str, Any]]:
     return result
 
 
-def category_mix(db_path: Path | None = None, days: int = 14) -> list[dict[str, Any]]:
+def category_mix(db_path: Path | str | None = None, days: int = 14) -> list[dict[str, Any]]:
     """Return per-day article counts broken down by category for the last `days` days."""
     since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
     init_db(db_path)
@@ -372,7 +374,7 @@ def category_mix(db_path: Path | None = None, days: int = 14) -> list[dict[str, 
 def _load_stats_rows(
     start: datetime,
     end: datetime,
-    db_path: Path | None,
+    db_path: Path | str | None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     init_db(db_path)
     with connect(db_path) as conn:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -122,10 +122,16 @@ def pg_clean(pg_url: str) -> str:
     """
     import psycopg
 
+    from news_dashboard import db as db_mod
+
+    db_mod._INITIALIZED_DATABASES.clear()
+    init_db(database_url=pg_url)
     with psycopg.connect(pg_url) as conn:
         conn.execute(
             "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
-            " briefing_articles, briefings, articles, sources, users RESTART IDENTITY CASCADE"
+            " user_push_subscriptions, article_shares, user_events, briefing_articles,"
+            " briefings, ingest_run_sources, ingest_runs, articles, sources, users"
+            " RESTART IDENTITY CASCADE"
         )
         conn.commit()
     return pg_url

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from pathlib import Path
-
 import pytest
 
-import news_dashboard.db as db_mod
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect
 from news_dashboard.ingest import sync_sources
@@ -22,23 +18,18 @@ from news_dashboard.shares import (
 
 
 @pytest.fixture
-def db(tmp_path: Path) -> Iterator[Path]:
-    """A test schema with sources synced and DB_PATH patched for share helpers."""
-    path = tmp_path / "shares.db"
-    sync_sources(path)
-    orig = db_mod.DB_PATH
-    db_mod.DB_PATH = path
-    try:
-        yield path
-    finally:
-        db_mod.DB_PATH = orig
+def db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    """A test database with sources synced for share helpers."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    return pg_clean
 
 
-def _make_user(username: str) -> int:
-    return int(create_user(username, "password123")["id"])
+def _make_user(db_path: str, username: str) -> int:
+    return int(create_user(username, "password123", db_path=db_path)["id"])
 
 
-def _insert_article(db_path: Path, suffix: str = "1") -> int:
+def _insert_article(db_path: str, suffix: str = "1") -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             """
@@ -61,9 +52,9 @@ def _insert_article(db_path: Path, suffix: str = "1") -> int:
     return int(row["id"])
 
 
-def test_share_and_list(db: Path) -> None:
-    alice = _make_user("alice")
-    bob = _make_user("bob")
+def test_share_and_list(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
     article_id = _insert_article(db)
 
     share_article(article_id=article_id, from_user_id=alice, to_user_id=bob, note="  read this  ")
@@ -79,9 +70,9 @@ def test_share_and_list(db: Path) -> None:
     assert list_received_shares(alice) == []
 
 
-def test_mark_read(db: Path) -> None:
-    alice = _make_user("alice")
-    bob = _make_user("bob")
+def test_mark_read(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
     article_id = _insert_article(db)
     share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
 
@@ -93,22 +84,22 @@ def test_mark_read(db: Path) -> None:
     assert mark_share_read(int(share["id"]), alice) is False
 
 
-def test_shareable_users_excludes_self(db: Path) -> None:
-    alice = _make_user("alice")
-    _make_user("bob")
+def test_shareable_users_excludes_self(db: str) -> None:
+    alice = _make_user(db, "alice")
+    _make_user(db, "bob")
     usernames = {u["username"] for u in shareable_users(alice)}
     assert usernames == {"bob"}
 
 
-def test_cannot_share_with_self(db: Path) -> None:
-    alice = _make_user("alice")
+def test_cannot_share_with_self(db: str) -> None:
+    alice = _make_user(db, "alice")
     article_id = _insert_article(db)
     with pytest.raises(ShareError):
         share_article(article_id=article_id, from_user_id=alice, to_user_id=alice)
 
 
-def test_share_unknown_article_raises(db: Path) -> None:
-    alice = _make_user("alice")
-    bob = _make_user("bob")
+def test_share_unknown_article_raises(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
     with pytest.raises(ShareError):
         share_article(article_id=999999, from_user_id=alice, to_user_id=bob)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
-import news_dashboard.db as db_mod
 from news_dashboard.auth import (
     authenticate,
     bootstrap_admin,
@@ -41,12 +39,11 @@ def _fresh_client() -> TestClient:
 
 
 @pytest.fixture
-def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Fresh PostgreSQL test schema with DB_PATH patched so auth helpers use it."""
-    db = tmp_path / "test.db"
-    init_db(db)
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
-    return db
+def tmp_db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Fresh PostgreSQL test database routed through DATABASE_URL."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    return pg_clean
 
 
 # ── Password hashing ──────────────────────────────────────────────────────────
@@ -95,7 +92,7 @@ def test_expired_token_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
 # ── User CRUD ─────────────────────────────────────────────────────────────────
 
 
-def test_create_and_get_user(tmp_db: Path) -> None:
+def test_create_and_get_user(tmp_db: str) -> None:
     user = create_user("alice", "secret", email="a@b.com", is_admin=False)
     assert user["username"] == "alice"
     assert user["email"] == "a@b.com"
@@ -142,7 +139,7 @@ def test_create_user_passes_boolean_admin_value(monkeypatch: pytest.MonkeyPatch)
     assert fake_connect.conn.params[3] is True
 
 
-def test_list_users(tmp_db: Path) -> None:
+def test_list_users(tmp_db: str) -> None:
     create_user("u1", "p1")
     create_user("u2", "p2")
     usernames = [u["username"] for u in list_users()]
@@ -150,14 +147,14 @@ def test_list_users(tmp_db: Path) -> None:
     assert "u2" in usernames
 
 
-def test_update_password(tmp_db: Path) -> None:
+def test_update_password(tmp_db: str) -> None:
     user = create_user("bob", "old")
     assert update_password(user["id"], "new-pass")
     assert authenticate("bob", "new-pass") is not None
     assert authenticate("bob", "old") is None
 
 
-def test_delete_user(tmp_db: Path) -> None:
+def test_delete_user(tmp_db: str) -> None:
     user = create_user("carol", "pw")
     assert delete_user(user["id"])
     assert get_user_by_id(user["id"]) is None
@@ -166,7 +163,7 @@ def test_delete_user(tmp_db: Path) -> None:
 # ── authenticate() ────────────────────────────────────────────────────────────
 
 
-def test_authenticate_correct(tmp_db: Path) -> None:
+def test_authenticate_correct(tmp_db: str) -> None:
     create_user("dave", "correct")
     result = authenticate("dave", "correct")
     assert result is not None
@@ -174,12 +171,12 @@ def test_authenticate_correct(tmp_db: Path) -> None:
     assert "password_hash" not in result
 
 
-def test_authenticate_wrong_password(tmp_db: Path) -> None:
+def test_authenticate_wrong_password(tmp_db: str) -> None:
     create_user("eve", "right")
     assert authenticate("eve", "wrong") is None
 
 
-def test_authenticate_unknown_user(tmp_db: Path) -> None:
+def test_authenticate_unknown_user(tmp_db: str) -> None:
     assert authenticate("nobody", "pw") is None
 
 
@@ -235,7 +232,7 @@ def test_keycloak_token_request_data_omits_blank_client_secret(
 
 
 def test_ensure_keycloak_user_creates_local_user(
-    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("KEYCLOAK_ADMIN_USERNAMES", "ioachim")
     user = ensure_keycloak_user(
@@ -247,7 +244,7 @@ def test_ensure_keycloak_user_creates_local_user(
 
 
 def test_password_login_disabled_when_keycloak_enabled(
-    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
     create_user("local", "pw")
@@ -255,7 +252,7 @@ def test_password_login_disabled_when_keycloak_enabled(
 
 
 def test_init_auth_requires_session_secret_for_keycloak(
-    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
     monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
@@ -267,7 +264,7 @@ def test_init_auth_requires_session_secret_for_keycloak(
 
 
 def test_init_auth_accepts_keycloak_when_session_secret_is_set(
-    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
     monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
@@ -279,7 +276,7 @@ def test_init_auth_accepts_keycloak_when_session_secret_is_set(
 # ── Bootstrap ─────────────────────────────────────────────────────────────────
 
 
-def test_bootstrap_creates_first_admin(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_bootstrap_creates_first_admin(tmp_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOOTSTRAP_ADMIN_USERNAME", "admin")
     monkeypatch.setenv("BOOTSTRAP_ADMIN_PASSWORD", "adminpass")
     bootstrap_admin()
@@ -289,7 +286,7 @@ def test_bootstrap_creates_first_admin(tmp_db: Path, monkeypatch: pytest.MonkeyP
     assert users[0]["is_admin"]
 
 
-def test_bootstrap_noop_if_users_exist(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_bootstrap_noop_if_users_exist(tmp_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOOTSTRAP_ADMIN_USERNAME", "admin")
     monkeypatch.setenv("BOOTSTRAP_ADMIN_PASSWORD", "pw")
     create_user("existing", "pw2")
@@ -306,7 +303,7 @@ def test_user_count_from_row_reads_aliased_count() -> None:
 # ── Login / logout API ────────────────────────────────────────────────────────
 
 
-def test_login_sets_cookie(tmp_db: Path) -> None:
+def test_login_sets_cookie(tmp_db: str) -> None:
     create_user("frank", "frankpass", is_admin=False)
     client = _fresh_client()
     resp = client.post("/api/auth/login", json={"username": "frank", "password": "frankpass"})
@@ -315,7 +312,7 @@ def test_login_sets_cookie(tmp_db: Path) -> None:
     assert "nd_session" in resp.cookies
 
 
-def test_login_wrong_password_returns_401(tmp_db: Path) -> None:
+def test_login_wrong_password_returns_401(tmp_db: str) -> None:
     create_user("grace", "right")
     client = _fresh_client()
     resp = client.post("/api/auth/login", json={"username": "grace", "password": "wrong"})
@@ -323,7 +320,7 @@ def test_login_wrong_password_returns_401(tmp_db: Path) -> None:
     assert "nd_session" not in resp.cookies
 
 
-def test_logout_clears_cookie(tmp_db: Path) -> None:
+def test_logout_clears_cookie(tmp_db: str) -> None:
     create_user("henry", "pw")
     client = _fresh_client()
     client.post("/api/auth/login", json={"username": "henry", "password": "pw"})
@@ -335,13 +332,13 @@ def test_logout_clears_cookie(tmp_db: Path) -> None:
 # ── Auth middleware: protected routes require session ─────────────────────────
 
 
-def test_protected_route_without_session_returns_401(tmp_db: Path) -> None:
+def test_protected_route_without_session_returns_401(tmp_db: str) -> None:
     client = _fresh_client()
     resp = client.get("/api/articles", cookies={})
     assert resp.status_code == 401
 
 
-def test_protected_route_with_valid_session(tmp_db: Path) -> None:
+def test_protected_route_with_valid_session(tmp_db: str) -> None:
     user = create_user("irene", "pw")
     token = create_session_token(user["id"], is_admin=False)
     client = _fresh_client()
@@ -350,7 +347,7 @@ def test_protected_route_with_valid_session(tmp_db: Path) -> None:
     assert resp.status_code == 200
 
 
-def test_auth_me_returns_current_user(tmp_db: Path) -> None:
+def test_auth_me_returns_current_user(tmp_db: str) -> None:
     user = create_user("jane", "pw", is_admin=True)
     token = create_session_token(user["id"], is_admin=True)
     client = _fresh_client()
@@ -365,7 +362,7 @@ def test_auth_me_returns_current_user(tmp_db: Path) -> None:
 # ── Admin-only routes ─────────────────────────────────────────────────────────
 
 
-def test_admin_route_blocked_for_non_admin(tmp_db: Path) -> None:
+def test_admin_route_blocked_for_non_admin(tmp_db: str) -> None:
     user = create_user("regular", "pw", is_admin=False)
     token = create_session_token(user["id"], is_admin=False)
     client = _fresh_client()
@@ -374,7 +371,7 @@ def test_admin_route_blocked_for_non_admin(tmp_db: Path) -> None:
     assert resp.status_code == 403
 
 
-def test_admin_list_users(tmp_db: Path) -> None:
+def test_admin_list_users(tmp_db: str) -> None:
     admin = create_user("superadmin", "pw", is_admin=True)
     create_user("other", "pw2")
     token = create_session_token(admin["id"], is_admin=True)
@@ -387,7 +384,7 @@ def test_admin_list_users(tmp_db: Path) -> None:
     assert "other" in usernames
 
 
-def test_admin_create_user(tmp_db: Path) -> None:
+def test_admin_create_user(tmp_db: str) -> None:
     admin = create_user("superadmin", "pw", is_admin=True)
     token = create_session_token(admin["id"], is_admin=True)
     client = _fresh_client()
@@ -400,7 +397,7 @@ def test_admin_create_user(tmp_db: Path) -> None:
     assert resp.json()["username"] == "newuser"
 
 
-def test_admin_delete_user(tmp_db: Path) -> None:
+def test_admin_delete_user(tmp_db: str) -> None:
     admin = create_user("theadmin", "pw", is_admin=True)
     target = create_user("victim", "pw2", is_admin=False)
     token = create_session_token(admin["id"], is_admin=True)
@@ -411,7 +408,7 @@ def test_admin_delete_user(tmp_db: Path) -> None:
     assert get_user_by_id(target["id"]) is None
 
 
-def test_admin_cannot_delete_self(tmp_db: Path) -> None:
+def test_admin_cannot_delete_self(tmp_db: str) -> None:
     admin = create_user("self", "pw", is_admin=True)
     token = create_session_token(admin["id"], is_admin=True)
     client = _fresh_client()
@@ -423,7 +420,7 @@ def test_admin_cannot_delete_self(tmp_db: Path) -> None:
 # ── Health endpoint is public ─────────────────────────────────────────────────
 
 
-def test_health_is_public(tmp_db: Path) -> None:
+def test_health_is_public(tmp_db: str) -> None:
     client = _fresh_client()
     resp = client.get("/api/health")
     assert resp.status_code == 200
@@ -434,7 +431,7 @@ def test_health_is_public(tmp_db: Path) -> None:
     assert "next_ingest_at" not in body
 
 
-def test_health_details_requires_admin(tmp_db: Path) -> None:
+def test_health_details_requires_admin(tmp_db: str) -> None:
     client = _fresh_client()
     resp = client.get("/api/health/details")
     assert resp.status_code in (401, 403)

--- a/backend/tests/test_auth_extra.py
+++ b/backend/tests/test_auth_extra.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import secrets
-from pathlib import Path
 from typing import Any
 
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-import news_dashboard.db as db_mod
 from news_dashboard import auth as auth_mod
 from news_dashboard.auth import (
     create_user,
@@ -27,11 +25,10 @@ from news_dashboard.main import app
 
 
 @pytest.fixture
-def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    db = tmp_path / "test.db"
-    init_db(db)
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
-    return db
+def tmp_db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    return pg_clean
 
 
 def _enable_keycloak(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,7 +99,7 @@ def test_verify_session_token_rejects_garbage(monkeypatch: pytest.MonkeyPatch) -
 # ── get_current_user via the real dependency (no override) ───────────────────
 
 
-def test_me_rejects_invalid_session_cookie(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_me_rejects_invalid_session_cookie(tmp_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEST_SESSION_SECRET", "x" * 32)
     app.dependency_overrides.clear()
     client = TestClient(app)
@@ -110,7 +107,7 @@ def test_me_rejects_invalid_session_cookie(tmp_db: Path, monkeypatch: pytest.Mon
     assert resp.status_code == 401
 
 
-def test_me_rejects_when_user_missing(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_me_rejects_when_user_missing(tmp_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEST_SESSION_SECRET", "x" * 32)
     app.dependency_overrides.clear()
     # Valid signature but a user id that does not exist in the DB.
@@ -192,7 +189,7 @@ def test_exchange_userinfo_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc.value.status_code == 401
 
 
-def test_exchange_success_creates_user(tmp_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exchange_success_creates_user(tmp_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
     _enable_keycloak(monkeypatch)
     _patch_httpx(
         monkeypatch,
@@ -207,7 +204,7 @@ def test_exchange_success_creates_user(tmp_db: Path, monkeypatch: pytest.MonkeyP
 # ── admin user CRUD endpoints (admin override is autouse) ────────────────────
 
 
-def test_admin_get_user_found_and_missing(tmp_db: Path) -> None:
+def test_admin_get_user_found_and_missing(tmp_db: str) -> None:
     created = create_user("dora", "pw123456", email="dora@example.com")
     client = TestClient(app)
     ok = client.get(f"/api/admin/users/{created['id']}")
@@ -217,7 +214,7 @@ def test_admin_get_user_found_and_missing(tmp_db: Path) -> None:
     assert missing.status_code == 404
 
 
-def test_admin_update_password_found_and_missing(tmp_db: Path) -> None:
+def test_admin_update_password_found_and_missing(tmp_db: str) -> None:
     created = create_user("evan", "pw123456")
     client = TestClient(app)
     ok = client.patch(f"/api/admin/users/{created['id']}/password", json={"password": "newpass123"})
@@ -227,7 +224,7 @@ def test_admin_update_password_found_and_missing(tmp_db: Path) -> None:
     assert missing.status_code == 404
 
 
-def test_admin_create_user_conflict_on_duplicate(tmp_db: Path) -> None:
+def test_admin_create_user_conflict_on_duplicate(tmp_db: str) -> None:
     client = TestClient(app)
     first = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
     assert first.status_code == 200
@@ -235,7 +232,7 @@ def test_admin_create_user_conflict_on_duplicate(tmp_db: Path) -> None:
     assert dup.status_code == 409
 
 
-def test_admin_generate_user_returns_credentials(tmp_db: Path) -> None:
+def test_admin_generate_user_returns_credentials(tmp_db: str) -> None:
     client = TestClient(app)
     resp = client.post("/api/admin/users/generate", json={"username": "grace"})
     assert resp.status_code == 200
@@ -252,13 +249,13 @@ def test_admin_generate_user_returns_credentials(tmp_db: Path) -> None:
     assert login.status_code == 200
 
 
-def test_admin_generate_user_rejects_blank_username(tmp_db: Path) -> None:
+def test_admin_generate_user_rejects_blank_username(tmp_db: str) -> None:
     client = TestClient(app)
     resp = client.post("/api/admin/users/generate", json={"username": "   "})
     assert resp.status_code == 422
 
 
-def test_admin_generate_user_conflict_on_duplicate(tmp_db: Path) -> None:
+def test_admin_generate_user_conflict_on_duplicate(tmp_db: str) -> None:
     client = TestClient(app)
     first = client.post("/api/admin/users/generate", json={"username": "heidi"})
     assert first.status_code == 200
@@ -267,7 +264,7 @@ def test_admin_generate_user_conflict_on_duplicate(tmp_db: Path) -> None:
 
 
 def test_admin_generate_user_uses_keycloak_when_enabled(
-    tmp_db: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _enable_keycloak(monkeypatch)
     monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", secrets.token_hex(8))

--- a/backend/tests/test_behavioral_affinity.py
+++ b/backend/tests/test_behavioral_affinity.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pytest
 
-import news_dashboard.db as db_mod
 from news_dashboard.db import connect, init_db
 from news_dashboard.recommendations import (
     AFFINITY_SCORE_SPAN,
@@ -114,15 +113,13 @@ def test_scores_are_clamped_to_unit_range() -> None:
 # ── Database-backed recompute ─────────────────────────────────────────────────
 
 
-def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
-    db_path = tmp_path / name
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
     monkeypatch.setenv("DATABASE_URL", pg_url)
-    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
-    init_db(db_path)
-    return db_path
+    init_db(database_url=pg_url)
+    return pg_url
 
 
-def _make_user(db_path: Path, username: str) -> int:
+def _make_user(db_path: str, username: str) -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
@@ -132,7 +129,7 @@ def _make_user(db_path: Path, username: str) -> int:
     return int(row["id"])
 
 
-def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+def _insert_source(db_path: str, slug: str, *, category: str = "tech", priority: int = 50) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -145,7 +142,7 @@ def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority
 
 
 def _insert_article(
-    db_path: Path,
+    db_path: str,
     slug: str,
     suffix: str,
     *,
@@ -180,7 +177,7 @@ def _insert_article(
 
 
 def _set_state(
-    db_path: Path, user_id: int, article_id: int, *, state: str, starred: bool = False
+    db_path: str, user_id: int, article_id: int, *, state: str, starred: bool = False
 ) -> None:
     with connect(db_path) as conn:
         conn.execute(
@@ -194,7 +191,7 @@ def _set_state(
         )
 
 
-def _persisted_score(db_path: Path, user_id: int, article_id: int) -> float:
+def _persisted_score(db_path: str, user_id: int, article_id: int) -> float:
     with connect(db_path) as conn:
         row = conn.execute(
             "SELECT recommendation_score FROM user_article_recommendations"
@@ -208,7 +205,7 @@ def _persisted_score(db_path: Path, user_id: int, article_id: int) -> float:
 def test_recompute_persists_affinity_adjusted_scores(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "recompute.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "loved", category="ai", priority=50)
     _insert_source(db_path, "hated", category="crypto", priority=50)
     user_id = _make_user(db_path, "alice")
@@ -230,7 +227,7 @@ def test_recompute_persists_affinity_adjusted_scores(
 
 
 def test_recompute_is_isolated_per_user(tmp_path: Path, monkeypatch: Any, pg_clean: str) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "isolated.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src-a", category="ai")
     _insert_source(db_path, "src-b", category="crypto")
     alice = _make_user(db_path, "alice")
@@ -258,7 +255,7 @@ def test_recompute_is_isolated_per_user(tmp_path: Path, monkeypatch: Any, pg_cle
 def test_recompute_with_no_history_keeps_base_scores(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "no-history.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "only", category="ai")

--- a/backend/tests/test_migrate_multi_user.py
+++ b/backend/tests/test_migrate_multi_user.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-import news_dashboard.db as db_mod
 from news_dashboard.db import connect, init_db
 from news_dashboard.ingest import sync_sources
 from news_dashboard.migrate import _check_prerequisites, _row_count, app
@@ -21,7 +20,8 @@ def _setup_db(tmp_path: Path) -> Path:
     return db
 
 
-def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "done") -> int:
+def _insert_article(db_path: Path | str, *, url_suffix: str = "1", state: str = "done") -> int:
+    sync_sources(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
             """
@@ -65,7 +65,7 @@ def test_sqlite_to_postgres_rejects_missing_file(monkeypatch: pytest.MonkeyPatch
 
 
 def test_sqlite_to_postgres_migrates_rows(
-    tmp_path: Path, pg_url: str, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import sqlite3
 
@@ -100,9 +100,8 @@ def test_sqlite_to_postgres_migrates_rows(
     sqlite.close()
 
     # Route the command's init_db()/connect() at an isolated schema in the test DB.
-    schema_path = tmp_path / "migrate-target.db"
-    monkeypatch.setenv("DATABASE_URL", pg_url)
-    monkeypatch.setattr(db_mod, "DB_PATH", schema_path)
+    schema_path = pg_clean
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
 
     # The migrator seeds sources before articles, so the article's FK to 'acme'
     # is satisfied within the same run — no pre-seeding needed.
@@ -154,9 +153,10 @@ def test_prerequisites_detect_missing_table(tmp_path: Path) -> None:
 # ── migrate-multi-user command ────────────────────────────────────────────────
 
 
-def test_migration_creates_seed_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    db = _setup_db(tmp_path)
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+def test_migration_creates_seed_user(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = pg_clean
+    sync_sources(db)
+    monkeypatch.setenv("DATABASE_URL", str(db))
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -169,10 +169,10 @@ def test_migration_creates_seed_user(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert users[0]["username"] == "alice"
 
 
-def test_migration_migrates_article_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    db = _setup_db(tmp_path)
+def test_migration_migrates_article_state(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = pg_clean
     aid = _insert_article(db, url_suffix="m1", state="done")
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    monkeypatch.setenv("DATABASE_URL", str(db))
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -188,10 +188,11 @@ def test_migration_migrates_article_state(tmp_path: Path, monkeypatch: pytest.Mo
 
 
 def test_migration_seeds_source_subscriptions(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    db = _setup_db(tmp_path)
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    db = pg_clean
+    sync_sources(db)
+    monkeypatch.setenv("DATABASE_URL", str(db))
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -203,10 +204,10 @@ def test_migration_seeds_source_subscriptions(
     assert count > 0
 
 
-def test_migration_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    db = _setup_db(tmp_path)
+def test_migration_is_idempotent(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = pg_clean
     _insert_article(db, url_suffix="i1", state="done")
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    monkeypatch.setenv("DATABASE_URL", str(db))
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -225,10 +226,10 @@ def test_migration_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert uas_count == 1
 
 
-def test_migration_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    db = _setup_db(tmp_path)
+def test_migration_dry_run_does_not_write(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = pg_clean
     _insert_article(db, url_suffix="d1", state="done")
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    monkeypatch.setenv("DATABASE_URL", str(db))
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -245,14 +246,12 @@ def test_migration_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.Mo
     assert uas_count == 0
 
 
-def test_migration_aborts_on_missing_schema(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    db = tmp_path / "bare.db"
+def test_migration_aborts_on_missing_schema(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = pg_clean
     init_db(db)
     with connect(db) as conn:
         conn.execute("DROP TABLE IF EXISTS user_article_state")
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    monkeypatch.setenv("DATABASE_URL", db)
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 
@@ -262,14 +261,14 @@ def test_migration_aborts_on_missing_schema(
 
 
 def test_migration_skips_user_creation_if_exists(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    db = _setup_db(tmp_path)
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", str(db))
     from news_dashboard.auth import create_user
 
     create_user("existing", "pass")
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    monkeypatch.setenv("DATABASE_URL", str(db))
     monkeypatch.setenv("SEED_USER", "alice")
     monkeypatch.setenv("SEED_PASSWORD", "password123")
 

--- a/backend/tests/test_novelty_freshness.py
+++ b/backend/tests/test_novelty_freshness.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pytest
 
-import news_dashboard.db as db_mod
 from news_dashboard.db import connect, init_db
 from news_dashboard.recommendations import (
     FRESHNESS_SCORE_SPAN,
@@ -66,15 +65,13 @@ def test_novelty_degrades_when_vectors_missing() -> None:
 # ── Database-backed recompute ─────────────────────────────────────────────────
 
 
-def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
-    db_path = tmp_path / name
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
     monkeypatch.setenv("DATABASE_URL", pg_url)
-    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
-    init_db(db_path)
-    return db_path
+    init_db(database_url=pg_url)
+    return pg_url
 
 
-def _make_user(db_path: Path, username: str) -> int:
+def _make_user(db_path: str, username: str) -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
@@ -84,7 +81,7 @@ def _make_user(db_path: Path, username: str) -> int:
     return int(row["id"])
 
 
-def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+def _insert_source(db_path: str, slug: str, *, category: str = "tech", priority: int = 50) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -97,7 +94,7 @@ def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority
 
 
 def _insert_article(
-    db_path: Path,
+    db_path: str,
     slug: str,
     suffix: str,
     *,
@@ -134,7 +131,7 @@ def _insert_article(
 
 
 def _set_state(
-    db_path: Path, user_id: int, article_id: int, *, state: str, starred: bool = False
+    db_path: str, user_id: int, article_id: int, *, state: str, starred: bool = False
 ) -> None:
     with connect(db_path) as conn:
         conn.execute(
@@ -148,7 +145,7 @@ def _set_state(
         )
 
 
-def _signals(db_path: Path, user_id: int, article_id: int) -> dict[str, Any]:
+def _signals(db_path: str, user_id: int, article_id: int) -> dict[str, Any]:
     with connect(db_path) as conn:
         row = conn.execute(
             "SELECT recommendation_score, signals FROM user_article_recommendations"
@@ -164,7 +161,7 @@ def _signals(db_path: Path, user_id: int, article_id: int) -> dict[str, Any]:
 def test_freshness_lifts_recent_article_over_older_twin(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "freshness.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src")
     user_id = _make_user(db_path, "alice")
 
@@ -187,7 +184,7 @@ def test_freshness_lifts_recent_article_over_older_twin(
 def test_novelty_contributes_positively_and_relevance_does_not_dominate(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "novelty.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src")
     user_id = _make_user(db_path, "alice")
 
@@ -217,7 +214,7 @@ def test_novelty_contributes_positively_and_relevance_does_not_dominate(
 def test_low_signal_articles_remain_visible(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "low-signal.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src")
     user_id = _make_user(db_path, "alice")
 

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-import news_dashboard.db as db_mod
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect
 from news_dashboard.ingest import (
@@ -28,7 +27,7 @@ def _setup_db(tmp_path: Path) -> Path:
     return db
 
 
-def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "today") -> int:
+def _insert_article(db_path: Path | str, *, url_suffix: str = "1", state: str = "today") -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             """
@@ -52,14 +51,8 @@ def _insert_article(db_path: Path, *, url_suffix: str = "1", state: str = "today
     return int(row["id"] if isinstance(row, dict) else row[0])
 
 
-def _make_user(db_path: Path, username: str = "alice") -> int:
-    """Create a user and return their id, patching DB_PATH so auth uses our test DB."""
-    orig = db_mod.DB_PATH
-    db_mod.DB_PATH = db_path
-    try:
-        user = create_user(username, "password123")
-    finally:
-        db_mod.DB_PATH = orig
+def _make_user(db_path: Path | str, username: str = "alice") -> int:
+    user = create_user(username, "password123", db_path=db_path)
     return int(user["id"])
 
 
@@ -302,10 +295,10 @@ def test_search_excludes_archived_by_default(tmp_path: Path) -> None:
 # ── API layer integration ──────────────────────────────────────────────────────
 
 
-def test_api_articles_uses_user_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_api_articles_uses_user_state(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """GET /api/articles returns per-user state for the authenticated user."""
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api.db")
-    sync_sources(tmp_path / "api.db")
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
 
     from fastapi.testclient import TestClient
 
@@ -313,8 +306,8 @@ def test_api_articles_uses_user_state(tmp_path: Path, monkeypatch: pytest.Monkey
     from news_dashboard.main import app
 
     # Create a real user in our test DB
-    uid = _make_user(tmp_path / "api.db", "testuser")
-    aid = _insert_article(tmp_path / "api.db", url_suffix="api1")
+    uid = _make_user(pg_clean, "testuser")
+    aid = _insert_article(pg_clean, url_suffix="api1")
 
     fake_user = {"id": uid, "username": "testuser", "email": None, "is_admin": False}
     app.dependency_overrides[require_auth] = lambda: fake_user
@@ -329,18 +322,18 @@ def test_api_articles_uses_user_state(tmp_path: Path, monkeypatch: pytest.Monkey
         app.dependency_overrides.pop(require_auth, None)
 
 
-def test_api_state_transition_writes_uas(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_api_state_transition_writes_uas(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """PATCH /api/articles/{id}/state writes to user_article_state."""
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api2.db")
-    sync_sources(tmp_path / "api2.db")
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
 
     from fastapi.testclient import TestClient
 
     from news_dashboard.auth import require_auth
     from news_dashboard.main import app
 
-    uid = _make_user(tmp_path / "api2.db", "testuser2")
-    aid = _insert_article(tmp_path / "api2.db", url_suffix="api2")
+    uid = _make_user(pg_clean, "testuser2")
+    aid = _insert_article(pg_clean, url_suffix="api2")
 
     fake_user = {"id": uid, "username": "testuser2", "email": None, "is_admin": False}
     app.dependency_overrides[require_auth] = lambda: fake_user
@@ -352,7 +345,7 @@ def test_api_state_transition_writes_uas(tmp_path: Path, monkeypatch: pytest.Mon
             assert resp.json()["state"] == "done"
 
         # Confirm UAS row was written, article table state unchanged
-        with connect(tmp_path / "api2.db") as conn:
+        with connect(pg_clean) as conn:
             uas = conn.execute(
                 "SELECT * FROM user_article_state WHERE article_id = %s AND user_id = %s",
                 (aid, uid),
@@ -371,11 +364,11 @@ def test_api_state_transition_writes_uas(tmp_path: Path, monkeypatch: pytest.Mon
 
 
 def test_api_articles_includes_recommendation_score(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """GET /api/articles?state=today includes recommendation_score when ranked."""
-    db = tmp_path / "rec-score-api.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", str(db))
     sync_sources(db)
 
     from fastapi.testclient import TestClient
@@ -405,7 +398,7 @@ def test_api_articles_includes_recommendation_score(
 
 
 def test_api_articles_recommendation_score_falls_back_to_cold_start_when_unranked(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """GET /api/articles?state=today exposes the cold-start score for unranked articles.
 
@@ -414,8 +407,8 @@ def test_api_articles_recommendation_score_falls_back_to_cold_start_when_unranke
     otherwise high-churn sources whose fresh items outpace the recompute sweep
     would show no recommendation insight at all.
     """
-    db = tmp_path / "rec-score-null.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", str(db))
     sync_sources(db)
 
     from fastapi.testclient import TestClient

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -505,16 +505,10 @@ def test_pg_articles_starred_is_boolean(pg_clean: str) -> None:
 
 def test_pg_init_db_converts_legacy_integer_booleans(pg_url: str, tmp_path: Any) -> None:
     """init_db must repair legacy integer 0/1 boolean columns before runtime SQL uses TRUE."""
-    import psycopg
-    from psycopg import sql
+    from news_dashboard.db import connect, init_db
 
-    from news_dashboard.db import _schema_name, init_db
-
-    schema = _schema_name(tmp_path / "legacy-integer-booleans")
-    with psycopg.connect(pg_url) as conn:
-        conn.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(schema)))
-        conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema)))
-        conn.execute(sql.SQL("SET search_path TO {}").format(sql.Identifier(schema)))
+    db_path = tmp_path / "legacy-integer-booleans"
+    with connect(db_path, database_url=pg_url) as conn:
         conn.execute(
             """
             CREATE TABLE sources (
@@ -576,10 +570,9 @@ def test_pg_init_db_converts_legacy_integer_booleans(pg_url: str, tmp_path: Any)
         )
         conn.commit()
 
-    init_db(tmp_path / "legacy-integer-booleans", database_url=pg_url)
+    init_db(db_path, database_url=pg_url)
 
-    with psycopg.connect(pg_url) as conn:
-        conn.execute(sql.SQL("SET search_path TO {}").format(sql.Identifier(schema)))
+    with connect(db_path, database_url=pg_url) as conn:
         rows = conn.execute(
             """
             SELECT table_name, column_name, data_type, column_default
@@ -593,12 +586,14 @@ def test_pg_init_db_converts_legacy_integer_booleans(pg_url: str, tmp_path: Any)
             ORDER BY table_name, column_name
             """
         ).fetchall()
-        conn.execute(sql.SQL("DROP SCHEMA {} CASCADE").format(sql.Identifier(schema)))
-        conn.commit()
 
-    assert {(row[0], row[1], row[2]) for row in rows} == {
+    assert {(row["table_name"], row["column_name"], row["data_type"]) for row in rows} == {
         ("articles", "starred", "boolean"),
         ("sources", "enabled", "boolean"),
         ("user_sources", "enabled", "boolean"),
     }
-    assert all("true" in str(row[3]).lower() or "false" in str(row[3]).lower() for row in rows)
+    assert all(
+        "true" in str(row["column_default"]).lower()
+        or "false" in str(row["column_default"]).lower()
+        for row in rows
+    )

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -23,7 +23,6 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-import news_dashboard.db as db_mod
 from news_dashboard.auth import require_auth
 from news_dashboard.db import connect, init_db
 from news_dashboard.main import app
@@ -35,15 +34,13 @@ pytestmark = pytest.mark.postgres
 # ── Fixtures / helpers ────────────────────────────────────────────────────────
 
 
-def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
-    db_path = tmp_path / name
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
     monkeypatch.setenv("DATABASE_URL", pg_url)
-    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
-    init_db(db_path)
-    return db_path
+    init_db(database_url=pg_url)
+    return pg_url
 
 
-def _make_user(db_path: Path, username: str) -> int:
+def _make_user(db_path: str, username: str) -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
@@ -53,7 +50,7 @@ def _make_user(db_path: Path, username: str) -> int:
     return int(row["id"])
 
 
-def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+def _insert_source(db_path: str, slug: str, *, category: str = "tech", priority: int = 50) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -66,7 +63,7 @@ def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority
 
 
 def _insert_article(
-    db_path: Path,
+    db_path: str,
     slug: str,
     suffix: str,
     *,
@@ -121,7 +118,7 @@ def test_today_ranks_by_score_while_keeping_all_eligible_article_kinds_visible(
 ) -> None:
     """Today is ranked by persisted score, yet low-signal, stale, missing-score,
     and missing-embedding articles all remain in the feed and usable."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-ranking.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "quiet-source", category="misc", priority=1)
     user_id = _make_user(db_path, "alice")
 
@@ -166,7 +163,7 @@ def test_low_signal_and_unscored_articles_remain_usable(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
     """A low-signal article keeps its link/title payload so it stays actionable."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-lowsignal.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "quiet-source", category="misc", priority=1)
     user_id = _make_user(db_path, "alice")
     low = _insert_article(db_path, "quiet-source", "low", category="misc", importance=1)
@@ -192,7 +189,7 @@ def test_same_article_carries_different_score_metadata_per_user(
 ) -> None:
     """One shared article exposes different recommendation_score to each user,
     which is what drives the different compact labels in the UI."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-isolation.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "shared", category="misc", priority=1)
     alice = _make_user(db_path, "alice")
     bob = _make_user(db_path, "bob")
@@ -223,7 +220,7 @@ def test_today_stays_intact_when_no_scores_have_been_computed(
 ) -> None:
     """If scoring never ran (ingestion/recalc failure), Today still serves every
     eligible article via the cold-start fallback rather than breaking."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-noscore.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai", priority=80)
     user_id = _make_user(db_path, "alice")
     first = _insert_article(db_path, "src", "first", category="ai", importance=70)
@@ -256,7 +253,7 @@ def test_single_article_read_exposes_recommendation_metadata(
     carry the same per-user recommendation_score / signals as the Today list, so
     a refresh that personalizes scores is reflected on the reader rather than
     always falling back to "Not personalized yet"."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-reader.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai", priority=80)
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "reader", category="ai", importance=70)
@@ -280,7 +277,7 @@ def test_single_article_read_returns_null_score_when_unranked(
 ) -> None:
     """An article with no stored score returns a null score/signals on the reader
     path so the frontend uses its cold-start explanation, not a stale one."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-reader-null.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai", priority=80)
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "unranked", category="ai", importance=70)
@@ -305,7 +302,7 @@ def test_release_stays_scoped_to_ranking_without_hiding_or_separate_feed(
 ) -> None:
     """The recommendation release reorders Today; it must not suppress articles
     nor introduce a separate Recommended endpoint."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "contracts-scope.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="misc", priority=1)
     user_id = _make_user(db_path, "alice")
     disliked = _insert_article(db_path, "src", "disliked", category="misc", importance=1)

--- a/backend/tests/test_recommendation_recalc.py
+++ b/backend/tests/test_recommendation_recalc.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pytest
 
-import news_dashboard.db as db_mod
 import news_dashboard.recommendation_jobs as jobs
 from news_dashboard.db import connect, init_db
 from news_dashboard.ingest import list_articles, transition_article_state
@@ -22,15 +21,13 @@ pytestmark = pytest.mark.postgres
 # ── Fixtures / helpers ────────────────────────────────────────────────────────
 
 
-def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
-    db_path = tmp_path / name
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
     monkeypatch.setenv("DATABASE_URL", pg_url)
-    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
-    init_db(db_path)
-    return db_path
+    init_db(database_url=pg_url)
+    return pg_url
 
 
-def _make_user(db_path: Path, username: str) -> int:
+def _make_user(db_path: str, username: str) -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
@@ -40,7 +37,7 @@ def _make_user(db_path: Path, username: str) -> int:
     return int(row["id"])
 
 
-def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+def _insert_source(db_path: str, slug: str, *, category: str = "tech", priority: int = 50) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -52,7 +49,7 @@ def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority
         )
 
 
-def _insert_article(db_path: Path, slug: str, suffix: str, *, category: str = "tech") -> int:
+def _insert_article(db_path: str, slug: str, suffix: str, *, category: str = "tech") -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             """
@@ -77,7 +74,7 @@ def _insert_article(db_path: Path, slug: str, suffix: str, *, category: str = "t
     return int(row["id"])
 
 
-def _set_state(db_path: Path, user_id: int, article_id: int, *, state: str) -> None:
+def _set_state(db_path: str, user_id: int, article_id: int, *, state: str) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -90,7 +87,7 @@ def _set_state(db_path: Path, user_id: int, article_id: int, *, state: str) -> N
 
 
 def _insert_rec(
-    db_path: Path,
+    db_path: str,
     user_id: int,
     article_id: int,
     *,
@@ -110,7 +107,7 @@ def _insert_rec(
         )
 
 
-def _rec_row(db_path: Path, user_id: int, article_id: int) -> dict[str, Any] | None:
+def _rec_row(db_path: str, user_id: int, article_id: int) -> dict[str, Any] | None:
     with connect(db_path) as conn:
         row = conn.execute(
             "SELECT recommendation_score, model_version, stale"
@@ -126,7 +123,7 @@ def _rec_row(db_path: Path, user_id: int, article_id: int) -> dict[str, Any] | N
 def test_stale_score_is_recalculated_and_cleared(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "stale.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "a", category="ai")
@@ -144,7 +141,7 @@ def test_stale_score_is_recalculated_and_cleared(
 
 
 def test_missing_score_is_created(tmp_path: Path, monkeypatch: Any, pg_clean: str) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "missing.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "a", category="ai")
@@ -160,7 +157,7 @@ def test_missing_score_is_created(tmp_path: Path, monkeypatch: Any, pg_clean: st
 def test_superseded_model_version_is_repaired(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "superseded.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "a", category="ai")
@@ -182,7 +179,7 @@ def test_superseded_model_version_is_repaired(
 def test_per_user_failure_does_not_abort_sweep(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "failure.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     alice = _make_user(db_path, "alice")
     bob = _make_user(db_path, "bob")
@@ -214,7 +211,7 @@ def test_per_user_failure_does_not_abort_sweep(
 def test_today_read_does_not_compute_scores(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "today-read.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "a", category="ai")
@@ -232,7 +229,7 @@ def test_today_read_does_not_compute_scores(
 def test_preference_change_marks_scores_stale(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "pref.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     art_one = _insert_article(db_path, "src", "one", category="ai")
@@ -253,7 +250,7 @@ def test_preference_change_marks_scores_stale(
 def test_recommendation_health_reports_stale_and_missing(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "health.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     scored = _insert_article(db_path, "src", "scored", category="ai")
@@ -273,7 +270,7 @@ def test_recommendation_health_reports_stale_and_missing(
 def test_recalculate_all_refreshes_non_stale_current_scores(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "daily.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     article = _insert_article(db_path, "src", "a", category="ai")

--- a/backend/tests/test_run_history_api.py
+++ b/backend/tests/test_run_history_api.py
@@ -11,7 +11,7 @@ from news_dashboard.main import app
 client = TestClient(app, raise_server_exceptions=True)
 
 
-def _seed_db(db_path: Path) -> tuple[int, int]:
+def _seed_db(db_path: Path | str) -> tuple[int, int]:
     init_db(db_path)
     with connect(db_path) as conn:
         r1 = conn.execute(
@@ -58,13 +58,9 @@ def _seed_db(db_path: Path) -> tuple[int, int]:
     return int(r1), int(r2)
 
 
-def test_list_runs_returns_paginated_response(tmp_path: Path, monkeypatch: Any) -> None:
-    db = tmp_path / "api_runs.db"
-    import news_dashboard.db as db_mod
-    import news_dashboard.run_history as rh_mod
-
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
-    monkeypatch.setattr(rh_mod, "DB_PATH", db, raising=False)
+def test_list_runs_returns_paginated_response(pg_clean: str, monkeypatch: Any) -> None:
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", db)
     _seed_db(db)
 
     resp = client.get("/api/ingest/runs?page=1&per_page=10")
@@ -79,13 +75,9 @@ def test_list_runs_returns_paginated_response(tmp_path: Path, monkeypatch: Any) 
     assert ids[0] > ids[1]
 
 
-def test_list_runs_pagination(tmp_path: Path, monkeypatch: Any) -> None:
-    db = tmp_path / "api_page.db"
-    import news_dashboard.db as db_mod
-    import news_dashboard.run_history as rh_mod
-
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
-    monkeypatch.setattr(rh_mod, "DB_PATH", db, raising=False)
+def test_list_runs_pagination(pg_clean: str, monkeypatch: Any) -> None:
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", db)
     _seed_db(db)
 
     resp = client.get("/api/ingest/runs?page=1&per_page=1")
@@ -104,13 +96,9 @@ def test_list_runs_pagination(tmp_path: Path, monkeypatch: Any) -> None:
     assert body2["items"][0]["id"] != body["items"][0]["id"]
 
 
-def test_get_run_sources_returns_breakdown(tmp_path: Path, monkeypatch: Any) -> None:
-    db = tmp_path / "api_sources.db"
-    import news_dashboard.db as db_mod
-    import news_dashboard.run_history as rh_mod
-
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
-    monkeypatch.setattr(rh_mod, "DB_PATH", db, raising=False)
+def test_get_run_sources_returns_breakdown(pg_clean: str, monkeypatch: Any) -> None:
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", db)
     r1, _ = _seed_db(db)
 
     resp = client.get(f"/api/ingest/runs/{r1}")
@@ -126,26 +114,18 @@ def test_get_run_sources_returns_breakdown(tmp_path: Path, monkeypatch: Any) -> 
     assert python_insider["duplicates"] == 2  # 5 found - 3 new
 
 
-def test_get_run_sources_404_for_unknown_id(tmp_path: Path, monkeypatch: Any) -> None:
-    db = tmp_path / "api_404.db"
-    import news_dashboard.db as db_mod
-    import news_dashboard.run_history as rh_mod
-
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
-    monkeypatch.setattr(rh_mod, "DB_PATH", db, raising=False)
+def test_get_run_sources_404_for_unknown_id(pg_clean: str, monkeypatch: Any) -> None:
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", db)
     init_db(db)
 
     resp = client.get("/api/ingest/runs/9999")
     assert resp.status_code == 404
 
 
-def test_list_runs_empty_state(tmp_path: Path, monkeypatch: Any) -> None:
-    db = tmp_path / "api_empty.db"
-    import news_dashboard.db as db_mod
-    import news_dashboard.run_history as rh_mod
-
-    monkeypatch.setattr(db_mod, "DB_PATH", db)
-    monkeypatch.setattr(rh_mod, "DB_PATH", db, raising=False)
+def test_list_runs_empty_state(pg_clean: str, monkeypatch: Any) -> None:
+    db = pg_clean
+    monkeypatch.setenv("DATABASE_URL", db)
     init_db(db)
 
     resp = client.get("/api/ingest/runs")

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -100,7 +100,7 @@ def test_run_briefing_logs_generation_error(caplog: pytest.LogCaptureFixture) ->
 #   from apscheduler.schedulers.background import BackgroundScheduler
 #   from .db import get_setting, init_db
 _BGSCHED_PATH = "apscheduler.schedulers.background.BackgroundScheduler"
-_INIT_DB_PATH = "news_dashboard.db.init_db"
+_INIT_DB_PATCH_PATH = "news_dashboard.db.init_db"
 _GET_SETTING_PATH = "news_dashboard.db.get_setting"
 
 
@@ -127,7 +127,7 @@ def _start_with_env(monkeypatch: pytest.MonkeyPatch, briefing_cron: str | None =
 
     with (
         patch(_BGSCHED_PATH, return_value=mock_sched),
-        patch(_INIT_DB_PATH),
+        patch(_INIT_DB_PATCH_PATH),
         patch(_GET_SETTING_PATH, return_value=None),
     ):
         from news_dashboard import scheduler
@@ -367,7 +367,7 @@ def test_start_scheduler_pauses_when_db_flag_set(monkeypatch: pytest.MonkeyPatch
 
     with (
         patch(_BGSCHED_PATH, return_value=mock_sched),
-        patch(_INIT_DB_PATH),
+        patch(_INIT_DB_PATCH_PATH),
         patch(_GET_SETTING_PATH, side_effect=get_setting),
     ):
         from news_dashboard import scheduler
@@ -387,7 +387,7 @@ def test_start_scheduler_uses_db_interval(monkeypatch: pytest.MonkeyPatch) -> No
 
     with (
         patch(_BGSCHED_PATH, return_value=mock_sched),
-        patch(_INIT_DB_PATH),
+        patch(_INIT_DB_PATCH_PATH),
         patch(_GET_SETTING_PATH, side_effect=get_setting),
     ):
         from news_dashboard import scheduler
@@ -429,7 +429,7 @@ def test_start_scheduler_ignores_saved_pause_when_interval_ingest_disabled(
 
     with (
         patch(_BGSCHED_PATH, return_value=mock_sched),
-        patch(_INIT_DB_PATH),
+        patch(_INIT_DB_PATCH_PATH),
         patch(_GET_SETTING_PATH, side_effect=get_setting),
     ):
         from news_dashboard import scheduler
@@ -600,7 +600,7 @@ def test_start_scheduler_pause_failure_is_suppressed(monkeypatch: pytest.MonkeyP
 
     with (
         patch(_BGSCHED_PATH, return_value=mock_sched),
-        patch(_INIT_DB_PATH),
+        patch(_INIT_DB_PATCH_PATH),
         patch(_GET_SETTING_PATH, side_effect=get_setting),
     ):
         from news_dashboard import scheduler

--- a/backend/tests/test_search_filters.py
+++ b/backend/tests/test_search_filters.py
@@ -273,21 +273,16 @@ def test_starred_plus_category_filter(db: Path) -> None:
 
 
 @pytest.fixture
-def api_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Use an isolated PostgreSQL schema and patch the app to use it."""
-    import news_dashboard.db as db_mod
-    import news_dashboard.ingest as ingest_mod
-
-    path = tmp_path / "search_api.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", path)
-    monkeypatch.setattr(ingest_mod, "DB_PATH", path, raising=False)
-    init_db(path)
-    sync_sources(path)
-    return path
+def api_db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Use an isolated PostgreSQL database and patch the app to use it."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(pg_clean)
+    sync_sources(pg_clean)
+    return pg_clean
 
 
 @pytest.fixture
-def client(api_db: Path) -> TestClient:
+def client(api_db: str) -> TestClient:
     return TestClient(app)
 
 

--- a/backend/tests/test_semantic_similarity.py
+++ b/backend/tests/test_semantic_similarity.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pytest
 
-import news_dashboard.db as db_mod
 import news_dashboard.embeddings as embeddings_mod
 from news_dashboard.db import connect, init_db
 from news_dashboard.embeddings import embedding_text, ensure_article_embedded
@@ -61,15 +60,13 @@ def test_semantic_adjustment_degrades_when_vectors_missing() -> None:
 # ── Database-backed recompute ─────────────────────────────────────────────────
 
 
-def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
-    db_path = tmp_path / name
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
     monkeypatch.setenv("DATABASE_URL", pg_url)
-    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
-    init_db(db_path)
-    return db_path
+    init_db(database_url=pg_url)
+    return pg_url
 
 
-def _make_user(db_path: Path, username: str) -> int:
+def _make_user(db_path: str, username: str) -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
@@ -79,7 +76,7 @@ def _make_user(db_path: Path, username: str) -> int:
     return int(row["id"])
 
 
-def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority: int = 50) -> None:
+def _insert_source(db_path: str, slug: str, *, category: str = "tech", priority: int = 50) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -92,7 +89,7 @@ def _insert_source(db_path: Path, slug: str, *, category: str = "tech", priority
 
 
 def _insert_article(
-    db_path: Path,
+    db_path: str,
     slug: str,
     suffix: str,
     *,
@@ -128,7 +125,7 @@ def _insert_article(
 
 
 def _set_state(
-    db_path: Path, user_id: int, article_id: int, *, state: str, starred: bool = False
+    db_path: str, user_id: int, article_id: int, *, state: str, starred: bool = False
 ) -> None:
     with connect(db_path) as conn:
         conn.execute(
@@ -142,7 +139,7 @@ def _set_state(
         )
 
 
-def _persisted_score(db_path: Path, user_id: int, article_id: int) -> float:
+def _persisted_score(db_path: str, user_id: int, article_id: int) -> float:
     with connect(db_path) as conn:
         row = conn.execute(
             "SELECT recommendation_score FROM user_article_recommendations"
@@ -156,7 +153,7 @@ def _persisted_score(db_path: Path, user_id: int, article_id: int) -> float:
 def test_semantic_lift_raises_similar_articles(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "semantic-lift.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="tech", priority=50)
     user_id = _make_user(db_path, "alice")
 
@@ -178,7 +175,7 @@ def test_semantic_lift_raises_similar_articles(
 def test_missing_candidate_embedding_falls_back_to_non_semantic(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "missing-embed.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="tech", priority=50)
     user_id = _make_user(db_path, "alice")
 
@@ -204,7 +201,7 @@ def test_missing_candidate_embedding_falls_back_to_non_semantic(
 def test_recompute_survives_unavailable_embedding_generation(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "embed-down.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="tech", priority=50)
     user_id = _make_user(db_path, "alice")
 
@@ -239,7 +236,7 @@ def test_recompute_survives_unavailable_embedding_generation(
 def test_semantic_scoring_is_isolated_per_user(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "semantic-isolated.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="tech", priority=50)
     alice = _make_user(db_path, "alice")
     bob = _make_user(db_path, "bob")

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 
-import news_dashboard.db as db_mod
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect, row_to_dict
 from news_dashboard.ingest import list_articles, sync_sources
@@ -21,17 +20,12 @@ def _setup_db(tmp_path: Path) -> Path:
     return db
 
 
-def _make_user(db_path: Path, username: str = "alice") -> int:
-    orig = db_mod.DB_PATH
-    db_mod.DB_PATH = db_path
-    try:
-        user = create_user(username, "pw")
-    finally:
-        db_mod.DB_PATH = orig
+def _make_user(db_path: Path | str, username: str = "alice") -> int:
+    user = create_user(username, "pw", db_path=db_path)
     return int(user["id"])
 
 
-def _insert_article(db_path: Path, *, source_slug: str, url_suffix: str = "1") -> int:
+def _insert_article(db_path: Path | str, *, source_slug: str, url_suffix: str = "1") -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             """
@@ -51,7 +45,7 @@ def _insert_article(db_path: Path, *, source_slug: str, url_suffix: str = "1") -
     return int(row["id"] if isinstance(row, dict) else row[0])
 
 
-def _global_slug(db_path: Path) -> str:
+def _global_slug(db_path: Path | str) -> str:
     """Return the slug of an arbitrary global source."""
     with connect(db_path) as conn:
         row = conn.execute(
@@ -60,7 +54,7 @@ def _global_slug(db_path: Path) -> str:
         return str(row_to_dict(row)["slug"])
 
 
-def _add_private_source(db_path: Path, *, slug: str, owner_user_id: int) -> None:
+def _add_private_source(db_path: Path | str, *, slug: str, owner_user_id: int) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -173,7 +167,7 @@ def test_unsubscription_is_per_user(tmp_path: Path) -> None:
 # ── API layer ─────────────────────────────────────────────────────────────────
 
 
-def _api_client(db_path: Path, user_id: int, is_admin: bool = False) -> Any:
+def _api_client(db_path: Path | str | str, user_id: int, is_admin: bool = False) -> Any:
     from fastapi.testclient import TestClient
 
     from news_dashboard.auth import require_admin, require_auth
@@ -186,13 +180,13 @@ def _api_client(db_path: Path, user_id: int, is_admin: bool = False) -> Any:
 
 
 def test_api_list_sources_returns_subscription_status(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api.db")
-    sync_sources(tmp_path / "api.db")
-    uid = _make_user(tmp_path / "api.db")
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
 
-    client = _api_client(tmp_path / "api.db", uid)
+    client = _api_client(pg_clean, uid)
     try:
         resp = client.get("/api/sources")
         assert resp.status_code == 200
@@ -208,12 +202,12 @@ def test_api_list_sources_returns_subscription_status(
         app.dependency_overrides.pop(require_admin, None)
 
 
-def test_api_create_private_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api2.db")
-    sync_sources(tmp_path / "api2.db")
-    uid = _make_user(tmp_path / "api2.db")
+def test_api_create_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
 
-    client = _api_client(tmp_path / "api2.db", uid)
+    client = _api_client(pg_clean, uid)
     try:
         resp = client.post(
             "/api/sources",
@@ -242,15 +236,15 @@ def test_api_create_private_source(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
 
 def test_api_private_source_not_visible_to_other_user(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api3.db")
-    sync_sources(tmp_path / "api3.db")
-    uid_a = _make_user(tmp_path / "api3.db", "alice")
-    uid_b = _make_user(tmp_path / "api3.db", "bob")
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid_a = _make_user(pg_clean, "alice")
+    uid_b = _make_user(pg_clean, "bob")
 
     # Alice creates a private source
-    client_a = _api_client(tmp_path / "api3.db", uid_a)
+    client_a = _api_client(pg_clean, uid_a)
     try:
         resp = client_a.post(
             "/api/sources",
@@ -269,7 +263,7 @@ def test_api_private_source_not_visible_to_other_user(
         app.dependency_overrides.pop(require_admin, None)
 
     # Bob doesn't see it
-    client_b = _api_client(tmp_path / "api3.db", uid_b)
+    client_b = _api_client(pg_clean, uid_b)
     try:
         resp2 = client_b.get("/api/sources")
         slugs = [i["slug"] for i in resp2.json()["items"]]
@@ -282,12 +276,12 @@ def test_api_private_source_not_visible_to_other_user(
         app.dependency_overrides.pop(require_admin, None)
 
 
-def test_api_delete_own_private_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api4.db")
-    sync_sources(tmp_path / "api4.db")
-    uid = _make_user(tmp_path / "api4.db")
+def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
 
-    client = _api_client(tmp_path / "api4.db", uid)
+    client = _api_client(pg_clean, uid)
     try:
         client.post(
             "/api/sources",
@@ -308,13 +302,13 @@ def test_api_delete_own_private_source(tmp_path: Path, monkeypatch: pytest.Monke
         app.dependency_overrides.pop(require_admin, None)
 
 
-def test_api_cannot_delete_others_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api5.db")
-    sync_sources(tmp_path / "api5.db")
-    uid_a = _make_user(tmp_path / "api5.db", "alice")
-    uid_b = _make_user(tmp_path / "api5.db", "bob")
+def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid_a = _make_user(pg_clean, "alice")
+    uid_b = _make_user(pg_clean, "bob")
 
-    client_a = _api_client(tmp_path / "api5.db", uid_a)
+    client_a = _api_client(pg_clean, uid_a)
     try:
         client_a.post(
             "/api/sources",
@@ -331,7 +325,7 @@ def test_api_cannot_delete_others_source(tmp_path: Path, monkeypatch: pytest.Mon
         app.dependency_overrides.pop(require_auth, None)
         app.dependency_overrides.pop(require_admin, None)
 
-    client_b = _api_client(tmp_path / "api5.db", uid_b)
+    client_b = _api_client(pg_clean, uid_b)
     try:
         resp = client_b.delete("/api/sources/alice-src")
         assert resp.status_code == 403
@@ -343,13 +337,13 @@ def test_api_cannot_delete_others_source(tmp_path: Path, monkeypatch: pytest.Mon
         app.dependency_overrides.pop(require_admin, None)
 
 
-def test_api_toggle_subscription(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "api6.db")
-    sync_sources(tmp_path / "api6.db")
-    uid = _make_user(tmp_path / "api6.db")
+def test_api_toggle_subscription(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
 
-    slug = _global_slug(tmp_path / "api6.db")
-    client = _api_client(tmp_path / "api6.db", uid)
+    slug = _global_slug(pg_clean)
+    client = _api_client(pg_clean, uid)
     try:
         # Unsubscribe
         resp = client.patch(f"/api/sources/{slug}/enabled", json={"enabled": False})

--- a/backend/tests/test_summary_user_scoped.py
+++ b/backend/tests/test_summary_user_scoped.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
-import news_dashboard.db as db_mod
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect
 from news_dashboard.ingest import (
@@ -37,18 +37,13 @@ def _setup_db(tmp_path: Path) -> Path:
     return db
 
 
-def _make_user(db_path: Path, username: str = "alice") -> int:
-    orig = db_mod.DB_PATH
-    db_mod.DB_PATH = db_path
-    try:
-        user = create_user(username, "password123")
-    finally:
-        db_mod.DB_PATH = orig
+def _make_user(db_path: Path | str, username: str = "alice") -> int:
+    user = create_user(username, "password123", db_path=db_path)
     return int(user["id"])
 
 
 def _insert_article(
-    db_path: Path,
+    db_path: Path | str,
     *,
     url_suffix: str = "1",
     category: str = "AI/LLM",
@@ -77,7 +72,7 @@ def _insert_article(
     return int(row["id"] if isinstance(row, dict) else row[0])
 
 
-def _insert_private_source(db_path: Path, *, slug: str, owner_user_id: int) -> None:
+def _insert_private_source(db_path: Path | str, *, slug: str, owner_user_id: int) -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -262,95 +257,81 @@ def test_multiple_states_counted_independently(tmp_path: Path) -> None:
 # ── /api/summary API endpoint tests ──────────────────────────────────────────
 
 
-def test_api_summary_requires_auth(tmp_path: Path) -> None:
+def test_api_summary_requires_auth(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """Without the auth override, /api/summary returns 401."""
-    orig = db_mod.DB_PATH
-    db_mod.DB_PATH = _setup_db(tmp_path)
-    try:
-        from news_dashboard.auth import require_auth
-        from news_dashboard.main import app
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
 
-        # Clear the autouse override
-        app.dependency_overrides.pop(require_auth, None)
-        client = TestClient(app, raise_server_exceptions=False)
-        try:
-            resp = client.get("/api/summary")
-            assert resp.status_code == 401
-        finally:
-            # Restore for other tests (conftest autouse will re-inject after this test)
-            pass
-    finally:
-        db_mod.DB_PATH = orig
+    app.dependency_overrides.pop(require_auth, None)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/summary")
+    assert resp.status_code == 401
 
 
-def test_api_summary_returns_by_status_and_category(tmp_path: Path) -> None:
+def test_api_summary_returns_by_status_and_category(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Authenticated call returns the expected shape with byStatus and byCategory."""
-    db = _setup_db(tmp_path)
-    orig = db_mod.DB_PATH
-    db_mod.DB_PATH = db
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "apitestuser")
+    _insert_article(pg_clean, url_suffix="a1")
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    fake_user = {"id": uid, "username": "apitestuser", "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    client = TestClient(app)
     try:
-        uid = _make_user(db, "apitestuser")
-        _insert_article(db, url_suffix="a1")
-
-        from news_dashboard.auth import require_auth
-        from news_dashboard.main import app
-
-        fake_user = {"id": uid, "username": "apitestuser", "is_admin": False}
-        app.dependency_overrides[require_auth] = lambda: fake_user
-        client = TestClient(app)
-        try:
-            resp = client.get("/api/summary")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert "byStatus" in data
-            assert "byCategory" in data
-            assert data["byStatus"]["new"] == 1
-        finally:
-            app.dependency_overrides.pop(require_auth, None)
+        resp = client.get("/api/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "byStatus" in data
+        assert "byCategory" in data
+        assert data["byStatus"]["new"] == 1
     finally:
-        db_mod.DB_PATH = orig
-
-
-def test_api_summary_isolates_users(tmp_path: Path) -> None:
-    """Two users hitting /api/summary each see only their own counts."""
-    db = _setup_db(tmp_path)
-    orig = db_mod.DB_PATH
-    db_mod.DB_PATH = db
-    try:
-        uid_a = _make_user(db, "user_a")
-        uid_b = _make_user(db, "user_b")
-        aid = _insert_article(db)
-
-        # User A marks article as done
-        transition_article_state(aid, "done", db_path=db, user_id=uid_a)
-
-        from news_dashboard.auth import require_auth
-        from news_dashboard.main import app
-
-        # Check as user A
-        app.dependency_overrides[require_auth] = lambda: {
-            "id": uid_a,
-            "username": "user_a",
-            "is_admin": False,
-        }
-        client = TestClient(app)
-        resp_a = client.get("/api/summary")
-        data_a = resp_a.json()
-
-        # Check as user B
-        app.dependency_overrides[require_auth] = lambda: {
-            "id": uid_b,
-            "username": "user_b",
-            "is_admin": False,
-        }
-        resp_b = client.get("/api/summary")
-        data_b = resp_b.json()
-
         app.dependency_overrides.pop(require_auth, None)
 
-        assert data_a["byStatus"]["read"] == 1
-        assert data_a["byStatus"]["new"] == 0
-        assert data_b["byStatus"]["new"] == 1
-        assert data_b["byStatus"]["read"] == 0
-    finally:
-        db_mod.DB_PATH = orig
+
+def test_api_summary_isolates_users(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two users hitting /api/summary each see only their own counts."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    uid_a = _make_user(pg_clean, "user_a")
+    uid_b = _make_user(pg_clean, "user_b")
+    aid = _insert_article(pg_clean)
+
+    # User A marks article as done
+    transition_article_state(aid, "done", db_path=pg_clean, user_id=uid_a)
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    # Check as user A
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": uid_a,
+        "username": "user_a",
+        "is_admin": False,
+    }
+    client = TestClient(app)
+    resp_a = client.get("/api/summary")
+    data_a = resp_a.json()
+
+    # Check as user B
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": uid_b,
+        "username": "user_b",
+        "is_admin": False,
+    }
+    resp_b = client.get("/api/summary")
+    data_b = resp_b.json()
+
+    app.dependency_overrides.pop(require_auth, None)
+
+    assert data_a["byStatus"]["read"] == 1
+    assert data_a["byStatus"]["new"] == 0
+    assert data_b["byStatus"]["new"] == 1
+    assert data_b["byStatus"]["read"] == 0

--- a/backend/tests/test_today_recommendations.py
+++ b/backend/tests/test_today_recommendations.py
@@ -6,7 +6,6 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-import news_dashboard.db as db_mod
 from news_dashboard.auth import require_auth
 from news_dashboard.db import connect, init_db
 from news_dashboard.ingest import sync_sources
@@ -16,15 +15,13 @@ from news_dashboard.recommendations import upsert_recommendation_score
 pytestmark = pytest.mark.postgres
 
 
-def _setup_db(tmp_path: Path, monkeypatch: Any, pg_url: str, name: str) -> Path:
-    db_path = tmp_path / name
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
     monkeypatch.setenv("DATABASE_URL", pg_url)
-    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
-    init_db(db_path)
-    return db_path
+    init_db(database_url=pg_url)
+    return pg_url
 
 
-def _make_user(db_path: Path, username: str) -> int:
+def _make_user(db_path: str, username: str) -> int:
     with connect(db_path) as conn:
         row = conn.execute(
             "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
@@ -35,7 +32,7 @@ def _make_user(db_path: Path, username: str) -> int:
 
 
 def _insert_source(
-    db_path: Path,
+    db_path: str,
     slug: str,
     *,
     category: str = "tech",
@@ -58,7 +55,7 @@ def _insert_source(
 
 
 def _insert_article(
-    db_path: Path,
+    db_path: str,
     slug: str,
     suffix: str,
     *,
@@ -122,7 +119,7 @@ def test_today_endpoint_exposes_cold_start_score_for_unscored_candidate(
     that same score (not ``null``) — otherwise the UI shows "no recommendation
     insight" for them.
     """
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "cold-start-expose.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "hacker-news-ai", category="ai", priority=95)
     user_id = _make_user(db_path, "alice")
 
@@ -153,7 +150,7 @@ def test_today_endpoint_keeps_persisted_score_over_cold_start(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
     """A persisted personalized score must win over the cold-start fallback."""
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "persisted-wins.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "quiet-source", category="misc", priority=1)
     user_id = _make_user(db_path, "alice")
     scored = _insert_article(db_path, "quiet-source", "scored", category="misc", importance=1)
@@ -176,7 +173,7 @@ def test_today_endpoint_keeps_persisted_score_over_cold_start(
 def test_today_endpoint_orders_by_persisted_scores_and_keeps_missing_visible(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "today-recs.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "quiet-source", category="misc", priority=1)
     user_id = _make_user(db_path, "alice")
 
@@ -221,7 +218,7 @@ def test_today_endpoint_orders_by_persisted_scores_and_keeps_missing_visible(
 def test_today_recommendation_scores_are_isolated_per_user(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "per-user-recs.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "shared-source", category="misc", priority=1)
     alice_id = _make_user(db_path, "alice")
     bob_id = _make_user(db_path, "bob")
@@ -248,7 +245,7 @@ def test_today_recommendation_scores_are_isolated_per_user(
 def test_today_endpoint_uses_cold_start_fallback_for_missing_scores(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "cold-start-recs.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     sync_sources(db_path)
     _insert_source(db_path, "hot-ai-source", category="ai", priority=95)
     _insert_source(db_path, "low-priority-source", category="misc", priority=1)
@@ -294,7 +291,7 @@ def test_today_endpoint_uses_cold_start_fallback_for_missing_scores(
 def test_recalculate_mine_scores_callers_own_feed(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "recalc-mine.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "hot-ai-source", category="ai", priority=95)
     user_id = _make_user(db_path, "alice")
 
@@ -319,7 +316,7 @@ def test_cold_start_ai_llm_category_ranks_above_generic_tech(
     Before the fix, `ai-llm` fell through to ELSE 2.0, silently demoting every
     Google AI Blog / HuggingFace / Anthropic / OpenAI article in cold-start rank.
     """
-    db_path = _setup_db(tmp_path, monkeypatch, pg_clean, "ai-llm-category.db")
+    db_path = _setup_db(monkeypatch, pg_clean)
     sync_sources(db_path)
     _insert_source(db_path, "google-ai-test", category="ai-llm", priority=75)
     _insert_source(db_path, "generic-tech", category="tech", priority=75)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "issue-335-remove-sqlite-fallback",
+  "name": "news-dashboard",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Closes #339

## Summary
- removed test references to the global DB_PATH switch and routed implicit app tests through DATABASE_URL/pg_clean
- widened PostgreSQL helper db_path annotations to accept explicit DSNs where tests pass pg_clean
- expanded pg_clean cleanup for ingest/share/event tables and repaired schema after drop-table tests

## Test results
- make lint
- make typecheck
- source .env && make test
- npm run build --silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)