### PR TITLE
fix: prune expired web push subscriptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         stages: [pre-push]
       - id: pytest
         name: pytest (backend)
-        entry: zsh -c 'set -a; if [ -f .env ]; then source .env; fi; set +a; pytest'
+        entry: zsh -c 'set -a; if [ -f .env ]; then source .env; fi; set +a; pytest -p no:xdist'
         language: system
         types: [python]
         pass_filenames: false

--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -5,9 +5,21 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
+
+PushDeliveryResult = Literal["sent", "skipped_not_configured", "temporary_failure", "gone"]
+
+
+def _is_permanent_push_failure(exc: Exception) -> bool:
+    """Return True if the exception represents a permanent failure (e.g. HTTP 404 or 410)."""
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status_code = getattr(response, "status_code", None)
+        if status_code in (404, 410):
+            return True
+    return False
 
 
 def get_vapid_public_key() -> str | None:
@@ -35,13 +47,13 @@ def send_push_notification(
     auth: str,
     title: str,
     body: str,
-) -> None:
+) -> PushDeliveryResult:
     """Send a single Web Push notification to the given subscription."""
     try:
         from pywebpush import WebPushException, webpush
     except ImportError:
         logger.warning("pywebpush not installed — push notification skipped")
-        return
+        return "skipped_not_configured"
 
     payload = json.dumps({"title": title, "body": body})
     try:
@@ -54,10 +66,16 @@ def send_push_notification(
             vapid_private_key=_vapid_private_key(),
             vapid_claims=_vapid_claims(),
         )
+        return "sent"
     except WebPushException as exc:
-        logger.warning("Push notification to %s failed: %s", endpoint[:40], exc)
+        if _is_permanent_push_failure(exc):
+            logger.warning("Push notification to %s failed permanently: %s", endpoint[:40], exc)
+            return "gone"
+        logger.warning("Push notification to %s failed temporarily: %s", endpoint[:40], exc)
+        return "temporary_failure"
     except RuntimeError:
         logger.warning("Push notification skipped: VAPID key not configured")
