### PR TITLE
feat: agentic paywall and cookie banner bypass using Selenium (#354)

### DIFF
--- a/backend/news_dashboard/selenium_client.py
+++ b/backend/news_dashboard/selenium_client.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator
+import urllib.parse
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 
 from selenium import webdriver
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
@@ -21,6 +22,58 @@ logger = logging.getLogger(__name__)
 
 _ARTICLE_SELECTORS = "article, main, .post-content, .entry-content, p"
 _DEFAULT_TIMEOUT = 10.0
+
+# Button text substrings for cookie/consent banners (matched case-insensitively)
+_CONSENT_BUTTON_TEXTS = [
+    "accept all",
+    "allow all",
+    "allow cookies",
+    "accept cookies",
+    "i accept",
+    "i agree",
+    "agree",
+    "consent",
+    "got it",
+]
+
+# CSS selectors tried in order for modal close buttons
+_MODAL_CLOSE_SELECTORS = [
+    '[aria-label="Close"]',
+    '[aria-label="close"]',
+    ".modal-close",
+    ".pop-up-close",
+    ".popup-close",
+    ".modal__close",
+    ".close-button",
+    ".dialog-close",
+    '[data-dismiss="modal"]',
+    ".modal .close",
+    ".overlay .close",
+    "button.close",
+]
+
+# JS that removes common overlay/paywall elements and restores body scroll
+_OVERLAY_REMOVAL_JS = """
+(function() {
+    var selectors = [
+        '.modal', '.overlay', '.popup', '.pop-up',
+        '[role="dialog"]', '[aria-modal="true"]',
+        '.cookie-banner', '.cookie-notice', '.cookie-consent',
+        '.newsletter-modal', '.subscription-wall',
+        '#cookie-banner', '#cookie-notice', '#cookie-consent',
+        '#newsletter-modal', '#subscription-wall',
+        '.paywall', '#paywall'
+    ];
+    selectors.forEach(function(sel) {
+        document.querySelectorAll(sel).forEach(function(el) { el.remove(); });
+    });
+    document.body.style.overflow = '';
+    document.body.style.position = '';
+    document.documentElement.style.overflow = '';
+})();
+"""
+
+DomainHandler = Callable[[webdriver.Chrome], None]
 
 
 def _build_options() -> Options:
@@ -52,12 +105,154 @@ def headless_browser() -> Generator[webdriver.Chrome]:
         driver.quit()
 
 
+def _click_consent_buttons(driver: webdriver.Chrome) -> bool:
+    """Find and click cookie/consent banner buttons. Returns True if any were clicked."""
+    try:
+        buttons = driver.find_elements(By.TAG_NAME, "button")
+        for btn in buttons:
+            try:
+                text = (btn.text or "").strip().lower()
+                if any(phrase in text for phrase in _CONSENT_BUTTON_TEXTS):
+                    btn.click()
+                    logger.info("selenium: clicked consent button %r", btn.text)
+                    return True
+            except Exception as btn_exc:
+                logger.debug("selenium: error interacting with button: %s", btn_exc)
+                continue
+    except Exception as exc:
+        logger.debug("selenium: error scanning consent buttons: %s", exc)
+    return False
+
+
+def _dismiss_modal_close_buttons(driver: webdriver.Chrome) -> bool:
+    """Click a modal close button via CSS selectors. Returns True if one was clicked."""
+    for selector in _MODAL_CLOSE_SELECTORS:
+        try:
+            el = driver.find_element(By.CSS_SELECTOR, selector)
+            el.click()
+            logger.info("selenium: closed modal via selector %r", selector)
+            return True
+        except NoSuchElementException:
+            continue
+        except Exception as exc:
+            logger.debug("selenium: error clicking modal close %r: %s", selector, exc)
+    return False
+
+
+def _remove_overlays_js(driver: webdriver.Chrome) -> None:
+    """Programmatically remove overlay elements and restore body scroll via JS."""
+    try:
+        driver.execute_script(_OVERLAY_REMOVAL_JS)
+        logger.debug("selenium: executed overlay removal JS")
+    except Exception as exc:
+        logger.debug("selenium: JS overlay removal failed: %s", exc)
+
+
+def _handle_medium(driver: webdriver.Chrome) -> None:
+    """Dismiss Medium metered paywall overlay."""
+    try:
+        driver.execute_script(
+            """
+            document.querySelectorAll(
+                '.meteredContent, .branch-journeys-top, [data-testid="paywall"]'
+            ).forEach(function(el) { el.remove(); });
+            var article = document.querySelector('article');
+            if (article) { article.style.maxHeight = ''; article.style.overflow = ''; }
+            """
+        )
+        logger.debug("selenium: applied Medium paywall bypass")
+    except Exception as exc:
+        logger.debug("selenium: Medium handler error: %s", exc)
+
+
+def _handle_substack(driver: webdriver.Chrome) -> None:
+    """Dismiss Substack subscription modals and paywalls."""
+    try:
+        driver.execute_script(
+            """
+            document.querySelectorAll(
+                '.paywall, .subscription-widget-wrap, .subscribe-widget, [class*="paywall"]'
+            ).forEach(function(el) { el.remove(); });
+            """
+        )
+        logger.debug("selenium: applied Substack paywall bypass")
+    except Exception as exc:
+        logger.debug("selenium: Substack handler error: %s", exc)
+
+
+# Domain-specific handlers keyed by apex domain
+_DOMAIN_HANDLERS: dict[str, DomainHandler] = {
+    "medium.com": _handle_medium,
+    "substack.com": _handle_substack,
+}
+
+
+def _get_domain_handler(hostname: str) -> DomainHandler | None:
+    for domain, handler in _DOMAIN_HANDLERS.items():
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return handler
+    return None
+
+
+def dismiss_overlays(driver: webdriver.Chrome, url: str) -> None:
+    """Detect and dismiss cookie banners, modal overlays, and soft paywalls.
+
+    Runs four strategies in sequence and logs outcomes for diagnostics:
+    1. Click common consent/cookie buttons.
+    2. Click modal close buttons via CSS selectors.
+    3. Remove remaining overlay elements via JS and restore body scroll.
+    4. Run a domain-specific bypass handler (Medium, Substack, …).
+    """
+    hostname = urllib.parse.urlparse(url).hostname or ""
+
+    consent_clicked = _click_consent_buttons(driver)
+    if not consent_clicked:
+        logger.debug("selenium: no consent banner found on %s", hostname)
+
+    modal_closed = _dismiss_modal_close_buttons(driver)
+    if not modal_closed:
+        logger.debug("selenium: no modal close button found on %s", hostname)
+
+    _remove_overlays_js(driver)
+
+    handler = _get_domain_handler(hostname)
+    if handler:
+        logger.debug("selenium: running domain handler for %s", hostname)
+        handler(driver)
+
+
+def _try_amp_url(url: str) -> str | None:
+    """Return an AMP variant of *url* for domains that support it, or None."""
+    parsed = urllib.parse.urlparse(url)
+    hostname = parsed.hostname or ""
+    if "medium.com" in hostname:
+        path = parsed.path
+        if not path.startswith("/amp"):
+            return urllib.parse.urlunparse(parsed._replace(path=f"/amp{path}"))
+    return None
+
+
 def fetch_spa_html(url: str, timeout: float = _DEFAULT_TIMEOUT) -> str:
     """Fetch a JS-rendered page using headless Chrome.
 
-    Waits up to *timeout* seconds for common article selectors to appear in the
-    DOM before returning the rendered page source.
+    After the page loads, automatically dismisses cookie banners, modal overlays,
+    and soft paywalls before returning the rendered page source.
     """
+    amp_url = _try_amp_url(url)
+    if amp_url:
+        try:
+            result = _fetch_with_cleanup(amp_url, timeout=timeout)
+            if result:
+                logger.info("selenium: AMP fetch succeeded for %r", url)
+                return result
+        except Exception as exc:
+            logger.debug("selenium: AMP fetch failed for %r: %s", url, exc)
+
+    return _fetch_with_cleanup(url, timeout=timeout)
+
+
+def _fetch_with_cleanup(url: str, timeout: float = _DEFAULT_TIMEOUT) -> str:
+    """Fetch *url* with headless Chrome, run overlay dismissal, return page source."""
     with headless_browser() as driver:
         driver.get(url)
         try:
@@ -66,4 +261,6 @@ def fetch_spa_html(url: str, timeout: float = _DEFAULT_TIMEOUT) -> str:
             )
         except TimeoutException:
             logger.debug("selenium: article selector timeout for %r — using raw page source", url)
