### PR TITLE
ci: create deploy namespace before secrets (#358)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,8 @@ jobs:
           # Pull eagerly — surfaces auth failures before touching the cluster.
           docker pull "${IMG}:${SHA}"
 
+          kubectl create namespace news-dashboard --dry-run=client -o yaml | kubectl apply -f -
+
           # Let Kubernetes pull the private GHCR image during rollout.
           kubectl -n news-dashboard create secret docker-registry ghcr-pull-secret \
             --docker-server=ghcr.io \

--- a/docs/RUNNER_SETUP.md
+++ b/docs/RUNNER_SETUP.md
@@ -71,16 +71,17 @@ Once generated, add the public and private keys as GitHub Actions **Secrets**, a
 | `VAPID_PRIVATE_KEY` | Secret | The generated VAPID private key |
 | `VAPID_EMAIL` | Variable | The contact email address (e.g., `admin@example.com`) |
 
-### 6. Create the Kubernetes namespace (first time only)
+### 6. Check Kubernetes access
 
 ```bash
-kubectl create namespace news-dashboard --dry-run=client -o yaml | kubectl apply -f -
+kubectl get nodes
 ```
 
-The `helm upgrade --install ... --create-namespace` flag in the workflow does this
-automatically, but running it once now confirms `kubectl` is working.
+The deploy workflow creates the `news-dashboard` namespace before refreshing
+secrets, and Helm still runs with `--create-namespace` during install/upgrade.
+No manual namespace creation is required before the first workflow deploy.
 
-### 6. Make the GHCR package visible to the runner
+### 7. Make the GHCR package visible to the runner
 
 The workflow's "Refresh GHCR pull secret" step handles cluster-side pull auth
 automatically on every deploy.  If you want to test a manual pull first:

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -96,15 +96,15 @@ are not in the runner user's `PATH`, add them to `~/.profile` for that user.
 
 ## Step 4 — First-time cluster check
 
-Confirm `kubectl` is pointing at the correct cluster and the namespace exists:
+Confirm `kubectl` is pointing at the correct cluster:
 
 ```bash
 kubectl get nodes
-kubectl create namespace news-dashboard --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-The `helm upgrade --install ... --create-namespace` flag in the workflow also
-creates the namespace automatically on first deploy.
+The deploy workflow creates the `news-dashboard` namespace before refreshing
+secrets, and Helm still runs with `--create-namespace` during install/upgrade.
+No manual namespace creation is required before the first workflow deploy.
 
 ## How the full flow works after setup
 

--- a/scripts/test_ci_deploy_namespace.py
+++ b/scripts/test_ci_deploy_namespace.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_deploy_creates_namespace_before_secrets() -> None:
+    workflow = WORKFLOW.read_text()
+
+    namespace_command = (
+        "kubectl create namespace news-dashboard --dry-run=client -o yaml | kubectl apply -f -"
+    )
+    pull_command = "kubectl -n news-dashboard create secret docker-registry ghcr-pull-secret"
+    ai_command = "kubectl -n news-dashboard create secret generic news-dashboard-ai"
+
+    namespace_index = workflow.index(namespace_command)
+    pull_index = workflow.index(pull_command)
+    ai_index = workflow.index(ai_command)
+
+    assert namespace_index < pull_index  # noqa: S101
+    assert namespace_index < ai_index  # noqa: S101


### PR DESCRIPTION
Closes #358

## Summary
- Create the `news-dashboard` namespace before refreshing GHCR or optional AI Kubernetes secrets in the deploy workflow.
- Keep Helm `--create-namespace` in place for install/upgrade idempotence.
- Update runner setup docs so manual namespace creation is no longer a first-deploy prerequisite.
- Add a regression test covering deploy namespace creation ordering before secret creation.

## Test results
- `pytest scripts/test_ci_deploy_namespace.py`
- `ruff check scripts/test_ci_deploy_namespace.py && ruff format --check scripts/test_ci_deploy_namespace.py`
- extracted deploy script block piped to `bash -n`
- `make lint`
- `source .env && make test` (899 passed, 6 skipped; frontend 465 passed)
- `source .venv/bin/activate && make typecheck`
- `npm run build --silent`
- commit/pre-push hooks passed

Generated with Codex.