+        return "skipped_not_configured"
 
 
 def save_push_subscription(
@@ -137,10 +155,16 @@ def send_push_for_user(
     """Send a push notification to all subscriptions registered by a user."""
     subs = get_user_push_subscriptions(user_id, database_url=database_url)
     for sub in subs:
-        send_push_notification(
+        result = send_push_notification(
             endpoint=sub["endpoint"],
             p256dh=sub["p256dh_key"],
             auth=sub["auth_key"],
             title=title,
             body=body,
         )
+        if result == "gone":
+            delete_push_subscriptions(
+                user_id,
+                endpoint=sub["endpoint"],
+                database_url=database_url,
+            )

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -282,3 +282,55 @@ def test_push_unsubscribe_endpoint() -> None:
     assert resp.status_code == 200
     assert resp.json() == {"unsubscribed": True}
     mock_del.assert_called_once_with(1)
+
+
+@pytest.mark.postgres
+def test_send_push_for_user_prunes_expired_endpoints(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
+    init_db(database_url=pg_clean)
+    from news_dashboard.auth import create_user
+
+    user = create_user("pushuser7", "pass")
+    uid = int(user["id"])
+
+    ep_success = "https://ep-success.example.com"
+    ep_gone = "https://ep-gone.example.com"
+    ep_transient = "https://ep-transient.example.com"
+
+    save_push_subscription(uid, ep_success, "k1", "a1", database_url=pg_clean)
+    save_push_subscription(uid, ep_gone, "k2", "a2", database_url=pg_clean)
+    save_push_subscription(uid, ep_transient, "k3", "a3", database_url=pg_clean)
+
+    class _FakeResponse:
+        def __init__(self, status_code: int) -> None:
+            self.status_code = status_code
+
+    class _FakeWebPushError(Exception):
+        def __init__(self, message: str, response: Any = None) -> None:
+            super().__init__(message)
+            self.response = response
+
+    def mock_webpush(subscription_info: dict[str, Any], **kwargs: Any) -> None:
+        endpoint = subscription_info["endpoint"]
+        if endpoint == ep_gone:
+            msg = "Gone"
+            raise _FakeWebPushError(msg, response=_FakeResponse(410))
+        if endpoint == ep_transient:
+            msg = "Server Error"
+            raise _FakeWebPushError(msg, response=_FakeResponse(500))
+
+    fake_module: dict[str, Any] = {
+        "webpush": mock_webpush,
+        "WebPushException": _FakeWebPushError,
+    }
+    with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
+        send_push_for_user(uid, "Title", "Body", database_url=pg_clean)
+
+    remaining = get_user_push_subscriptions(uid, database_url=pg_clean)
+    endpoints = {sub["endpoint"] for sub in remaining}
+    assert ep_success in endpoints
+    assert ep_transient in endpoints
+    assert ep_gone not in endpoints

--- a/frontend/src/__tests__/dailyBriefSettings.test.tsx
+++ b/frontend/src/__tests__/dailyBriefSettings.test.tsx
@@ -171,4 +171,22 @@ describe('DailyBriefSection', () => {
     await waitFor(() => expect(mockUpdateSettings).toHaveBeenCalledWith({ push_enabled: true }));
     await waitFor(() => expect(screen.getByText('Enabled')).toBeInTheDocument());
   });
+
+  it('hides Enable button and shows server-configuration warning when PushManager is present but VAPID key is missing', async () => {
+    vi.stubGlobal('navigator', { serviceWorker: {} });
+    vi.stubGlobal('PushManager', {});
+    mockFetchSettings.mockResolvedValue({
+      ...defaultSettings,
+      vapid_public_key: null,
+    });
+    renderSettings();
+    await waitFor(() => expect(screen.getByText('Push notifications')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /enable push/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Push notifications are not supported in this environment.')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Push notifications require server configuration (VAPID keys).')
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -464,7 +464,8 @@ function DailyBriefSection() {
 
   const canEnablePush =
     !pushEnabled &&
-    (!!window.electronAPI || ('serviceWorker' in navigator && 'PushManager' in window));
+    (!!window.electronAPI ||
+      (!!vapidKey && 'serviceWorker' in navigator && 'PushManager' in window));
 
   if (!loaded) return null;
 
@@ -523,11 +524,12 @@ function DailyBriefSection() {
               )}
               {pushState === 'requesting' ? 'Requesting…' : 'Enable push notifications'}
             </button>
-          ) : (
+          ) : !window.electronAPI &&
+            (!('serviceWorker' in navigator) || !('PushManager' in window)) ? (
             <p className="text-xs text-muted-foreground">
               Push notifications are not supported in this environment.
             </p>
-          )}
+          ) : null}
 
           {pushState === 'denied' && (
             <p className="text-xs text-destructive">


### PR DESCRIPTION
Closes #364

### Summary
1. Hardened the push notification settings UI to hide the "Enable push notifications" button if the server configuration (VAPID key) is missing, and show a clear server-configuration warning instead.
2. Modified backend `send_push_notification` to return a `PushDeliveryResult` ('sent', 'skipped_not_configured', 'temporary_failure', or 'gone').
3. Checked for HTTP 404/410 errors in `pywebpush.WebPushException` (via the helper `_is_permanent_push_failure`) to identify endpoints that are permanently gone.
4. Updated `send_push_for_user` to automatically delete subscription endpoints that return 'gone'.
5. Updated pre-push pytest command to run sequentially to avoid DB parallel execution state race conditions.

### Tests
- Added unit tests in `backend/tests/test_push_notifications.py` (`test_send_push_for_user_prunes_expired_endpoints`) verifying that expired endpoints are successfully pruned, transient failures are kept as warnings, and successful deliveries function normally.
- Added frontend settings view tests in `frontend/src/__tests__/dailyBriefSettings.test.tsx` verifying that when PushManager exists but the VAPID key is missing, the "Enable push notifications" button is hidden and the warning is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)