### PR TITLE
feat: surface backend error details in frontend requests (#359)

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -41,9 +41,67 @@ describe('requestJson', () => {
     );
   });
 
-  it('throws on non-ok responses', async () => {
-    stubFetch(() => ({ ok: false, status: 500, statusText: 'Server Error' }));
+  it('throws on non-ok responses with status text when no body', async () => {
+    stubFetch(() => ({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      json: () => Promise.reject(new SyntaxError('no json')),
+      text: () => Promise.resolve(''),
+    }));
     await expect(api.requestJson('/api/boom')).rejects.toThrow('500 Server Error');
+  });
+
+  it('includes FastAPI detail string in thrown error', async () => {
+    stubFetch(() => ({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      json: () => Promise.resolve({ detail: 'Invalid briefing time' }),
+      text: () => Promise.resolve('{"detail":"Invalid briefing time"}'),
+    }));
+    await expect(api.requestJson('/api/briefings')).rejects.toThrow('Invalid briefing time');
+  });
+
+  it('joins Pydantic validation error array into readable message', async () => {
+    stubFetch(() => ({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      json: () =>
+        Promise.resolve({
+          detail: [
+            { msg: 'field required', loc: ['body', 'name'] },
+            { msg: 'value is not a valid email', loc: ['body', 'email'] },
+          ],
+        }),
+      text: () => Promise.resolve(''),
+    }));
+    const err = await api.requestJson('/api/thing').catch((e: Error) => e);
+    expect((err as Error).message).toContain('field required');
+    expect((err as Error).message).toContain('value is not a valid email');
+  });
+
+  it('uses message field as fallback detail shape', async () => {
+    stubFetch(() => ({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ message: 'Username already taken' }),
+      text: () => Promise.resolve(''),
+    }));
+    await expect(api.requestJson('/api/auth/register')).rejects.toThrow('Username already taken');
+  });
+
+  it('falls back to status text for non-JSON error bodies', async () => {
+    stubFetch(() => ({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      json: () => Promise.reject(new SyntaxError('not json')),
+      text: () => Promise.resolve('upstream error'),
+    }));
+    await expect(api.requestJson('/api/thing')).rejects.toThrow('503 Service Unavailable');
   });
 
   it('honors caller-provided headers', async () => {
@@ -112,9 +170,33 @@ describe('fetchArticleAudioUrl', () => {
   it('throws on a failed audio response', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(() => Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' }))
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          json: () => Promise.reject(new SyntaxError('no json')),
+          text: () => Promise.resolve(''),
+        })
+      )
     );
     await expect(api.fetchArticleAudioUrl(3)).rejects.toThrow('404 Not Found');
+  });
+
+  it('includes backend detail in audio error when JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          json: () => Promise.resolve({ detail: 'Article has no audio' }),
+          text: () => Promise.resolve(''),
+        })
+      )
+    );
+    await expect(api.fetchArticleAudioUrl(3)).rejects.toThrow('Article has no audio');
   });
 });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -33,6 +33,26 @@ import type {
   User,
 } from './types';
 
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body: unknown = await (response.json() as Promise<unknown>);
+    if (body && typeof body === 'object') {
+      const { detail, message } = body as Record<string, unknown>;
+      if (typeof detail === 'string' && detail) return detail;
+      if (Array.isArray(detail) && detail.length > 0) {
+        const msgs = detail
+          .map((d) => (d && typeof d === 'object' ? (d as Record<string, unknown>).msg : null))
+          .filter((m): m is string => typeof m === 'string');
+        if (msgs.length > 0) return msgs.join('; ');
+      }
+      if (typeof message === 'string' && message) return message;
+    }
+  } catch {
+    // non-JSON body — fall through
+  }
+  return `${response.status} ${response.statusText}`;
+}
+
 export async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
     headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
@@ -40,7 +60,7 @@ export async function requestJson<T>(url: string, init?: RequestInit): Promise<T
     ...init,
   });
   if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
+    throw new Error(await readErrorMessage(response));
   }
   return response.json() as Promise<T>;
 }
@@ -81,7 +101,7 @@ export async function fetchArticleAudioUrl(id: number | string): Promise<string>
     credentials: 'same-origin',
   });
   if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
+    throw new Error(await readErrorMessage(response));
   }
   const blob = await response.blob();
   return URL.createObjectURL(blob);


### PR DESCRIPTION
Closes #359

## Summary

- Added `readErrorMessage(response)` helper in `frontend/src/api.ts` that parses FastAPI/Pydantic error bodies before falling back to generic status text
- Supports `{ detail: string }`, `{ detail: [{ msg: string }] }` (Pydantic validation arrays), and `{ message: string }` shapes
- Applied to both `requestJson` and `fetchArticleAudioUrl`
- Non-JSON and empty error bodies continue to fall back to `${status} ${statusText}`

## Tests

Added 6 new tests covering:
- FastAPI `detail` string → used directly
- Pydantic validation array → msgs joined with `; `
- `message` field fallback
- Non-JSON body → status text fallback
- Audio error with JSON detail
- Audio error without JSON body

All 470 frontend tests pass. TypeScript strict + ESLint (0 warnings) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)