### PR TITLE
fix: use briefing AI credentials for podcast script generation (#403)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1231,6 +1231,8 @@ def generate_podcast_endpoint(
             try:
                 script = generate_podcast_script(content_dict)
                 update_briefing_script(briefing_id, script)
+            except TTSNotConfiguredError as exc:
+                raise HTTPException(status_code=501, detail=str(exc)) from exc
             except Exception as exc:
                 raise HTTPException(
                     status_code=500, detail=f"Failed to generate podcast script: {exc}"

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -41,6 +41,27 @@ def _tts_ai_config() -> tuple[str, str | None]:
     return api_key, base_url
 
 
+def _script_ai_config() -> tuple[str, str | None]:
+    """Resolve the (api_key, base_url) for podcast script (LLM chat) generation.
+
+    Script generation is a chat-completion call, so it uses the same
+    briefing AI credentials (``OPENAI_BRIEFING_API_KEY`` /
+    ``OPENAI_BRIEFING_BASE_URL``) as every other LLM feature, falling back to
+    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL``. This is intentionally separate
+    from ``_tts_ai_config`` because the free LLM gateway supports chat
+    completions but not the ``audio/speech`` endpoint required for TTS.
+    """
+    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = (
+            "Podcast script generation requires an API key. "
+            "Set OPENAI_BRIEFING_API_KEY or OPENAI_API_KEY"
+        )
+        raise TTSNotConfiguredError(msg)
+    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    return api_key, base_url
+
+
 def _data_dir() -> Path:
     return Path(os.getenv("DATA_DIR", str(_DEFAULT_DATA_DIR)))
 
@@ -179,7 +200,7 @@ _PODCAST_SYSTEM_PROMPT = (
 
 def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, str]]:
     """Generate a conversational podcast script from briefing content using LLM."""
-    api_key, base_url = _tts_ai_config()
+    api_key, base_url = _script_ai_config()
 
     from news_dashboard.ai_client import chat_create, get_openai_client
 

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -14,6 +14,7 @@ import pytest
 from news_dashboard.tts import (
     TTSNotConfiguredError,
     _build_text,
+    _script_ai_config,
     _tts_ai_config,
     generate_audio,
     generate_podcast_audio,
@@ -243,6 +244,42 @@ def test_generate_audio_creates_audio_directory(tmp_path: Path) -> None:
     assert path.exists()
 
 
+# ── _script_ai_config ─────────────────────────────────────────────────────────
+
+
+def test_script_ai_config_uses_briefing_specific_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_BRIEFING_API_KEY", "sk-briefing")
+    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gw:9130/v1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    api_key, base_url = _script_ai_config()
+
+    assert api_key == "sk-briefing"
+    assert base_url == "http://briefing-gw:9130/v1"
+
+
+def test_script_ai_config_falls_back_to_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
+    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+
+    api_key, base_url = _script_ai_config()
+
+    assert api_key == "sk-shared"
+    assert base_url is None
+
+
+def test_script_ai_config_raises_when_no_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(TTSNotConfiguredError):
+        _script_ai_config()
+
+
+# ── generate_podcast_script ───────────────────────────────────────────────────
+
+
 def test_generate_podcast_script() -> None:
     mock_response = MagicMock()
     mock_response.choices = [
@@ -258,7 +295,7 @@ def test_generate_podcast_script() -> None:
         )
     ]
     with (
-        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch.dict("os.environ", {"OPENAI_BRIEFING_API_KEY": "sk-briefing"}),
         patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
     ):
         script = generate_podcast_script(
@@ -275,6 +312,16 @@ def test_generate_podcast_script() -> None:
     assert script[1]["speaker"] == "Taylor"
     assert script[1]["voice"] == "shimmer"
     assert script[1]["text"] == "Hi Alex!"
+
+
+def test_generate_podcast_script_raises_when_no_briefing_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(TTSNotConfiguredError):
+        generate_podcast_script({"title": "T", "summary": "S", "sections": []})
 
 
 def test_generate_podcast_audio(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `generate_podcast_script` was calling `_tts_ai_config()` which reads `OPENAI_TTS_API_KEY`/`OPENAI_API_KEY`. This is wrong because script generation is a chat-completion (LLM) call, not a TTS call — it should use the briefing credentials that can target the free LLM gateway.
- Added `_script_ai_config()` in `tts.py` that reads `OPENAI_BRIEFING_API_KEY`/`OPENAI_BRIEFING_BASE_URL`, mirroring the pattern from `briefings.py`.
- Updated the podcast endpoint in `main.py` to catch `TTSNotConfiguredError` from the script step and return 501 instead of 500.

## Test results

All 19 TTS tests pass and all 31 briefings API tests pass locally:
- `test_script_ai_config_uses_briefing_specific_key` ✓
- `test_script_ai_config_falls_back_to_openai_key` ✓
- `test_script_ai_config_raises_when_no_key` ✓
- `test_generate_podcast_script` (updated to use `OPENAI_BRIEFING_API_KEY`) ✓
- `test_generate_podcast_script_raises_when_no_briefing_key` ✓

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)