+
+        dismiss_overlays(driver, url)
         return str(driver.page_source)

--- a/backend/tests/test_selenium_client.py
+++ b/backend/tests/test_selenium_client.py
@@ -1,0 +1,170 @@
+"""Tests for the Selenium overlay/paywall bypass client (issue #354).
+
+Skipped automatically when the `selenium` package is not installed.
+"""
+
+from __future__ import annotations
+
+pytest = __import__("pytest")
+pytest.importorskip("selenium")
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from selenium.common.exceptions import NoSuchElementException  # noqa: E402
+
+from news_dashboard.selenium_client import (  # noqa: E402
+    _click_consent_buttons,
+    _dismiss_modal_close_buttons,
+    _get_domain_handler,
+    _remove_overlays_js,
+    _try_amp_url,
+    dismiss_overlays,
+)
+
+
+def _make_driver(*, buttons: list[str] | None = None) -> MagicMock:
+    """Return a mock webdriver with configurable button elements."""
+    driver = MagicMock()
+    mock_buttons: list[MagicMock] = []
+    for text in buttons or []:
+        btn = MagicMock()
+        btn.text = text
+        mock_buttons.append(btn)
+    driver.find_elements.return_value = mock_buttons
+    return driver
+
+
+# ── Cookie / consent banner ───────────────────────────────────────────────────
+
+
+def test_click_consent_buttons_accepts_all() -> None:
+    driver = _make_driver(buttons=["Reject", "Accept All"])
+    result = _click_consent_buttons(driver)
+    assert result is True
+    clicked_btn = driver.find_elements.return_value[1]
+    clicked_btn.click.assert_called_once()
+
+
+def test_click_consent_buttons_no_match_returns_false() -> None:
+    driver = _make_driver(buttons=["Subscribe", "Log in"])
+    result = _click_consent_buttons(driver)
+    assert result is False
+
+
+def test_click_consent_buttons_empty_page_returns_false() -> None:
+    driver = _make_driver(buttons=[])
+    result = _click_consent_buttons(driver)
+    assert result is False
+
+
+def test_click_consent_buttons_case_insensitive() -> None:
+    driver = _make_driver(buttons=["ALLOW COOKIES"])
+    result = _click_consent_buttons(driver)
+    assert result is True
+
+
+# ── Modal close buttons ───────────────────────────────────────────────────────
+
+
+def test_dismiss_modal_close_buttons_clicks_first_match() -> None:
+    driver = MagicMock()
+    close_el = MagicMock()
+    driver.find_element.return_value = close_el
+    result = _dismiss_modal_close_buttons(driver)
+    assert result is True
+    close_el.click.assert_called_once()
+
+
+def test_dismiss_modal_close_buttons_no_element_returns_false() -> None:
+    driver = MagicMock()
+    driver.find_element.side_effect = NoSuchElementException
+    result = _dismiss_modal_close_buttons(driver)
+    assert result is False
+
+
+# ── JS overlay removal ────────────────────────────────────────────────────────
+
+
+def test_remove_overlays_js_executes_script() -> None:
+    driver = MagicMock()
+    _remove_overlays_js(driver)
+    driver.execute_script.assert_called_once()
+    script = driver.execute_script.call_args[0][0]
+    assert "cookie-banner" in script
+    assert "overflow" in script
+
+
+def test_remove_overlays_js_silences_errors() -> None:
+    driver = MagicMock()
+    driver.execute_script.side_effect = Exception("JS error")
+    _remove_overlays_js(driver)  # must not raise
+
+
+# ── dismiss_overlays pipeline ─────────────────────────────────────────────────
+
+
+def test_dismiss_overlays_calls_js_cleanup() -> None:
+    driver = _make_driver(buttons=["Accept All"])
+    with patch("news_dashboard.selenium_client._remove_overlays_js") as mock_js:
+        dismiss_overlays(driver, "https://example.com/article")
+    mock_js.assert_called_once_with(driver)
+
+
+def test_dismiss_overlays_medium_handler_runs() -> None:
+    driver = _make_driver()
+    mock_handler = MagicMock()
+    with patch("news_dashboard.selenium_client._DOMAIN_HANDLERS", {"medium.com": mock_handler}):
+        dismiss_overlays(driver, "https://medium.com/some-post")
+    mock_handler.assert_called_once_with(driver)
+
+
+def test_dismiss_overlays_substack_handler_runs() -> None:
+    driver = _make_driver()
+    mock_handler = MagicMock()
+    with patch("news_dashboard.selenium_client._DOMAIN_HANDLERS", {"substack.com": mock_handler}):
+        dismiss_overlays(driver, "https://newsletter.substack.com/p/article")
+    mock_handler.assert_called_once_with(driver)
+
+
+def test_dismiss_overlays_no_handler_for_unknown_domain() -> None:
+    driver = _make_driver()
+    mock_handler = MagicMock()
+    with patch("news_dashboard.selenium_client._DOMAIN_HANDLERS", {"medium.com": mock_handler}):
+        dismiss_overlays(driver, "https://example.com/article")
+    mock_handler.assert_not_called()
+
+
+# ── Domain handler registry ───────────────────────────────────────────────────
+
+
+def test_get_domain_handler_medium() -> None:
+    assert _get_domain_handler("medium.com") is not None
+
+
+def test_get_domain_handler_medium_subdomain() -> None:
+    assert _get_domain_handler("towardsdatascience.medium.com") is not None
+
+
+def test_get_domain_handler_substack() -> None:
+    assert _get_domain_handler("newsletter.substack.com") is not None
+
+
+def test_get_domain_handler_unknown_returns_none() -> None:
+    assert _get_domain_handler("example.com") is None
+
+
+# ── AMP URL construction ──────────────────────────────────────────────────────
+
+
+def test_try_amp_url_medium() -> None:
+    amp = _try_amp_url("https://medium.com/@user/some-post-abc123")
+    assert amp is not None
+    assert "/amp/" in amp
+
+
+def test_try_amp_url_medium_already_amp() -> None:
+    assert _try_amp_url("https://medium.com/amp/@user/some-post") is None
+
+
+def test_try_amp_url_non_medium_returns_none() -> None:
+    assert _try_amp_url("https://example.com/article") is None


