### PR TITLE
feat: add Reading DNA preferences (#346)

### DIFF
--- a/backend/news_dashboard/analytics.py
+++ b/backend/news_dashboard/analytics.py
@@ -90,6 +90,98 @@ def admin_analytics(
         }
 
 
+def reading_dna(
+    user_id: int,
+    days: int = 30,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate one user's reading distribution and dwell metrics."""
+    init_db(db_path, database_url=database_url)
+    days = max(1, min(days, 365))
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(days=days)
+    with connect(db_path, database_url=database_url) as conn:
+        return {
+            "range_days": days,
+            "generated_at": now.isoformat(),
+            "categories": _reading_distribution(conn, user_id, start, "a.category", "category"),
+            "sources": _reading_distribution(conn, user_id, start, "a.source_name", "source"),
+            "monthly_time": _monthly_time(conn, user_id, start),
+            "average_dwell_seconds": _average_dwell_seconds(conn, user_id, start),
+        }
+
+
+def _reading_distribution(
+    conn: Any,
+    user_id: int,
+    start: datetime,
+    field_sql: str,
+    alias: str,
+) -> list[dict[str, Any]]:
+    rows = _query(
+        conn,
+        f"""
+        SELECT {field_sql} AS {alias},
+               COUNT(*) FILTER (WHERE s.state = 'done') AS done,
+               COUNT(*) FILTER (WHERE s.state = 'skipped' OR s.skipped_at IS NOT NULL) AS skipped
+        FROM user_article_state s
+        JOIN articles a ON a.id = s.article_id
+        WHERE s.user_id = %s
+          AND (
+            s.done_at >= %s OR s.skipped_at >= %s OR s.updated_at >= %s
+          )
+        GROUP BY 1
+        ORDER BY done DESC, skipped ASC, {alias}
+        LIMIT 20
+        """,
+        (user_id, start, start, start),
+    )
+    totals = [int(row["done"]) + int(row["skipped"]) for row in rows]
+    denominator = sum(totals)
+    for row, total in zip(rows, totals, strict=True):
+        row["total"] = total
+        row["percentage"] = round((total / denominator) * 100.0, 1) if denominator else 0.0
+    return rows
+
+
+def _monthly_time(conn: Any, user_id: int, start: datetime) -> list[dict[str, Any]]:
+    rows = _query(
+        conn,
+        """
+        SELECT to_char(date_trunc('month', created_at), 'YYYY-MM') AS month,
+               ROUND(COALESCE(SUM(duration_ms), 0) / 60000.0, 1) AS minutes
+        FROM user_events
+        WHERE user_id = %s
+          AND event_type = 'heartbeat'
+          AND created_at >= %s
+        GROUP BY 1
+        ORDER BY 1
+        """,
+        (user_id, start),
+    )
+    for row in rows:
+        row["minutes"] = float(row["minutes"])
+    return rows
+
+
+def _average_dwell_seconds(conn: Any, user_id: int, start: datetime) -> float:
+    row = conn.execute(
+        """
+        SELECT ROUND(AVG(duration_ms) / 1000.0, 1) AS seconds
+        FROM user_events
+        WHERE user_id = %s
+          AND event_type = 'article_close'
+          AND duration_ms IS NOT NULL
+          AND created_at >= %s
+        """,
+        (user_id, start),
+    ).fetchone()
+    if row is None or row["seconds"] is None:
+        return 0.0
+    return float(row["seconds"])
+
+
 def _summary(conn: Any, start: datetime, now: datetime) -> dict[str, Any]:
     day_ago = now - timedelta(days=1)
     week_ago = now - timedelta(days=7)

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -351,6 +351,15 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_events_user_time ON user_events(user_id, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_user_events_type_time ON user_events(event_type, created_at)",
+    """
+    CREATE TABLE IF NOT EXISTS user_settings (
+      user_id          INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      category_weights JSONB NOT NULL DEFAULT '{}'::jsonb,
+      novelty_weight   DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+      updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CHECK (novelty_weight >= 0 AND novelty_weight <= 3)
+    )
+    """,
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_time TEXT DEFAULT '09:00'",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_push_enabled"
     " BOOLEAN NOT NULL DEFAULT FALSE",

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response as StarletteResponse
 
-from news_dashboard.analytics import admin_analytics, record_events
+from news_dashboard.analytics import admin_analytics, reading_dna, record_events
 from news_dashboard.auth import (
     _session_days,
     authenticate,
@@ -1097,6 +1097,54 @@ class PushSubscribeRequest(BaseModel):
     endpoint: str
     p256dh: str
     auth: str
+
+
+class RecommendationPreferencesUpdate(BaseModel):
+    category_weights: dict[str, float] | None = None
+    novelty_weight: float | None = None
+
+
+def _preference_payload(preferences: Any) -> dict[str, Any]:
+    return {
+        "category_weights": preferences.category_weights,
+        "novelty_weight": preferences.novelty_weight,
+    }
+
+
+@api.get("/api/users/me/reading-dna")
+def reading_dna_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    days: Annotated[int, Query(ge=1, le=365)] = 30,
+) -> dict[str, Any]:
+    return reading_dna(current_user["id"], days=days)
+
+
+@api.get("/api/users/me/recommendation-preferences")
+def get_recommendation_preferences_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.recommendations import get_recommendation_preferences
+
+    return _preference_payload(get_recommendation_preferences(current_user["id"]))
+
+
+@api.patch("/api/users/me/recommendation-preferences")
+def update_recommendation_preferences_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    payload: RecommendationPreferencesUpdate,
+) -> dict[str, Any]:
+    from news_dashboard.recommendations import (
+        recompute_user_recommendations,
+        save_recommendation_preferences,
+    )
+
+    preferences = save_recommendation_preferences(
+        current_user["id"],
+        category_weights=payload.category_weights,
+        novelty_weight=payload.novelty_weight,
+    )
+    scored = recompute_user_recommendations(current_user["id"])
+    return {**_preference_payload(preferences), "recomputed": scored}
 
 
 @api.get("/api/settings/notifications")

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -141,6 +141,14 @@ class AffinityProfile:
         return _clamp(blended, -1.0, 1.0) * AFFINITY_SCORE_SPAN
 
 
+@dataclass(frozen=True)
+class RecommendationPreferences:
+    """Manual user controls layered on top of learned recommendation signals."""
+
+    category_weights: dict[str, float] = field(default_factory=dict)
+    novelty_weight: float = 1.0
+
+
 def _normalize_affinity(weighted_sum: float, count: int) -> float:
     """Smoothed, normalized affinity in [-1, 1] for one feature value."""
     smoothed = weighted_sum / (count + AFFINITY_SMOOTHING)
@@ -279,6 +287,78 @@ def novelty_adjustment(
     # candidate is from the user's taste, the more novel it is.
     dissimilarity = _clamp((1.0 - similarity) / 2.0, 0.0, 1.0)
     return dissimilarity * _quality_factor(importance) * NOVELTY_SCORE_SPAN
+
+
+def get_recommendation_preferences(
+    user_id: int,
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> RecommendationPreferences:
+    """Return persisted manual recommendation preferences for ``user_id``."""
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            SELECT category_weights, novelty_weight
+            FROM user_settings
+            WHERE user_id = %s
+            """,
+            (user_id,),
+        ).fetchone()
+    if row is None:
+        return RecommendationPreferences()
+    data = row_to_dict(row)
+    raw_weights = data.get("category_weights") or {}
+    category_weights = {
+        str(category): _clamp(float(weight), 0.0, 3.0)
+        for category, weight in dict(raw_weights).items()
+    }
+    return RecommendationPreferences(
+        category_weights=category_weights,
+        novelty_weight=_clamp(float(data.get("novelty_weight") or 1.0), 0.0, 3.0),
+    )
+
+
+def save_recommendation_preferences(
+    user_id: int,
+    *,
+    category_weights: dict[str, float] | None = None,
+    novelty_weight: float | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> RecommendationPreferences:
+    """Persist manual recommendation preferences and mark current scores stale."""
+    current = get_recommendation_preferences(user_id, db_path=db_path, database_url=database_url)
+    next_weights = current.category_weights if category_weights is None else category_weights
+    cleaned_weights = {
+        str(category).strip().lower(): _clamp(float(weight), 0.0, 3.0)
+        for category, weight in next_weights.items()
+        if str(category).strip()
+    }
+    next_novelty = current.novelty_weight if novelty_weight is None else novelty_weight
+    cleaned_novelty = _clamp(float(next_novelty), 0.0, 3.0)
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_settings(user_id, category_weights, novelty_weight)
+            VALUES (%s, %s::jsonb, %s)
+            ON CONFLICT(user_id) DO UPDATE SET
+              category_weights = excluded.category_weights,
+              novelty_weight = excluded.novelty_weight,
+              updated_at = NOW()
+            """,
+            (user_id, json.dumps(cleaned_weights), cleaned_novelty),
+        )
+        conn.execute(
+            "UPDATE user_article_recommendations SET stale = TRUE WHERE user_id = %s",
+            (user_id,),
+        )
+    return RecommendationPreferences(
+        category_weights=cleaned_weights,
+        novelty_weight=cleaned_novelty,
+    )
 
 
 def generate_recommendation_explanation(
@@ -520,6 +600,11 @@ def recompute_user_recommendations(
     with connect(db_path, database_url=database_url) as conn:
         profile = build_affinity_profile(_load_user_signals(conn, user_id))
         semantic_profile = build_semantic_profile(_load_user_history_vectors(conn, user_id))
+        preferences = get_recommendation_preferences(
+            user_id,
+            db_path=db_path,
+            database_url=database_url,
+        )
         candidates = _load_candidates(conn, user_id, limit)
 
     # Novelty needs an embedded taste vector to measure surprise against; without
@@ -536,11 +621,20 @@ def recompute_user_recommendations(
         importance = _opt_float(candidate.get("importance_score"))
         age_hours = _opt_float(candidate.get("age_hours"))
         adjustment = profile.adjustment(source_slug, category, tags)
+        category_factor = preferences.category_weights.get(str(category).lower(), 1.0)
+        manual_category = (category_factor - 1.0) * CATEGORY_AFFINITY_WEIGHT * AFFINITY_SCORE_SPAN
         candidate_vector = _decode_candidate_embedding(candidate.get("embedding"))
         semantic = semantic_adjustment(candidate_vector, semantic_profile)
         freshness = freshness_adjustment(age_hours, importance)
-        novelty = novelty_adjustment(candidate_vector, semantic_profile, importance)
-        final_score = _clamp(base + adjustment + semantic + freshness + novelty, 0.0, 100.0)
+        novelty = (
+            novelty_adjustment(candidate_vector, semantic_profile, importance)
+            * preferences.novelty_weight
+        )
+        final_score = _clamp(
+            base + adjustment + manual_category + semantic + freshness + novelty,
+            0.0,
+            100.0,
+        )
         upsert_recommendation_score(
             user_id,
             int(candidate["id"]),
@@ -551,9 +645,11 @@ def recompute_user_recommendations(
             signals={
                 "base_score": round(base, 4),
                 "affinity_adjustment": round(adjustment, 4),
+                "manual_category_adjustment": round(manual_category, 4),
                 "semantic_adjustment": round(semantic, 4),
                 "freshness_adjustment": round(freshness, 4),
                 "novelty_adjustment": round(novelty, 4),
+                "novelty_weight": round(preferences.novelty_weight, 4),
                 "source_slug": source_slug,
                 "category": category,
             },

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -126,12 +126,11 @@ def pg_clean(pg_url: str) -> str:
 
     db_mod._INITIALIZED_DATABASES.clear()
     init_db(database_url=pg_url)
-    with psycopg.connect(pg_url) as conn:
+    with psycopg.connect(pg_url, autocommit=True) as conn:
         conn.execute(
             "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
-            " user_push_subscriptions, article_shares, user_events, briefing_articles,"
-            " briefings, ingest_run_sources, ingest_runs, articles, sources, users"
-            " RESTART IDENTITY CASCADE"
+            " user_settings, user_push_subscriptions, article_shares, user_events,"
+            " briefing_articles, briefings, ingest_run_sources, ingest_runs, articles,"
+            " sources, users RESTART IDENTITY CASCADE"
         )
-        conn.commit()
     return pg_url

--- a/backend/tests/test_behavioral_affinity.py
+++ b/backend/tests/test_behavioral_affinity.py
@@ -12,6 +12,7 @@ from news_dashboard.recommendations import (
     build_affinity_profile,
     parse_tags,
     recompute_user_recommendations,
+    save_recommendation_preferences,
     score_article,
 )
 
@@ -202,6 +203,17 @@ def _persisted_score(db_path: str, user_id: int, article_id: int) -> float:
     return float(row["recommendation_score"])
 
 
+def _persisted_signals(db_path: str, user_id: int, article_id: int) -> dict[str, Any]:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT signals FROM user_article_recommendations"
+            " WHERE user_id = %s AND article_id = %s",
+            (user_id, article_id),
+        ).fetchone()
+    assert row is not None
+    return dict(row["signals"])
+
+
 def test_recompute_persists_affinity_adjusted_scores(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
@@ -280,3 +292,76 @@ def test_recompute_with_no_history_keeps_base_scores(
         + signals["novelty_adjustment"]
     )
     assert float(row["recommendation_score"]) == pytest.approx(expected)
+
+
+def test_manual_category_preferences_change_user_scores(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "tech-src", category="tech")
+    _insert_source(db_path, "science-src", category="science")
+    user_id = _make_user(db_path, "alice")
+    tech = _insert_article(db_path, "tech-src", "tech", category="tech", importance=50)
+    science = _insert_article(
+        db_path,
+        "science-src",
+        "science",
+        category="science",
+        importance=50,
+    )
+
+    recompute_user_recommendations(user_id, db_path=db_path)
+    baseline_delta = _persisted_score(db_path, user_id, science) - _persisted_score(
+        db_path,
+        user_id,
+        tech,
+    )
+
+    save_recommendation_preferences(
+        user_id,
+        category_weights={"science": 1.8, "tech": 0.6},
+        db_path=db_path,
+    )
+    recompute_user_recommendations(user_id, db_path=db_path)
+
+    adjusted_delta = _persisted_score(db_path, user_id, science) - _persisted_score(
+        db_path,
+        user_id,
+        tech,
+    )
+    assert adjusted_delta > baseline_delta
+    assert _persisted_signals(db_path, user_id, science)["manual_category_adjustment"] > 0
+    assert _persisted_signals(db_path, user_id, tech)["manual_category_adjustment"] < 0
+
+
+def test_manual_novelty_weight_changes_novel_article_score(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    import struct
+
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    history = _insert_article(db_path, "src", "history", category="ai")
+    candidate = _insert_article(db_path, "src", "candidate", category="ai", importance=100)
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE articles SET embedding = %s WHERE id = %s",
+            (struct.pack("2f", 1.0, 0.0), history),
+        )
+        conn.execute(
+            "UPDATE articles SET embedding = %s WHERE id = %s",
+            (struct.pack("2f", -1.0, 0.0), candidate),
+        )
+    _set_state(db_path, user_id, history, state="done")
+
+    save_recommendation_preferences(user_id, novelty_weight=0.0, db_path=db_path)
+    recompute_user_recommendations(user_id, db_path=db_path)
+    conservative = _persisted_score(db_path, user_id, candidate)
+
+    save_recommendation_preferences(user_id, novelty_weight=2.0, db_path=db_path)
+    recompute_user_recommendations(user_id, db_path=db_path)
+
+    exploratory = _persisted_score(db_path, user_id, candidate)
+    assert exploratory > conservative
+    assert _persisted_signals(db_path, user_id, candidate)["novelty_weight"] == pytest.approx(2.0)

--- a/backend/tests/test_reading_dna_api.py
+++ b/backend/tests/test_reading_dna_api.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+
+pytestmark = pytest.mark.postgres
+
+
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    init_db(database_url=pg_url)
+    return pg_url
+
+
+def _make_user(db_path: str, username: str) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_article(db_path: str, slug: str, category: str) -> int:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, %s, 'rss_feed', 50, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml", category),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/{slug}/article",
+                f"https://example.com/{slug}/article",
+                f"{category.title()} Article",
+                slug,
+                slug.title(),
+                category,
+                "2026-06-21T10:00:00+00:00",
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_reading_dna_endpoint_aggregates_current_user_activity(
+    monkeypatch: Any,
+    pg_clean: str,
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    article_id = _insert_article(db_path, "science-weekly", "science")
+    now = datetime.now(timezone.utc)
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state, done_at)
+            VALUES (%s, %s, 'done', %s)
+            """,
+            (user_id, article_id, now),
+        )
+        conn.execute(
+            """
+            INSERT INTO user_events(user_id, event_type, article_id, duration_ms, created_at)
+            VALUES
+              (%s, 'heartbeat', NULL, 120000, %s),
+              (%s, 'article_close', %s, 30000, %s)
+            """,
+            (user_id, now, user_id, article_id, now),
+        )
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.get("/api/users/me/reading-dna")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["categories"][0]["category"] == "science"
+    assert payload["categories"][0]["done"] == 1
+    assert payload["sources"][0]["source"] == "Science-Weekly"
+    assert payload["monthly_time"][0]["minutes"] == 2.0
+    assert payload["average_dwell_seconds"] == 30.0
+
+
+def test_recommendation_preferences_round_trip(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+
+    try:
+        with _client_for(user_id) as client:
+            update = client.patch(
+                "/api/users/me/recommendation-preferences",
+                json={"category_weights": {"Science": 1.5}, "novelty_weight": 1.8},
+            )
+            readback = client.get("/api/users/me/recommendation-preferences")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert update.status_code == 200
+    assert update.json()["category_weights"] == {"science": 1.5}
+    assert update.json()["novelty_weight"] == 1.8
+    assert update.json()["recomputed"] == 0
+    assert readback.status_code == 200
+    assert readback.json()["category_weights"] == {"science": 1.5}

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -29,6 +29,9 @@ const FeedsLogsPage = lazy(() =>
   import('./pages/FeedsLogsPage').then((m) => ({ default: m.FeedsLogsPage }))
 );
 const StatsPage = lazy(() => import('./pages/StatsPage').then((m) => ({ default: m.StatsPage })));
+const ReadingDnaPage = lazy(() =>
+  import('./pages/ReadingDnaPage').then((m) => ({ default: m.ReadingDnaPage }))
+);
 const SettingsPage = lazy(() =>
   import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage }))
 );
@@ -122,6 +125,7 @@ export const routes: RouteObject[] = [
       { path: 'briefs', element: withSuspense(BriefingsHistoryPage) },
       { path: 'briefs/:id', element: withSuspense(BriefingDetailPage) },
       { path: 'stats', element: withSuspense(StatsPage) },
+      { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'settings', element: withSuspense(SettingsPage) },
       { path: 'admin', element: withSuspense(AdminPage) },

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,6 +13,8 @@ import type {
   NotificationSettings,
   NotificationSettingsUpdate,
   PushSubscribeRequest,
+  ReadingDna,
+  RecommendationPreferences,
   ReceivedShare,
   ShareableUser,
   Source,
@@ -108,6 +110,23 @@ export async function fetchSourceHealth(): Promise<SourceHealth[]> {
 
 export async function fetchSummary(): Promise<Summary> {
   return requestJson<Summary>('/api/summary');
+}
+
+export async function fetchReadingDna(): Promise<ReadingDna> {
+  return requestJson<ReadingDna>('/api/users/me/reading-dna');
+}
+
+export async function fetchRecommendationPreferences(): Promise<RecommendationPreferences> {
+  return requestJson<RecommendationPreferences>('/api/users/me/recommendation-preferences');
+}
+
+export async function saveRecommendationPreferences(
+  preferences: Partial<RecommendationPreferences>
+): Promise<RecommendationPreferences> {
+  return requestJson<RecommendationPreferences>('/api/users/me/recommendation-preferences', {
+    method: 'PATCH',
+    body: JSON.stringify(preferences),
+  });
 }
 
 export async function ingestNow(): Promise<{ inserted: number; results: Record<string, number> }> {

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -12,6 +12,7 @@ import {
   Settings,
   Sparkles,
   Star,
+  SlidersHorizontal,
   Users,
   type LucideIcon,
 } from 'lucide-react';
@@ -38,6 +39,7 @@ export const secondaryNavigationItems: NavigationItem[] = [
   { to: '/briefs', label: 'Briefing History', icon: History, shortcut: 'h' },
   { to: '/feeds', label: 'Feeds', icon: Radio, shortcut: 'f' },
   { to: '/stats', label: 'Stats', icon: BarChart3 },
+  { to: '/reading-dna', label: 'Reading DNA', icon: SlidersHorizontal },
   { to: '/archive', label: 'Archive', icon: Archive },
   { to: '/settings', label: 'Settings', icon: Settings },
 ];
@@ -107,6 +109,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/briefs')) return 'Briefs';
   if (pathname.startsWith('/feeds')) return 'Feeds';
   if (pathname.startsWith('/stats')) return 'Stats';
+  if (pathname.startsWith('/reading-dna')) return 'Reading DNA';
   if (pathname.startsWith('/archive')) return 'Archive';
   if (pathname.startsWith('/settings')) return 'Settings';
   if (pathname.startsWith('/analytics')) return 'Analytics';

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Loader2, RefreshCw } from 'lucide-react';
+import {
+  fetchReadingDna,
+  fetchRecommendationPreferences,
+  saveRecommendationPreferences,
+} from '../api';
+import type { ReadingDna, ReadingDnaBucket, RecommendationPreferences } from '../types';
+
+const DEFAULT_CATEGORIES = ['tech', 'science', 'business', 'world', 'ai'];
+
+interface PageState {
+  dna: ReadingDna | null;
+  preferences: RecommendationPreferences | null;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+}
+
+export function ReadingDnaPage() {
+  const [state, setState] = useState<PageState>({
+    dna: null,
+    preferences: null,
+    loading: true,
+    saving: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([fetchReadingDna(), fetchRecommendationPreferences()])
+      .then(([dna, preferences]) => {
+        if (!cancelled) {
+          setState({ dna, preferences, loading: false, saving: false, error: null });
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setState((s) => ({
+            ...s,
+            loading: false,
+            error: err instanceof Error ? err.message : 'Failed to load Reading DNA',
+          }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const categories = useMemo(() => {
+    const fromStats = state.dna?.categories.map((item) => item.category).filter(Boolean) ?? [];
+    return Array.from(new Set([...fromStats, ...DEFAULT_CATEGORIES])).slice(0, 8) as string[];
+  }, [state.dna]);
+
+  async function updatePreferences(next: Partial<RecommendationPreferences>) {
+    if (!state.preferences) return;
+    const optimistic = {
+      ...state.preferences,
+      ...next,
+      category_weights: next.category_weights ?? state.preferences.category_weights,
+    };
+    setState((s) => ({ ...s, preferences: optimistic, saving: true, error: null }));
+    try {
+      const preferences = await saveRecommendationPreferences(next);
+      const dna = await fetchReadingDna();
+      setState((s) => ({ ...s, dna, preferences, saving: false }));
+    } catch (err) {
+      setState((s) => ({
+        ...s,
+        saving: false,
+        error: err instanceof Error ? err.message : 'Failed to save preferences',
+      }));
+    }
+  }
+
+  const { dna, preferences, loading, saving, error } = state;
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center p-8">
+        <Loader2 className="text-muted-foreground size-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl space-y-5 p-4 md:p-5">
+      <section>
+        <h2 className="text-[22px] font-semibold tracking-tight">Reading DNA</h2>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Your recent reading mix and recommendation controls
+        </p>
+      </section>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <section className="grid grid-cols-2 gap-2 md:grid-cols-4">
+        <Metric label="Window" value={`${dna?.range_days ?? 30}d`} />
+        <Metric label="Avg dwell" value={`${dna?.average_dwell_seconds ?? 0}s`} />
+        <Metric
+          label="Read"
+          value={String(dna?.categories.reduce((sum, item) => sum + item.done, 0) ?? 0)}
+        />
+        <Metric
+          label="Skipped"
+          value={String(dna?.categories.reduce((sum, item) => sum + item.skipped, 0) ?? 0)}
+        />
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Panel title="Category mix">
+          <BucketBars items={dna?.categories ?? []} labelKey="category" />
+        </Panel>
+        <Panel title="Source mix">
+          <BucketBars items={dna?.sources ?? []} labelKey="source" />
+        </Panel>
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+        <Panel title="Time on app">
+          <div className="flex h-40 items-end gap-2">
+            {(dna?.monthly_time ?? []).map((point) => {
+              const max = Math.max(...(dna?.monthly_time ?? []).map((p) => p.minutes), 1);
+              return (
+                <div key={point.month} className="flex h-full flex-1 flex-col justify-end gap-2">
+                  <div
+                    className="min-h-1 rounded-t bg-chart-2"
+                    style={{ height: `${Math.max(4, (point.minutes / max) * 100)}%` }}
+                    title={`${point.minutes} min`}
+                  />
+                  <div className="truncate text-center text-[10px] text-subtle">{point.month}</div>
+                </div>
+              );
+            })}
+            {dna?.monthly_time.length === 0 && <EmptyLine />}
+          </div>
+        </Panel>
+
+        <Panel title="Active nudges">
+          <div className="space-y-4">
+            {categories.map((category) => {
+              const value = preferences?.category_weights[category] ?? 1;
+              return (
+                <SliderRow
+                  key={category}
+                  label={category}
+                  value={value}
+                  onChange={(next) =>
+                    void updatePreferences({
+                      category_weights: {
+                        ...(preferences?.category_weights ?? {}),
+                        [category]: next,
+                      },
+                    })
+                  }
+                />
+              );
+            })}
+            <SliderRow
+              label="novelty"
+              value={preferences?.novelty_weight ?? 1}
+              onChange={(next) => void updatePreferences({ novelty_weight: next })}
+            />
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {saving && <RefreshCw className="size-3 animate-spin" />}
+              <span>{saving ? 'Saving and recalculating' : 'Changes save immediately'}</span>
+            </div>
+          </div>
+        </Panel>
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-surface px-3 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="mt-1 text-xl font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-md border border-border bg-surface p-3">
+      <h3 className="text-sm font-medium">{title}</h3>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function BucketBars({
+  items,
+  labelKey,
+}: {
+  items: ReadingDnaBucket[];
+  labelKey: 'category' | 'source';
+}) {
+  if (items.length === 0) return <EmptyLine />;
+  return (
+    <div className="space-y-3">
+      {items.slice(0, 8).map((item) => {
+        const label = item[labelKey] ?? 'unknown';
+        return (
+          <div key={label} className="space-y-1">
+            <div className="flex items-center justify-between gap-3 text-xs">
+              <span className="truncate font-medium capitalize">{label}</span>
+              <span className="text-muted-foreground tabular-nums">{item.percentage}%</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded bg-muted">
+              <div className="h-full bg-chart-1" style={{ width: `${item.percentage}%` }} />
+            </div>
+            <div className="text-[10px] text-subtle">
+              {item.done} read / {item.skipped} skipped
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SliderRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="block space-y-1.5">
+      <div className="flex items-center justify-between gap-3 text-xs">
+        <span className="font-medium capitalize">{label}</span>
+        <span className="tabular-nums text-muted-foreground">{value.toFixed(1)}x</span>
+      </div>
+      <input
+        className="w-full accent-primary"
+        type="range"
+        min="0"
+        max="3"
+        step="0.1"
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+    </label>
+  );
+}
+
+function EmptyLine() {
+  return <div className="py-8 text-center text-sm text-muted-foreground">No activity yet</div>;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -260,6 +260,35 @@ export interface PushSubscribeRequest {
   auth: string;
 }
 
+export interface ReadingDnaBucket {
+  category?: string;
+  source?: string;
+  done: number;
+  skipped: number;
+  total: number;
+  percentage: number;
+}
+
+export interface MonthlyTimePoint {
+  month: string;
+  minutes: number;
+}
+
+export interface ReadingDna {
+  range_days: number;
+  generated_at: string;
+  categories: ReadingDnaBucket[];
+  sources: ReadingDnaBucket[];
+  monthly_time: MonthlyTimePoint[];
+  average_dwell_seconds: number;
+}
+
+export interface RecommendationPreferences {
+  category_weights: Record<string, number>;
+  novelty_weight: number;
+  recomputed?: number;
+}
+
 export interface AnalyticsSummary {
   dau: number;
   wau: number;


### PR DESCRIPTION
Closes #346

## Summary
- add per-user recommendation preference storage for category nudges and novelty weighting
- expose authenticated Reading DNA and recommendation preference endpoints
- add a Reading DNA dashboard page with reading distribution, time-on-app, dwell metrics, and sliders that save/recompute preferences
- tighten PostgreSQL test cleanup for the new user_settings table

## Tests
- set -a && source .env && set +a && make check
- pre-push hook: backend pytest and frontend vitest passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)