### PR TITLE
feat: proactive Fact-Checker & Perspective Balancer context cards (#345)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -380,6 +380,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
     " ON article_shares(to_user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_article_shares_unread"
     " ON article_shares(to_user_id) WHERE read_at IS NULL",
+    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS perspective_analysis JSONB",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -510,6 +510,27 @@ def article_insights(
     return {"bullets": bullets}
 
 
+@api.get("/api/articles/{article_id}/perspectives")
+def article_perspectives(
+    article_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.perspectives import (
+        PerspectivesNotConfiguredError,
+        get_or_generate_perspectives,
+    )
+
+    try:
+        analysis = get_or_generate_perspectives(article_id, user_id=current_user["id"])
+    except PerspectivesNotConfiguredError as exc:
+        raise HTTPException(status_code=501, detail=str(exc)) from exc
+
+    if analysis is None:
+        raise HTTPException(status_code=404, detail="article not found")
+
+    return analysis
+
+
 @api.patch("/api/articles/{article_id}/status")
 def update_status(article_id: int, payload: StatusUpdate) -> dict[str, Any]:
     try:

--- a/backend/news_dashboard/perspectives.py
+++ b/backend/news_dashboard/perspectives.py
@@ -1,0 +1,216 @@
+"""AI-generated fact-checking and perspective analysis for articles.
+
+Calls an OpenAI-compatible chat model with the article text and related
+articles from the DB, then caches the structured result in
+articles.perspective_analysis (JSONB) so the AI is invoked at most once.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from news_dashboard.body_fetch import get_article
+from news_dashboard.db import connect, init_db
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PERSPECTIVES_MODEL = "gpt-4o-mini"
+_MAX_CHARS = 8_000
+_MAX_RELATED = 3
+_MAX_RELATED_CHARS = 1_000
+
+_PROMPT = """\
+You are an impartial media analyst. Given a news article and optionally some \
+related articles from the same database, produce a structured JSON analysis with \
+exactly three keys:
+  "verified_facts": a list of strings — key claims in the article that are \
+  widely corroborated or can be taken as factual based on the source material.
+  "omissions": a list of strings — important context, background, or caveats \
+  that the article leaves out but are relevant to a balanced understanding.
+  "alternative_perspectives": a list of strings — differing viewpoints, \
+  counter-arguments, or competing narratives found in the related articles or \
+  widely known on this topic.
+
+Rules:
+- Base every point strictly on what the article(s) say. Do not invent facts.
+- Each list must have 1-4 items. If a category has nothing to add, return an \
+  empty list.
+- Return ONLY the JSON object, no prose before or after.
+"""
+
+
+class PerspectivesNotConfiguredError(Exception):
+    """Raised when OPENAI_API_KEY is not set."""
+
+
+def _build_text(article: dict[str, Any], related: list[dict[str, Any]]) -> str:
+    title = str(article.get("title") or "")
+    body = str(article.get("body") or "")
+    summary = str(article.get("summary") or "")
+    content = body if len(body) > len(summary) else summary
+    main_text = f"Title: {title}\n\n{content}" if title else content
+    main_text = main_text[:_MAX_CHARS]
+
+    if not related:
+        return main_text
+
+    related_parts: list[str] = []
+    for r in related:
+        r_title = str(r.get("title") or "")
+        r_body = str(r.get("body") or "")
+        r_summary = str(r.get("summary") or "")
+        r_content = r_body if len(r_body) > len(r_summary) else r_summary
+        snippet = f"- {r_title}: {r_content}"[:_MAX_RELATED_CHARS]
+        related_parts.append(snippet)
+
+    related_block = "\n\nRelated articles:\n" + "\n".join(related_parts)
+    return main_text + related_block
+
+
+def _perspectives_ai_config() -> tuple[str, str | None, str]:
+    """Resolve (api_key, base_url, model) for perspective analysis.
+
+    Can target any OpenAI-compatible endpoint via
+    ``OPENAI_PERSPECTIVES_BASE_URL`` / ``OPENAI_PERSPECTIVES_API_KEY``, falling
+    back to the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``.
+    """
+    api_key = os.getenv("OPENAI_PERSPECTIVES_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = "OPENAI_API_KEY is not configured"
+        raise PerspectivesNotConfiguredError(msg)
+    base_url = os.getenv("OPENAI_PERSPECTIVES_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    model = os.getenv("OPENAI_PERSPECTIVES_MODEL", DEFAULT_PERSPECTIVES_MODEL)
+    return api_key, base_url, model
+
+
+def _parse_analysis(response_text: str) -> dict[str, list[str]]:
+    """Parse the JSON response from the LLM into a typed dict."""
+    empty: dict[str, list[str]] = {
+        "verified_facts": [],
+        "omissions": [],
+        "alternative_perspectives": [],
+    }
+    text = response_text.strip()
+    # Strip markdown code fences if present
+    if text.startswith("```"):
+        lines = text.splitlines()
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("perspectives: failed to parse LLM JSON response")
+        return empty
+
+    result: dict[str, list[str]] = {}
+    for key in ("verified_facts", "omissions", "alternative_perspectives"):
+        raw = data.get(key, [])
+        result[key] = [str(item) for item in raw if str(item).strip()]
+    return result
+
+
+def _fetch_related_articles(
+    article_id: int, *, database_url: str | None = None
+) -> list[dict[str, Any]]:
+    """Return up to _MAX_RELATED articles that share the same source/category."""
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT a.title, a.body, a.summary
+            FROM articles a
+            JOIN articles pivot ON pivot.id = %s
+            WHERE a.id <> %s
+              AND a.category = pivot.category
+              AND (a.body IS NOT NULL OR a.summary IS NOT NULL)
+            ORDER BY a.discovered_at DESC
+            LIMIT %s
+            """,
+            (article_id, article_id, _MAX_RELATED),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def generate_perspectives(
+    article: dict[str, Any],
+    related: list[dict[str, Any]] | None = None,
+    *,
+    user_id: int | None = None,
+) -> dict[str, list[str]]:
+    """Call the LLM and return structured perspective analysis.
+
+    Raises PerspectivesNotConfiguredError when OPENAI_API_KEY is absent.
+    """
+    api_key, base_url, model = _perspectives_ai_config()
+
+    text = _build_text(article, related or [])
+    if not text.strip():
+        return {"verified_facts": [], "omissions": [], "alternative_perspectives": []}
+
+    from news_dashboard.ai_client import chat_create, get_openai_client, get_prompt
+
+    client = get_openai_client(api_key=api_key, base_url=base_url)
+    prompt = get_prompt("article-perspectives", fallback=_PROMPT)
+    logger.info("Generating perspectives for article %s", article.get("id"))
+    result = chat_create(
+        client,
+        name="article-perspectives",
+        tags=["perspectives"],
+        user_id=user_id,
+        prompt=prompt,
+        model=model,
+        messages=[{"role": "user", "content": f"{prompt.text}\n\n{text}"}],
+        max_tokens=1024,
+    )
+    response_text = (result.choices[0].message.content or "").strip()
+    analysis = _parse_analysis(response_text)
+    logger.info("Perspectives generated for article %s", article.get("id"))
+    return analysis
+
+
+def get_or_generate_perspectives(
+    article_id: int,
+    user_id: int | None = None,
+    database_url: str | None = None,
+) -> dict[str, list[str]] | None:
+    """Return cached perspective analysis or generate and cache it.
+
+    Returns None if the article does not exist.
+    Raises PerspectivesNotConfiguredError when OPENAI_API_KEY is absent and
+    no cached analysis exists.
+    """
+    init_db(database_url=database_url)
+
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT perspective_analysis FROM articles WHERE id = %s", (article_id,)
+        ).fetchone()
+
+    if row is None:
+        return None
+
+    cached = row["perspective_analysis"] if isinstance(row, dict) else row[0]
+    if cached is not None:
+        if isinstance(cached, str):
+            parsed: dict[str, list[str]] = json.loads(cached)
+            return parsed
+        return dict(cached)
+
+    article = get_article(article_id, user_id=user_id)
+    if article is None:
+        return None
+
+    if not str(article.get("body") or "").strip():
+        return {"verified_facts": [], "omissions": [], "alternative_perspectives": []}
+
+    related = _fetch_related_articles(article_id, database_url=database_url)
+    analysis = generate_perspectives(article, related, user_id=user_id)
+
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            "UPDATE articles SET perspective_analysis = %s WHERE id = %s",
+            (json.dumps(analysis), article_id),
+        )
+
+    return analysis

