### PR TITLE
feat: implement Keycloak user registration and default source provisioning (#355)

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -85,6 +85,7 @@ def keycloak_auth_metadata() -> dict[str, Any]:
         "keycloak_enabled": config.enabled,
         "login_url": "/auth/login" if config.enabled else None,
         "logout_url": "/auth/logout" if config.enabled else "/api/auth/logout",
+        "registration_url": "/auth/register" if config.enabled else None,
     }
 
 
@@ -346,6 +347,22 @@ def keycloak_authorization_url(state: str) -> str:
     return f"{config.public_realm_url}/protocol/openid-connect/auth?{params}"
 
 
+def keycloak_registration_url(state: str) -> str:
+    config = keycloak_config()
+    if not config.enabled or not config.public_server_url:
+        raise HTTPException(status_code=500, detail="Keycloak authentication is not configured")
+    params = urlencode(
+        {
+            "client_id": config.client_id,
+            "response_type": "code",
+            "scope": "openid email profile",
+            "redirect_uri": config.redirect_uri,
+            "state": state,
+        }
+    )
+    return f"{config.public_realm_url}/protocol/openid-connect/registrations?{params}"
+
+
 def keycloak_token_request_data(code: str) -> dict[str, str]:
     config = keycloak_config()
     data = {
@@ -357,6 +374,22 @@ def keycloak_token_request_data(code: str) -> dict[str, str]:
     if config.client_secret:
         data["client_secret"] = config.client_secret
     return data
+
+
+def subscribe_user_to_default_sources(user_id: int) -> None:
+    from news_dashboard.ingest import sync_sources
+
+    sync_sources()
+    with connect() as conn:
+        rows = conn.execute("SELECT slug FROM sources WHERE owner_user_id IS NULL").fetchall()
+        for r in rows:
+            slug = row_to_dict(r)["slug"]
+            conn.execute(
+                "INSERT INTO user_sources(user_id, source_slug, enabled) "
+                "VALUES (%s, %s, TRUE) "
+                "ON CONFLICT(user_id, source_slug) DO NOTHING",
+                (user_id, slug),
+            )
 
 
 def ensure_keycloak_user(info: dict[str, Any]) -> dict[str, Any]:
@@ -382,6 +415,7 @@ def ensure_keycloak_user(info: dict[str, Any]) -> dict[str, Any]:
         email=email,
         is_admin=username.lower() in _keycloak_admin_usernames(),
     )
