### PR TITLE
feat: add subscription optimizer cleanup suggestions (#348)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         stages: [pre-push]
       - id: pytest
         name: pytest (backend)
-        entry: pytest
+        entry: zsh -c 'set -a; if [ -f .env ]; then source .env; fi; set +a; pytest'
         language: system
         types: [python]
         pass_filenames: false

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -80,7 +80,10 @@ from news_dashboard.scheduler import (
     start_scheduler,
     stop_scheduler,
 )
-from news_dashboard.source_health import list_source_health
+from news_dashboard.source_health import (
+    generate_subscription_cleanup_suggestions,
+    list_source_health,
+)
 from news_dashboard.stats import (
     article_counts,
     articles_over_time,
@@ -169,6 +172,10 @@ class CreateSourceRequest(BaseModel):
     name: str
     category: str = "tech"
     slug: str | None = None
+
+
+class SourceCleanupRequest(BaseModel):
+    source_slugs: list[str]
 
 
 class IntervalUpdate(BaseModel):
@@ -757,6 +764,63 @@ def delete_source(
 @api.get("/api/sources/health")
 def sources_health() -> dict[str, Any]:
     return {"items": list_source_health()}
+
+
+@api.get("/api/sources/cleanup-suggestions")
+def source_cleanup_suggestions(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": generate_subscription_cleanup_suggestions(int(current_user["id"]))}
+
+
+@api.post("/api/sources/cleanup")
+def source_cleanup(
+    payload: SourceCleanupRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    uid = int(current_user["id"])
+    requested_slugs = list(dict.fromkeys(payload.source_slugs))
+    if not requested_slugs:
+        return {"updated": [], "skipped": []}
+
+    init_db()
+    with connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT slug, owner_user_id
+            FROM sources
+            WHERE slug = ANY(%s)
+              AND (owner_user_id IS NULL OR owner_user_id = %s)
+            """,
+            (requested_slugs, uid),
+        ).fetchall()
+        allowed = {str(row["slug"]): row_to_dict(row) for row in rows}
+        updated: list[str] = []
+        for slug in requested_slugs:
+            source = allowed.get(slug)
+            if source is None:
+                continue
+            if source.get("owner_user_id") is None:
+                conn.execute(
+                    """
+                    INSERT INTO user_sources(user_id, source_slug, enabled)
+                    VALUES (%s, %s, FALSE)
+                    ON CONFLICT(user_id, source_slug)
+                    DO UPDATE SET enabled = excluded.enabled
+                    """,
+                    (uid, slug),
+                )
+            else:
+                conn.execute(
+                    "UPDATE sources SET enabled = FALSE WHERE slug = %s AND owner_user_id = %s",
+                    (slug, uid),
+                )
+            updated.append(slug)
+
+    return {
+        "updated": updated,
+        "skipped": [slug for slug in requested_slugs if slug not in updated],
+    }
 
 
 @api.patch("/api/sources/{slug}/enabled")

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -5,6 +5,9 @@ from typing import Any
 
 from news_dashboard.db import connect, init_db, row_to_dict
 
+LOW_SIGNAL_MIN_ARTICLES = 50
+LOW_SIGNAL_SKIP_RATE = 0.9
+
 
 def _clean_error(value: Any) -> str | None:
     if value is None:
@@ -39,6 +42,15 @@ def _as_int(value: Any, default: int = 0) -> int:
         return default
     try:
         return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
     except (TypeError, ValueError):
         return default
 
@@ -137,3 +149,107 @@ def list_source_health(db_path: Path | str | None = None) -> list[dict[str, Any]
             str(item["name"]).lower(),
         ),
     )
+
+
+def generate_subscription_cleanup_suggestions(
+    user_id: int,
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Find noisy or stale sources the user may want to unsubscribe from."""
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            WITH user_visible_sources AS (
+              SELECT s.slug, s.name
+              FROM sources s
+              LEFT JOIN user_sources us
+                ON us.source_slug = s.slug AND us.user_id = %s
+              WHERE (s.owner_user_id IS NULL OR s.owner_user_id = %s)
+                AND CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, TRUE)
+                         ELSE s.enabled IS TRUE END
+            ),
+            source_totals AS (
+              SELECT
+                uvs.slug,
+                uvs.name,
+                COUNT(a.id) FILTER (
+                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                ) AS articles_last_30_days,
+                COUNT(uas.article_id) FILTER (
+                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                    AND uas.state = 'skipped'
+                ) AS skipped_count,
+                COUNT(uas.article_id) FILTER (
+                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                    AND uas.state = 'done'
+                ) AS done_count,
+                COUNT(uas.article_id) FILTER (
+                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                    AND uas.starred IS TRUE
+                ) AS starred_count,
+                COUNT(uas.article_id) FILTER (
+                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                    AND uas.state = 'archived'
+                ) AS archived_count,
+                COUNT(a.id) AS lifetime_articles
+              FROM user_visible_sources uvs
+              LEFT JOIN articles a ON a.source_slug = uvs.slug
+              LEFT JOIN user_article_state uas
+                ON uas.article_id = a.id AND uas.user_id = %s
+              GROUP BY uvs.slug, uvs.name
+            )
+            SELECT *
+            FROM source_totals
+            WHERE lifetime_articles > 0
+            ORDER BY articles_last_30_days DESC, name ASC
+            """,
+            (user_id, user_id, user_id),
+        ).fetchall()
+
+    suggestions: list[dict[str, Any]] = []
+    for row in rows:
+        source = row_to_dict(row)
+        total = _as_int(source.get("articles_last_30_days"))
+        skipped = _as_int(source.get("skipped_count"))
+        done = _as_int(source.get("done_count"))
+        starred = _as_int(source.get("starred_count"))
+        archived = _as_int(source.get("archived_count"))
+        skip_rate = round(skipped / total, 2) if total else 0.0
+        engagement_score = round((done + starred) / total, 2) if total else 0.0
+        source_name = str(source["name"])
+
+        reason: str | None = None
+        message: str | None = None
+        if total >= LOW_SIGNAL_MIN_ARTICLES and skip_rate > LOW_SIGNAL_SKIP_RATE:
+            reason = "low_signal"
+            message = (
+                f"Unsubscribe from '{source_name}' ({skip_rate:.0%} skipped in the last 30 days)"
+            )
+        elif total == 0:
+            reason = "stale"
+            message = f"Unsubscribe from '{source_name}' (no articles in the last 30 days)"
+
+        if reason is None or message is None:
+            continue
+
+        suggestions.append(
+            {
+                "source_slug": str(source["slug"]),
+                "source_name": source_name,
+                "action": "unsubscribe",
+                "reason": reason,
+                "message": message,
+                "articles_last_30_days": total,
+                "skipped_count": skipped,
+                "done_count": done,
+                "starred_count": starred,
+                "archived_count": archived,
+                "skip_rate": _as_float(skip_rate),
+                "engagement_score": _as_float(engagement_score),
+            }
+        )
+
+    return suggestions

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -6,6 +6,7 @@ import contextlib
 from pathlib import Path
 from typing import Any
 
+from news_dashboard.auth import create_user
 from news_dashboard.db import connect
 from news_dashboard.ingest import (
     infer_tags,
@@ -13,7 +14,10 @@ from news_dashboard.ingest import (
     search_articles,
     sync_sources,
 )
-from news_dashboard.source_health import list_source_health
+from news_dashboard.source_health import (
+    generate_subscription_cleanup_suggestions,
+    list_source_health,
+)
 from news_dashboard.sources import SourceDefinition
 
 # ──────────────────────────────────────────────
@@ -32,6 +36,81 @@ def _insert_article(conn: Any, n: int = 1) -> None:
                ON CONFLICT (url) DO NOTHING""",
             (f"https://example.com/art-{i}", f"https://example.com/art-{i}", f"Article {i}"),
         )
+
+
+def _make_user(db_path: Path | str, username: str = "alice") -> int:
+    user = create_user(username, "pw", db_path=db_path)
+    return int(user["id"])
+
+
+def _api_client(user_id: int) -> Any:
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_admin, require_auth
+    from news_dashboard.main import app
+
+    fake = {"id": user_id, "username": "testuser", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake
+    app.dependency_overrides[require_admin] = lambda: fake
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _add_source(conn: Any, slug: str, name: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+        VALUES (%s, %s, %s, 'tech', 'rss_feed', 10, TRUE)
+        """,
+        (slug, name, f"https://example.com/{slug}.xml"),
+    )
+
+
+def _add_article(
+    conn: Any,
+    *,
+    user_id: int,
+    slug: str,
+    index: int,
+    state: str = "today",
+    days_old: int = 1,
+) -> None:
+    row = conn.execute(
+        """
+        INSERT INTO articles(
+          url, canonical_url, title, source_slug, source_name, category, kind, discovered_at
+        )
+        VALUES (
+          %s, %s, %s, %s, %s, 'tech', 'rss_feed',
+          NOW() - (%s * INTERVAL '1 day')
+        )
+        RETURNING id
+        """,
+        (
+            f"https://example.com/{slug}/{index}",
+            f"https://example.com/{slug}/{index}",
+            f"{slug} article {index}",
+            slug,
+            slug,
+            days_old,
+        ),
+    ).fetchone()
+    article_id = int(row["id"])
+    if state == "today":
+        return
+    conn.execute(
+        """
+        INSERT INTO user_article_state(
+          user_id, article_id, state, starred, done_at, skipped_at, archived_at
+        )
+        VALUES (
+          %s, %s, %s, %s,
+          CASE WHEN %s = 'done' THEN NOW() ELSE NULL END,
+          CASE WHEN %s = 'skipped' THEN NOW() ELSE NULL END,
+          CASE WHEN %s = 'archived' THEN NOW() ELSE NULL END
+        )
+        """,
+        (user_id, article_id, state, state == "starred", state, state, state),
+    )
 
 
 def test_source_columns_present(tmp_path: Path) -> None:
@@ -139,6 +218,102 @@ def test_source_health_counts_leading_errors_and_sorts_first(tmp_path: Path) -> 
     assert python["status"] == "ERROR"
     assert python["last_error"] == "TimeoutError: connection timed out"
     assert items[0]["slug"] == "python-insider"
+
+
+def test_subscription_cleanup_suggests_high_skip_rate_source(
+    pg_clean: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "noise-feed", "Noise Feed")
+        for i in range(46):
+            _add_article(conn, user_id=uid, slug="noise-feed", index=i, state="skipped")
+        for i in range(46, 50):
+            _add_article(conn, user_id=uid, slug="noise-feed", index=i, state="done")
+
+    suggestions = generate_subscription_cleanup_suggestions(uid, database_url=pg_clean)
+
+    assert suggestions == [
+        {
+            "source_slug": "noise-feed",
+            "source_name": "Noise Feed",
+            "action": "unsubscribe",
+            "reason": "low_signal",
+            "message": "Unsubscribe from 'Noise Feed' (92% skipped in the last 30 days)",
+            "articles_last_30_days": 50,
+            "skipped_count": 46,
+            "done_count": 4,
+            "starred_count": 0,
+            "archived_count": 0,
+            "skip_rate": 0.92,
+            "engagement_score": 0.08,
+        }
+    ]
+
+
+def test_subscription_cleanup_suggests_stale_source(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "quiet-feed", "Quiet Feed")
+        _add_article(conn, user_id=uid, slug="quiet-feed", index=1, days_old=45)
+
+    suggestions = generate_subscription_cleanup_suggestions(uid, database_url=pg_clean)
+
+    assert suggestions == [
+        {
+            "source_slug": "quiet-feed",
+            "source_name": "Quiet Feed",
+            "action": "unsubscribe",
+            "reason": "stale",
+            "message": "Unsubscribe from 'Quiet Feed' (no articles in the last 30 days)",
+            "articles_last_30_days": 0,
+            "skipped_count": 0,
+            "done_count": 0,
+            "starred_count": 0,
+            "archived_count": 0,
+            "skip_rate": 0.0,
+            "engagement_score": 0.0,
+        }
+    ]
+
+
+def test_subscription_cleanup_api_unsubscribes_requested_sources(
+    pg_clean: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "noise-feed", "Noise Feed")
+        _add_source(conn, "keeper-feed", "Keeper Feed")
+
+    client = _api_client(uid)
+    try:
+        suggestions = client.get("/api/sources/cleanup-suggestions")
+        assert suggestions.status_code == 200
+
+        response = client.post("/api/sources/cleanup", json={"source_slugs": ["noise-feed"]})
+        assert response.status_code == 200
+        assert response.json() == {"updated": ["noise-feed"], "skipped": []}
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+    with connect(pg_clean) as conn:
+        rows = conn.execute(
+            """
+            SELECT source_slug, enabled
+            FROM user_sources
+            WHERE user_id = %s
+            ORDER BY source_slug
+            """,
+            (uid,),
+        ).fetchall()
+    assert [(row["source_slug"], row["enabled"]) for row in rows] == [("noise-feed", False)]
 
 
 # ──────────────────────────────────────────────

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -129,6 +129,19 @@ describe('sources, summary, ingest', () => {
     expect(await api.fetchSourceHealth()).toEqual([{ slug: 's' }]);
   });
 
+  it('fetchSourceCleanupSuggestions unwraps items', async () => {
+    stubFetch(() => jsonOk({ items: [{ source_slug: 's' }] }));
+    expect(await api.fetchSourceCleanupSuggestions()).toEqual([{ source_slug: 's' }]);
+  });
+
+  it('applySourceCleanup POSTs selected slugs', async () => {
+    const { calls } = stubFetch(() => jsonOk({ updated: ['s'], skipped: [] }));
+    await api.applySourceCleanup(['s']);
+    expect(calls[0].url).toBe('/api/sources/cleanup');
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].init?.body).toBe(JSON.stringify({ source_slugs: ['s'] }));
+  });
+
   it('fetchSummary returns the summary', async () => {
     stubFetch(() => jsonOk({ total: 5 }));
     expect(await api.fetchSummary()).toEqual({ total: 5 });

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -11,7 +11,9 @@ import type { Source } from '../types';
 // the same module, so one mock factory covers both import specifiers.
 const apiMock = vi.hoisted(() => ({
   fetchSources: vi.fn(),
+  fetchSourceCleanupSuggestions: vi.fn(),
   updateSourceEnabled: vi.fn(),
+  applySourceCleanup: vi.fn(),
   fetchSchedulerStatus: vi.fn(),
   setSchedulerInterval: vi.fn(),
   pauseScheduler: vi.fn(),
@@ -89,6 +91,10 @@ describe('FeedsPage', () => {
 // ── SourcesPage ──────────────────────────────────────────────────────────────
 
 describe('SourcesPage', () => {
+  beforeEach(() => {
+    apiMock.fetchSourceCleanupSuggestions.mockResolvedValue([]);
+  });
+
   it('shows a loading skeleton before data resolves', () => {
     apiMock.fetchSources.mockReturnValue(new Promise(vi.fn()));
     const { container } = withProviders(<SourcesPage />);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -18,6 +18,7 @@ import type {
   ReceivedShare,
   ShareableUser,
   Source,
+  SourceCleanupSuggestion,
   SourceHealth,
   SourceQualityRow,
   SourceVolumePoint,
@@ -106,6 +107,23 @@ export async function fetchSources(): Promise<Source[]> {
 export async function fetchSourceHealth(): Promise<SourceHealth[]> {
   const data = await requestJson<{ items: SourceHealth[] }>('/api/sources/health');
   return data.items;
+}
+
+export async function fetchSourceCleanupSuggestions(): Promise<SourceCleanupSuggestion[]> {
+  const data = await requestJson<{ items: SourceCleanupSuggestion[] }>(
+    '/api/sources/cleanup-suggestions'
+  );
+  return data.items;
+}
+
+export async function applySourceCleanup(sourceSlugs: string[]): Promise<{
+  updated: string[];
+  skipped: string[];
+}> {
+  return requestJson('/api/sources/cleanup', {
+    method: 'POST',
+    body: JSON.stringify({ source_slugs: sourceSlugs }),
+  });
 }
 
 export async function fetchSummary(): Promise<Summary> {

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,10 +1,16 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, AlertTriangle, AlertCircle } from 'lucide-react';
+import { CheckCircle2, AlertTriangle, AlertCircle, Sparkles, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
-import { fetchSources, updateSourceEnabled } from '@/api';
+import {
+  applySourceCleanup,
+  fetchSourceCleanupSuggestions,
+  fetchSources,
+  updateSourceEnabled,
+} from '@/api';
 import { relativeTime } from '@/lib/format';
-import type { Source } from '@/types';
+import type { Source, SourceCleanupSuggestion } from '@/types';
 
 type HealthState = 'ok' | 'stale' | 'error';
 
@@ -47,12 +53,22 @@ function HealthBadge({ health }: { health: HealthState }) {
 }
 
 const SOURCES_KEY = 'sources';
+const SOURCE_CLEANUP_KEY = 'source-cleanup-suggestions';
+
+function formatSuggestionMeta(suggestion: SourceCleanupSuggestion): string {
+  if (suggestion.reason === 'stale') return 'No articles in 30 days';
+  return `${Math.round(suggestion.skip_rate * 100)}% skipped · ${suggestion.articles_last_30_days} articles`;
+}
 
 export function SourcesPage() {
   const qc = useQueryClient();
   const { data: sources = [], isLoading } = useQuery({
     queryKey: [SOURCES_KEY],
     queryFn: fetchSources,
+  });
+  const { data: cleanupSuggestions = [] } = useQuery({
+    queryKey: [SOURCE_CLEANUP_KEY],
+    queryFn: fetchSourceCleanupSuggestions,
   });
 
   const toggleMutation = useMutation({
@@ -73,6 +89,32 @@ export function SourcesPage() {
       void qc.invalidateQueries({ queryKey: [SOURCES_KEY] });
     },
   });
+  const cleanupMutation = useMutation({
+    mutationFn: (sourceSlug: string) => applySourceCleanup([sourceSlug]),
+    onMutate: async (sourceSlug) => {
+      await Promise.all([
+        qc.cancelQueries({ queryKey: [SOURCES_KEY] }),
+        qc.cancelQueries({ queryKey: [SOURCE_CLEANUP_KEY] }),
+      ]);
+      const prevSources = qc.getQueryData<Source[]>([SOURCES_KEY]);
+      const prevSuggestions = qc.getQueryData<SourceCleanupSuggestion[]>([SOURCE_CLEANUP_KEY]);
+      qc.setQueryData<Source[]>([SOURCES_KEY], (old = []) =>
+        old.map((s) => (s.slug === sourceSlug ? { ...s, enabled: 0, subscribed: false } : s))
+      );
+      qc.setQueryData<SourceCleanupSuggestion[]>([SOURCE_CLEANUP_KEY], (old = []) =>
+        old.filter((s) => s.source_slug !== sourceSlug)
+      );
+      return { prevSources, prevSuggestions };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prevSources) qc.setQueryData([SOURCES_KEY], ctx.prevSources);
+      if (ctx?.prevSuggestions) qc.setQueryData([SOURCE_CLEANUP_KEY], ctx.prevSuggestions);
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: [SOURCES_KEY] });
+      void qc.invalidateQueries({ queryKey: [SOURCE_CLEANUP_KEY] });
+    },
+  });
 
   if (isLoading) {
     return (
@@ -86,6 +128,41 @@ export function SourcesPage() {
 
   return (
     <div>
+      {cleanupSuggestions.length > 0 && (
+        <section className="border-b border-border bg-muted/25 px-4 py-4 md:px-5">
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Sparkles className="size-4 text-primary" />
+              <span>Subscription Optimizer</span>
+            </div>
+            <div className="grid gap-2 lg:grid-cols-2">
+              {cleanupSuggestions.map((suggestion) => (
+                <div
+                  key={suggestion.source_slug}
+                  className="flex flex-col gap-3 rounded-md border border-border bg-background p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{suggestion.message}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {formatSuggestionMeta(suggestion)}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => cleanupMutation.mutate(suggestion.source_slug)}
+                    disabled={cleanupMutation.isPending}
+                  >
+                    <Trash2 className="size-4" />
+                    Apply Cleanup
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
       {/* desktop table */}
       <div className="hidden md:block overflow-x-auto">
         <table className="w-full text-sm">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -95,6 +95,21 @@ export interface SourceHealth {
   status: 'OK' | 'ERROR';
 }
 
+export interface SourceCleanupSuggestion {
+  source_slug: string;
+  source_name: string;
+  action: 'unsubscribe';
+  reason: 'low_signal' | 'stale';
+  message: string;
+  articles_last_30_days: number;
+  skipped_count: number;
+  done_count: number;
+  starred_count: number;
+  archived_count: number;
+  skip_rate: number;
+  engagement_score: number;
+}
+
 export interface Summary {
   byStatus: Record<string, number>;
   byCategory: Record<string, number>;


### PR DESCRIPTION
Closes #348

## Summary
- Added per-user subscription cleanup analytics for noisy high-skip sources and stale sources.
- Added `GET /api/sources/cleanup-suggestions` and `POST /api/sources/cleanup` for bulk source cleanup.
- Added a Subscription Optimizer widget to the Sources page with typed frontend API calls and tests.
- Updated the pre-push backend pytest hook to export local `.env` variables before running tests, matching the documented local `source .env && make test` workflow.

## Tests
- `source .env && make check`
- pre-push hooks on `git push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
