### PR TITLE
ops: split liveness and readiness health endpoints (closes #378)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -239,6 +239,21 @@ def health() -> dict[str, Any]:
     return {"status": "ok"}
 
 
+@public_router.get("/api/live")
+def liveness() -> dict[str, Any]:
+    return {"status": "ok"}
+
+
+@public_router.get("/api/ready")
+def readiness() -> dict[str, Any]:
+    try:
+        with connect() as conn:
+            conn.execute("SELECT 1")
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail="database unavailable") from exc
+    return {"status": "ok"}
+
+
 @public_router.get("/api/auth/config")
 def auth_config() -> dict[str, Any]:
     return keycloak_auth_metadata()

--- a/backend/tests/test_health_endpoints.py
+++ b/backend/tests/test_health_endpoints.py
@@ -1,0 +1,54 @@
+"""Tests for /api/live and /api/ready health probe endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import app
+
+
+def _client() -> TestClient:
+    app.dependency_overrides.clear()
+    return TestClient(app, follow_redirects=False)
+
+
+def test_live_returns_200_without_db() -> None:
+    with patch("news_dashboard.main.connect") as mock_connect:
+        resp = _client().get("/api/live")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    mock_connect.assert_not_called()
+
+
+def test_ready_returns_200_when_db_ok() -> None:
+    @contextmanager
+    def fake_connect() -> Iterator[object]:
+        class _Conn:
+            def execute(self, sql: str) -> None:
+                pass
+
+        yield _Conn()
+
+    with patch("news_dashboard.main.connect", fake_connect):
+        resp = _client().get("/api/ready")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_ready_returns_503_when_db_unavailable() -> None:
+    @contextmanager
+    def broken_connect() -> Iterator[object]:
+        class _BrokenConn:
+            def execute(self, sql: str) -> None:  # noqa: ARG002
+                msg = "connection refused"
+                raise OSError(msg)
+
+        yield _BrokenConn()
+
+    with patch("news_dashboard.main.connect", broken_connect):
+        resp = _client().get("/api/ready")
+    assert resp.status_code == 503

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -179,13 +179,13 @@ spec:
               name: http
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: /api/ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: /api/live
               port: http
             initialDelaySeconds: 15
             periodSeconds: 20


### PR DESCRIPTION
## Summary

- Adds `GET /api/live`: lightweight process-level probe that never touches PostgreSQL, always returns `200 {"status":"ok"}`
- Adds `GET /api/ready`: verifies PostgreSQL connectivity via `SELECT 1`, returns `200` on success and `503` when the database is unreachable
- Updates Helm `deployment.yaml` to point liveness probe at `/api/live` and readiness probe at `/api/ready`
- Keeps `/api/health` unchanged for backward compatibility

## Test results

3 new unit tests in `backend/tests/test_health_endpoints.py` — all pass:
- `test_live_returns_200_without_db` — confirms `connect()` is never called by `/api/live`
- `test_ready_returns_200_when_db_ok` — confirms `200` when `SELECT 1` succeeds
- `test_ready_returns_503_when_db_unavailable` — confirms `503` when the database raises

All linting (ruff), type checks (mypy, ty, pyrefly), and new tests pass cleanly.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)