+    subscribe_user_to_default_sources(int(user["id"]))
     _touch_last_login(int(user["id"]))
     return get_user_by_id(int(user["id"])) or user
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -40,6 +40,7 @@ from news_dashboard.auth import (
     keycloak_authorization_url,
     keycloak_config,
     keycloak_logout_url,
+    keycloak_registration_url,
     list_users,
     require_admin,
     require_auth,
@@ -242,12 +243,35 @@ def auth_config() -> dict[str, Any]:
     return keycloak_auth_metadata()
 
 
+@public_router.get("/api/auth/metadata")
+def auth_metadata() -> dict[str, Any]:
+    return keycloak_auth_metadata()
+
+
 @public_router.get("/auth/login")
 def keycloak_login() -> RedirectResponse:
     if not keycloak_config().enabled:
         return RedirectResponse(url="/login")
     state = secrets.token_urlsafe(32)
     redirect = RedirectResponse(url=keycloak_authorization_url(state))
+    redirect.set_cookie(
+        key=_OAUTH_STATE_COOKIE,
+        value=state,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=600,
+        path="/auth/callback",
+    )
+    return redirect
+
+
+@public_router.get("/auth/register")
+def keycloak_register() -> RedirectResponse:
+    if not keycloak_config().enabled:
+        return RedirectResponse(url="/login")
+    state = secrets.token_urlsafe(32)
+    redirect = RedirectResponse(url=keycloak_registration_url(state))
     redirect.set_cookie(
         key=_OAUTH_STATE_COOKIE,
         value=state,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -19,6 +19,7 @@ from news_dashboard.auth import (
     init_auth,
     keycloak_auth_metadata,
     keycloak_authorization_url,
+    keycloak_registration_url,
     keycloak_token_request_data,
     list_users,
     update_password,
@@ -26,7 +27,7 @@ from news_dashboard.auth import (
     verify_password,
     verify_session_token,
 )
-from news_dashboard.db import init_db
+from news_dashboard.db import connect, init_db
 from news_dashboard.main import app
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -435,3 +436,62 @@ def test_health_details_requires_admin(tmp_db: str) -> None:
     client = _fresh_client()
     resp = client.get("/api/health/details")
     assert resp.status_code in (401, 403)
+
+
+def test_ensure_keycloak_user_provisions_default_sources(
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Keycloak auth enabled to run ensure_keycloak_user
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    user = ensure_keycloak_user(
+        {
+            "preferred_username": "newkeycloakuser",
+            "email": "newuser@example.test",
+            "sub": "kc-sub-2",
+        }
+    )
+    assert user["username"] == "newkeycloakuser"
+
+    # Verify that the user is subscribed to all sources in the sources table.
+    with connect() as conn:
+        # Get count of default sources
+        default_sources_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM sources WHERE owner_user_id IS NULL"
+        ).fetchone()["count"]
+        # Get count of user subscriptions
+        user_subs_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM user_sources WHERE user_id = %s AND enabled IS TRUE",
+            (user["id"],),
+        ).fetchone()["count"]
+
+        assert default_sources_count > 0
+        assert user_subs_count == default_sources_count
+
+
+def test_keycloak_registration_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.lihor.ro")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
+    url = keycloak_registration_url("state-456")
+    assert url.startswith(
+        "https://news.lihor.ro/keycloak/realms/news-dashboard/protocol/openid-connect/registrations?"
+    )
+    assert "client_id=news-dashboard" in url
+    assert "redirect_uri=https%3A%2F%2Fnews.lihor.ro%2Fauth%2Fcallback" in url
+    assert "state=state-456" in url
+
+
+def test_keycloak_register_endpoint_redirects_and_sets_cookie(
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://news.lihor.ro/keycloak")
+    monkeypatch.setenv("SESSION_SECRET", "test-secret")
+
+    client = _fresh_client()
+    resp = client.get("/auth/register", follow_redirects=False)
+    assert resp.status_code == 307
+    assert resp.headers["location"].startswith(
+        "https://news.lihor.ro/keycloak/realms/news-dashboard/protocol/openid-connect/registrations?"
+    )
+    assert "nd_oauth_state" in resp.cookies

--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -289,4 +289,30 @@ describe('LoginPage', () => {
       expect(api.loginUser).toHaveBeenCalledWith('alice', 'correct');
     });
   });
+
+  it('renders Keycloak sign-in and registration links when Keycloak is enabled', async () => {
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'keycloak',
+      keycloak_enabled: true,
+      login_url: '/auth/login',
+      logout_url: '/auth/logout',
+      registration_url: '/auth/register',
+    });
+
+    renderWithRouter(
+      <Routes>
+        <Route path="/" element={<LoginPage />} />
+      </Routes>
+    );
+
+    await waitFor(() => {
+      const loginLink = screen.getByRole('link', { name: /sign in with keycloak/i });
+      expect(loginLink).toBeTruthy();
+      expect(loginLink.getAttribute('href')).toBe('/auth/login');
+
+      const registerLink = screen.getByRole('link', { name: /create account/i });
+      expect(registerLink).toBeTruthy();
+      expect(registerLink.getAttribute('href')).toBe('/auth/register');
+    });
+  });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -320,6 +320,7 @@ export interface AuthConfig {
   keycloak_enabled: boolean;
   login_url: string | null;
   logout_url: string;
+  registration_url?: string | null;
 }
 
 export async function fetchAuthConfig(): Promise<AuthConfig> {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -62,12 +62,24 @@ export function LoginPage() {
         </div>
 
         {keycloakLoginUrl ? (
-          <a
-            href={keycloakLoginUrl}
-            className="flex w-full items-center justify-center rounded-md bg-foreground px-4 py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-90"
-          >
-            Sign in with Keycloak
-          </a>
+          <div className="space-y-4">
+            <a
+              href={keycloakLoginUrl}
+              className="flex w-full items-center justify-center rounded-md bg-foreground px-4 py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-90"
+            >
+              Sign in with Keycloak
+            </a>
+            {authConfig?.registration_url && (
+              <div className="text-center">
+                <a
+                  href={authConfig.registration_url}
+                  className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+                >
+                  Create Account
+                </a>
+              </div>
+            )}
+          </div>
         ) : (
           <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
             <div className="space-y-1">


### PR DESCRIPTION
Closes #355. Implements Keycloak user registration URL, /auth/register API endpoint redirect, updates metadata/configs, and adds a 'Create Account' link on the login page. Automatically subscribes new Keycloak-registered users to default sources.