### PR TITLE
feat: deep-link web push notifications to target content (closes #373)

### DIFF
--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -47,6 +47,7 @@ def send_push_notification(
     auth: str,
     title: str,
     body: str,
+    target_url: str | None = None,
 ) -> PushDeliveryResult:
     """Send a single Web Push notification to the given subscription."""
     try:
@@ -55,7 +56,10 @@ def send_push_notification(
         logger.warning("pywebpush not installed — push notification skipped")
         return "skipped_not_configured"
 
-    payload = json.dumps({"title": title, "body": body})
+    data: dict[str, str] = {"title": title, "body": body}
+    if target_url is not None:
+        data["url"] = target_url
+    payload = json.dumps(data)
     try:
         webpush(
             subscription_info={
@@ -150,6 +154,7 @@ def send_push_for_user(
     title: str,
     body: str,
     *,
+    target_url: str | None = None,
     database_url: str | None = None,
 ) -> None:
     """Send a push notification to all subscriptions registered by a user."""
@@ -161,6 +166,7 @@ def send_push_for_user(
             auth=sub["auth_key"],
             title=title,
             body=body,
+            target_url=target_url,
         )
         if result == "gone":
             delete_push_subscriptions(

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -131,7 +131,14 @@ def _run_per_user_briefings() -> None:
                     "Per-user briefing: complete for user_id=%s id=%s", user_id, result.get("id")
                 )
                 try:
-                    send_push_for_user(user_id, "Your daily brief is ready", "")
+                    briefing_id = result.get("id")
+                    target_url = f"/briefs/{briefing_id}" if briefing_id is not None else None
+                    send_push_for_user(
+                        user_id,
+                        "Your daily brief is ready",
+                        "",
+                        target_url=target_url,
+                    )
                 except Exception:
                     logger.exception(
                         "Per-user briefing: push notification failed for user_id=%s", user_id

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -160,6 +160,66 @@ def test_send_push_notification_calls_webpush(monkeypatch: pytest.MonkeyPatch) -
     assert call_kwargs["vapid_claims"]["sub"] == "mailto:test@example.com"
 
 
+def test_send_push_notification_payload_without_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    import news_dashboard.push as push_mod
+
+    monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
+
+    mock_webpush = MagicMock()
+
+    class _FakeWebPushError(Exception):
+        pass
+
+    fake_module: dict[str, Any] = {
+        "webpush": mock_webpush,
+        "WebPushException": _FakeWebPushError,
+    }
+    with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
+        push_mod.send_push_notification(
+            endpoint="https://ep.example.com",
+            p256dh="abc",
+            auth="xyz",
+            title="T",
+            body="B",
+        )
+
+    payload = json.loads(mock_webpush.call_args.kwargs["data"])
+    assert payload == {"title": "T", "body": "B"}
+    assert "url" not in payload
+
+
+def test_send_push_notification_payload_with_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    import news_dashboard.push as push_mod
+
+    monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
+
+    mock_webpush = MagicMock()
+
+    class _FakeWebPushError(Exception):
+        pass
+
+    fake_module: dict[str, Any] = {
+        "webpush": mock_webpush,
+        "WebPushException": _FakeWebPushError,
+    }
+    with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
+        push_mod.send_push_notification(
+            endpoint="https://ep.example.com",
+            p256dh="abc",
+            auth="xyz",
+            title="T",
+            body="B",
+            target_url="/briefs/42",
+        )
+
+    payload = json.loads(mock_webpush.call_args.kwargs["data"])
+    assert payload == {"title": "T", "body": "B", "url": "/briefs/42"}
+
+
 def test_send_push_notification_logs_on_webpush_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/frontend/src/__tests__/pushHandler.test.ts
+++ b/frontend/src/__tests__/pushHandler.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+/**
+ * Unit tests for the push-handler.js service worker logic.
+ *
+ * We load the JS file in a mocked service worker global context and verify
+ * that push payloads are handled correctly and notification clicks route to
+ * the right URL.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createContext, runInContext } from 'node:vm';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Minimal SW global mocks ────────────────────────────────────────────────────
+
+type EventHandler = (event: MockEvent) => void;
+
+interface MockEvent {
+  type: string;
+  data?: { json: () => unknown };
+  notification?: { close: () => void; data?: { url?: string } };
+  waitUntil: (p: Promise<unknown>) => void;
+}
+
+const handlers: Record<string, EventHandler[]> = {};
+
+const mockSelf = {
+  addEventListener(type: string, handler: EventHandler) {
+    if (!handlers[type]) handlers[type] = [];
+    handlers[type].push(handler);
+  },
+  registration: {
+    showNotification: vi.fn().mockResolvedValue(undefined),
+  },
+};
+
+const mockClients = {
+  matchAll: vi.fn(),
+  openWindow: vi.fn().mockResolvedValue(null),
+};
+
+// Install globals before loading the script
+Object.assign(globalThis, {
+  self: mockSelf,
+  clients: mockClients,
+});
+
+// Load the push handler script once
+const handlerCode = readFileSync(resolve(process.cwd(), 'public/push-handler.js'), 'utf-8');
+
+// Execute the service worker script in an isolated VM context with our mocks.
+const ctx = createContext({ self: mockSelf, clients: mockClients });
+runInContext(handlerCode, ctx);
+
+function fireEvent(type: string, event: MockEvent): void {
+  for (const h of handlers[type] ?? []) h(event);
+}
+
+function makePushEvent(payload: unknown): MockEvent {
+  return {
+    type: 'push',
+    data: { json: () => payload },
+    waitUntil: vi.fn(),
+  };
+}
+
+function makeNotificationClickEvent(notificationData: { url?: string }): MockEvent {
+  return {
+    type: 'notificationclick',
+    notification: { close: vi.fn(), data: notificationData },
+    waitUntil: vi.fn(),
+  };
+}
+
+// ── push event tests ───────────────────────────────────────────────────────────
+
+describe('push event — payload handling', () => {
+  beforeEach(() => {
+    mockSelf.registration.showNotification.mockClear();
+  });
+
+  it('shows notification with title and body from payload', () => {
+    const ev = makePushEvent({ title: 'Hello', body: 'World', url: '/briefs/99' });
+    fireEvent('push', ev);
+    expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+      'Hello',
+      expect.objectContaining({ body: 'World', data: { url: '/briefs/99' } })
+    );
+  });
+
+  it('uses default title and body when payload has none', () => {
+    const ev = makePushEvent({});
+    fireEvent('push', ev);
+    expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+      'Daily Brief',
+      expect.objectContaining({ body: 'Your daily brief is ready.' })
+    );
+  });
+
+  it('stores / in notification data when no url in payload', () => {
+    const ev = makePushEvent({ title: 'T', body: 'B' });
+    fireEvent('push', ev);
+    expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+      'T',
+      expect.objectContaining({ data: { url: '/' } })
+    );
+  });
+
+  it('rejects external URL in payload and falls back to /', () => {
+    const ev = makePushEvent({ title: 'T', body: 'B', url: 'https://evil.example.com/' });
+    fireEvent('push', ev);
+    expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+      'T',
+      expect.objectContaining({ data: { url: '/' } })
+    );
+  });
+});
+
+// ── notificationclick event tests ─────────────────────────────────────────────
+
+describe('notificationclick — URL routing', () => {
+  beforeEach(() => {
+    mockClients.matchAll.mockClear();
+    mockClients.openWindow.mockClear();
+  });
+
+  it('opens the target URL when no matching window exists', async () => {
+    mockClients.matchAll.mockResolvedValue([]);
+    const ev = makeNotificationClickEvent({ url: '/briefs/42' });
+    fireEvent('notificationclick', ev);
+    await (ev.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(mockClients.openWindow).toHaveBeenCalledWith('/briefs/42');
+  });
+
+  it('focuses an existing client whose URL ends with the target', async () => {
+    const focusMock = vi.fn().mockResolvedValue(null);
+    mockClients.matchAll.mockResolvedValue([
+      { url: 'http://localhost/briefs/42', focus: focusMock },
+    ]);
+    const ev = makeNotificationClickEvent({ url: '/briefs/42' });
+    fireEvent('notificationclick', ev);
+    await (ev.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(focusMock).toHaveBeenCalled();
+    expect(mockClients.openWindow).not.toHaveBeenCalled();
+  });
+
+  it('falls back to / when notification has no url data', async () => {
+    mockClients.matchAll.mockResolvedValue([]);
+    const ev = makeNotificationClickEvent({});
+    fireEvent('notificationclick', ev);
+    await (ev.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(mockClients.openWindow).toHaveBeenCalledWith('/');
+  });
+});

--- a/public/push-handler.js
+++ b/public/push-handler.js
@@ -1,12 +1,21 @@
 /* Push notification event handlers — imported by the Workbox-generated SW. */
 
+/** Return url if it is a same-origin relative path starting with /, otherwise '/'. */
+function _safeUrl(url) {
+  if (typeof url !== 'string' || url === '') return '/';
+  if (url === '/' || /^\/[^/]/.test(url)) return url;
+  return '/';
+}
+
 self.addEventListener('push', function (event) {
   let title = 'Daily Brief';
   let body = 'Your daily brief is ready.';
+  let targetUrl = '/';
   try {
     const data = event.data ? event.data.json() : {};
     if (data.title) title = data.title;
     if (data.body) body = data.body;
+    if (data.url) targetUrl = _safeUrl(data.url);
   } catch {
     // keep defaults if payload is not valid JSON
   }
@@ -17,24 +26,29 @@ self.addEventListener('push', function (event) {
       badge: '/icons/icon-monochrome-512.png',
       tag: 'daily-brief',
       renotify: true,
+      data: { url: targetUrl },
     })
   );
 });
 
 self.addEventListener('notificationclick', function (event) {
   event.notification.close();
+  const targetUrl = _safeUrl(
+    event.notification.data && event.notification.data.url
+      ? event.notification.data.url
+      : '/'
+  );
   event.waitUntil(
     clients
       .matchAll({ type: 'window', includeUncontrolled: true })
       .then(function (windowClients) {
         for (const client of windowClients) {
-          if ('focus' in client) {
-            client.focus();
-            return;
+          if (client.url.endsWith(targetUrl) && 'focus' in client) {
+            return client.focus();
           }
         }
         if (clients.openWindow) {
-          return clients.openWindow('/');
+          return clients.openWindow(targetUrl);
         }
       })
   );


### PR DESCRIPTION
## Summary

- Extends `send_push_notification()` and `send_push_for_user()` with an optional `target_url` parameter; when set, it is included in the JSON push payload as `url`
- The per-user briefing scheduler now passes `/briefs/{id}` as `target_url` when a briefing ID is available
- Updates `public/push-handler.js` to extract `data.url` from the push payload, store it in `notification.data`, and route notification clicks to that URL (focusing an existing matching client, or opening the URL); validates the URL is a relative same-origin path; falls back to `/` for missing or external URLs

## Test results

- Backend: 19/19 push notification tests pass (`pytest backend/tests/test_push_notifications.py`)
- Frontend: 478/478 tests pass including 7 new SW unit tests (`npm run test:frontend`)
- All pre-commit hooks pass (ruff, mypy, ty, pyrefly, eslint, prettier, tsc)

Note: pre-push hook `pytest (backend)` fails due to pre-existing unrelated test ordering issues in `test_briefings_db.py` and `test_recommendation_recalc.py`; CI should be authoritative.

Closes #373