### PR TITLE
chore: wire VAPID push config through production deploy (#360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,9 @@ jobs:
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
           LANGFUSE_HOST: ${{ vars.LANGFUSE_HOST }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          VAPID_PUBLIC_KEY: ${{ secrets.VAPID_PUBLIC_KEY }}
+          VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
+          VAPID_EMAIL: ${{ vars.VAPID_EMAIL }}
         run: |
           set -euo pipefail
 
@@ -306,6 +309,25 @@ jobs:
             ai_helm_args+=(--set-string "app.ai.langfuse.host=$LANGFUSE_HOST")
           fi
 
+          push_secret_args=()
+          if [ -n "$VAPID_PUBLIC_KEY" ]; then
+            push_secret_args+=(--from-literal=VAPID_PUBLIC_KEY="$VAPID_PUBLIC_KEY")
+          fi
+          if [ -n "$VAPID_PRIVATE_KEY" ]; then
+            push_secret_args+=(--from-literal=VAPID_PRIVATE_KEY="$VAPID_PRIVATE_KEY")
+          fi
+
+          push_helm_args=()
+          if [ ${#push_secret_args[@]} -gt 0 ]; then
+            kubectl -n news-dashboard create secret generic news-dashboard-push \
+              "${push_secret_args[@]}" \
+              --dry-run=client -o yaml | kubectl apply -f -
+            push_helm_args+=(--set app.push.existingSecret=news-dashboard-push)
+          fi
+          if [ -n "$VAPID_EMAIL" ]; then
+            push_helm_args+=(--set-string "app.push.email=$VAPID_EMAIL")
+          fi
+
           # Sync Helm chart changes from main. Avoid relying on the deploy
           # host clone's branch/upstream config, which may point at a deleted
           # feature branch.
@@ -327,6 +349,7 @@ jobs:
             --set ingress.enabled=false
             --set-string app.auth.sessionSecret="$SESSION_SECRET"
             "${ai_helm_args[@]}"
+            "${push_helm_args[@]}"
           )
           helm "${helm_args[@]}"
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Runtime storage is PostgreSQL only. Set `DATABASE_URL` or the split
 | `OPENAI_BRIEFING_BASE_URL`, `OPENAI_BRIEFING_API_KEY` | Point briefing generation at an OpenAI-compatible endpoint (e.g. a self-hosted gateway). Optional; falls back to `OPENAI_BASE_URL` / `OPENAI_API_KEY`. Pair with `OPENAI_BRIEFING_MODEL` (use `auto` for a routing gateway). |
 | `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` | Traces every OpenAI call (embeddings, Ask AI, briefings, insights, TTS, body fetch) in [Langfuse](https://langfuse.com), each tagged with a descriptive name (`ask-ai`, `briefing-generation`, …). Tracing activates only when both keys are set; otherwise the app uses a plain OpenAI client with no tracing. `LANGFUSE_BASE_URL` is accepted as an alias for `LANGFUSE_HOST`. |
 | `KEYCLOAK_AUTH_ENABLED`, `KEYCLOAK_SERVER_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET` | Enables Keycloak. See [docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md). |
+| `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` | VAPID public and private keys for Web Push notifications. Generate using `npx web-push generate-vapid-keys`. |
+| `VAPID_EMAIL` | Contact email address used in VAPID claims mailto link. Defaults to `admin@example.com` if unset. |
 | `CORS_ORIGINS` | Comma-separated browser dev origins. |
 
 SQLite is supported only as a legacy import source for

--- a/docs/RUNNER_SETUP.md
+++ b/docs/RUNNER_SETUP.md
@@ -55,7 +55,23 @@ and add:
 That's the only secret the deploy workflow needs.  `GITHUB_TOKEN` is provided
 automatically by GitHub for the test and publish jobs.
 
-### 5. Create the Kubernetes namespace (first time only)
+### 5. Generate and add VAPID keys for Web Push (Optional)
+
+To enable browser push notifications, you need a pair of VAPID keys. You can generate them by running:
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Once generated, add the public and private keys as GitHub Actions **Secrets**, and the claims email as a GitHub Actions **Variable** (under Settings → Secrets and variables → Actions):
+
+| Name | Type | Value |
+|------|------|-------|
+| `VAPID_PUBLIC_KEY` | Secret | The generated VAPID public key |
+| `VAPID_PRIVATE_KEY` | Secret | The generated VAPID private key |
+| `VAPID_EMAIL` | Variable | The contact email address (e.g., `admin@example.com`) |
+
+### 6. Create the Kubernetes namespace (first time only)
 
 ```bash
 kubectl create namespace news-dashboard --dry-run=client -o yaml | kubectl apply -f -

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -121,6 +121,26 @@ spec:
                   optional: true
 {{- end }}
 {{- end }}
+{{- if .Values.app.push }}
+{{- if .Values.app.push.existingSecret }}
+            - name: VAPID_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.push.existingSecret | quote }}
+                  key: {{ .Values.app.push.vapidPublicKeyKey | default "VAPID_PUBLIC_KEY" | quote }}
+                  optional: true
+            - name: VAPID_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.push.existingSecret | quote }}
+                  key: {{ .Values.app.push.vapidPrivateKeyKey | default "VAPID_PRIVATE_KEY" | quote }}
+                  optional: true
+{{- end }}
+{{- if .Values.app.push.email }}
+            - name: VAPID_EMAIL
+              value: {{ .Values.app.push.email | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.app.auth.enabled }}
             - name: KEYCLOAK_AUTH_ENABLED
               value: "1"

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -74,6 +74,13 @@ app:
       # Keys within `app.ai.existingSecret` holding the Langfuse credentials.
       publicKeyKey: LANGFUSE_PUBLIC_KEY
       secretKeyKey: LANGFUSE_SECRET_KEY
+  push:
+    # Optional: pre-existing Secret with VAPID keys.
+    existingSecret: ""
+    vapidPublicKeyKey: VAPID_PUBLIC_KEY
+    vapidPrivateKeyKey: VAPID_PRIVATE_KEY
+    # VAPID claims email address. Omit or leave empty to default safely.
+    email: ""
 
 ingestCronJob:
   enabled: true


### PR DESCRIPTION
Resolves #360

### Summary of Implementation
- **Helm configuration (`helm/news-dashboard/values.yaml` & `helm/news-dashboard/templates/deployment.yaml`)**:
  - Exposed `app.push` values for VAPID configurations (`existingSecret`, `vapidPublicKeyKey`, `vapidPrivateKeyKey`, and `email`).
  - Wired `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` (from Kubernetes Secret if `app.push.existingSecret` is configured) and `VAPID_EMAIL` (if `app.push.email` is configured) as environment variables in the app container.
- **CI / CD Deploy Job (`.github/workflows/ci.yml`)**:
  - Wired VAPID secrets and variables from GitHub Actions env (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_EMAIL`).
  - Dynamically creates the `news-dashboard-push` secret and passes the configuration values to Helm.
- **Documentation (`README.md` & `docs/RUNNER_SETUP.md`)**:
  - Documented VAPID variables in `README.md`.
  - Added VAPID key generation and setup instructions in `docs/RUNNER_SETUP.md`.

### Verification Results
- Helm template successfully validated:
  - Default runs render no VAPID environment variables.
  - Custom push values render VAPID env vars referencing the intended secret keys and the custom VAPID email.
- Unit and integration tests passing:
  - Backend tests run and passed (`pytest backend/tests/test_push_notifications.py`).
  - Frontend vitest suite run and passed (`npm run test:frontend`).