### PR DESCRIPTION
## Summary

Closes #354

Extends `selenium_client.py` with an agentic overlay dismissal pipeline that runs after every headless page load:

- **Cookie/consent banner dismissal**: scans all `<button>` elements for common consent phrases ("Accept All", "Allow Cookies", "I Agree", etc.) and clicks the first match
- **Modal overlay removal**: tries a list of CSS selectors (`[aria-label="Close"]`, `.modal-close`, `.popup-close`, …) and clicks the first close button found
- **JS-based cleanup**: removes common overlay/paywall DOM elements (`.cookie-banner`, `.modal`, `.overlay`, `[role="dialog"]`, …) and restores `body.style.overflow`
- **Domain-specific bypass handlers**: Medium (removes `.meteredContent` / paywall overlay, restores article overflow) and Substack (removes `.paywall` / subscription widgets)
- **AMP URL fallback**: for Medium articles, tries the `/amp/…` variant before falling back to the standard URL
- **Diagnostic logging**: every bypass action (consent click, modal close, JS removal, domain handler) is logged at INFO/DEBUG for crawler diagnostics

## Test plan

- [x] 19 unit tests added in `backend/tests/test_selenium_client.py` (skipped gracefully when `selenium` is not installed)
- [x] Covers: consent button detection, modal close selectors, JS overlay removal, domain handler registry, AMP URL construction, and the full `dismiss_overlays` pipeline
- [x] `make check` passes (lint + typecheck + all tests + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)