### PR TITLE
feat: headless Selenium fetcher for JS-rendered SPA pages (#353)

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -167,10 +167,41 @@ class _BodyExtractor(HTMLParser):
         return "\n\n".join(paragraphs)
 
 
+def _selenium_extract_body(url: str) -> tuple[str, str]:
+    """Fallback: fetch via headless browser and extract body text.
+
+    Returns ('', 'error') if selenium is unavailable or rendering fails.
+    """
+    try:
+        from news_dashboard.selenium_client import fetch_spa_html
+
+        html = fetch_spa_html(url)
+    except ImportError:
+        return "", "error"
+    except Exception as exc:
+        logger.warning("selenium_body_fetch: fetch failed for %r: %s", url, exc)
+        return "", "error"
+
+    try:
+        parser = _BodyExtractor()
+        parser.feed(html)
+        text = parser.result()
+    except Exception as exc:
+        logger.warning("selenium_body_fetch: parse failed for %r: %s", url, exc)
+        return "", "error"
+
+    if not text.strip():
+        return "", "error"
+
+    return text, "ok"
+
+
 def extract_body(url: str) -> tuple[str, str]:
     """Fetch URL and extract readable text.
 
-    Returns (body_text, 'ok') on success or ('', 'error') on failure.
+    Falls back to headless browser rendering when static HTML yields no content
+    (e.g. JS-rendered SPAs).  Returns (body_text, 'ok') on success or
+    ('', 'error') on failure.
     """
     if not url.startswith(("http:", "https:")):
         return "", "error"
@@ -195,7 +226,7 @@ def extract_body(url: str) -> tuple[str, str]:
         return "", "error"
 
     if not text.strip():
-        return "", "error"
+        return _selenium_extract_body(url)
 
     return text, "ok"
 

--- a/backend/news_dashboard/scraper.py
+++ b/backend/news_dashboard/scraper.py
@@ -15,10 +15,14 @@ USER_AGENT = "news-dashboard/0.1 (personal RSS reader; contact@lihor.ro)"
 TIMEOUT_SECS = 15
 
 
-def _fetch_html(url: str) -> str:
+def _fetch_html(url: str, *, use_selenium: bool = False) -> str:
     if not url.startswith(("http:", "https:")):
         message = f"Refusing to fetch non-HTTP URL: {url!r}"
         raise ValueError(message)
+    if use_selenium:
+        from news_dashboard.selenium_client import fetch_spa_html
+
+        return fetch_spa_html(url)
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})  # noqa: S310 - scheme validated above
     with urllib.request.urlopen(req, timeout=TIMEOUT_SECS) as resp:  # noqa: S310 - scheme validated above
         raw: bytes = resp.read()

