### PR TITLE
docs: align runtime contract docs with PostgreSQL (#375)

### DIFF
--- a/deploy/news.lihor.ro.caddyfile.disabled
+++ b/deploy/news.lihor.ro.caddyfile.disabled
@@ -1,5 +1,5 @@
 # Staged only. Do not import/reload until news.lihor.ro DNS resolves.
-# Add basic_auth before public exposure.
+# Authentication is enforced by the app before public exposure.
 
 news.lihor.ro {
   encode zstd gzip

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ The system is not a large microservice platform. It is best understood as a modu
 - `news-dashboard`: the FastAPI backend, which also serves the built React frontend in container and Kubernetes deployments.
 - `postgres`: the durable production database.
 - `news-dashboard-ingest`: a Kubernetes CronJob batch workload that runs ingestion on a schedule.
-- Optional external integrations: RSS/Atom feeds, a scraped Anthropic News page, SMTP, GHCR, GitHub Actions, and host-level Caddy.
+- Optional external integrations: RSS/Atom feeds, a scraped Anthropic News page, SMTP, GHCR, GitHub Actions, Keycloak SSO, and host-level Caddy.
 
 ## Database Contract
 
@@ -35,7 +35,8 @@ flowchart TB
   end
 
   subgraph Kubernetes["Kubernetes via Helm"]
-    Caddy["Host Caddy<br/>news.lihor.ro<br/>Basic Auth"]
+    Caddy["Host Caddy<br/>news.lihor.ro<br/>reverse proxy"]
+    Keycloak["Keycloak<br/>optional SSO under /keycloak"]
     Service["K8s Service<br/>NodePort 30088 or ClusterIP"]
     Deployment["news-dashboard Deployment<br/>replicas: 1"]
     CronJob["K8s CronJob<br/>news-dashboard ingest<br/>every 6 hours"]
@@ -56,7 +57,9 @@ flowchart TB
   Vite --> FastAPIDev
   FastAPIDev --> PostgresDev
 
-  User --> Caddy --> Service --> Deployment
+  User --> Caddy
+  Caddy --> Service --> Deployment
+  Caddy --> Keycloak
   Deployment --> App
   App --> PostgresSvc --> Postgres --> PVC
   CronJob --> PostgresSvc
@@ -229,7 +232,7 @@ The database has two main tables:
 - `sources`: source registry and health information, including `last_checked_at`, `last_success_at`, `last_error`, `last_fetched_count`, and `last_inserted_count`.
 - `articles`: normalized article records, including source metadata, category, kind, publication/discovery timestamps, status, importance score, summary, reason, tags, and status-specific timestamps.
 
-PostgreSQL adds a generated `tsvector` column and GIN index. User-facing search uses PostgreSQL-native `ILIKE` filters today, leaving the generated full-text index available for a future ranking pass.
+PostgreSQL adds generated `tsvector` columns and GIN indexes in `backend/news_dashboard/db.py`. User-facing search uses PostgreSQL-native predicates today, with the generated full-text index available for ranked search behavior without adding another runtime database.
 
 ## How It Works
 
@@ -239,11 +242,11 @@ During ingestion, each source is fetched through either `feedparser` for RSS/Ato
 
 The React UI reads articles by status and category, displays summary counts, shows source health, and lets the user update article status. Status changes are persisted through `PATCH /api/articles/{article_id}/status`, and the UI reloads articles and counts afterward. Search calls `/api/search` and returns matching articles across statuses.
 
-For production, GitHub Actions tests the Python backend, builds the frontend, builds a Docker image, pushes it to GHCR, and deploys it on a self-hosted runner with Helm. The host-level Caddy route exposes the Kubernetes NodePort at `news.lihor.ro` and applies Basic Auth outside the app.
+For production, GitHub Actions tests the Python backend, builds the frontend, builds a Docker image, pushes it to GHCR, and deploys it on a self-hosted runner with Helm. The host-level Caddy route exposes the Kubernetes NodePort at `news.lihor.ro` and can also proxy `/keycloak` to the colocated identity provider. Authentication is enforced by the FastAPI app through local password sessions or optional Keycloak SSO; see `docs/KEYCLOAK_AUTH.md` and `deploy/news.lihor.ro.caddyfile`.
 
 ## Operational Notes
 
 - PostgreSQL is required in every runtime environment. SQLite is only a legacy migration input for importing old local data into PostgreSQL.
 - The React app is served separately only in local development. In the production image, the built frontend is served by FastAPI.
 - There are two scheduling mechanisms: in-process APScheduler and the Kubernetes CronJob. If duplicate ingestion is undesirable, configure one of them as the authoritative scheduler.
-- Authentication is handled outside the app by host-level Caddy Basic Auth, according to the repository deployment notes.
+- Authentication is handled by the app. Local password login is always part of the app model, and production can enable Keycloak SSO with `KEYCLOAK_AUTH_ENABLED=1` plus the related `KEYCLOAK_*` settings documented in `README.md` and `docs/KEYCLOAK_AUTH.md`.

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -101,11 +101,12 @@ After ≥ 100 saved/read articles exist:
 - Fetch full article body for saved/read articles (via Trafilatura or goose3).
 - Run FTS over full_text when available.
 
-### Embeddings / vector search (v1.2)
+### Embeddings / semantic search (v1.2)
 
-- Embed title + summary via OpenAI.
-- Store in the `articles` table as a `BYTEA` column.
-- Enables semantic search and similarity grouping.
+- Embed title + summary via the configured OpenAI-compatible embeddings provider.
+- Store embeddings in PostgreSQL-managed article data structures; runtime storage remains PostgreSQL only.
+- Enables semantic search and similarity grouping without adding a second runtime database.
+- Configure with feature-specific variables such as `OPENAI_EMBEDDINGS_API_KEY`, `OPENAI_EMBEDDINGS_BASE_URL`, and `OPENAI_EMBEDDING_MODEL`; see `README.md` and `backend/news_dashboard/embeddings.py`.
 
 ### Ask Clau endpoint (v1.3)
 
@@ -125,16 +126,17 @@ Implementation:
 4. Return answer + article IDs used as citations.
 
 Privacy/security:
-- Endpoint is internal-only (behind Caddy basic_auth).
-- No article content is sent to external APIs unless the user explicitly enables the AI hook.
+- Endpoint requires the app authentication boundary, either local password sessions or optional Keycloak SSO.
+- No article content is sent to external APIs unless the relevant AI feature is configured with an API key.
 - OpenAI API key stored as an environment secret, never in source.
-- The AI hook is behind an `AI_ENABLED=1` env flag — disabled by default.
+- Briefing generation can use `OPENAI_BRIEFING_API_KEY`, `OPENAI_BRIEFING_BASE_URL`, and `OPENAI_BRIEFING_MODEL`; see `README.md` and `backend/news_dashboard/briefings.py`.
 
 ### Privacy/security boundaries
 
-- No article content leaves the server unless `AI_ENABLED=1` is set.
+- No article content leaves the server unless the relevant feature-specific AI provider variables are configured.
 - Search index uses PostgreSQL full-text search.
-- Caddy basic_auth is the only authentication layer at v1.
+- Local password auth is built into the app, and production can enable Keycloak SSO while preserving local `user_id` authorization boundaries. See `docs/KEYCLOAK_AUTH.md`.
+- Caddy is a reverse proxy for the app and Keycloak paths, not the primary authentication layer.
 
 ## Deployment
 


### PR DESCRIPTION
Closes #375

## Summary
- Updated the product spec to describe PostgreSQL-backed search/semantic search and feature-specific AI configuration instead of stale global AI/runtime assumptions.
- Updated architecture docs to show Caddy as a reverse proxy and app/local-password plus optional Keycloak auth as the authentication boundary.
- Removed the stale disabled Caddy sample comment that still suggested basic_auth before public exposure.

## Test results
- `rg -n "SQLite FTS5|SQLite-VSS|AI_ENABLED|Caddy Basic Auth|basic_auth" README.md docs deploy backend/news_dashboard helm` (no matches)
- `git diff --check`
- pre-commit/pre-push hooks: passed; code checks skipped because this is docs-only

🤖 Generated with [Codex](https://openai.com/codex)