### PR TITLE
fix: route body extraction through briefing gateway (#319)

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -28,13 +28,21 @@ _AI_PROMPT = (
 )
 
 
+def _body_ai_config() -> tuple[str, str | None, str]:
+    """Resolve (api_key, base_url, model) for AI body extraction."""
+    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    model = os.getenv("OPENAI_BRIEFING_MODEL", _AI_MODEL)
+    return api_key or "", base_url, model
+
+
 def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]:
-    """Fallback: fetch raw HTML via httpx and extract body text via OpenAI.
+    """Fallback: fetch raw HTML via httpx and extract body text via AI.
 
     Returns (text, 'ok') on success or ('', 'error') if OPENAI_API_KEY is
     absent, the HTTP fetch fails, or the AI call fails.
     """
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key, base_url, model = _body_ai_config()
     if not api_key:
         return "", "error"
 
@@ -55,13 +63,13 @@ def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]
     try:
         from news_dashboard.ai_client import chat_create, get_openai_client
 
-        client = get_openai_client(api_key=api_key)
+        client = get_openai_client(api_key=api_key, base_url=base_url)
         result = chat_create(
             client,
             name="ai-body-fetch",
             tags=["body-fetch"],
             user_id=user_id,
-            model=_AI_MODEL,
+            model=model,
             messages=[{"role": "user", "content": f"{_AI_PROMPT}\n\n{html}"}],
             max_tokens=2048,
         )

--- a/backend/tests/test_user_attribution.py
+++ b/backend/tests/test_user_attribution.py
@@ -247,6 +247,54 @@ def test_ai_extract_body_passes_none_user_id_by_default() -> None:
     assert mock_cc.call_args.kwargs["user_id"] is None
 
 
+def test_ai_extract_body_uses_briefing_gateway_config() -> None:
+    from news_dashboard.body_fetch import _ai_extract_body
+
+    mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
+    mock_http_response = MagicMock()
+    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "sk-openai",
+                "OPENAI_BRIEFING_API_KEY": "sk-gateway",
+                "OPENAI_BRIEFING_BASE_URL": "http://gateway:9130/v1",
+                "OPENAI_BRIEFING_MODEL": "gateway-chat-model",
+            },
+        ),
+        patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+        patch("httpx.get", return_value=mock_http_response),
+    ):
+        _ai_extract_body("https://example.com/article")
+
+    mock_client_factory.assert_called_once_with(
+        api_key="sk-gateway", base_url="http://gateway:9130/v1"
+    )
+    assert mock_cc.call_args.kwargs["model"] == "gateway-chat-model"
+
+
+def test_ai_extract_body_falls_back_to_openai_when_gateway_unset() -> None:
+    from news_dashboard.body_fetch import _ai_extract_body
+
+    mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
+    mock_http_response = MagicMock()
+    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-openai"}, clear=True),
+        patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
+        patch("news_dashboard.ai_client.chat_create", new=mock_cc),
+        patch("httpx.get", return_value=mock_http_response),
+    ):
+        _ai_extract_body("https://example.com/article")
+
+    mock_client_factory.assert_called_once_with(api_key="sk-openai", base_url=None)
+    assert mock_cc.call_args.kwargs["model"] == "gpt-4o-mini"
+
+
 # ── briefings: generation threads user_id ─────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #319

## Summary
- route AI body extraction through the briefing gateway API key/base URL when configured
- reuse the briefing model override so body extraction can target gateway-served models
- preserve OpenAI fallback when no gateway configuration is present

## Tests
- pytest backend/tests/test_user_attribution.py -k 'ai_extract_body'
- make lint
- make typecheck
- npm run build --silent
- source .env && make test (fails locally: 958 passed, 5 failed because PostgreSQL could not resize shared memory segments with `No space left on device` while querying information_schema)

Generated by codex automation.