### PR TITLE
feat: add Reading Goals and AI-generated retention quizzes (#351)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -390,6 +390,26 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_article_shares_unread"
     " ON article_shares(to_user_id) WHERE read_at IS NULL",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS perspective_analysis JSONB",
+    """
+    CREATE TABLE IF NOT EXISTS user_goals (
+      id          SERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      description TEXT NOT NULL,
+      keywords    TEXT NOT NULL DEFAULT '',
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_goals_user ON user_goals(user_id)",
+    """
+    CREATE TABLE IF NOT EXISTS user_quizzes (
+      id          SERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      questions   JSONB NOT NULL DEFAULT '[]'::jsonb,
+      score       INTEGER
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_quizzes_user ON user_quizzes(user_id, created_at DESC)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1350,6 +1350,93 @@ def summary(
     return get_user_summary(user_id=current_user["id"])
 
 
+# ── Reading Goals & Quizzes ───────────────────────────────────────────────────
+
+
+class GoalCreateRequest(BaseModel):
+    description: str
+    keywords: str = ""
+
+
+class QuizSubmitRequest(BaseModel):
+    answers: list[int]
+
+
+@api.post("/api/goals")
+def create_goal_endpoint(
+    payload: GoalCreateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import create_goal
+
+    description = payload.description.strip()
+    if not description:
+        raise HTTPException(status_code=400, detail="description must not be empty")
+    return create_goal(current_user["id"], description, payload.keywords)
+
+
+@api.get("/api/goals")
+def list_goals_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import list_goals
+
+    return {"items": list_goals(current_user["id"])}
+
+
+@api.delete("/api/goals/{goal_id}")
+def delete_goal_endpoint(
+    goal_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import delete_goal
+
+    if not delete_goal(goal_id, current_user["id"]):
+        raise HTTPException(status_code=404, detail="goal not found")
+    return {"deleted": True}
+
+
+@api.get("/api/quizzes/latest")
+def get_latest_quiz_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import get_latest_quiz
+
+    quiz = get_latest_quiz(current_user["id"])
+    if not quiz:
+        raise HTTPException(status_code=404, detail="no quiz available")
+    return quiz
+
+
+@api.post("/api/quizzes/generate")
+def generate_quiz_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import generate_weekly_quiz
+
+    try:
+        quiz = generate_weekly_quiz(current_user["id"])
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    if not quiz:
+        raise HTTPException(status_code=404, detail="no eligible articles to quiz on")
+    return quiz
+
+
+@api.post("/api/quizzes/{quiz_id}/submit")
+def submit_quiz_endpoint(
+    quiz_id: int,
+    payload: QuizSubmitRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import submit_quiz
+
+    try:
+        return submit_quiz(quiz_id, current_user["id"], payload.answers)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 # ── Admin user-management routes ─────────────────────────────────────────────
 
 admin = APIRouter(prefix="/api/admin", dependencies=[Depends(require_admin)])

--- a/backend/news_dashboard/quiz.py
+++ b/backend/news_dashboard/quiz.py
@@ -1,0 +1,340 @@
+"""Reading Goals and AI-generated retention quizzes.
+
+Users set learning goals (description + keywords). The recommendation engine
+gives a small boost to articles that match those keywords. Weekly, an LLM
+generates 3 multiple-choice questions from articles the user marked done.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_QUIZ_MODEL = "gpt-4o-mini"
+GOAL_ALIGNMENT_ADJUSTMENT = 4.0  # points added to recommendation score per matching goal
+_MAX_ARTICLE_CHARS = 3_000
+_QUIZ_PROMPT = (
+    "You are a study-aid assistant. Based ONLY on the articles listed below, generate exactly 3 "
+    "multiple-choice questions that test the reader's understanding of key facts or arguments. "
+    "For each question provide:\n"
+    "- question: the question text\n"
+    "- options: a JSON array of exactly 4 answer strings\n"
+    "- correct_index: 0-based index of the correct answer\n"
+    "- explanation: one sentence explaining why that answer is correct, citing the article\n"
+    "- article_id: the integer id of the article the question is drawn from\n\n"
+    "Return ONLY a JSON array of 3 objects with those exact keys. No other text."
+)
+
+
+# ── Goal CRUD helpers ─────────────────────────────────────────────────────────
+
+
+def create_goal(
+    user_id: int,
+    description: str,
+    keywords: str = "",
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_goals (user_id, description, keywords)
+            VALUES (%s, %s, %s)
+            RETURNING id, user_id, description, keywords, created_at
+            """,
+            (user_id, description.strip(), keywords.strip()),
+        ).fetchone()
+    return dict(row)
+
+
+def list_goals(
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            "SELECT id, user_id, description, keywords, created_at"
+            " FROM user_goals WHERE user_id = %s ORDER BY created_at DESC",
+            (user_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def delete_goal(
+    goal_id: int,
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> bool:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        result = conn.execute(
+            "DELETE FROM user_goals WHERE id = %s AND user_id = %s",
+            (goal_id, user_id),
+        )
+        return bool(result.rowcount > 0)
+
+
+# ── Goal alignment score adjustment ──────────────────────────────────────────
+
+
+def goal_alignment_adjustment(
+    article_title: str | None,
+    article_category: str | None,
+    article_tags: str | None,
+    goals: list[dict[str, Any]],
+) -> float:
+    """Return a score boost when the article matches any active goal's keywords."""
+    if not goals:
+        return 0.0
+    text = " ".join(filter(None, [article_title, article_category, article_tags])).lower()
+    for goal in goals:
+        keywords_raw = str(goal.get("keywords") or goal.get("description") or "")
+        for kw in keywords_raw.lower().split():
+            if kw and kw in text:
+                return GOAL_ALIGNMENT_ADJUSTMENT
+    return 0.0
+
+
+# ── Weekly quiz generation ────────────────────────────────────────────────────
+
+
+def _quiz_ai_config() -> tuple[str, str | None, str]:
+    api_key = os.getenv("OPENAI_QUIZ_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = "OPENAI_API_KEY is not configured"
+        raise RuntimeError(msg)
+    base_url = os.getenv("OPENAI_QUIZ_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    model = os.getenv("OPENAI_QUIZ_MODEL", DEFAULT_QUIZ_MODEL)
+    return api_key, base_url, model
+
+
+def _build_article_blurb(article: dict[str, Any]) -> str:
+    title = str(article.get("title") or "")
+    body = str(article.get("body") or article.get("summary") or "")
+    blurb = f"Article id={article['id']}\nTitle: {title}\n{body}"
+    return blurb[:_MAX_ARTICLE_CHARS]
+
+
+def _parse_questions(response_text: str) -> list[dict[str, Any]]:
+    """Extract the JSON array from the LLM response, tolerating markdown fences."""
+    text = response_text.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    try:
+        data = json.loads(text)
+        if not isinstance(data, list):
+            return []
+        result: list[dict[str, Any]] = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            question = str(item.get("question") or "")
+            options = item.get("options")
+            correct_index = item.get("correct_index")
+            if not question or not isinstance(options, list) or correct_index is None:
+                continue
+            result.append(
+                {
+                    "question": question,
+                    "options": [str(o) for o in options],
+                    "correct_index": int(correct_index),
+                    "explanation": str(item.get("explanation") or ""),
+                    "article_id": item.get("article_id"),
+                }
+            )
+        return result
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+
+def generate_weekly_quiz(
+    user_id: int,
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    """Generate and persist a weekly quiz for the user.
+
+    Queries articles marked `done` in the last 7 days that align with the
+    user's active goals (or falls back to the most-recent reads). Calls an
+    LLM to produce 3 MCQs and saves the result to `user_quizzes`.
+
+    Returns the saved quiz row, or None when no eligible articles are found.
+    """
+    init_db(db_path, database_url=database_url)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+
+    with connect(db_path, database_url=database_url) as conn:
+        goals = conn.execute(
+            "SELECT description, keywords FROM user_goals WHERE user_id = %s",
+            (user_id,),
+        ).fetchall()
+        goal_list = [dict(g) for g in goals]
+
+        # Build keyword filter for the SQL query when goals are present.
+        articles: list[dict[str, Any]]
+        if goal_list:
+            keyword_terms: list[str] = []
+            for g in goal_list:
+                kw_str = g.get("keywords") or g.get("description") or ""
+                keyword_terms.extend(kw_str.lower().split())
+            if keyword_terms:
+                ilike_clauses = " OR ".join(
+                    "(LOWER(a.title) LIKE %s OR LOWER(a.category) LIKE %s)" for _ in keyword_terms
+                )
+                params: list[Any] = []
+                for kw in keyword_terms:
+                    params.extend([f"%{kw}%", f"%{kw}%"])
+                params.extend([user_id, cutoff])
+                rows = conn.execute(
+                    f"""
+                    SELECT a.id, a.title, a.body, a.summary, a.category
+                    FROM articles a
+                    JOIN user_article_state s ON s.article_id = a.id
+                    WHERE ({ilike_clauses})
+                      AND s.user_id = %s
+                      AND s.state = 'done'
+                      AND s.done_at >= %s
+                    ORDER BY s.done_at DESC
+                    LIMIT 10
+                    """,
+                    params,
+                ).fetchall()
+                articles = [dict(r) for r in rows]
+            else:
+                articles = []
+        else:
+            articles = []
+
+        # Fall back to any recently-read articles when no goal matches.
+        if not articles:
+            rows = conn.execute(
+                """
+                SELECT a.id, a.title, a.body, a.summary, a.category
+                FROM articles a
+                JOIN user_article_state s ON s.article_id = a.id
+                WHERE s.user_id = %s
+                  AND s.state = 'done'
+                  AND s.done_at >= %s
+                ORDER BY s.done_at DESC
+                LIMIT 10
+                """,
+                (user_id, cutoff),
+            ).fetchall()
+            articles = [dict(r) for r in rows]
+
+    if not articles:
+        logger.info("No eligible articles for quiz generation for user %s", user_id)
+        return None
+
+    api_key, base_url, model = _quiz_ai_config()
+    blurbs = "\n\n---\n\n".join(_build_article_blurb(a) for a in articles[:5])
+    messages = [{"role": "user", "content": f"{_QUIZ_PROMPT}\n\nArticles:\n{blurbs}"}]
+
+    from news_dashboard.ai_client import chat_create, get_openai_client
+
+    client = get_openai_client(api_key=api_key, base_url=base_url)
+    logger.info("Generating weekly quiz for user %s from %d articles", user_id, len(articles))
+    result = chat_create(
+        client,
+        name="weekly-quiz",
+        tags=["quiz"],
+        user_id=user_id,
+        model=model,
+        messages=messages,
+        max_tokens=1024,
+    )
+    response_text = (result.choices[0].message.content or "").strip()
+    questions = _parse_questions(response_text)
+    if not questions:
+        logger.warning("LLM returned no parseable questions for user %s", user_id)
+        return None
+
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_quizzes (user_id, questions)
+            VALUES (%s, %s::jsonb)
+            RETURNING id, user_id, created_at, questions, score
+            """,
+            (user_id, json.dumps(questions)),
+        ).fetchone()
+    quiz = dict(row)
+    quiz["questions"] = questions
+    return quiz
+
+
+# ── Quiz retrieval and submission ─────────────────────────────────────────────
+
+
+def get_latest_quiz(
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT id, user_id, created_at, questions, score"
+            " FROM user_quizzes WHERE user_id = %s ORDER BY created_at DESC LIMIT 1",
+            (user_id,),
+        ).fetchone()
+    if not row:
+        return None
+    return dict(row)
+
+
+def submit_quiz(
+    quiz_id: int,
+    user_id: int,
+    answers: list[int],
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT id, user_id, questions, score FROM user_quizzes WHERE id = %s AND user_id = %s",
+            (quiz_id, user_id),
+        ).fetchone()
+        if not row:
+            msg = f"Quiz {quiz_id} not found for user {user_id}"
+            raise ValueError(msg)
+        quiz = dict(row)
+        questions: list[dict[str, Any]] = quiz["questions"]
+
+        correct = sum(
+            1
+            for i, q in enumerate(questions)
+            if i < len(answers) and answers[i] == q.get("correct_index")
+        )
+        score = correct
+
+        conn.execute(
+            "UPDATE user_quizzes SET score = %s WHERE id = %s AND user_id = %s",
+            (score, quiz_id, user_id),
+        )
+
+    return {
+        "quiz_id": quiz_id,
+        "score": score,
+        "total": len(questions),
+        "questions": [
+            {**q, "your_answer": answers[i] if i < len(answers) else None}
+            for i, q in enumerate(questions)
+        ],
+    }

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -562,7 +562,7 @@ def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]
 
     rows = conn.execute(
         f"""
-        SELECT a.id, a.source_slug, a.category, a.tags, a.embedding,
+        SELECT a.id, a.title, a.source_slug, a.category, a.tags, a.embedding,
           a.importance_score,
           EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - a.discovered_at::timestamptz))
             / 3600.0 AS age_hours,
@@ -606,6 +606,13 @@ def recompute_user_recommendations(
             database_url=database_url,
         )
         candidates = _load_candidates(conn, user_id, limit)
+        goal_rows = conn.execute(
+            "SELECT description, keywords FROM user_goals WHERE user_id = %s",
+            (user_id,),
+        ).fetchall()
+        goals = [dict(r) for r in goal_rows]
+
+    from news_dashboard.quiz import goal_alignment_adjustment
 
     # Novelty needs an embedded taste vector to measure surprise against; without
     # one it degrades to a no-op, so the version only advertises novelty when the
@@ -630,8 +637,14 @@ def recompute_user_recommendations(
             novelty_adjustment(candidate_vector, semantic_profile, importance)
             * preferences.novelty_weight
         )
+        goal_boost = goal_alignment_adjustment(
+            candidate.get("title"),
+            str(category) if category else None,
+            candidate.get("tags"),
+            goals,
+        )
         final_score = _clamp(
-            base + adjustment + manual_category + semantic + freshness + novelty,
+            base + adjustment + manual_category + semantic + freshness + novelty + goal_boost,
             0.0,
             100.0,
         )
@@ -650,6 +663,7 @@ def recompute_user_recommendations(
                 "freshness_adjustment": round(freshness, 4),
                 "novelty_adjustment": round(novelty, 4),
                 "novelty_weight": round(preferences.novelty_weight, 4),
+                "goal_alignment_adjustment": round(goal_boost, 4),
                 "source_slug": source_slug,
                 "category": category,
             },

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -1,0 +1,302 @@
+"""Tests for Reading Goals and quiz builder."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.quiz import (
+    create_goal,
+    delete_goal,
+    generate_weekly_quiz,
+    get_latest_quiz,
+    goal_alignment_adjustment,
+    list_goals,
+    submit_quiz,
+)
+
+
+def _seed(db_path: Path) -> tuple[int, int]:
+    """Create one user, source, and article; return (user_id, article_id)."""
+    init_db(db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash, is_admin)"
+            " VALUES (1, 'reader', 'x', FALSE)"
+        )
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind)"
+            " VALUES ('s1', 'Source One', 'https://s1.example', 'tech', 'rss')"
+        )
+        conn.execute(
+            """
+            INSERT INTO articles(id, url, canonical_url, title, source_slug,
+                                 source_name, category, kind)
+            VALUES (10, 'https://s1.example/a', 'https://s1.example/a',
+                    'AI Transformer Deep Dive', 's1', 'Source One', 'tech', 'rss')
+            """
+        )
+    return 1, 10
+
+
+# ── goal_alignment_adjustment unit tests ────────────────────────────────────
+
+
+def test_goal_alignment_no_goals() -> None:
+    assert goal_alignment_adjustment("Any title", "tech", None, []) == 0.0
+
+
+def test_goal_alignment_keyword_match() -> None:
+    goals = [{"description": "AI research", "keywords": "transformer ai"}]
+    score = goal_alignment_adjustment("Transformer architecture overview", "tech", None, goals)
+    assert score > 0.0
+
+
+def test_goal_alignment_description_fallback() -> None:
+    goals = [{"description": "transformer architecture", "keywords": ""}]
+    score = goal_alignment_adjustment("Transformer in production", "ml", None, goals)
+    assert score > 0.0
+
+
+def test_goal_alignment_no_match() -> None:
+    goals = [{"description": "quantum computing", "keywords": "quantum qubit"}]
+    score = goal_alignment_adjustment("Football highlights recap", "sports", None, goals)
+    assert score == 0.0
+
+
+# ── Goal CRUD tests ───────────────────────────────────────────────────────────
+
+
+def test_create_and_list_goals(tmp_path: Path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path)
+
+    goal = create_goal(1, "Learn AI policy", "regulation policy", db_path=db_path)
+    assert goal["id"] is not None
+    assert goal["description"] == "Learn AI policy"
+    assert goal["keywords"] == "regulation policy"
+
+    goals = list_goals(1, db_path=db_path)
+    assert len(goals) == 1
+    assert goals[0]["description"] == "Learn AI policy"
+
+
+def test_delete_goal(tmp_path: Path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path)
+
+    goal = create_goal(1, "Temporary goal", db_path=db_path)
+    assert len(list_goals(1, db_path=db_path)) == 1
+
+    deleted = delete_goal(goal["id"], 1, db_path=db_path)
+    assert deleted is True
+    assert list_goals(1, db_path=db_path) == []
+
+
+def test_delete_goal_wrong_user(tmp_path: Path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path)
+
+    goal = create_goal(1, "My goal", db_path=db_path)
+    deleted = delete_goal(goal["id"], 999, db_path=db_path)
+    assert deleted is False
+
+
+# ── Quiz builder unit tests ───────────────────────────────────────────────────
+
+
+def test_parse_questions_valid_json() -> None:
+    from news_dashboard.quiz import _parse_questions
+
+    raw = """[
+      {
+        "question": "What is a transformer?",
+        "options": ["A robot", "An attention-based model", "A dataset", "A loss function"],
+        "correct_index": 1,
+        "explanation": "Transformers use self-attention.",
+        "article_id": 10
+      }
+    ]"""
+    questions = _parse_questions(raw)
+    assert len(questions) == 1
+    assert questions[0]["question"] == "What is a transformer?"
+    assert questions[0]["correct_index"] == 1
+    assert len(questions[0]["options"]) == 4
+
+
+def test_parse_questions_markdown_fence() -> None:
+    from news_dashboard.quiz import _parse_questions
+
+    raw = """```json
+[{"question":"Q?","options":["A","B","C","D"],"correct_index":0,"explanation":"E","article_id":1}]
+```"""
+    questions = _parse_questions(raw)
+    assert len(questions) == 1
+    assert questions[0]["question"] == "Q?"
+
+
+def test_parse_questions_invalid_json_returns_empty() -> None:
+    from news_dashboard.quiz import _parse_questions
+
+    assert _parse_questions("not json at all") == []
+
+
+def test_parse_questions_missing_required_fields() -> None:
+    from news_dashboard.quiz import _parse_questions
+
+    raw = '[{"question": "Q?"}]'
+    assert _parse_questions(raw) == []
+
+
+# ── Quiz generation + submit integration tests ────────────────────────────────
+
+
+def _seed_done_article(db_path: Path, user_id: int, article_id: int) -> None:
+    done_at = datetime.now(timezone.utc) - timedelta(days=1)
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_state (user_id, article_id, state, done_at)
+            VALUES (%s, %s, 'done', %s)
+            ON CONFLICT (user_id, article_id) DO UPDATE SET state='done', done_at=%s
+            """,
+            (user_id, article_id, done_at, done_at),
+        )
+
+
+_MOCK_QUESTIONS: list[dict[str, Any]] = [
+    {
+        "question": "What does self-attention compute?",
+        "options": ["Sums", "Dot products", "Convolutions", "Averages"],
+        "correct_index": 1,
+        "explanation": "Self-attention computes scaled dot products.",
+        "article_id": 10,
+    },
+    {
+        "question": "What is BERT?",
+        "options": [
+            "A transformer model",
+            "A dataset",
+            "A loss function",
+            "An optimizer",
+        ],
+        "correct_index": 0,
+        "explanation": "BERT is a bidirectional transformer.",
+        "article_id": 10,
+    },
+    {
+        "question": "What does GPT stand for?",
+        "options": [
+            "Generative Pre-trained Transformer",
+            "General Purpose Tokenizer",
+            "Gradient Path Tracker",
+            "Graph Processing Toolkit",
+        ],
+        "correct_index": 0,
+        "explanation": "GPT = Generative Pre-trained Transformer.",
+        "article_id": 10,
+    },
+]
+
+
+def test_generate_weekly_quiz_no_articles(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    _seed(db_path)
+    # No done articles → should return None without calling LLM
+    result = generate_weekly_quiz(1, db_path=db_path)
+    assert result is None
+
+
+def test_generate_weekly_quiz_with_articles(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+
+    import json
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
+        patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
+    ):
+        mock_client_factory.return_value = MagicMock()
+        quiz = generate_weekly_quiz(user_id, db_path=db_path)
+
+    assert quiz is not None
+    assert quiz["user_id"] == user_id
+    assert len(quiz["questions"]) == 3
+    assert quiz["score"] is None
+
+
+def test_get_latest_quiz_empty(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    _seed(db_path)
+    assert get_latest_quiz(1, db_path=db_path) is None
+
+
+def test_submit_quiz_scoring(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+
+    import json
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
+        patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
+    ):
+        mock_client_factory.return_value = MagicMock()
+        quiz = generate_weekly_quiz(user_id, db_path=db_path)
+
+    assert quiz is not None
+    # All correct answers: correct_index is 1, 0, 0
+    correct_answers = [q["correct_index"] for q in _MOCK_QUESTIONS]
+    result = submit_quiz(quiz["id"], user_id, correct_answers, db_path=db_path)
+
+    assert result["score"] == 3
+    assert result["total"] == 3
+
+
+def test_submit_quiz_partial_score(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+
+    import json
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
+        patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
+    ):
+        mock_client_factory.return_value = MagicMock()
+        quiz = generate_weekly_quiz(user_id, db_path=db_path)
+
+    assert quiz is not None
+    # First answer correct, rest wrong
+    wrong_answers = [_MOCK_QUESTIONS[0]["correct_index"], 99, 99]
+    result = submit_quiz(quiz["id"], user_id, wrong_answers, db_path=db_path)
+    assert result["score"] == 1
+    assert result["total"] == 3
+
+
+def test_submit_quiz_not_found(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    _seed(db_path)
+    with pytest.raises(ValueError, match="not found"):
+        submit_quiz(9999, 1, [0, 0, 0], db_path=db_path)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,7 +13,10 @@ import type {
   NotificationSettings,
   NotificationSettingsUpdate,
   PushSubscribeRequest,
+  Quiz,
+  QuizResult,
   ReadingDna,
+  ReadingGoal,
   RecommendationPreferences,
   ReceivedShare,
   ShareableUser,
@@ -460,6 +463,43 @@ export async function fetchReceivedShares(): Promise<{
 export async function fetchSharesUnreadCount(): Promise<number> {
   const data = await requestJson<{ unread: number }>('/api/shares/unread_count');
   return data.unread;
+}
+
+// ── Reading Goals & Quizzes ───────────────────────────────────────────────────
+
+export async function fetchGoals(): Promise<ReadingGoal[]> {
+  const data = await requestJson<{ items: ReadingGoal[] }>('/api/goals');
+  return data.items;
+}
+
+export async function createGoal(description: string, keywords: string): Promise<ReadingGoal> {
+  return requestJson<ReadingGoal>('/api/goals', {
+    method: 'POST',
+    body: JSON.stringify({ description, keywords }),
+  });
+}
+
+export async function deleteGoal(goalId: number): Promise<void> {
+  await requestJson(`/api/goals/${goalId}`, { method: 'DELETE' });
+}
+
+export async function fetchLatestQuiz(): Promise<Quiz | null> {
+  try {
+    return await requestJson<Quiz>('/api/quizzes/latest');
+  } catch {
+    return null;
+  }
+}
+
+export async function generateQuiz(): Promise<Quiz> {
+  return requestJson<Quiz>('/api/quizzes/generate', { method: 'POST' });
+}
+
+export async function submitQuiz(quizId: number, answers: number[]): Promise<QuizResult> {
+  return requestJson<QuizResult>(`/api/quizzes/${quizId}/submit`, {
+    method: 'POST',
+    body: JSON.stringify({ answers }),
+  });
 }
 
 export async function markShareRead(shareId: number): Promise<void> {

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -1,14 +1,30 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Loader2, RefreshCw } from 'lucide-react';
+import { CheckCircle, Loader2, Plus, RefreshCw, Trash2, XCircle } from 'lucide-react';
 import {
+  createGoal,
+  deleteGoal,
+  fetchGoals,
+  fetchLatestQuiz,
   fetchReadingDna,
   fetchRecommendationPreferences,
+  generateQuiz,
   saveRecommendationPreferences,
+  submitQuiz,
 } from '../api';
-import type { ReadingDna, ReadingDnaBucket, RecommendationPreferences } from '../types';
+import type {
+  Quiz,
+  QuizQuestion,
+  QuizResult,
+  ReadingDna,
+  ReadingDnaBucket,
+  ReadingGoal,
+  RecommendationPreferences,
+} from '../types';
 
 const DEFAULT_CATEGORIES = ['tech', 'science', 'business', 'world', 'ai'];
+
+type Tab = 'dna' | 'learning';
 
 interface PageState {
   dna: ReadingDna | null;
@@ -19,6 +35,7 @@ interface PageState {
 }
 
 export function ReadingDnaPage() {
+  const [tab, setTab] = useState<Tab>('dna');
   const [state, setState] = useState<PageState>({
     dna: null,
     preferences: null,
@@ -100,81 +117,471 @@ export function ReadingDnaPage() {
         </div>
       )}
 
-      <section className="grid grid-cols-2 gap-2 md:grid-cols-4">
-        <Metric label="Window" value={`${dna?.range_days ?? 30}d`} />
-        <Metric label="Avg dwell" value={`${dna?.average_dwell_seconds ?? 0}s`} />
-        <Metric
-          label="Read"
-          value={String(dna?.categories.reduce((sum, item) => sum + item.done, 0) ?? 0)}
-        />
-        <Metric
-          label="Skipped"
-          value={String(dna?.categories.reduce((sum, item) => sum + item.skipped, 0) ?? 0)}
-        />
-      </section>
+      <div className="flex gap-1 border-b border-border">
+        <TabButton active={tab === 'dna'} onClick={() => setTab('dna')}>
+          Reading DNA
+        </TabButton>
+        <TabButton active={tab === 'learning'} onClick={() => setTab('learning')}>
+          Learning Center
+        </TabButton>
+      </div>
 
-      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <Panel title="Category mix">
-          <BucketBars items={dna?.categories ?? []} labelKey="category" />
-        </Panel>
-        <Panel title="Source mix">
-          <BucketBars items={dna?.sources ?? []} labelKey="source" />
-        </Panel>
-      </section>
-
-      <section className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_0.8fr]">
-        <Panel title="Time on app">
-          <div className="flex h-40 items-end gap-2">
-            {(dna?.monthly_time ?? []).map((point) => {
-              const max = Math.max(...(dna?.monthly_time ?? []).map((p) => p.minutes), 1);
-              return (
-                <div key={point.month} className="flex h-full flex-1 flex-col justify-end gap-2">
-                  <div
-                    className="min-h-1 rounded-t bg-chart-2"
-                    style={{ height: `${Math.max(4, (point.minutes / max) * 100)}%` }}
-                    title={`${point.minutes} min`}
-                  />
-                  <div className="truncate text-center text-[10px] text-subtle">{point.month}</div>
-                </div>
-              );
-            })}
-            {dna?.monthly_time.length === 0 && <EmptyLine />}
-          </div>
-        </Panel>
-
-        <Panel title="Active nudges">
-          <div className="space-y-4">
-            {categories.map((category) => {
-              const value = preferences?.category_weights[category] ?? 1;
-              return (
-                <SliderRow
-                  key={category}
-                  label={category}
-                  value={value}
-                  onChange={(next) =>
-                    void updatePreferences({
-                      category_weights: {
-                        ...(preferences?.category_weights ?? {}),
-                        [category]: next,
-                      },
-                    })
-                  }
-                />
-              );
-            })}
-            <SliderRow
-              label="novelty"
-              value={preferences?.novelty_weight ?? 1}
-              onChange={(next) => void updatePreferences({ novelty_weight: next })}
+      {tab === 'dna' && (
+        <>
+          <section className="grid grid-cols-2 gap-2 md:grid-cols-4">
+            <Metric label="Window" value={`${dna?.range_days ?? 30}d`} />
+            <Metric label="Avg dwell" value={`${dna?.average_dwell_seconds ?? 0}s`} />
+            <Metric
+              label="Read"
+              value={String(dna?.categories.reduce((sum, item) => sum + item.done, 0) ?? 0)}
             />
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              {saving && <RefreshCw className="size-3 animate-spin" />}
-              <span>{saving ? 'Saving and recalculating' : 'Changes save immediately'}</span>
-            </div>
-          </div>
-        </Panel>
-      </section>
+            <Metric
+              label="Skipped"
+              value={String(dna?.categories.reduce((sum, item) => sum + item.skipped, 0) ?? 0)}
+            />
+          </section>
+
+          <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <Panel title="Category mix">
+              <BucketBars items={dna?.categories ?? []} labelKey="category" />
+            </Panel>
+            <Panel title="Source mix">
+              <BucketBars items={dna?.sources ?? []} labelKey="source" />
+            </Panel>
+          </section>
+
+          <section className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+            <Panel title="Time on app">
+              <div className="flex h-40 items-end gap-2">
+                {(dna?.monthly_time ?? []).map((point) => {
+                  const max = Math.max(...(dna?.monthly_time ?? []).map((p) => p.minutes), 1);
+                  return (
+                    <div
+                      key={point.month}
+                      className="flex h-full flex-1 flex-col justify-end gap-2"
+                    >
+                      <div
+                        className="min-h-1 rounded-t bg-chart-2"
+                        style={{ height: `${Math.max(4, (point.minutes / max) * 100)}%` }}
+                        title={`${point.minutes} min`}
+                      />
+                      <div className="truncate text-center text-[10px] text-subtle">
+                        {point.month}
+                      </div>
+                    </div>
+                  );
+                })}
+                {dna?.monthly_time.length === 0 && <EmptyLine />}
+              </div>
+            </Panel>
+
+            <Panel title="Active nudges">
+              <div className="space-y-4">
+                {categories.map((category) => {
+                  const value = preferences?.category_weights[category] ?? 1;
+                  return (
+                    <SliderRow
+                      key={category}
+                      label={category}
+                      value={value}
+                      onChange={(next) =>
+                        void updatePreferences({
+                          category_weights: {
+                            ...(preferences?.category_weights ?? {}),
+                            [category]: next,
+                          },
+                        })
+                      }
+                    />
+                  );
+                })}
+                <SliderRow
+                  label="novelty"
+                  value={preferences?.novelty_weight ?? 1}
+                  onChange={(next) => void updatePreferences({ novelty_weight: next })}
+                />
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  {saving && <RefreshCw className="size-3 animate-spin" />}
+                  <span>{saving ? 'Saving and recalculating' : 'Changes save immediately'}</span>
+                </div>
+              </div>
+            </Panel>
+          </section>
+        </>
+      )}
+
+      {tab === 'learning' && <LearningCenter />}
     </div>
+  );
+}
+
+function LearningCenter() {
+  const [goals, setGoals] = useState<ReadingGoal[]>([]);
+  const [quiz, setQuiz] = useState<Quiz | null>(null);
+  const [result, setResult] = useState<QuizResult | null>(null);
+  const [answers, setAnswers] = useState<Record<number, number>>({});
+  const [loadingGoals, setLoadingGoals] = useState(true);
+  const [loadingQuiz, setLoadingQuiz] = useState(true);
+  const [generatingQuiz, setGeneratingQuiz] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newDescription, setNewDescription] = useState('');
+  const [newKeywords, setNewKeywords] = useState('');
+  const [addingGoal, setAddingGoal] = useState(false);
+  const [showGoalForm, setShowGoalForm] = useState(false);
+
+  useEffect(() => {
+    fetchGoals()
+      .then(setGoals)
+      .catch(() => setGoals([]))
+      .finally(() => setLoadingGoals(false));
+    fetchLatestQuiz()
+      .then(setQuiz)
+      .catch(() => setQuiz(null))
+      .finally(() => setLoadingQuiz(false));
+  }, []);
+
+  async function handleAddGoal() {
+    if (!newDescription.trim()) return;
+    setAddingGoal(true);
+    setError(null);
+    try {
+      const goal = await createGoal(newDescription.trim(), newKeywords.trim());
+      setGoals((prev) => [goal, ...prev]);
+      setNewDescription('');
+      setNewKeywords('');
+      setShowGoalForm(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add goal');
+    } finally {
+      setAddingGoal(false);
+    }
+  }
+
+  async function handleDeleteGoal(goalId: number) {
+    try {
+      await deleteGoal(goalId);
+      setGoals((prev) => prev.filter((g) => g.id !== goalId));
+    } catch {
+      setError('Failed to delete goal');
+    }
+  }
+
+  async function handleGenerateQuiz() {
+    setGeneratingQuiz(true);
+    setError(null);
+    setResult(null);
+    setAnswers({});
+    try {
+      const newQuiz = await generateQuiz();
+      setQuiz(newQuiz);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate quiz');
+    } finally {
+      setGeneratingQuiz(false);
+    }
+  }
+
+  async function handleSubmitQuiz() {
+    if (!quiz) return;
+    const answerList = quiz.questions.map((_, i) => answers[i] ?? -1);
+    setSubmitting(true);
+    setError(null);
+    try {
+      const quizResult = await submitQuiz(quiz.id, answerList);
+      setResult(quizResult);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit quiz');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Goals section */}
+      <Panel title="Learning Goals">
+        <div className="space-y-3">
+          {loadingGoals ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" /> Loading goals…
+            </div>
+          ) : goals.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No goals yet. Add one to boost relevant articles.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {goals.map((goal) => (
+                <li
+                  key={goal.id}
+                  className="flex items-start justify-between gap-3 rounded border border-border px-3 py-2 text-sm"
+                >
+                  <div>
+                    <div className="font-medium">{goal.description}</div>
+                    {goal.keywords && (
+                      <div className="mt-0.5 text-xs text-muted-foreground">
+                        Keywords: {goal.keywords}
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    className="shrink-0 text-muted-foreground hover:text-destructive"
+                    onClick={() => void handleDeleteGoal(goal.id)}
+                    title="Delete goal"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {showGoalForm ? (
+            <div className="space-y-2 rounded border border-border p-3">
+              <input
+                className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder="Goal description (e.g. Understand transformer architectures)"
+                value={newDescription}
+                onChange={(e) => setNewDescription(e.target.value)}
+              />
+              <input
+                className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder="Keywords (space-separated, optional)"
+                value={newKeywords}
+                onChange={(e) => setNewKeywords(e.target.value)}
+              />
+              <div className="flex gap-2">
+                <button
+                  className="rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50"
+                  disabled={!newDescription.trim() || addingGoal}
+                  onClick={() => void handleAddGoal()}
+                >
+                  {addingGoal ? 'Saving…' : 'Save goal'}
+                </button>
+                <button
+                  className="rounded border border-border px-3 py-1.5 text-xs"
+                  onClick={() => {
+                    setShowGoalForm(false);
+                    setNewDescription('');
+                    setNewKeywords('');
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              className="flex items-center gap-1.5 text-xs text-primary hover:underline"
+              onClick={() => setShowGoalForm(true)}
+            >
+              <Plus className="size-3" /> Add goal
+            </button>
+          )}
+        </div>
+      </Panel>
+
+      {/* Quiz section */}
+      <Panel title="Weekly Knowledge Quiz">
+        {loadingQuiz ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-3 animate-spin" /> Loading quiz…
+          </div>
+        ) : result ? (
+          <QuizResultView result={result} />
+        ) : quiz ? (
+          <QuizView
+            quiz={quiz}
+            answers={answers}
+            onAnswer={(qi, ai) => setAnswers((prev) => ({ ...prev, [qi]: ai }))}
+            onSubmit={() => void handleSubmitQuiz()}
+            submitting={submitting}
+          />
+        ) : (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              No quiz yet. Generate one based on your recent reading.
+            </p>
+            <button
+              className="flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50"
+              disabled={generatingQuiz}
+              onClick={() => void handleGenerateQuiz()}
+            >
+              {generatingQuiz && <Loader2 className="size-3 animate-spin" />}
+              {generatingQuiz ? 'Generating…' : 'Generate quiz'}
+            </button>
+          </div>
+        )}
+        {quiz && !result && (
+          <div className="mt-3">
+            <button
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+              disabled={generatingQuiz}
+              onClick={() => void handleGenerateQuiz()}
+            >
+              {generatingQuiz ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+              Regenerate quiz
+            </button>
+          </div>
+        )}
+      </Panel>
+    </div>
+  );
+}
+
+function QuizView({
+  quiz,
+  answers,
+  onAnswer,
+  onSubmit,
+  submitting,
+}: {
+  quiz: Quiz;
+  answers: Record<number, number>;
+  onAnswer: (questionIndex: number, answerIndex: number) => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}) {
+  const allAnswered = quiz.questions.every((_, i) => answers[i] !== undefined);
+
+  return (
+    <div className="space-y-5">
+      {quiz.questions.map((q, qi) => (
+        <QuestionCard
+          key={qi}
+          question={q}
+          questionIndex={qi}
+          selectedAnswer={answers[qi]}
+          onSelect={(ai) => onAnswer(qi, ai)}
+        />
+      ))}
+      <button
+        className="flex items-center gap-1.5 rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        disabled={!allAnswered || submitting}
+        onClick={onSubmit}
+      >
+        {submitting && <Loader2 className="size-3.5 animate-spin" />}
+        {submitting ? 'Submitting…' : 'Submit answers'}
+      </button>
+    </div>
+  );
+}
+
+function QuestionCard({
+  question,
+  questionIndex,
+  selectedAnswer,
+  onSelect,
+}: {
+  question: QuizQuestion;
+  questionIndex: number;
+  selectedAnswer: number | undefined;
+  onSelect: (answerIndex: number) => void;
+}) {
+  return (
+    <div className="rounded border border-border p-3 space-y-2">
+      <p className="text-sm font-medium">
+        {questionIndex + 1}. {question.question}
+      </p>
+      <div className="space-y-1.5">
+        {question.options.map((opt, ai) => (
+          <label
+            key={ai}
+            className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+          >
+            <input
+              type="radio"
+              name={`q-${questionIndex}`}
+              checked={selectedAnswer === ai}
+              onChange={() => onSelect(ai)}
+              className="accent-primary"
+            />
+            {opt}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function QuizResultView({ result }: { result: QuizResult }) {
+  const pct = Math.round((result.score / result.total) * 100);
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <div className="text-3xl font-bold tabular-nums">
+          {result.score}/{result.total}
+        </div>
+        <div className="text-sm text-muted-foreground">{pct}% correct</div>
+      </div>
+      <div className="space-y-3">
+        {result.questions.map((q, qi) => {
+          const isCorrect = q.your_answer === q.correct_index;
+          return (
+            <div
+              key={qi}
+              className={`rounded border p-3 space-y-1.5 ${isCorrect ? 'border-green-500/40 bg-green-500/5' : 'border-destructive/40 bg-destructive/5'}`}
+            >
+              <div className="flex items-start gap-2">
+                {isCorrect ? (
+                  <CheckCircle className="mt-0.5 size-3.5 shrink-0 text-green-500" />
+                ) : (
+                  <XCircle className="mt-0.5 size-3.5 shrink-0 text-destructive" />
+                )}
+                <p className="text-sm font-medium">{q.question}</p>
+              </div>
+              <div className="space-y-1 pl-5">
+                {q.options.map((opt, ai) => (
+                  <div
+                    key={ai}
+                    className={`text-xs ${ai === q.correct_index ? 'font-semibold text-green-600' : ai === q.your_answer && !isCorrect ? 'text-destructive line-through' : 'text-muted-foreground'}`}
+                  >
+                    {opt}
+                  </div>
+                ))}
+              </div>
+              {q.explanation && (
+                <p className="pl-5 text-xs text-muted-foreground">{q.explanation}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      className={`px-4 py-2 text-sm font-medium transition-colors ${
+        active
+          ? 'border-b-2 border-primary text-foreground'
+          : 'text-muted-foreground hover:text-foreground'
+      }`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -348,3 +348,35 @@ export interface AdminAnalytics {
   skip_rate_trend: { day: string; skips: number; reads: number }[];
   recommendation_funnel: { recommended: number; read: number; skipped: number };
 }
+
+export interface ReadingGoal {
+  id: number;
+  user_id: number;
+  description: string;
+  keywords: string;
+  created_at: string;
+}
+
+export interface QuizQuestion {
+  question: string;
+  options: string[];
+  correct_index: number;
+  explanation: string;
+  article_id: number | null;
+  your_answer?: number | null;
+}
+
+export interface Quiz {
+  id: number;
+  user_id: number;
+  created_at: string;
+  questions: QuizQuestion[];
+  score: number | null;
+}
+
+export interface QuizResult {
+  quiz_id: number;
+  score: number;
+  total: number;
+  questions: QuizQuestion[];
+}


### PR DESCRIPTION
Closes #351

## Summary
- **DB schema**: adds `user_goals` and `user_quizzes` tables (via `MIGRATIONS` in `db.py`)
- **Backend module** (`quiz.py`): goal CRUD, `goal_alignment_adjustment` helper, weekly quiz generation via LLM, quiz retrieval and answer scoring
- **Recommendation boost**: `recompute_user_recommendations` now loads the user's active goals and adds a `goal_alignment_adjustment` score bonus to articles whose title/category/tags match goal keywords
- **API endpoints**: `POST /api/goals`, `GET /api/goals`, `DELETE /api/goals/{id}`, `GET /api/quizzes/latest`, `POST /api/quizzes/generate`, `POST /api/quizzes/{id}/submit`
- **Frontend**: new "Learning Center" tab on the ReadingDNA page with goal management UI and an interactive multiple-choice quiz card with instant scoring and per-question explanations

## Test plan
- [ ] 17 new tests in `backend/tests/test_quiz.py` cover goal alignment logic, goal CRUD, quiz JSON parsing, quiz generation (mocked LLM), and submit scoring
- [ ] `make check` passes locally (ruff, mypy, ty, pyrefly, eslint, prettier, tsc, pytest, vitest all green)
- [ ] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)