### PR TITLE
feat: natural language 'Why Recommended' explanations for ranked articles (#342)

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -245,7 +245,7 @@ def _merge_user_recommendation(
     its cold-start explanation rather than a stale one.
     """
     rec_row = conn.execute(
-        "SELECT recommendation_score, model_version, signals"
+        "SELECT recommendation_score, model_version, signals, explanation"
         " FROM user_article_recommendations WHERE user_id = %s AND article_id = %s",
         (user_id, article_id),
     ).fetchone()
@@ -254,6 +254,7 @@ def _merge_user_recommendation(
     d["recommendation_score"] = float(score) if score is not None else None
     d["recommendation_model"] = rec.get("model_version") if rec else None
     d["recommendation_signals"] = rec.get("signals") if rec else None
+    d["recommendation_explanation"] = rec.get("explanation") if rec else None
     return d
 
 

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -329,6 +329,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
     CREATE INDEX IF NOT EXISTS idx_uar_user_stale
       ON user_article_recommendations(user_id) WHERE stale = TRUE
     """,
+    ("ALTER TABLE user_article_recommendations ADD COLUMN IF NOT EXISTS explanation TEXT"),
     # Behavioral telemetry: every row is one client-emitted event. A single
     # table covers time-on-app (heartbeat), page popularity (route), per-article
     # dwell (article_open/article_close), and feature usage (feature). Sessions

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -757,6 +757,9 @@ def _apply_recommendation_fields(d: dict[str, Any]) -> None:
     # freshness, novelty) used to produce on-demand explanations; absent for
     # unranked articles.
     d["recommendation_signals"] = d.pop("_uar_recommendation_signals", None)
+    # Natural language explanation of why this article was recommended; only
+    # present for personalized (non-cold-start) scored articles.
+    d["recommendation_explanation"] = d.pop("_uar_recommendation_explanation", None)
 
 
 def _article_list_select(alias: str | None = None) -> str:
@@ -1110,6 +1113,7 @@ def _list_articles_for_user(  # noqa: PLR0913
           uar.recommendation_score AS _uar_recommendation_score,
           uar.model_version        AS _uar_recommendation_model,
           uar.signals              AS _uar_recommendation_signals,
+          uar.explanation          AS _uar_recommendation_explanation,
           {_COLD_START_RECOMMENDATION_SCORE_SQL} AS _cold_start_score
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -281,6 +281,98 @@ def novelty_adjustment(
     return dissimilarity * _quality_factor(importance) * NOVELTY_SCORE_SPAN
 
 
+def generate_recommendation_explanation(
+    user_id: int,
+    article_id: int,
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> str | None:
+    """Generate a natural language explanation of why an article was recommended.
+
+    Queries the user's recent positive interactions (starred/done) and the
+    article's metadata, then asks the LLM for a single concise sentence
+    (under 20 words).  Returns ``None`` when the AI client is not configured or
+    the call fails, so callers treat it as an optional enrichment.
+    """
+    import os
+
+    from news_dashboard.ai_client import chat_create, get_openai_client
+
+    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
+
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        article_row = conn.execute(
+            "SELECT title, category, tags, source_name FROM articles WHERE id = %s",
+            (article_id,),
+        ).fetchone()
+        if article_row is None:
+            return None
+        article = row_to_dict(article_row)
+
+        history_rows = conn.execute(
+            """
+            SELECT a.title, a.category, a.source_name, a.tags, uas.starred
+            FROM user_article_state uas
+            JOIN articles a ON a.id = uas.article_id
+            WHERE uas.user_id = %s
+              AND (uas.starred IS TRUE OR uas.state = 'done')
+            ORDER BY uas.done_at DESC NULLS LAST, uas.starred_at DESC NULLS LAST
+            LIMIT 10
+            """,
+            (user_id,),
+        ).fetchall()
+
+    history = [row_to_dict(r) for r in history_rows]
+
+    if not history:
+        history_text = "No reading history yet."
+    else:
+        lines = []
+        for h in history:
+            label = "starred" if h.get("starred") else "read"
+            lines.append(
+                f'- {label}: "{h.get("title", "")}" '
+                f"({h.get('source_name', '')} / {h.get('category', '')})"
+            )
+        history_text = "\n".join(lines)
+
+    tags = article.get("tags") or ""
+    prompt = (
+        f"You are a personalized news assistant. Explain in one short sentence (under 20 words) "
+        f"why this article matches the user's reading interests.\n\n"
+        f'Article: "{article.get("title", "")}"\n'
+        f"Source: {article.get('source_name', '')}\n"
+        f"Category: {article.get('category', '')}\n"
+        f"Tags: {tags}\n\n"
+        f"User's recent reading history:\n{history_text}\n\n"
+        f"Reply with just the explanation sentence, no preamble."
+    )
+
+    try:
+        client = get_openai_client(api_key=api_key, base_url=base_url)
+        response = chat_create(
+            client,
+            name="recommendation-explanation",
+            tags=["recommendation", "explanation"],
+            user_id=user_id,
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=60,
+            temperature=0.3,
+        )
+        text = response.choices[0].message.content
+        return text.strip() if text else None
+    except Exception:
+        return None
+
+
 def upsert_recommendation_score(  # noqa: PLR0913
     user_id: int,
     article_id: int,
@@ -291,6 +383,7 @@ def upsert_recommendation_score(  # noqa: PLR0913
     cold_start_score: float | None = None,
     signals: dict[str, Any] | None = None,
     model_version: str = COLD_START_MODEL_VERSION,
+    explanation: str | None = None,
 ) -> None:
     """Persist recommendation metadata for one user/article pair."""
     init_db(db_path, database_url=database_url)
@@ -299,15 +392,18 @@ def upsert_recommendation_score(  # noqa: PLR0913
             """
             INSERT INTO user_article_recommendations(
               user_id, article_id, recommendation_score, cold_start_score,
-              signals, model_version, stale
+              signals, model_version, stale, explanation
             )
-            VALUES (%s, %s, %s, %s, %s::jsonb, %s, FALSE)
+            VALUES (%s, %s, %s, %s, %s::jsonb, %s, FALSE, %s)
             ON CONFLICT(user_id, article_id) DO UPDATE SET
               recommendation_score = excluded.recommendation_score,
               cold_start_score = excluded.cold_start_score,
               signals = excluded.signals,
               model_version = excluded.model_version,
               stale = FALSE,
+              explanation = COALESCE(
+                excluded.explanation, user_article_recommendations.explanation
+              ),
               updated_at = NOW()
             """,
             (
@@ -317,6 +413,7 @@ def upsert_recommendation_score(  # noqa: PLR0913
                 cold_start_score,
                 json.dumps(signals or {}),
                 model_version,
+                explanation,
             ),
         )
 
@@ -430,6 +527,7 @@ def recompute_user_recommendations(
     # semantic profile is present.
     model_version = NOVELTY_MODEL_VERSION if semantic_profile else BEHAVIORAL_MODEL_VERSION
     scored = 0
+    scored_items: list[tuple[int, float]] = []
     for candidate in candidates:
         base = float(candidate["base_score"])
         source_slug = str(candidate["source_slug"])
@@ -461,7 +559,27 @@ def recompute_user_recommendations(
             },
             model_version=model_version,
         )
+        scored_items.append((int(candidate["id"]), final_score))
         scored += 1
+
+    # Generate explanations for the top 20 articles only; the rest are low-signal
+    # enough that a generic label suffices and the AI quota stays manageable.
+    top_articles = sorted(scored_items, key=lambda x: x[1], reverse=True)[:20]
+    for article_id, _ in top_articles:
+        explanation = generate_recommendation_explanation(
+            user_id,
+            article_id,
+            db_path=db_path,
+            database_url=database_url,
+        )
+        if explanation:
+            with connect(db_path, database_url=database_url) as conn:
+                conn.execute(
+                    "UPDATE user_article_recommendations SET explanation = %s"
+                    " WHERE user_id = %s AND article_id = %s AND explanation IS NULL",
+                    (explanation, user_id, article_id),
+                )
+
     return scored
 
 

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -322,3 +322,114 @@ def test_release_stays_scoped_to_ranking_without_hiding_or_separate_feed(
     ids = {int(item["id"]) for item in items}
     assert {disliked, liked} <= ids
     assert recommended_feed.status_code == 404
+
+
+# ── Explanation column stored and serialised ───────────────────────────────────
+
+
+def test_explanation_stored_and_returned_by_article_list(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """An explanation written directly to the DB is returned in the Today feed."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "expl-list", category="ai", importance=70)
+
+    upsert_recommendation_score(
+        user_id,
+        article,
+        85.0,
+        db_path=db_path,
+        explanation="You read several Python articles recently.",
+    )
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            items = _today_items(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    item = next(it for it in items if int(it["id"]) == article)
+    assert item["recommendation_explanation"] == "You read several Python articles recently."
+
+
+def test_explanation_stored_and_returned_by_single_article_endpoint(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """The single-article reader endpoint also exposes the explanation field."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "expl-reader", category="ai", importance=70)
+
+    upsert_recommendation_score(
+        user_id,
+        article,
+        88.0,
+        db_path=db_path,
+        explanation="Matches your interest in FastAPI.",
+    )
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            response = client.get(f"/api/articles/{article}")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["recommendation_explanation"] == "Matches your interest in FastAPI."
+
+
+def test_explanation_null_when_not_generated(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """An article with a score but no explanation returns null for the field."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "no-expl", category="ai", importance=70)
+
+    upsert_recommendation_score(user_id, article, 75.0, db_path=db_path)
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            response = client.get(f"/api/articles/{article}")
+            items = _today_items(client)
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json()["recommendation_explanation"] is None
+    item = next(it for it in items if int(it["id"]) == article)
+    assert item["recommendation_explanation"] is None
+
+
+def test_explanation_not_overwritten_on_rescore(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """Re-upserting a score without an explanation preserves an existing one."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "preserve-expl", category="ai", importance=70)
+
+    upsert_recommendation_score(
+        user_id,
+        article,
+        80.0,
+        db_path=db_path,
+        explanation="Covers topics you follow.",
+    )
+    # Re-score without providing explanation — existing explanation must survive.
+    upsert_recommendation_score(user_id, article, 85.0, db_path=db_path)
+
+    try:
+        with _client_for(user_id, "alice") as client:
+            response = client.get(f"/api/articles/{article}")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json()["recommendation_explanation"] == "Covers topics you follow."

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -66,6 +66,7 @@ export function adaptArticle(a: LegacyArticle): WorkflowArticle {
     recommendationScore: a.recommendation_score ?? undefined,
     recommendationModel: a.recommendation_model ?? undefined,
     recommendationSignals: a.recommendation_signals ?? undefined,
+    recommendationExplanation: a.recommendation_explanation ?? undefined,
     tags: parseTags(a.tags),
     body: a.body ?? undefined,
     bodyStatus: a.body_status ?? 'missing',

--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -1,6 +1,6 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Star } from 'lucide-react';
+import { Star, Info } from 'lucide-react';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
 import { relativeTime, signalLabel } from '@/lib/format';
 import { recommendationLabel, RECOMMENDATION_LABEL_TEXT } from '@/lib/recommendation';
@@ -85,6 +85,9 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
                 </span>
               </>
             )}
+            {article.recommendationExplanation && (
+              <RecommendationExplanationIcon explanation={article.recommendationExplanation} />
+            )}
             {showLaterUntil && article.later_until && (
               <>
                 <span className="text-subtle">·</span>
@@ -95,6 +98,38 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
         </Link>
       </SwipeableRow>
     </div>
+  );
+}
+
+function RecommendationExplanationIcon({ explanation }: { explanation: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        type="button"
+        aria-label="Why recommended"
+        data-testid="recommendation-explanation-trigger"
+        className="text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+      >
+        <Info className="size-3.5" strokeWidth={1.5} />
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          data-testid="recommendation-explanation-tooltip"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 z-50 w-56 rounded-md bg-popover border border-border px-2.5 py-1.5 text-[11px] leading-snug text-popover-foreground shadow-md"
+        >
+          {explanation}
+        </span>
+      )}
+    </span>
   );
 }
 

--- a/frontend/src/lib/workflowTypes.ts
+++ b/frontend/src/lib/workflowTypes.ts
@@ -36,6 +36,8 @@ export interface WorkflowArticle {
   recommendationModel?: string;
   /** Per-factor breakdown powering on-demand explanations; undefined when unranked. */
   recommendationSignals?: RecommendationSignals;
+  /** Natural language explanation of why this article was recommended; undefined when unavailable. */
+  recommendationExplanation?: string;
   tags: string[];
   body?: string;
   bodyStatus: 'ok' | 'missing' | 'error';

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -524,6 +524,7 @@ export function ArticlePage() {
               </button>
               {showWhyRecommended &&
                 (() => {
+                  const aiExplanation = article.recommendationExplanation;
                   const explanation = recommendationExplanation({
                     score: article.recommendationScore,
                     signals: article.recommendationSignals,
@@ -536,17 +537,26 @@ export function ArticlePage() {
                       <div className="text-[10px] font-medium uppercase tracking-wider text-subtle mb-2">
                         Why recommended
                       </div>
-                      <ul className="space-y-1.5">
-                        {explanation.reasons.map((reason, i) => (
-                          <li
-                            key={i}
-                            className="flex items-start gap-2 text-[13px] leading-snug text-foreground"
-                          >
-                            <span className="mt-0.5 shrink-0 text-accent">•</span>
-                            <span>{reason}</span>
-                          </li>
-                        ))}
-                      </ul>
+                      {aiExplanation ? (
+                        <p
+                          className="text-[13px] leading-snug text-foreground"
+                          data-testid="why-recommended-ai-explanation"
+                        >
+                          {aiExplanation}
+                        </p>
+                      ) : (
+                        <ul className="space-y-1.5">
+                          {explanation.reasons.map((reason, i) => (
+                            <li
+                              key={i}
+                              className="flex items-start gap-2 text-[13px] leading-snug text-foreground"
+                            >
+                              <span className="mt-0.5 shrink-0 text-accent">•</span>
+                              <span>{reason}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                     </div>
                   );
                 })()}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface Article {
   recommendation_score?: number | null;
   recommendation_model?: string | null;
   recommendation_signals?: RecommendationSignals | null;
+  recommendation_explanation?: string | null;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary

Closes #342.

- **DB migration**: adds `explanation TEXT` column (nullable, `ADD COLUMN IF NOT EXISTS`) to `user_article_recommendations`; no downtime risk
- **Backend generator**: `generate_recommendation_explanation()` in `recommendations.py` queries the user's recent starred/done history and the article metadata, then calls the OpenAI-compatible gateway (same `OPENAI_BRIEFING_*` env vars as briefings) to produce a ≤20-word friendly sentence; degrades silently to `None` when the API key is absent
- **Recompute integration**: `recompute_user_recommendations()` generates explanations for the top-20 scored articles per run; existing explanations are preserved on rescore (`COALESCE(excluded.explanation, existing.explanation)`)
- **API exposure**: `recommendation_explanation` field added to both the article list (`GET /api/articles`) and single-article reader (`GET /api/articles/:id`) payloads
- **Frontend UX**: article row shows a hoverable `ⓘ` icon when an explanation is available; the article reader's "Why recommended?" section prefers the AI sentence over the bullet-point signal breakdown

## Test plan

- [x] `make lint` — passes
- [x] `make typecheck` — passes (mypy strict + ty + pyrefly)
- [x] 4 new integration tests in `test_recommendation_contracts.py`: explanation stored → returned by list, returned by reader, null when not generated, preserved across rescores
- [x] Full backend suite: 763 passed, 5 skipped (expected — langfuse/helm)
- [x] Frontend vitest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)