### PR TITLE
ci: enforce auto-merge on all non-draft PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,34 @@
+name: Auto-merge
+
+# Repo policy: every PR uses auto-merge. When a non-draft PR is opened, reopened,
+# or marked ready for review, enable squash auto-merge so it lands the moment the
+# required checks pass — no manual merge step. Branch protection on `main` (the
+# `Lint & typecheck` and `Test & build` checks) still gates the actual merge, so
+# this never merges anything that isn't green.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, ready_for_review]
+
+# Least privilege: enabling auto-merge needs to write the PR and the merge ref.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge
+    # Draft PRs are works in progress — don't queue them to merge.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
Closes #419

## Summary

Adds `.github/workflows/auto-merge.yml`, which enables squash auto-merge on every non-draft PR (`opened`, `reopened`, `ready_for_review`). PRs now land automatically the moment the required checks pass, with no manual merge step.

Branch protection on `main` (the `Lint & typecheck` and `Test & build` checks) still gates the actual merge, so nothing merges that isn't green. The repo already has `allow_auto_merge` enabled, so no settings change is needed. Uses least-privilege permissions (`contents: write`, `pull-requests: write`).

This complements the `tdd-ship` skill update (which has agents set `--auto` themselves); the workflow is the repo-level backstop.

## Testing

CI-config change. Validated by this very PR: once required checks go green it should auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)