--- a/backend/news_dashboard/selenium_client.py
+++ b/backend/news_dashboard/selenium_client.py
@@ -1,0 +1,69 @@
+"""Headless Chrome browser client for JS-rendered (SPA) web pages."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.expected_conditions import presence_of_element_located
+from selenium.webdriver.support.wait import WebDriverWait
+from webdriver_manager.chrome import ChromeDriverManager
+
+from news_dashboard.scraper import USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+_ARTICLE_SELECTORS = "article, main, .post-content, .entry-content, p"
+_DEFAULT_TIMEOUT = 10.0
+
+
+def _build_options() -> Options:
+    opts = Options()
+    opts.add_argument("--headless=new")
+    opts.add_argument("--no-sandbox")
+    opts.add_argument("--disable-dev-shm-usage")
+    opts.add_argument("--disable-gpu")
+    opts.add_argument(f"--user-agent={USER_AGENT}")
+    opts.add_experimental_option("excludeSwitches", ["enable-automation"])
+    opts.add_experimental_option("useAutomationExtension", False)
+    prefs: dict[str, int] = {
+        "profile.managed_default_content_settings.images": 2,
+        "profile.managed_default_content_settings.stylesheet": 2,
+        "profile.managed_default_content_settings.media_stream": 2,
+    }
+    opts.add_experimental_option("prefs", prefs)
+    return opts
+
+
+@contextmanager
+def headless_browser() -> Generator[webdriver.Chrome]:
+    """Context manager yielding a headless Chrome driver; always calls quit() on exit."""
+    service = Service(ChromeDriverManager().install())
+    driver = webdriver.Chrome(service=service, options=_build_options())
+    try:
+        yield driver
+    finally:
+        driver.quit()
+
+
+def fetch_spa_html(url: str, timeout: float = _DEFAULT_TIMEOUT) -> str:
+    """Fetch a JS-rendered page using headless Chrome.
+
+    Waits up to *timeout* seconds for common article selectors to appear in the
+    DOM before returning the rendered page source.
+    """
+    with headless_browser() as driver:
+        driver.get(url)
+        try:
+            WebDriverWait(driver, timeout).until(
+                presence_of_element_located((By.CSS_SELECTOR, _ARTICLE_SELECTORS))
+            )
+        except TimeoutException:
+            logger.debug("selenium: article selector timeout for %r — using raw page source", url)
+        return str(driver.page_source)

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -100,7 +100,8 @@ def test_extract_body_rejects_non_http() -> None:
 
 def test_extract_body_empty_page_returns_error() -> None:
     url, thread = _start_server(b"<html><body></body></html>")
-    _body, status = extract_body(url)
+    with patch("news_dashboard.body_fetch._selenium_extract_body", return_value=("", "error")):
+        _body, status = extract_body(url)
     thread.join(timeout=2)
     assert status == "error"
 
@@ -532,3 +533,103 @@ def test_fetch_and_cache_body_ai_fallback_result_is_cached(tmp_path: Path) -> No
     assert result1["body"] == "AI body text"
     assert result2["body"] == "AI body text"
     assert len(ai_calls) == 1, "AI fallback must be called only once; second call uses cache"
+
+
+# ── _selenium_extract_body ────────────────────────────────────────────────────
+
+
+def test_extract_body_falls_back_to_selenium_when_static_empty() -> None:
+    url, thread = _start_server(b"<html><body></body></html>")
+    spa_content = "SPA article content rendered by JavaScript and extracted by headless browser."
+    with patch(
+        "news_dashboard.body_fetch._selenium_extract_body",
+        return_value=(spa_content, "ok"),
+    ) as mock_sel:
+        body, status = extract_body(url)
+    thread.join(timeout=2)
+    mock_sel.assert_called_once_with(url)
+    assert status == "ok"
+    assert body == spa_content
+
+
+def test_extract_body_does_not_call_selenium_when_static_ok() -> None:
+    html = b"""
+    <html><body>
+      <p>This is a long enough paragraph that should be extracted by the body parser.</p>
+    </body></html>
+    """
+    url, thread = _start_server(html)
+    with patch("news_dashboard.body_fetch._selenium_extract_body") as mock_sel:
+        _body, status = extract_body(url)
+    thread.join(timeout=2)
+    mock_sel.assert_not_called()
+    assert status == "ok"
+
+
+def test_extract_body_skips_selenium_on_network_failure() -> None:
+    with patch("news_dashboard.body_fetch._selenium_extract_body") as mock_sel:
+        body, status = extract_body("http://127.0.0.1:1/")
+    mock_sel.assert_not_called()
+    assert status == "error"
+    assert body == ""
+
+
+def _make_selenium_client_mock(fetch_spa_html_impl: object) -> object:
+    """Build a minimal sys.modules mock for news_dashboard.selenium_client."""
+    from types import ModuleType
+    from unittest.mock import MagicMock
+
+    mod = ModuleType("news_dashboard.selenium_client")
+    mod.fetch_spa_html = fetch_spa_html_impl  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    mod.__spec__ = MagicMock()
+    return mod
+
+
+def test_selenium_extract_body_returns_ok_on_rendered_html() -> None:
+    import sys
+
+    from news_dashboard.body_fetch import _selenium_extract_body
+
+    rendered = (
+        "<html><body>"
+        "<article><p>This SPA article paragraph is long enough to be extracted.</p>"
+        "<p>A second paragraph confirming the headless renderer worked correctly.</p></article>"
+        "</body></html>"
+    )
+    mock_mod = _make_selenium_client_mock(lambda _url: rendered)
+    with patch.dict(sys.modules, {"news_dashboard.selenium_client": mock_mod}):
+        body, status = _selenium_extract_body("http://example.com/spa")
+
+    assert status == "ok"
+    assert "SPA article paragraph" in body
+
+
+def test_selenium_extract_body_returns_error_when_fetch_fails() -> None:
+    import sys
+
+    from news_dashboard.body_fetch import _selenium_extract_body
+
+    err_msg = "browser crashed"
+
+    def _crash(_url: str) -> str:
+        raise RuntimeError(err_msg)
+
+    mock_mod = _make_selenium_client_mock(_crash)
+    with patch.dict(sys.modules, {"news_dashboard.selenium_client": mock_mod}):
+        body, status = _selenium_extract_body("http://example.com/spa")
+
+    assert status == "error"
+    assert body == ""
+
+
+def test_selenium_extract_body_returns_error_on_empty_rendered_page() -> None:
+    import sys
+
+    from news_dashboard.body_fetch import _selenium_extract_body
+
+    mock_mod = _make_selenium_client_mock(lambda _url: "<html><body></body></html>")
+    with patch.dict(sys.modules, {"news_dashboard.selenium_client": mock_mod}):
+        body, status = _selenium_extract_body("http://example.com/spa")
+
+    assert status == "error"
+    assert body == ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
   "httpx>=0.27.0",
   "itsdangerous>=2.2.0",
   "pywebpush>=2.0.0",
+  "selenium>=4.0.0",
+  "webdriver-manager>=4.0.0",
 ]
 
 [project.optional-dependencies]
@@ -155,7 +157,7 @@ warn_unreachable = true
 pretty = true
 
 [[tool.mypy.overrides]]
-module = ["feedparser.*", "apscheduler.*", "testcontainers.*", "pywebpush.*", "py_vapid.*"]
+module = ["feedparser.*", "apscheduler.*", "testcontainers.*", "pywebpush.*", "py_vapid.*", "webdriver_manager.*", "selenium.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/uv.lock
+++ b/uv.lock
@@ -874,8 +874,10 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pywebpush" },
     { name = "rapidfuzz" },
+    { name = "selenium" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "webdriver-manager" },
 ]
 
 [package.optional-dependencies]
@@ -912,10 +914,12 @@ requires-dist = [
     { name = "pywebpush", specifier = ">=2.0.0" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "selenium", specifier = ">=4.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.49" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
+    { name = "webdriver-manager", specifier = ">=4.0.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1055,6 +1059,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
 ]
 
 [[package]]
@@ -1308,6 +1324,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1498,6 +1523,23 @@ wheels = [
 ]
 
 [[package]]
+name = "selenium"
+version = "4.45.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "trio" },
+    { name = "trio-websocket" },
+    { name = "typing-extensions" },
+    { name = "urllib3", extra = ["socks"] },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/48/486aa67320f27452e9f551b8608f1a59ce7091c8fe7ebc9f4eba274775d4/selenium-4.45.0.tar.gz", hash = "sha256:563f0c4102f112df1cda30d46ce6d177b2e4a7a3d4b0756902d5dc84d3a8a365", size = 1005503, upload-time = "2026-06-16T04:43:57.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/8a/6ff6beb9c7c6cc642f628df9328a8b6637f86602eff8d28e70b5d4e8bca7/selenium-4.45.0-py3-none-any.whl", hash = "sha256:1fd9d0dc08192b2f8100e264ed720f83b05d2dd3a7feff673df04e0c7580df4b", size = 9536616, upload-time = "2026-06-16T04:43:55.968Z" },
+]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1519,6 +1561,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -1559,6 +1610,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
+]
+
+[[package]]
+name = "trio"
+version = "0.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
+]
+
+[[package]]
+name = "trio-websocket"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "outcome" },
+    { name = "trio" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221, upload-time = "2025-02-25T05:16:57.545Z" },
 ]
 
 [[package]]
@@ -1650,6 +1732,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]
@@ -1759,6 +1846,29 @@ wheels = [
 ]
 
 [[package]]
+name = "webdriver-manager"
+version = "4.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/e5/78d362c3507473d27708068fa66c2439b55127571351a096c7ec8eb85e9c/webdriver_manager-4.1.2.tar.gz", hash = "sha256:230515ff4dc4c2feff1add25306ca262421b31016d77ded305e8dd921266445f", size = 38948, upload-time = "2026-06-04T06:00:00.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/2c/7414ab135e99df7d9cc4a4afbd21b46906a9397aa2519beac50f6517138e/webdriver_manager-4.1.2-py3-none-any.whl", hash = "sha256:552bbb4e6f95e6e8b772565d2023e7c0ec5ff1736db0b186922d0466fc78c3de", size = 32512, upload-time = "2026-06-04T05:59:59.565Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1814,6 +1924,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
     { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
     { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `selenium` and `webdriver-manager` as project dependencies (uv.lock synced)
- Creates `backend/news_dashboard/selenium_client.py` with a headless Chrome context manager (`headless_browser()`) and `fetch_spa_html()` that waits up to 10 s for common article selectors (`article`, `main`, `.post-content`, `.entry-content`, `p`) to appear before extracting the rendered page source
- Updates `extract_body` in `body_fetch.py` to call the new `_selenium_extract_body()` fallback when static HTML parsing yields empty content (e.g. Next.js/React SPAs)
- Adds `use_selenium` keyword argument to `_fetch_html` in `scraper.py` so custom scrapers for known-dynamic feeds can opt in to headless rendering
- Extends mypy overrides to suppress `selenium.*` and `webdriver_manager.*` missing-stub warnings

## Test plan

- [ ] `test_extract_body_falls_back_to_selenium_when_static_empty` — verifies `_selenium_extract_body` is called when static parse yields empty text
- [ ] `test_extract_body_does_not_call_selenium_when_static_ok` — verifies selenium is NOT invoked when static succeeds
- [ ] `test_extract_body_skips_selenium_on_network_failure` — selenium not tried when static fetch itself fails (connection refused)
- [ ] `test_selenium_extract_body_returns_ok_on_rendered_html` — `_selenium_extract_body` parses rendered HTML correctly
- [ ] `test_selenium_extract_body_returns_error_when_fetch_fails` — browser crash → `('', 'error')`
- [ ] `test_selenium_extract_body_returns_error_on_empty_rendered_page` — renderer returns empty page → `('', 'error')`
- [ ] All 36 existing `test_body_fetch.py` and `test_scraper.py` tests continue to pass

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)