--- a/backend/tests/test_perspectives.py
+++ b/backend/tests/test_perspectives.py
@@ -1,0 +1,303 @@
+"""Unit tests for news_dashboard.perspectives.
+
+All OpenAI calls are mocked — no network or live API key needed.
+DB-touching tests use the pg_clean fixture (live Postgres).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.db import connect
+from news_dashboard.perspectives import (
+    DEFAULT_PERSPECTIVES_MODEL,
+    PerspectivesNotConfiguredError,
+    _build_text,
+    _parse_analysis,
+    _perspectives_ai_config,
+    generate_perspectives,
+    get_or_generate_perspectives,
+)
+
+# ── shared test data ──────────────────────────────────────────────────────────
+
+_ARTICLE: dict[str, Any] = {
+    "id": 1,
+    "title": "Test Headline",
+    "body": "This is the body text about a major event.",
+    "summary": "Short summary.",
+}
+
+_ARTICLE_EMPTY: dict[str, Any] = {
+    "id": 3,
+    "title": "",
+    "body": None,
+    "summary": "",
+}
+
+_VALID_ANALYSIS = {
+    "verified_facts": ["Fact one"],
+    "omissions": ["Missing context"],
+    "alternative_perspectives": ["Counter view"],
+}
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _seed_article(pg_url: str, *, perspective_analysis: str | None = None) -> int:
+    """Insert a minimal article row and return its id."""
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind)
+            VALUES ('test-src', 'Test', 'https://example.com', 'tech', 'rss_feed')
+            ON CONFLICT(slug) DO NOTHING
+            """
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, summary, perspective_analysis
+            )
+            VALUES (
+              'https://example.com/p', 'https://example.com/p',
+              'Test Headline', 'test-src', 'Test', 'tech', 'rss_feed',
+              'A short summary.', %s
+            )
+            RETURNING id
+            """,
+            (perspective_analysis,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+# ── _parse_analysis ───────────────────────────────────────────────────────────
+
+
+def test_parse_analysis_valid_json() -> None:
+    text = json.dumps(_VALID_ANALYSIS)
+    result = _parse_analysis(text)
+    assert result["verified_facts"] == ["Fact one"]
+    assert result["omissions"] == ["Missing context"]
+    assert result["alternative_perspectives"] == ["Counter view"]
+
+
+def test_parse_analysis_strips_markdown_fences() -> None:
+    text = f"```json\n{json.dumps(_VALID_ANALYSIS)}\n```"
+    result = _parse_analysis(text)
+    assert result["verified_facts"] == ["Fact one"]
+
+
+def test_parse_analysis_returns_empty_on_invalid_json() -> None:
+    result = _parse_analysis("not json at all")
+    assert result == {
+        "verified_facts": [],
+        "omissions": [],
+        "alternative_perspectives": [],
+    }
+
+
+def test_parse_analysis_filters_blank_items() -> None:
+    data = {"verified_facts": ["  ", "Real fact"], "omissions": [], "alternative_perspectives": []}
+    result = _parse_analysis(json.dumps(data))
+    assert result["verified_facts"] == ["Real fact"]
+
+
+# ── _build_text ───────────────────────────────────────────────────────────────
+
+
+def test_build_text_includes_title_and_body() -> None:
+    text = _build_text(_ARTICLE, [])
+    assert "Test Headline" in text
+    assert "body text" in text
+
+
+def test_build_text_appends_related_articles() -> None:
+    related = [{"title": "Related", "body": "Related body", "summary": ""}]
+    text = _build_text(_ARTICLE, related)
+    assert "Related articles" in text
+    assert "Related" in text
+
+
+def test_build_text_empty_article_returns_empty() -> None:
+    text = _build_text(_ARTICLE_EMPTY, [])
+    assert text.strip() == ""
+
+
+# ── _perspectives_ai_config ───────────────────────────────────────────────────
+
+
+def test_perspectives_ai_config_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_PERSPECTIVES_API_KEY", raising=False)
+    with pytest.raises(PerspectivesNotConfiguredError):
+        _perspectives_ai_config()
+
+
+def test_perspectives_ai_config_uses_shared_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://gateway/v1")
+    api_key, base_url, model = _perspectives_ai_config()
+    assert api_key == "sk-shared"
+    assert base_url == "http://gateway/v1"
+    assert model == DEFAULT_PERSPECTIVES_MODEL
+
+
+def test_perspectives_ai_config_prefers_perspectives_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
+    monkeypatch.setenv("OPENAI_PERSPECTIVES_API_KEY", "sk-perspectives")
+    monkeypatch.setenv("OPENAI_PERSPECTIVES_BASE_URL", "http://p-gateway/v1")
+    monkeypatch.setenv("OPENAI_PERSPECTIVES_MODEL", "custom-model")
+    api_key, base_url, model = _perspectives_ai_config()
+    assert api_key == "sk-perspectives"
+    assert base_url == "http://p-gateway/v1"
+    assert model == "custom-model"
+
+
+# ── generate_perspectives ─────────────────────────────────────────────────────
+
+
+def test_generate_perspectives_returns_parsed_analysis() -> None:
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = json.dumps(_VALID_ANALYSIS)
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_completion
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        result = generate_perspectives(_ARTICLE)
+
+    assert result["verified_facts"] == ["Fact one"]
+    assert result["omissions"] == ["Missing context"]
+    assert result["alternative_perspectives"] == ["Counter view"]
+    mock_client.chat.completions.create.assert_called_once()
+
+
+def test_generate_perspectives_returns_empty_for_empty_article() -> None:
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+        result = generate_perspectives(_ARTICLE_EMPTY)
+    assert result == {"verified_facts": [], "omissions": [], "alternative_perspectives": []}
+
+
+def test_generate_perspectives_raises_without_api_key() -> None:
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("OPENAI_PERSPECTIVES_API_KEY", None)
+        os.environ.pop("OPENAI_API_KEY", None)
+        with pytest.raises(PerspectivesNotConfiguredError):
+            generate_perspectives(_ARTICLE)
+
+
+# ── get_or_generate_perspectives ─────────────────────────────────────────────
+
+
+def test_get_or_generate_returns_cached_without_api_call(pg_clean: str) -> None:
+    cached = json.dumps(_VALID_ANALYSIS)
+    article_id = _seed_article(pg_clean, perspective_analysis=cached)
+
+    mock_client = MagicMock()
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        result = get_or_generate_perspectives(article_id, database_url=pg_clean)
+
+    assert result is not None
+    assert result["verified_facts"] == ["Fact one"]
+    mock_client.chat.completions.create.assert_not_called()
+
+
+def test_get_or_generate_generates_and_caches_when_missing(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean)
+
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = json.dumps(_VALID_ANALYSIS)
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_completion
+
+    fake_article = {
+        "id": article_id,
+        "title": "Test Headline",
+        "body": "body text about a major event",
+        "summary": "A short summary.",
+    }
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+        patch("news_dashboard.perspectives.get_article", return_value=fake_article),
+    ):
+        result = get_or_generate_perspectives(article_id, database_url=pg_clean)
+
+    assert result is not None
+    assert result["verified_facts"] == ["Fact one"]
+    mock_client.chat.completions.create.assert_called_once()
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT perspective_analysis FROM articles WHERE id = %s", (article_id,)
+        ).fetchone()
+    stored = row["perspective_analysis"] if isinstance(row, dict) else row[0]
+    parsed = json.loads(stored) if isinstance(stored, str) else stored
+    assert parsed["verified_facts"] == ["Fact one"]
+
+
+def test_get_or_generate_returns_none_for_missing_article(pg_clean: str) -> None:
+    result = get_or_generate_perspectives(99999, database_url=pg_clean)
+    assert result is None
+
+
+def test_get_or_generate_returns_empty_when_no_body(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean)
+
+    mock_client = MagicMock()
+    fake_article = {"id": article_id, "title": "T", "body": None, "summary": "s"}
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+        patch("news_dashboard.perspectives.get_article", return_value=fake_article),
+    ):
+        result = get_or_generate_perspectives(article_id, database_url=pg_clean)
+
+    assert result == {"verified_facts": [], "omissions": [], "alternative_perspectives": []}
+    mock_client.chat.completions.create.assert_not_called()
+
+
+def test_get_or_generate_second_call_uses_cache(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean)
+    call_count: list[int] = []
+
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = json.dumps(_VALID_ANALYSIS)
+    mock_client = MagicMock()
+
+    def count_call(**_kwargs: object) -> object:
+        call_count.append(1)
+        return mock_completion
+
+    mock_client.chat.completions.create.side_effect = count_call
+    fake_article = {"id": article_id, "title": "T", "body": "body text", "summary": "s"}
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+        patch("news_dashboard.perspectives.get_article", return_value=fake_article),
+    ):
+        r1 = get_or_generate_perspectives(article_id, database_url=pg_clean)
+        r2 = get_or_generate_perspectives(article_id, database_url=pg_clean)
+
+    assert r1 == r2
+    assert len(call_count) == 1, "AI called more than once — cache not working"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -86,6 +86,16 @@ export async function fetchArticleInsights(id: number | string): Promise<string[
   return data.bullets;
 }
 
+export interface PerspectiveAnalysis {
+  verified_facts: string[];
+  omissions: string[];
+  alternative_perspectives: string[];
+}
+
+export async function fetchArticlePerspectives(id: number | string): Promise<PerspectiveAnalysis> {
+  return requestJson<PerspectiveAnalysis>(`/api/articles/${id}/perspectives`);
+}
+
 export async function fetchSources(): Promise<Source[]> {
   const data = await requestJson<{ items: Source[] }>('/api/sources');
   return data.items;

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -19,9 +19,16 @@ import {
   Share2,
   Sparkles,
   Lightbulb,
+  Scale,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { fetchArticle, fetchArticleBody, fetchArticleAudioUrl, fetchArticleInsights } from '@/api';
+import {
+  fetchArticle,
+  fetchArticleBody,
+  fetchArticleAudioUrl,
+  fetchArticleInsights,
+  fetchArticlePerspectives,
+} from '@/api';
 import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflowApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { formatDate, readingTime, signalLabel } from '@/lib/format';
@@ -180,6 +187,10 @@ export function ArticlePage() {
 
   const insightsMutation = useMutation({
     mutationFn: () => fetchArticleInsights(id!),
+  });
+
+  const perspectivesMutation = useMutation({
+    mutationFn: () => fetchArticlePerspectives(id!),
   });
 
   // Prev/next navigation from sessionStorage list
@@ -497,6 +508,82 @@ export function ArticlePage() {
                     </li>
                   ))}
                 </ul>
+              </div>
+            )}
+
+            {/* Context & Perspectives — on-demand AI fact-check widget */}
+            {perspectivesMutation.isIdle && (
+              <button
+                onClick={() => perspectivesMutation.mutate()}
+                data-testid="perspectives-button"
+                className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-border bg-surface/40 px-3 py-1.5 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-surface transition-colors"
+              >
+                <Scale className="size-3.5" strokeWidth={1.75} />
+                Context &amp; Perspectives
+              </button>
+            )}
+            {perspectivesMutation.isPending && (
+              <div className="mt-4 rounded-lg border border-border bg-surface/40 px-4 py-3">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="size-3.5 animate-spin" />
+                  <span>Analyzing perspectives…</span>
+                </div>
+              </div>
+            )}
+            {perspectivesMutation.isSuccess && (
+              <div
+                className="mt-4 rounded-lg border border-border bg-surface/40 px-4 py-4"
+                data-testid="perspectives-section"
+              >
+                <div className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-subtle mb-3">
+                  <Scale className="size-3" strokeWidth={2} />
+                  Context &amp; Perspectives
+                </div>
+                {[
+                  {
+                    label: 'Facts Verified',
+                    items: perspectivesMutation.data.verified_facts,
+                    color: 'text-emerald-500',
+                  },
+                  {
+                    label: 'Missing Context',
+                    items: perspectivesMutation.data.omissions,
+                    color: 'text-amber-500',
+                  },
+                  {
+                    label: 'Differing Opinions',
+                    items: perspectivesMutation.data.alternative_perspectives,
+                    color: 'text-blue-400',
+                  },
+                ]
+                  .filter((section) => section.items.length > 0)
+                  .map((section) => (
+                    <div key={section.label} className="mb-3 last:mb-0">
+                      <div
+                        className={`text-[10px] font-semibold uppercase tracking-wide mb-1 ${section.color}`}
+                      >
+                        {section.label}
+                      </div>
+                      <ul className="space-y-1">
+                        {section.items.map((item, i) => (
+                          <li
+                            key={i}
+                            className="flex items-start gap-2 text-[13px] leading-snug text-foreground"
+                          >
+                            <span className={`mt-0.5 shrink-0 ${section.color}`}>•</span>
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                {perspectivesMutation.data.verified_facts.length === 0 &&
+                  perspectivesMutation.data.omissions.length === 0 &&
+                  perspectivesMutation.data.alternative_perspectives.length === 0 && (
+                    <p className="text-[13px] text-muted-foreground">
+                      No additional context available for this article.
+                    </p>
+                  )}
               </div>
             )}
 


### PR DESCRIPTION
## Summary

- Adds `perspectives.py` service that calls an LLM with the article text and related DB articles to produce structured JSON analysis (verified facts, omissions, alternative perspectives)
- Adds `perspective_analysis JSONB` column migration to `articles` table via a new entry in `db.py`'s migration list
- Exposes `GET /api/articles/{article_id}/perspectives` endpoint (same pattern as insights)
- Frontend: adds on-demand "Context & Perspectives" widget to ArticlePage with three tabbed sections (Facts Verified, Missing Context, Differing Opinions) using color-coded bullet lists
- Result is cached in DB after first LLM call (identical caching pattern to `insights`)
- Configurable via `OPENAI_PERSPECTIVES_*` env vars; falls back to shared `OPENAI_*` vars

Closes #345

## Test plan

- [x] 18 new unit tests in `backend/tests/test_perspectives.py` covering parsing, AI config, generate, and get-or-generate with caching — all pass in isolation
- [x] `make lint` clean (ruff + prettier)
- [x] `make typecheck` clean (mypy strict + ty + pyrefly + tsc)
- [x] Pre-existing test failures on `main` (test_behavioral_affinity, test_novelty_freshness, test_recommendation_recalc, test_semantic_similarity, test_postgres_types, test_per_user_article_state) are unrelated to this PR and reproduce on `main` with no changes — verified independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)