### PR TITLE
security: throttle password login attempts after 5 failures (#362)

### DIFF
--- a/backend/news_dashboard/login_throttle.py
+++ b/backend/news_dashboard/login_throttle.py
@@ -1,0 +1,77 @@
+"""In-process throttle for failed password-login attempts.
+
+Keys on normalized username only; client address is excluded because
+reverse-proxy deployments may not expose the original remote address reliably.
+
+Window: 15 minutes / 5 failures → HTTP 429.  A successful login clears the
+recorded failures for that key so legitimate users are never permanently locked.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+_WINDOW_SECONDS: int = 15 * 60
+_MAX_FAILURES: int = 5
+
+# Protected by _lock; maps normalised username → list[datetime (utc)]
+_failures: dict[str, list[datetime]] = defaultdict(list)
+_lock = threading.Lock()
+
+
+def _wall_clock() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# Swappable clock for deterministic tests (default: wall time)
+_now: Callable[[], datetime] = _wall_clock
+
+
+def _set_clock(clock: Callable[[], datetime]) -> None:
+    """Override the clock — test use only."""
+    global _now  # noqa: PLW0603
+    _now = clock
+
+
+def _reset_clock() -> None:
+    global _now  # noqa: PLW0603
+    _now = _wall_clock
+
+
+def _prune(key: str, now: datetime) -> None:
+    cutoff = now.timestamp() - _WINDOW_SECONDS
+    _failures[key] = [ts for ts in _failures[key] if ts.timestamp() >= cutoff]
+
+
+def is_throttled(username: str) -> bool:
+    """Return True if *username* has too many recent failures."""
+    key = username.strip().lower()
+    now = _now()
+    with _lock:
+        _prune(key, now)
+        return len(_failures[key]) >= _MAX_FAILURES
+
+
+def record_failure(username: str) -> None:
+    """Record one failed attempt for *username*."""
+    key = username.strip().lower()
+    now = _now()
+    with _lock:
+        _prune(key, now)
+        _failures[key].append(now)
+
+
+def clear_failures(username: str) -> None:
+    """Clear all recorded failures for *username* (call after successful login)."""
+    key = username.strip().lower()
+    with _lock:
+        _failures.pop(key, None)
+
+
+def reset_all() -> None:
+    """Wipe all throttle state — test use only."""
+    with _lock:
+        _failures.clear()

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -69,6 +69,7 @@ from news_dashboard.ingest import (
     transition_article_state,
 )
 from news_dashboard.ingest_events import stream_ingest_events
+from news_dashboard.login_throttle import clear_failures, is_throttled, record_failure
 from news_dashboard.run_history import get_ingest_run_sources, list_ingest_runs
 from news_dashboard.scheduler import (
     get_interval_minutes,
@@ -321,9 +322,16 @@ def keycloak_logout() -> RedirectResponse:
 def login(payload: LoginRequest, response: Response) -> dict[str, Any]:
     if keycloak_config().enabled:
         raise HTTPException(status_code=409, detail="Password login is disabled; use Keycloak")
+    if is_throttled(payload.username):
+        raise HTTPException(
+            status_code=429,
+            detail="Too many failed login attempts; try again later",
+        )
     user = authenticate(payload.username, payload.password)
     if not user:
+        record_failure(payload.username)
         raise HTTPException(status_code=401, detail="Invalid credentials")
+    clear_failures(payload.username)
     token = create_session_token(user["id"], bool(user["is_admin"]))
     response.set_cookie(
         key=_SESSION_COOKIE,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
+from news_dashboard import login_throttle
 from news_dashboard.auth import (
     authenticate,
     bootstrap_admin,
@@ -495,3 +497,102 @@ def test_keycloak_register_endpoint_redirects_and_sets_cookie(
         "https://news.lihor.ro/keycloak/realms/news-dashboard/protocol/openid-connect/registrations?"
     )
     assert "nd_oauth_state" in resp.cookies
+
+
+# ── Login throttle ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=False)
+def clean_throttle() -> Generator[None]:
+    login_throttle.reset_all()
+    login_throttle._reset_clock()
+    yield
+    login_throttle.reset_all()
+    login_throttle._reset_clock()
+
+
+def test_throttle_returns_429_after_threshold(tmp_db: str, clean_throttle: None) -> None:
+    create_user("throttled_user", "correct")
+    client = _fresh_client()
+    payload = {"username": "throttled_user", "password": "wrong"}
+    for _ in range(5):
+        resp = client.post("/api/auth/login", json=payload)
+        assert resp.status_code == 401
+    resp = client.post("/api/auth/login", json=payload)
+    assert resp.status_code == 429
+
+
+def test_throttle_response_body_does_not_reveal_username(tmp_db: str, clean_throttle: None) -> None:
+    create_user("secret_user", "correct")
+    client = _fresh_client()
+    for _ in range(5):
+        client.post("/api/auth/login", json={"username": "secret_user", "password": "wrong"})
+    resp = client.post("/api/auth/login", json={"username": "secret_user", "password": "wrong"})
+    assert resp.status_code == 429
+    body = resp.text
+    assert "secret_user" not in body
+
+
+def test_successful_login_clears_throttle(tmp_db: str, clean_throttle: None) -> None:
+    create_user("clearme", "right")
+    client = _fresh_client()
+    for _ in range(4):
+        client.post("/api/auth/login", json={"username": "clearme", "password": "wrong"})
+    # Correct password resets the counter
+    resp = client.post("/api/auth/login", json={"username": "clearme", "password": "right"})
+    assert resp.status_code == 200
+    # Should be able to fail again without immediately hitting 429
+    resp = client.post("/api/auth/login", json={"username": "clearme", "password": "wrong"})
+    assert resp.status_code == 401
+
+
+def test_throttle_window_expiry(tmp_db: str, clean_throttle: None) -> None:
+    from datetime import datetime, timezone
+
+    create_user("windowed", "correct")
+    client = _fresh_client()
+
+    # Record 5 failures at t=0
+    t0 = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    login_throttle._set_clock(lambda: t0)
+    for _ in range(5):
+        client.post("/api/auth/login", json={"username": "windowed", "password": "wrong"})
+
+    # Confirm throttled at t=0
+    resp = client.post("/api/auth/login", json={"username": "windowed", "password": "wrong"})
+    assert resp.status_code == 429
+
+    # Advance clock past the 15-minute window
+    from datetime import timedelta
+
+    t_after = t0 + timedelta(minutes=16)
+    login_throttle._set_clock(lambda: t_after)
+
+    # Failures should have expired; a wrong-password attempt returns 401, not 429
+    resp = client.post("/api/auth/login", json={"username": "windowed", "password": "wrong"})
+    assert resp.status_code == 401
+
+
+def test_throttle_below_threshold_returns_401(tmp_db: str, clean_throttle: None) -> None:
+    create_user("below", "correct")
+    client = _fresh_client()
+    for _ in range(4):
+        resp = client.post("/api/auth/login", json={"username": "below", "password": "wrong"})
+        assert resp.status_code == 401
+
+
+def test_throttle_does_not_affect_keycloak_mode(
+    clean_throttle: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_AUTH_ENABLED", "1")
+    monkeypatch.setenv("KEYCLOAK_SERVER_URL", "https://kc.example.com")
+    client = _fresh_client()
+    # Saturate the throttle counter for this key
+    login_throttle.record_failure("anyuser")
+    login_throttle.record_failure("anyuser")
+    login_throttle.record_failure("anyuser")
+    login_throttle.record_failure("anyuser")
+    login_throttle.record_failure("anyuser")
+    # Keycloak mode should still return 409, not 429
+    resp = client.post("/api/auth/login", json={"username": "anyuser", "password": "pw"})
+    assert resp.status_code == 409


### PR DESCRIPTION
## Summary

Closes #362.

- Adds `backend/news_dashboard/login_throttle.py`: an in-process throttle keyed by normalised username that returns HTTP 429 after 5 failed attempts within a 15-minute sliding window.
- Updates `POST /api/auth/login` in `main.py` to check the throttle before authentication, record failures, and clear the counter on success.
- Keycloak mode is unaffected (the 409 check runs before throttle logic).
- 6 new tests in `test_auth.py` cover: below-threshold (401), threshold lockout (429), generic error text, success-clears-counter, window expiry (injectable clock, no sleeps), and Keycloak mode isolation.

## Test plan

- [x] `make lint` — passes (ruff + prettier)
- [x] `make typecheck` — mypy passes; ty/pyrefly selenium errors are pre-existing in `selenium_client.py` (unrelated to this PR)
- [x] `python -m pytest backend/tests/test_auth.py` — **46/46 passed** including all 6 new throttle tests
- [ ] CI — pending

## Notes

The pre-push hook ran all 932 backend tests but was killed by the OS (SIGKILL / OOM) before completing. The pre-existing test failures in `test_behavioral_affinity`, `test_briefings_db`, `test_recommendation_recalc`, etc. are unrelated to this change. CI will provide the authoritative result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)