### PR TITLE
feat: multi-turn Briefing Q&A Assistant for follow-up news inquiries (#343)

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -650,3 +650,73 @@ def update_briefing_script(
             "UPDATE briefings SET script = %s::jsonb WHERE id = %s",
             (json.dumps(script), briefing_id),
         )
+
+
+_CHAT_SYSTEM_PROMPT = """\
+You are the Briefing Q&A Assistant. Your job is to answer follow-up questions \
+about the daily briefing provided below. Ground every answer in the briefing \
+summary and the full article texts supplied. If information is not present in \
+the provided context, say so clearly rather than guessing.
+
+--- BRIEFING ---
+{briefing_context}
+
+--- CITED ARTICLES ---
+{articles_context}
+"""
+
+
+def chat_with_briefing(
+    briefing_id: int,
+    message: str,
+    history: list[dict[str, str]],
+    *,
+    user_id: int | None = None,
+    database_url: str | None = None,
+) -> str:
+    """Answer a follow-up question grounded in the cited articles of a briefing."""
+    api_key, base_url = _briefing_ai_config()
+    model = os.getenv("OPENAI_BRIEFING_MODEL", DEFAULT_BRIEFING_MODEL)
+
+    briefing = get_briefing(briefing_id, database_url=database_url, user_id=user_id)
+    if briefing is None:
+        msg = f"briefing {briefing_id} not found"
+        raise KeyError(msg)
+
+    briefing_context = f"Title: {briefing.get('title', '')}\nSummary: {briefing.get('summary', '')}"
+
+    articles = briefing.get("articles") or []
+    if articles:
+        article_parts: list[str] = []
+        with connect(database_url=database_url) as conn:
+            for a in articles:
+                row = conn.execute("SELECT body FROM articles WHERE id = %s", (a["id"],)).fetchone()
+                body = (row[0] or "") if row else ""
+                article_parts.append(
+                    f"[{a['id']}] {a['title']} ({a.get('source_name', '')})\n{body[:3000]}"
+                )
+        articles_context = "\n\n".join(article_parts)
+    else:
+        articles_context = "(No articles cited — answer from the briefing summary only.)"
+
+    system = _CHAT_SYSTEM_PROMPT.format(
+        briefing_context=briefing_context,
+        articles_context=articles_context,
+    )
+
+    from news_dashboard.ai_client import chat_create, get_openai_client
+
+    client = get_openai_client(api_key=api_key, base_url=base_url)
+    messages: list[dict[str, str]] = [{"role": "system", "content": system}]
+    messages.extend(history)
+    messages.append({"role": "user", "content": message})
+
+    response = chat_create(
+        client,
+        name="briefing-chat",
+        tags=["briefing", "chat"],
+        user_id=user_id,
+        model=model,
+        messages=messages,
+    )
+    return response.choices[0].message.content or ""

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -49,6 +49,7 @@ from news_dashboard.body_fetch import fetch_and_cache_body, get_article, prefetc
 from news_dashboard.briefings import (
     BriefingAINotConfiguredError,
     BriefingGenerationError,
+    chat_with_briefing,
     generate_briefing,
     get_briefing,
     get_latest_briefing,
@@ -1029,6 +1030,36 @@ def briefings_create(
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except BriefingGenerationError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+class BriefingChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class BriefingChatRequest(BaseModel):
+    message: str
+    history: list[BriefingChatMessage] = []
+
+
+@api.post("/api/briefings/{briefing_id}/chat")
+def briefings_chat(
+    briefing_id: int,
+    body: BriefingChatRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        reply = chat_with_briefing(
+            briefing_id,
+            body.message,
+            [{"role": m.role, "content": m.content} for m in body.history],
+            user_id=current_user["id"],
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="briefing not found") from exc
+    except BriefingAINotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return {"reply": reply}
 
 
 # ── Notification settings & push subscriptions ───────────────────────────────

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -353,3 +353,105 @@ def test_get_podcast_audio_endpoint_not_found(monkeypatch: Any) -> None:
     resp = client.get("/api/briefings/1/podcast")
     assert resp.status_code == 404
     assert resp.json()["detail"] == "podcast audio file not found"
+
+
+# ── POST /api/briefings/{id}/chat ─────────────────────────────────────────────
+
+
+def test_chat_returns_reply_from_assistant(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        main_mod,
+        "chat_with_briefing",
+        lambda *_args, **_kwargs: "The layoffs were driven by cost cuts.",
+    )
+    resp = client.post(
+        "/api/briefings/1/chat",
+        json={"message": "Why did the company announce layoffs?", "history": []},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"reply": "The layoffs were driven by cost cuts."}
+
+
+def test_chat_passes_history_to_backend(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake(briefing_id: int, message: str, history: list[dict[str, str]], **_: Any) -> str:
+        captured["briefing_id"] = briefing_id
+        captured["message"] = message
+        captured["history"] = history
+        return "answer"
+
+    monkeypatch.setattr(main_mod, "chat_with_briefing", _fake)
+    history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi! Ask me anything."},
+    ]
+    resp = client.post(
+        "/api/briefings/7/chat",
+        json={"message": "What happened in section 2?", "history": history},
+    )
+    assert resp.status_code == 200
+    assert captured["briefing_id"] == 7
+    assert captured["message"] == "What happened in section 2?"
+    assert captured["history"] == history
+
+
+def test_chat_returns_404_when_briefing_missing(monkeypatch: Any) -> None:
+    def _raise(*_: Any, **__: Any) -> str:
+        msg = "briefing 99 not found"
+        raise KeyError(msg)
+
+    monkeypatch.setattr(main_mod, "chat_with_briefing", _raise)
+    resp = client.post("/api/briefings/99/chat", json={"message": "hello", "history": []})
+    assert resp.status_code == 404
+
+
+def test_chat_returns_503_when_ai_not_configured(monkeypatch: Any) -> None:
+    def _raise(*_: Any, **__: Any) -> str:
+        msg = "OPENAI_API_KEY not set"
+        raise BriefingAINotConfiguredError(msg)
+
+    monkeypatch.setattr(main_mod, "chat_with_briefing", _raise)
+    resp = client.post("/api/briefings/1/chat", json={"message": "hello", "history": []})
+    assert resp.status_code == 503
+    assert "OPENAI_API_KEY" in resp.json()["detail"]
+
+
+def test_chat_constructs_prompt_with_article_bodies(monkeypatch: Any) -> None:
+    """Verify the system prompt includes briefing summary and article body text."""
+    from unittest.mock import MagicMock, patch
+
+    sample_briefing = dict(_SAMPLE_BRIEFING)
+    article_body = "Detailed article body text about the announcement."
+
+    captured_messages: list[Any] = []
+
+    def fake_chat_create(client: Any, *, messages: list[Any], **kwargs: Any) -> Any:
+        captured_messages.extend(messages)
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "grounded answer"
+        return mock_response
+
+    with (
+        patch("news_dashboard.briefings.get_briefing", return_value=sample_briefing),
+        patch("news_dashboard.briefings._briefing_ai_config", return_value=("key", None)),
+        patch("news_dashboard.ai_client.get_openai_client", return_value=MagicMock()),
+        patch("news_dashboard.ai_client.chat_create", side_effect=fake_chat_create),
+        patch(
+            "news_dashboard.briefings.connect",
+        ) as mock_connect,
+    ):
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = (article_body,)
+        mock_connect.return_value = mock_conn
+
+        from news_dashboard.briefings import chat_with_briefing
+
+        reply = chat_with_briefing(1, "What are the benchmarks?", [], user_id=1)
+
+    assert reply == "grounded answer"
+    system_msg = next(m for m in captured_messages if m["role"] == "system")
+    assert "AI Frameworks Tighten Production Workflows" in system_msg["content"]
+    assert article_body in system_msg["content"]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -246,6 +246,23 @@ export async function generateBriefingPodcast(id: number): Promise<{ url: string
   return requestJson<{ url: string }>(`/api/briefings/${id}/podcast`, { method: 'POST' });
 }
 
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export async function chatWithBriefing(
+  briefingId: number,
+  message: string,
+  history: ChatMessage[]
+): Promise<{ reply: string }> {
+  return requestJson<{ reply: string }>(`/api/briefings/${briefingId}/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message, history }),
+  });
+}
+
 // ── Auth ──────────────────────────────────────────────────────────────────────
 
 export interface AuthConfig {

--- a/frontend/src/components/BriefingChat.tsx
+++ b/frontend/src/components/BriefingChat.tsx
@@ -1,0 +1,134 @@
+import { useState, useRef, useEffect } from 'react';
+import { MessageCircle, Send, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { chatWithBriefing, type ChatMessage } from '@/api';
+
+function MessageBubble({ msg }: { msg: ChatMessage }) {
+  const isUser = msg.role === 'user';
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
+      <div
+        className={`max-w-[85%] rounded-lg px-3 py-2 text-sm leading-relaxed ${
+          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+        }`}
+      >
+        {msg.content}
+      </div>
+    </div>
+  );
+}
+
+export function BriefingChat({ briefingId }: { briefingId: number }) {
+  const [open, setOpen] = useState(false);
+  const [history, setHistory] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [history, open]);
+
+  async function sendMessage() {
+    const text = input.trim();
+    if (!text || loading) return;
+
+    const userMsg: ChatMessage = { role: 'user', content: text };
+    const nextHistory = [...history, userMsg];
+    setHistory(nextHistory);
+    setInput('');
+    setLoading(true);
+
+    try {
+      const { reply } = await chatWithBriefing(briefingId, text, history);
+      setHistory([...nextHistory, { role: 'assistant', content: reply }]);
+    } catch {
+      setHistory([
+        ...nextHistory,
+        { role: 'assistant', content: 'Sorry, something went wrong. Please try again.' },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void sendMessage();
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button size="sm" variant="outline" className="shrink-0 mt-1" aria-label="Ask assistant">
+          <MessageCircle className="size-4" />
+          Ask Assistant
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex flex-col p-0 w-full sm:max-w-md">
+        <SheetHeader className="px-4 py-3 border-b shrink-0">
+          <div className="flex items-center justify-between">
+            <SheetTitle className="text-sm font-semibold">Briefing Q&A Assistant</SheetTitle>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-7"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Ask follow-up questions about this briefing.
+          </p>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3 min-h-0">
+          {history.length === 0 && (
+            <p className="text-xs text-muted-foreground text-center mt-8">
+              Ask anything about today&apos;s briefing or the articles it covers.
+            </p>
+          )}
+          {history.map((msg, i) => (
+            <MessageBubble key={i} msg={msg} />
+          ))}
+          {loading && (
+            <div className="flex justify-start mb-3">
+              <div className="bg-muted rounded-lg px-3 py-2 text-sm text-muted-foreground animate-pulse">
+                Thinking…
+              </div>
+            </div>
+          )}
+          <div ref={bottomRef} />
+        </div>
+
+        <div className="px-4 py-3 border-t shrink-0 flex gap-2">
+          <Input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask a question…"
+            disabled={loading}
+            className="flex-1"
+            aria-label="Chat input"
+          />
+          <Button
+            size="icon"
+            onClick={() => void sendMessage()}
+            disabled={loading || !input.trim()}
+            aria-label="Send"
+          >
+            <Send className="size-4" />
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -5,6 +5,7 @@ import { Newspaper, RefreshCw, AlertCircle, Inbox, History } from 'lucide-react'
 import { Button } from '@/components/ui/button';
 import { fetchLatestBriefing, createBriefing } from '@/api';
 import { BriefingView, BriefSkeleton } from '@/components/BriefingView';
+import { BriefingChat } from '@/components/BriefingChat';
 import { trackFeature } from '@/lib/analytics';
 
 // ── Main page ─────────────────────────────────────────────────────────────────
@@ -179,13 +180,16 @@ export function BriefPage() {
         void refetch();
       }}
       afterMeta={
-        <Link
-          to="/briefs"
-          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mt-1 transition-colors"
-        >
-          <History className="size-3" />
-          View history
-        </Link>
+        <div className="flex items-center gap-2 mt-1">
+          <Link
+            to="/briefs"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <History className="size-3" />
+            View history
+          </Link>
+          <BriefingChat briefingId={data.id} />
+        </div>
       }
     />
   );

--- a/frontend/src/pages/BriefingDetailPage.tsx
+++ b/frontend/src/pages/BriefingDetailPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, AlertCircle, Newspaper } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { fetchBriefing } from '@/api';
 import { BriefingView, BriefSkeleton } from '@/components/BriefingView';
+import { BriefingChat } from '@/components/BriefingChat';
 
 function BackLink() {
   return (
@@ -94,6 +95,7 @@ export function BriefingDetailPage() {
       <BackLink />
       <BriefingView
         briefing={data}
+        afterMeta={<BriefingChat briefingId={data.id} />}
         onRefreshBriefing={() => {
           void refetch();
         }}


### PR DESCRIPTION
## Summary

- Adds `POST /api/briefings/{id}/chat` endpoint backed by `chat_with_briefing()` in `briefings.py`, which builds a grounded system prompt from the briefing summary and the full body text of all cited articles, then passes the conversation history through an OpenAI-compatible chat call
- Adds a `BriefingChat` slide-out drawer component (using the existing Sheet UI primitive) with a scrollable message history and a send-on-Enter input — wired into both `BriefPage` and `BriefingDetailPage` via the existing `afterMeta` prop on `BriefingView`
- If no articles are cited, the assistant falls back gracefully to the briefing summary only
- Integration tests in `test_briefings_api.py` cover the reply path, history forwarding, 404 on missing briefing, 503 on missing AI key, and prompt construction (verifying article body text lands in the system message)

Closes #343

## Test plan

- [ ] `make check` passes (lint + typecheck + tests)
- [ ] `POST /api/briefings/{id}/chat` returns a grounded reply when called with `message` and `history`
- [ ] Returns 404 for an unknown briefing ID
- [ ] Returns 503 when `OPENAI_BRIEFING_API_KEY` is unset
- [ ] "Ask Assistant" button appears on the Daily Brief page and Briefing Detail page
- [ ] Chat drawer opens, accepts input, displays assistant reply, maintains history across turns
- [ ] Drawer degrades gracefully (shows error message) when the backend is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)