### PR TITLE
feat: agentic shared article annotations and contextual summaries (#352)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -390,26 +390,29 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_article_shares_unread"
     " ON article_shares(to_user_id) WHERE read_at IS NULL",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS perspective_analysis JSONB",
+    "ALTER TABLE article_shares ADD COLUMN IF NOT EXISTS context_summary TEXT",
     """
-    CREATE TABLE IF NOT EXISTS user_goals (
-      id          SERIAL PRIMARY KEY,
+    CREATE TABLE IF NOT EXISTS share_annotations (
+      id              BIGSERIAL PRIMARY KEY,
+      share_id        BIGINT NOT NULL REFERENCES article_shares(id) ON DELETE CASCADE,
+      highlighted_text TEXT NOT NULL,
+      offset_chars    INTEGER NOT NULL DEFAULT 0,
+      note            TEXT,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_share_annotations_share"
+    " ON share_annotations(share_id, created_at)",
+    """
+    CREATE TABLE IF NOT EXISTS share_messages (
+      id          BIGSERIAL PRIMARY KEY,
+      share_id    BIGINT NOT NULL REFERENCES article_shares(id) ON DELETE CASCADE,
       user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      description TEXT NOT NULL,
-      keywords    TEXT NOT NULL DEFAULT '',
+      message     TEXT NOT NULL,
       created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
     """,
-    "CREATE INDEX IF NOT EXISTS idx_user_goals_user ON user_goals(user_id)",
-    """
-    CREATE TABLE IF NOT EXISTS user_quizzes (
-      id          SERIAL PRIMARY KEY,
-      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      questions   JSONB NOT NULL DEFAULT '[]'::jsonb,
-      score       INTEGER
-    )
-    """,
-    "CREATE INDEX IF NOT EXISTS idx_user_quizzes_user ON user_quizzes(user_id, created_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_share_messages_share ON share_messages(share_id, created_at)",
 ]
 
 

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -390,6 +390,26 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_article_shares_unread"
     " ON article_shares(to_user_id) WHERE read_at IS NULL",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS perspective_analysis JSONB",
+    """
+    CREATE TABLE IF NOT EXISTS user_goals (
+      id          SERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      description TEXT NOT NULL,
+      keywords    TEXT NOT NULL DEFAULT '',
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_goals_user ON user_goals(user_id)",
+    """
+    CREATE TABLE IF NOT EXISTS user_quizzes (
+      id          SERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      questions   JSONB NOT NULL DEFAULT '[]'::jsonb,
+      score       INTEGER
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_quizzes_user ON user_quizzes(user_id, created_at DESC)",
     "ALTER TABLE article_shares ADD COLUMN IF NOT EXISTS context_summary TEXT",
     """
     CREATE TABLE IF NOT EXISTS share_annotations (

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -163,6 +163,16 @@ class ShareArticleRequest(BaseModel):
     note: str | None = None
 
 
+class AddAnnotationRequest(BaseModel):
+    highlighted_text: str
+    offset_chars: int = 0
+    note: str | None = None
+
+
+class AddMessageRequest(BaseModel):
+    message: str
+
+
 class EnabledUpdate(BaseModel):
     enabled: bool
 
@@ -630,6 +640,7 @@ def share_article_endpoint(
         sender=current_user["username"],
         article_title=title,
     )
+    background_tasks.add_task(_generate_share_context_bg, share_id=int(share["id"]))
     return share
 
 
@@ -641,6 +652,12 @@ def _notify_share_recipient(*, to_user_id: int, sender: str, article_title: str)
         f"{sender} shared an article",
         article_title,
     )
+
+
+def _generate_share_context_bg(*, share_id: int) -> None:
+    from news_dashboard.shares import generate_share_context
+
+    generate_share_context(share_id)
 
 
 @api.get("/api/shares")
@@ -672,6 +689,77 @@ def mark_share_read_endpoint(
     from news_dashboard.shares import mark_share_read
 
     return {"ok": mark_share_read(share_id, current_user["id"])}
+
+
+@api.get("/api/shares/{share_id}")
+def get_share_endpoint(
+    share_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import get_share
+
+    share = get_share(share_id, current_user["id"])
+    if share is None:
+        raise HTTPException(status_code=404, detail="Share not found")
+    return share
+
+
+@api.get("/api/shares/{share_id}/annotations")
+def list_share_annotations(
+    share_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import get_share, list_annotations
+
+    if get_share(share_id, current_user["id"]) is None:
+        raise HTTPException(status_code=404, detail="Share not found")
+    return {"items": list_annotations(share_id)}
+
+
+@api.post("/api/shares/{share_id}/annotations")
+def add_share_annotation(
+    share_id: int,
+    payload: AddAnnotationRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    background_tasks: BackgroundTasks,
+) -> dict[str, Any]:
+    from news_dashboard.shares import add_annotation, get_share
+
+    if get_share(share_id, current_user["id"]) is None:
+        raise HTTPException(status_code=404, detail="Share not found")
+    annotation = add_annotation(
+        share_id,
+        highlighted_text=payload.highlighted_text,
+        offset_chars=payload.offset_chars,
+        note=payload.note,
+    )
+    background_tasks.add_task(_generate_share_context_bg, share_id=share_id)
+    return annotation
+
+
+@api.get("/api/shares/{share_id}/messages")
+def list_share_messages(
+    share_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import get_share, list_messages
+
+    if get_share(share_id, current_user["id"]) is None:
+        raise HTTPException(status_code=404, detail="Share not found")
+    return {"items": list_messages(share_id)}
+
+
+@api.post("/api/shares/{share_id}/messages")
+def add_share_message(
+    share_id: int,
+    payload: AddMessageRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import add_message, get_share
+
+    if get_share(share_id, current_user["id"]) is None:
+        raise HTTPException(status_code=404, detail="Share not found")
+    return add_message(share_id, current_user["id"], payload.message)
 
 
 @api.get("/api/articles/{article_id}/read")
@@ -1348,93 +1436,6 @@ def summary(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
     return get_user_summary(user_id=current_user["id"])
-
-
-# ── Reading Goals & Quizzes ───────────────────────────────────────────────────
-
-
-class GoalCreateRequest(BaseModel):
-    description: str
-    keywords: str = ""
-
-
-class QuizSubmitRequest(BaseModel):
-    answers: list[int]
-
-
-@api.post("/api/goals")
-def create_goal_endpoint(
-    payload: GoalCreateRequest,
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.quiz import create_goal
-
-    description = payload.description.strip()
-    if not description:
-        raise HTTPException(status_code=400, detail="description must not be empty")
-    return create_goal(current_user["id"], description, payload.keywords)
-
-
-@api.get("/api/goals")
-def list_goals_endpoint(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.quiz import list_goals
-
-    return {"items": list_goals(current_user["id"])}
-
-
-@api.delete("/api/goals/{goal_id}")
-def delete_goal_endpoint(
-    goal_id: int,
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.quiz import delete_goal
-
-    if not delete_goal(goal_id, current_user["id"]):
-        raise HTTPException(status_code=404, detail="goal not found")
-    return {"deleted": True}
-
-
-@api.get("/api/quizzes/latest")
-def get_latest_quiz_endpoint(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.quiz import get_latest_quiz
-
-    quiz = get_latest_quiz(current_user["id"])
-    if not quiz:
-        raise HTTPException(status_code=404, detail="no quiz available")
-    return quiz
-
-
-@api.post("/api/quizzes/generate")
-def generate_quiz_endpoint(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.quiz import generate_weekly_quiz
-
-    try:
-        quiz = generate_weekly_quiz(current_user["id"])
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-    if not quiz:
-        raise HTTPException(status_code=404, detail="no eligible articles to quiz on")
-    return quiz
-
-
-@api.post("/api/quizzes/{quiz_id}/submit")
-def submit_quiz_endpoint(
-    quiz_id: int,
-    payload: QuizSubmitRequest,
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.quiz import submit_quiz
-
-    try:
-        return submit_quiz(quiz_id, current_user["id"], payload.answers)
-    except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 # ── Admin user-management routes ─────────────────────────────────────────────

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1438,6 +1438,93 @@ def summary(
     return get_user_summary(user_id=current_user["id"])
 
 
+# ── Reading Goals & Quizzes ───────────────────────────────────────────────────
+
+
+class GoalCreateRequest(BaseModel):
+    description: str
+    keywords: str = ""
+
+
+class QuizSubmitRequest(BaseModel):
+    answers: list[int]
+
+
+@api.post("/api/goals")
+def create_goal_endpoint(
+    payload: GoalCreateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import create_goal
+
+    description = payload.description.strip()
+    if not description:
+        raise HTTPException(status_code=400, detail="description must not be empty")
+    return create_goal(current_user["id"], description, payload.keywords)
+
+
+@api.get("/api/goals")
+def list_goals_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import list_goals
+
+    return {"items": list_goals(current_user["id"])}
+
+
+@api.delete("/api/goals/{goal_id}")
+def delete_goal_endpoint(
+    goal_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import delete_goal
+
+    if not delete_goal(goal_id, current_user["id"]):
+        raise HTTPException(status_code=404, detail="goal not found")
+    return {"deleted": True}
+
+
+@api.get("/api/quizzes/latest")
+def get_latest_quiz_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import get_latest_quiz
+
+    quiz = get_latest_quiz(current_user["id"])
+    if not quiz:
+        raise HTTPException(status_code=404, detail="no quiz available")
+    return quiz
+
+
+@api.post("/api/quizzes/generate")
+def generate_quiz_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import generate_weekly_quiz
+
+    try:
+        quiz = generate_weekly_quiz(current_user["id"])
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    if not quiz:
+        raise HTTPException(status_code=404, detail="no eligible articles to quiz on")
+    return quiz
+
+
+@api.post("/api/quizzes/{quiz_id}/submit")
+def submit_quiz_endpoint(
+    quiz_id: int,
+    payload: QuizSubmitRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import submit_quiz
+
+    try:
+        return submit_quiz(quiz_id, current_user["id"], payload.answers)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 # ── Admin user-management routes ─────────────────────────────────────────────
 
 admin = APIRouter(prefix="/api/admin", dependencies=[Depends(require_admin)])

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -10,11 +10,14 @@ Runtime SQL uses psycopg %s parameter style. No SQLite fallback.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from news_dashboard.db import connect, row_to_dict
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_SHARE_MODEL = "gpt-4o-mini"
 
 
 class ShareError(RuntimeError):
@@ -59,7 +62,8 @@ def share_article(
             """
             INSERT INTO article_shares (article_id, from_user_id, to_user_id, note)
             VALUES (%s, %s, %s, %s)
-            RETURNING id, article_id, from_user_id, to_user_id, note, created_at, read_at
+            RETURNING id, article_id, from_user_id, to_user_id, note,
+                      context_summary, created_at, read_at
             """,
             (article_id, from_user_id, to_user_id, clean_note),
         ).fetchone()
@@ -71,7 +75,7 @@ def list_received_shares(user_id: int, *, limit: int = 100) -> list[dict[str, An
     with connect() as conn:
         rows = conn.execute(
             """
-            SELECT s.id, s.note, s.created_at, s.read_at,
+            SELECT s.id, s.note, s.context_summary, s.created_at, s.read_at,
                    s.from_user_id, u.username AS from_username,
                    a.id AS article_id, a.title AS article_title,
                    a.url AS article_url, a.source_name AS article_source_name,
@@ -85,7 +89,36 @@ def list_received_shares(user_id: int, *, limit: int = 100) -> list[dict[str, An
             """,
             (user_id, limit),
         ).fetchall()
-        return [row_to_dict(r) for r in rows]
+        shares = [row_to_dict(r) for r in rows]
+    for share in shares:
+        share["annotations"] = list_annotations(int(share["id"]))
+        share["messages"] = list_messages(int(share["id"]))
+    return shares
+
+
+def get_share(share_id: int, user_id: int) -> dict[str, Any] | None:
+    """Return a single share visible to user_id (sender or recipient), with full detail."""
+    with connect() as conn:
+        row = conn.execute(
+            """
+            SELECT s.id, s.note, s.context_summary, s.created_at, s.read_at,
+                   s.from_user_id, u.username AS from_username,
+                   a.id AS article_id, a.title AS article_title,
+                   a.url AS article_url, a.source_name AS article_source_name,
+                   a.summary AS article_summary
+            FROM article_shares s
+            JOIN users u ON u.id = s.from_user_id
+            JOIN articles a ON a.id = s.article_id
+            WHERE s.id = %s AND (s.to_user_id = %s OR s.from_user_id = %s)
+            """,
+            (share_id, user_id, user_id),
+        ).fetchone()
+    if row is None:
+        return None
+    share = row_to_dict(row)
+    share["annotations"] = list_annotations(share_id)
+    share["messages"] = list_messages(share_id)
+    return share
 
 
 def mark_share_read(share_id: int, user_id: int) -> bool:
@@ -110,3 +143,182 @@ def unread_share_count(user_id: int) -> int:
             (user_id,),
         ).fetchone()
         return int(row_to_dict(row)["n"])
+
+
+# ── Annotations ──────────────────────────────────────────────────────────────
+
+
+def add_annotation(
+    share_id: int,
+    *,
+    highlighted_text: str,
+    offset_chars: int = 0,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Append a highlight annotation to a share."""
+    with connect() as conn:
+        row = conn.execute(
+            """
+            INSERT INTO share_annotations (share_id, highlighted_text, offset_chars, note)
+            VALUES (%s, %s, %s, %s)
+            RETURNING id, share_id, highlighted_text, offset_chars, note, created_at
+            """,
+            (share_id, highlighted_text, offset_chars, note),
+        ).fetchone()
+    return row_to_dict(row)
+
+
+def list_annotations(share_id: int) -> list[dict[str, Any]]:
+    """Return all annotations for a share, oldest first."""
+    with connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, share_id, highlighted_text, offset_chars, note, created_at
+            FROM share_annotations
+            WHERE share_id = %s
+            ORDER BY created_at
+            """,
+            (share_id,),
+        ).fetchall()
+    return [row_to_dict(r) for r in rows]
+
+
+# ── Messages (comment thread) ─────────────────────────────────────────────────
+
+
+def add_message(share_id: int, user_id: int, message: str) -> dict[str, Any]:
+    """Append a message to a share's comment thread."""
+    with connect() as conn:
+        row = conn.execute(
+            """
+            INSERT INTO share_messages (share_id, user_id, message)
+            VALUES (%s, %s, %s)
+            RETURNING id, share_id, user_id, message, created_at
+            """,
+            (share_id, user_id, message),
+        ).fetchone()
+    return row_to_dict(row)
+
+
+def list_messages(share_id: int) -> list[dict[str, Any]]:
+    """Return all messages in a share's comment thread, oldest first."""
+    with connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT m.id, m.share_id, m.user_id, u.username, m.message, m.created_at
+            FROM share_messages m
+            JOIN users u ON u.id = m.user_id
+            WHERE m.share_id = %s
+            ORDER BY m.created_at
+            """,
+            (share_id,),
+        ).fetchall()
+    return [row_to_dict(r) for r in rows]
+
+
+# ── AI context generation ─────────────────────────────────────────────────────
+
+
+def generate_share_context(share_id: int) -> str | None:
+    """Generate and persist a personalised context summary for a share.
+
+    Reads the article content, the sender's annotations, and the recipient's
+    recent reading categories, then asks the LLM for a 2-sentence explanation
+    of why the highlighted sections matter to the recipient.  The result is
+    stored in ``article_shares.context_summary`` and returned.
+
+    Returns None if no API key is configured or if the share doesn't exist.
+    """
+    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.warning("generate_share_context: no OpenAI API key configured, skipping")
+        return None
+
+    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    model = os.getenv("OPENAI_BRIEFING_MODEL", DEFAULT_SHARE_MODEL)
+
+    with connect() as conn:
+        row = conn.execute(
+            """
+            SELECT s.id, s.note, s.from_user_id, s.to_user_id,
+                   a.title, a.summary, a.body
+            FROM article_shares s
+            JOIN articles a ON a.id = s.article_id
+            WHERE s.id = %s
+            """,
+            (share_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        share_data = row_to_dict(row)
+
+        annotations = list_annotations(share_id)
+
+        # Recipient's top reading categories for personalisation
+        recipient_cats = conn.execute(
+            """
+            SELECT a.category, COUNT(*) AS n
+            FROM user_article_state s
+            JOIN articles a ON a.id = s.article_id
+            WHERE s.user_id = %s AND s.state = 'done'
+            GROUP BY a.category
+            ORDER BY n DESC
+            LIMIT 5
+            """,
+            (share_data["to_user_id"],),
+        ).fetchall()
+        top_categories = [r["category"] for r in recipient_cats]
+
+    annotation_text = ""
+    if annotations:
+        parts = []
+        for ann in annotations:
+            snippet = ann["highlighted_text"][:200]
+            ann_note = f": {ann['note']}" if ann.get("note") else ""
+            parts.append(f'- "{snippet}"{ann_note}')
+        annotation_text = "\n".join(parts)
+    else:
+        annotation_text = "(no highlights)"
+
+    sender_note = share_data.get("note") or ""
+    article_title = share_data.get("title") or ""
+    article_summary = (share_data.get("summary") or share_data.get("body") or "")[:800]
+    recipient_interests = ", ".join(top_categories) if top_categories else "general news"
+
+    prompt = (
+        f'Article: "{article_title}"\n'
+        f"Summary: {article_summary}\n\n"
+        f"Sender's note: {sender_note or '(none)'}\n"
+        f"Highlighted sections:\n{annotation_text}\n\n"
+        f"Recipient's main reading interests: {recipient_interests}\n\n"
+        "Write exactly 2 sentences explaining why the sender highlighted these specific "
+        "sections and why they are directly relevant to the recipient's interests. "
+        "Be specific and personal, not generic."
+    )
+
+    from news_dashboard.ai_client import chat_create, get_openai_client
+
+    client = get_openai_client(api_key=api_key, base_url=base_url)
+    try:
+        completion = chat_create(
+            client,
+            name="share-context",
+            tags=["shares"],
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=120,
+            temperature=0.7,
+        )
+        context = completion.choices[0].message.content or ""
+        context = context.strip()
+    except Exception:
+        logger.exception("generate_share_context: LLM call failed for share %d", share_id)
+        return None
+
+    with connect() as conn:
+        conn.execute(
+            "UPDATE article_shares SET context_summary = %s WHERE id = %s",
+            (context, share_id),
+        )
+
+    return context

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from news_dashboard.auth import create_user
@@ -9,6 +11,12 @@ from news_dashboard.db import connect
 from news_dashboard.ingest import sync_sources
 from news_dashboard.shares import (
     ShareError,
+    add_annotation,
+    add_message,
+    generate_share_context,
+    get_share,
+    list_annotations,
+    list_messages,
     list_received_shares,
     mark_share_read,
     share_article,
@@ -65,6 +73,8 @@ def test_share_and_list(db: str) -> None:
     assert received[0]["article_title"] == "Article 1"
     assert received[0]["note"] == "read this"
     assert received[0]["read_at"] is None
+    assert received[0]["annotations"] == []
+    assert received[0]["messages"] == []
     assert unread_share_count(bob) == 1
     # Sender sees nothing in their own inbox.
     assert list_received_shares(alice) == []
@@ -103,3 +113,127 @@ def test_share_unknown_article_raises(db: str) -> None:
     bob = _make_user(db, "bob")
     with pytest.raises(ShareError):
         share_article(article_id=999999, from_user_id=alice, to_user_id=bob)
+
+
+# ── Annotation tests ──────────────────────────────────────────────────────────
+
+
+def test_add_and_list_annotations(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    ann = add_annotation(
+        share_id, highlighted_text="important passage", offset_chars=42, note="key insight"
+    )
+    assert ann["highlighted_text"] == "important passage"
+    assert ann["offset_chars"] == 42
+    assert ann["note"] == "key insight"
+
+    annotations = list_annotations(share_id)
+    assert len(annotations) == 1
+    assert annotations[0]["highlighted_text"] == "important passage"
+
+
+def test_annotations_included_in_list_received_shares(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    add_annotation(int(share["id"]), highlighted_text="highlighted bit", note="why it matters")
+
+    received = list_received_shares(bob)
+    assert len(received[0]["annotations"]) == 1
+    assert received[0]["annotations"][0]["highlighted_text"] == "highlighted bit"
+
+
+# ── Message tests ─────────────────────────────────────────────────────────────
+
+
+def test_add_and_list_messages(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    msg1 = add_message(share_id, alice, "What do you think?")
+    msg2 = add_message(share_id, bob, "Great article!")
+
+    assert msg1["message"] == "What do you think?"
+    assert msg2["message"] == "Great article!"
+
+    messages = list_messages(share_id)
+    assert len(messages) == 2
+    assert messages[0]["username"] == "alice"
+    assert messages[1]["username"] == "bob"
+
+
+def test_messages_included_in_get_share(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+    add_message(share_id, alice, "Check this out")
+
+    detail = get_share(share_id, bob)
+    assert detail is not None
+    assert len(detail["messages"]) == 1
+    assert detail["messages"][0]["message"] == "Check this out"
+
+
+def test_get_share_returns_none_for_unauthorized(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    charlie = _make_user(db, "charlie")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+
+    assert get_share(int(share["id"]), charlie) is None
+
+
+# ── AI context generation tests ───────────────────────────────────────────────
+
+
+def test_generate_share_context_no_api_key(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+
+    result = generate_share_context(int(share["id"]))
+    assert result is None
+
+
+def test_generate_share_context_stores_summary(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+    add_annotation(share_id, highlighted_text="the key section", note="this is relevant")
+
+    mock_completion = MagicMock()
+    summary = "Alice highlighted this because it matters. You will find it useful."
+    mock_completion.choices[0].message.content = summary
+
+    with (
+        patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_completion),
+    ):
+        mock_client_factory.return_value = MagicMock()
+        result = generate_share_context(share_id)
+
+    assert result == summary
+
+    detail = get_share(share_id, bob)
+    assert detail is not None
+    assert detail["context_summary"] == result


### PR DESCRIPTION
## Summary

Closes #352

- **DB schema**: Adds `context_summary TEXT` to `article_shares`, plus new `share_annotations` and `share_messages` tables with FK cascade and indexes
- **AI context generation**: `generate_share_context(share_id)` in `shares.py` reads article content, sender's highlight annotations, and recipient's reading history to produce a personalised 2-sentence "why you should read this" card via the configured LLM (uses `OPENAI_BRIEFING_*` env, falls back to `OPENAI_API_KEY`); fires as a background task on share creation and on each new annotation
- **New API endpoints**:
  - `GET /api/shares/{share_id}` — full detail (annotations + messages + AI summary)
  - `GET/POST /api/shares/{share_id}/annotations` — list/add highlight annotations
  - `GET/POST /api/shares/{share_id}/messages` — list/add comment thread messages
- **Existing endpoints enriched**: `GET /api/shares` (inbox) now includes `annotations`, `messages`, and `context_summary` per share

## Test plan

- [x] 12 unit/integration tests in `backend/tests/test_article_shares.py` covering annotation CRUD, message threads, `get_share` access control, AI context generation with mocked LLM, and graceful no-key fallback
- [x] `ruff`, `ruff format`, `mypy`, `ty`, `pyrefly` all clean
- [x] Full `pytest` backend suite passes locally (877 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)