### PR TITLE
test: fix BackgroundScheduler thread leak from unclosed TestClients (#338)

### DIFF
--- a/backend/tests/test_auth_extra.py
+++ b/backend/tests/test_auth_extra.py
@@ -102,8 +102,8 @@ def test_verify_session_token_rejects_garbage(monkeypatch: pytest.MonkeyPatch) -
 def test_me_rejects_invalid_session_cookie(tmp_db: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEST_SESSION_SECRET", "x" * 32)
     app.dependency_overrides.clear()
-    client = TestClient(app)
-    resp = client.get("/api/auth/me", cookies={"nd_session": "tampered"})
+    with TestClient(app) as client:
+        resp = client.get("/api/auth/me", cookies={"nd_session": "tampered"})
     assert resp.status_code == 401
 
 
@@ -114,8 +114,8 @@ def test_me_rejects_when_user_missing(tmp_db: str, monkeypatch: pytest.MonkeyPat
     from news_dashboard.auth import create_session_token
 
     token = create_session_token(999999, is_admin=False)
-    client = TestClient(app)
-    resp = client.get("/api/auth/me", cookies={"nd_session": token})
+    with TestClient(app) as client:
+        resp = client.get("/api/auth/me", cookies={"nd_session": token})
     assert resp.status_code == 401
 
 
@@ -206,61 +206,63 @@ def test_exchange_success_creates_user(tmp_db: str, monkeypatch: pytest.MonkeyPa
 
 def test_admin_get_user_found_and_missing(tmp_db: str) -> None:
     created = create_user("dora", "pw123456", email="dora@example.com")
-    client = TestClient(app)
-    ok = client.get(f"/api/admin/users/{created['id']}")
-    assert ok.status_code == 200
-    assert ok.json()["username"] == "dora"
-    missing = client.get("/api/admin/users/987654")
-    assert missing.status_code == 404
+    with TestClient(app) as client:
+        ok = client.get(f"/api/admin/users/{created['id']}")
+        assert ok.status_code == 200
+        assert ok.json()["username"] == "dora"
+        missing = client.get("/api/admin/users/987654")
+        assert missing.status_code == 404
 
 
 def test_admin_update_password_found_and_missing(tmp_db: str) -> None:
     created = create_user("evan", "pw123456")
-    client = TestClient(app)
-    ok = client.patch(f"/api/admin/users/{created['id']}/password", json={"password": "newpass123"})
-    assert ok.status_code == 200
-    assert ok.json()["status"] == "updated"
-    missing = client.patch("/api/admin/users/987654/password", json={"password": "newpass123"})
-    assert missing.status_code == 404
+    with TestClient(app) as client:
+        ok = client.patch(
+            f"/api/admin/users/{created['id']}/password", json={"password": "newpass123"}
+        )
+        assert ok.status_code == 200
+        assert ok.json()["status"] == "updated"
+        missing = client.patch("/api/admin/users/987654/password", json={"password": "newpass123"})
+        assert missing.status_code == 404
 
 
 def test_admin_create_user_conflict_on_duplicate(tmp_db: str) -> None:
-    client = TestClient(app)
-    first = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
-    assert first.status_code == 200
-    dup = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
-    assert dup.status_code == 409
+    with TestClient(app) as client:
+        first = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
+        assert first.status_code == 200
+        dup = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
+        assert dup.status_code == 409
 
 
 def test_admin_generate_user_returns_credentials(tmp_db: str) -> None:
-    client = TestClient(app)
-    resp = client.post("/api/admin/users/generate", json={"username": "grace"})
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["username"] == "grace"
-    assert body["is_admin"] is False
-    # The generated password is returned once and must actually log the user in.
-    assert isinstance(body["password"], str)
-    assert len(body["password"]) >= 12
-    login = client.post(
-        "/api/auth/login",
-        json={"username": "grace", "password": body["password"]},
-    )
-    assert login.status_code == 200
+    with TestClient(app) as client:
+        resp = client.post("/api/admin/users/generate", json={"username": "grace"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["username"] == "grace"
+        assert body["is_admin"] is False
+        # The generated password is returned once and must actually log the user in.
+        assert isinstance(body["password"], str)
+        assert len(body["password"]) >= 12
+        login = client.post(
+            "/api/auth/login",
+            json={"username": "grace", "password": body["password"]},
+        )
+        assert login.status_code == 200
 
 
 def test_admin_generate_user_rejects_blank_username(tmp_db: str) -> None:
-    client = TestClient(app)
-    resp = client.post("/api/admin/users/generate", json={"username": "   "})
-    assert resp.status_code == 422
+    with TestClient(app) as client:
+        resp = client.post("/api/admin/users/generate", json={"username": "   "})
+        assert resp.status_code == 422
 
 
 def test_admin_generate_user_conflict_on_duplicate(tmp_db: str) -> None:
-    client = TestClient(app)
-    first = client.post("/api/admin/users/generate", json={"username": "heidi"})
-    assert first.status_code == 200
-    dup = client.post("/api/admin/users/generate", json={"username": "heidi"})
-    assert dup.status_code == 409
+    with TestClient(app) as client:
+        first = client.post("/api/admin/users/generate", json={"username": "heidi"})
+        assert first.status_code == 200
+        dup = client.post("/api/admin/users/generate", json={"username": "heidi"})
+        assert dup.status_code == 409
 
 
 def test_admin_generate_user_uses_keycloak_when_enabled(
@@ -277,8 +279,8 @@ def test_admin_generate_user_uses_keycloak_when_enabled(
         return {"id": "kc-1", "username": username, "email": None, "temporary": True}
 
     monkeypatch.setattr("news_dashboard.keycloak_admin.create_keycloak_user", fake_create)
-    client = TestClient(app)
-    resp = client.post("/api/admin/users/generate", json={"username": "ivan"})
+    with TestClient(app) as client:
+        resp = client.post("/api/admin/users/generate", json={"username": "ivan"})
     assert resp.status_code == 200
     body = resp.json()
     assert body["provider"] == "keycloak"

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -13,10 +13,12 @@ actual psycopg %s parameterisation, JSONB round-trip, and NULLS LAST ordering.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 import news_dashboard.main as main_mod
@@ -24,7 +26,12 @@ from news_dashboard.briefings import BriefingAINotConfiguredError, BriefingGener
 from news_dashboard.db import POSTGRES_SCHEMA
 from news_dashboard.main import app
 
-client = TestClient(app, raise_server_exceptions=True)
+
+@pytest.fixture
+def client() -> Generator[TestClient]:
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
 
 # ── Test fixtures ─────────────────────────────────────────────────────────────
 
@@ -109,7 +116,7 @@ def test_briefing_articles_table_columns() -> None:
 # ── GET /api/briefings/latest — empty state ───────────────────────────────────
 
 
-def test_latest_empty_state_when_no_briefing(monkeypatch: Any) -> None:
+def test_latest_empty_state_when_no_briefing(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "get_latest_briefing", lambda **_: None)
     resp = client.get("/api/briefings/latest")
     assert resp.status_code == 200
@@ -119,7 +126,7 @@ def test_latest_empty_state_when_no_briefing(monkeypatch: Any) -> None:
 # ── GET /api/briefings/latest — with a saved briefing ────────────────────────
 
 
-def test_latest_returns_briefing_metadata(monkeypatch: Any) -> None:
+def test_latest_returns_briefing_metadata(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "get_latest_briefing", lambda **_: dict(_SAMPLE_BRIEFING))
     resp = client.get("/api/briefings/latest")
     assert resp.status_code == 200
@@ -129,7 +136,7 @@ def test_latest_returns_briefing_metadata(monkeypatch: Any) -> None:
     assert data["status"] == "complete"
 
 
-def test_latest_returns_structured_content(monkeypatch: Any) -> None:
+def test_latest_returns_structured_content(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "get_latest_briefing", lambda **_: dict(_SAMPLE_BRIEFING))
     resp = client.get("/api/briefings/latest")
     data = resp.json()
@@ -139,7 +146,7 @@ def test_latest_returns_structured_content(monkeypatch: Any) -> None:
     assert data["content"]["worth_opening"] == [42]
 
 
-def test_latest_returns_cited_article_metadata(monkeypatch: Any) -> None:
+def test_latest_returns_cited_article_metadata(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "get_latest_briefing", lambda **_: dict(_SAMPLE_BRIEFING))
     resp = client.get("/api/briefings/latest")
     data = resp.json()
@@ -156,7 +163,7 @@ def test_latest_returns_cited_article_metadata(monkeypatch: Any) -> None:
 # ── GET /api/briefings — history list ────────────────────────────────────────
 
 
-def test_list_returns_items_key(monkeypatch: Any) -> None:
+def test_list_returns_items_key(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "list_briefings", lambda **_: [dict(_SAMPLE_LIST_ITEM)])
     resp = client.get("/api/briefings")
     assert resp.status_code == 200
@@ -166,14 +173,14 @@ def test_list_returns_items_key(monkeypatch: Any) -> None:
     assert data["items"][0]["id"] == 1
 
 
-def test_list_empty_when_no_briefings(monkeypatch: Any) -> None:
+def test_list_empty_when_no_briefings(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "list_briefings", lambda **_: [])
     resp = client.get("/api/briefings")
     assert resp.status_code == 200
     assert resp.json() == {"items": []}
 
 
-def test_list_items_omit_content_blob(monkeypatch: Any) -> None:
+def test_list_items_omit_content_blob(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "list_briefings", lambda **_: [dict(_SAMPLE_LIST_ITEM)])
     resp = client.get("/api/briefings")
     item = resp.json()["items"][0]
@@ -181,7 +188,7 @@ def test_list_items_omit_content_blob(monkeypatch: Any) -> None:
     assert "articles" not in item
 
 
-def test_list_respects_limit_and_offset_params(monkeypatch: Any) -> None:
+def test_list_respects_limit_and_offset_params(client: TestClient, monkeypatch: Any) -> None:
     captured: dict[str, Any] = {}
 
     def _mock(**kw: Any) -> list[dict[str, Any]]:
@@ -197,7 +204,7 @@ def test_list_respects_limit_and_offset_params(monkeypatch: Any) -> None:
 # ── GET /api/briefings/{id} — detail ─────────────────────────────────────────
 
 
-def test_detail_returns_full_briefing_with_articles(monkeypatch: Any) -> None:
+def test_detail_returns_full_briefing_with_articles(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: dict(_SAMPLE_BRIEFING))
     resp = client.get("/api/briefings/1")
     assert resp.status_code == 200
@@ -207,14 +214,14 @@ def test_detail_returns_full_briefing_with_articles(monkeypatch: Any) -> None:
     assert len(data["articles"]) == 1
 
 
-def test_detail_404_for_missing_briefing(monkeypatch: Any) -> None:
+def test_detail_404_for_missing_briefing(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: None)
     resp = client.get("/api/briefings/9999")
     assert resp.status_code == 404
     assert resp.json()["detail"] == "briefing not found"
 
 
-def test_detail_passes_id_to_backend(monkeypatch: Any) -> None:
+def test_detail_passes_id_to_backend(client: TestClient, monkeypatch: Any) -> None:
     captured: dict[str, Any] = {}
 
     def _mock(bid: int, **_: Any) -> dict[str, Any] | None:
@@ -226,7 +233,7 @@ def test_detail_passes_id_to_backend(monkeypatch: Any) -> None:
     assert captured["bid"] == 7
 
 
-def test_detail_returns_scope_and_time_window(monkeypatch: Any) -> None:
+def test_detail_returns_scope_and_time_window(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: dict(_SAMPLE_BRIEFING))
     resp = client.get("/api/briefings/1")
     data = resp.json()
@@ -235,7 +242,9 @@ def test_detail_returns_scope_and_time_window(monkeypatch: Any) -> None:
     assert data["until_at"] is not None
 
 
-def test_detail_cited_article_has_section_and_citation_index(monkeypatch: Any) -> None:
+def test_detail_cited_article_has_section_and_citation_index(
+    client: TestClient, monkeypatch: Any
+) -> None:
     monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: dict(_SAMPLE_BRIEFING))
     resp = client.get("/api/briefings/1")
     article = resp.json()["articles"][0]
@@ -246,7 +255,7 @@ def test_detail_cited_article_has_section_and_citation_index(monkeypatch: Any) -
 # ── POST /api/briefings — generate ───────────────────────────────────────────
 
 
-def test_create_returns_briefing_on_success(monkeypatch: Any) -> None:
+def test_create_returns_briefing_on_success(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(main_mod, "generate_briefing", lambda **_: dict(_SAMPLE_BRIEFING))
     resp = client.post("/api/briefings")
     assert resp.status_code == 200
@@ -256,14 +265,16 @@ def test_create_returns_briefing_on_success(monkeypatch: Any) -> None:
     assert "articles" in data
 
 
-def test_create_returns_no_candidates_when_no_today_articles(monkeypatch: Any) -> None:
+def test_create_returns_no_candidates_when_no_today_articles(
+    client: TestClient, monkeypatch: Any
+) -> None:
     monkeypatch.setattr(main_mod, "generate_briefing", lambda **_: {"status": "no_candidates"})
     resp = client.post("/api/briefings")
     assert resp.status_code == 200
     assert resp.json() == {"status": "no_candidates"}
 
 
-def test_create_returns_503_when_ai_not_configured(monkeypatch: Any) -> None:
+def test_create_returns_503_when_ai_not_configured(client: TestClient, monkeypatch: Any) -> None:
     def _raise(**_: Any) -> dict[str, Any]:
         msg = "OPENAI_API_KEY not set"
         raise BriefingAINotConfiguredError(msg)
@@ -274,7 +285,7 @@ def test_create_returns_503_when_ai_not_configured(monkeypatch: Any) -> None:
     assert "OPENAI_API_KEY" in resp.json()["detail"]
 
 
-def test_create_returns_500_when_generation_fails(monkeypatch: Any) -> None:
+def test_create_returns_500_when_generation_fails(client: TestClient, monkeypatch: Any) -> None:
     def _raise(**_: Any) -> dict[str, Any]:
         msg = "AI returned invalid JSON"
         raise BriefingGenerationError(msg)
@@ -285,7 +296,9 @@ def test_create_returns_500_when_generation_fails(monkeypatch: Any) -> None:
     assert "invalid JSON" in resp.json()["detail"]
 
 
-def test_create_returns_content_and_articles_on_success(monkeypatch: Any) -> None:
+def test_create_returns_content_and_articles_on_success(
+    client: TestClient, monkeypatch: Any
+) -> None:
     monkeypatch.setattr(main_mod, "generate_briefing", lambda **_: dict(_SAMPLE_BRIEFING))
     resp = client.post("/api/briefings")
     data = resp.json()
@@ -295,7 +308,9 @@ def test_create_returns_content_and_articles_on_success(monkeypatch: Any) -> Non
     assert len(data["articles"]) > 0
 
 
-def test_create_returns_existing_briefing_inside_idempotency_window(monkeypatch: Any) -> None:
+def test_create_returns_existing_briefing_inside_idempotency_window(
+    client: TestClient, monkeypatch: Any
+) -> None:
     existing = dict(_SAMPLE_BRIEFING)
     monkeypatch.setattr(main_mod, "generate_briefing", lambda **_: existing)
     resp = client.post("/api/briefings")
@@ -303,7 +318,7 @@ def test_create_returns_existing_briefing_inside_idempotency_window(monkeypatch:
     assert resp.json()["id"] == existing["id"]
 
 
-def test_generate_podcast_endpoint_success(monkeypatch: Any) -> None:
+def test_generate_podcast_endpoint_success(client: TestClient, monkeypatch: Any) -> None:
     briefing = dict(_SAMPLE_BRIEFING)
     briefing["script"] = None
     monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: briefing)
@@ -326,7 +341,9 @@ def test_generate_podcast_endpoint_success(monkeypatch: Any) -> None:
     assert resp.json() == {"url": "/api/briefings/1/podcast"}
 
 
-def test_get_podcast_audio_endpoint_success(monkeypatch: Any, tmp_path: Path) -> None:
+def test_get_podcast_audio_endpoint_success(
+    client: TestClient, monkeypatch: Any, tmp_path: Path
+) -> None:
     briefing = dict(_SAMPLE_BRIEFING)
     monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: briefing)
 
@@ -340,7 +357,7 @@ def test_get_podcast_audio_endpoint_success(monkeypatch: Any, tmp_path: Path) ->
     assert resp.read() == b"podcast-data"
 
 
-def test_get_podcast_audio_endpoint_not_found(monkeypatch: Any) -> None:
+def test_get_podcast_audio_endpoint_not_found(client: TestClient, monkeypatch: Any) -> None:
     briefing = dict(_SAMPLE_BRIEFING)
     monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: briefing)
 
@@ -358,7 +375,7 @@ def test_get_podcast_audio_endpoint_not_found(monkeypatch: Any) -> None:
 # ── POST /api/briefings/{id}/chat ─────────────────────────────────────────────
 
 
-def test_chat_returns_reply_from_assistant(monkeypatch: Any) -> None:
+def test_chat_returns_reply_from_assistant(client: TestClient, monkeypatch: Any) -> None:
     monkeypatch.setattr(
         main_mod,
         "chat_with_briefing",
@@ -372,7 +389,7 @@ def test_chat_returns_reply_from_assistant(monkeypatch: Any) -> None:
     assert resp.json() == {"reply": "The layoffs were driven by cost cuts."}
 
 
-def test_chat_passes_history_to_backend(monkeypatch: Any) -> None:
+def test_chat_passes_history_to_backend(client: TestClient, monkeypatch: Any) -> None:
     captured: dict[str, Any] = {}
 
     def _fake(briefing_id: int, message: str, history: list[dict[str, str]], **_: Any) -> str:
@@ -396,7 +413,7 @@ def test_chat_passes_history_to_backend(monkeypatch: Any) -> None:
     assert captured["history"] == history
 
 
-def test_chat_returns_404_when_briefing_missing(monkeypatch: Any) -> None:
+def test_chat_returns_404_when_briefing_missing(client: TestClient, monkeypatch: Any) -> None:
     def _raise(*_: Any, **__: Any) -> str:
         msg = "briefing 99 not found"
         raise KeyError(msg)
@@ -406,7 +423,7 @@ def test_chat_returns_404_when_briefing_missing(monkeypatch: Any) -> None:
     assert resp.status_code == 404
 
 
-def test_chat_returns_503_when_ai_not_configured(monkeypatch: Any) -> None:
+def test_chat_returns_503_when_ai_not_configured(client: TestClient, monkeypatch: Any) -> None:
     def _raise(*_: Any, **__: Any) -> str:
         msg = "OPENAI_API_KEY not set"
         raise BriefingAINotConfiguredError(msg)

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -113,23 +113,27 @@ def _add_article(pg_url: str, *, source_slug: str, url_suffix: str = "1") -> int
 
 
 def _api_client(uid: int, username: str = "user") -> Any:
+    from contextlib import contextmanager
+
     from fastapi.testclient import TestClient
 
     from news_dashboard.auth import require_admin, require_auth
     from news_dashboard.main import app
 
     fake = {"id": uid, "username": username, "email": None, "is_admin": False}
-    app.dependency_overrides[require_auth] = lambda: fake
-    app.dependency_overrides[require_admin] = lambda: fake
-    return TestClient(app, raise_server_exceptions=True)
 
+    @contextmanager
+    def _ctx() -> Generator[TestClient]:
+        app.dependency_overrides[require_auth] = lambda: fake
+        app.dependency_overrides[require_admin] = lambda: fake
+        try:
+            with TestClient(app, raise_server_exceptions=True) as c:
+                yield c
+        finally:
+            app.dependency_overrides.pop(require_auth, None)
+            app.dependency_overrides.pop(require_admin, None)
 
-def _clear_auth_overrides() -> None:
-    from news_dashboard.auth import require_admin, require_auth
-    from news_dashboard.main import app
-
-    app.dependency_overrides.pop(require_auth, None)
-    app.dependency_overrides.pop(require_admin, None)
+    return _ctx()
 
 
 # ── starred BOOLEAN column ────────────────────────────────────────────────────
@@ -331,16 +335,13 @@ def test_pg_sources_listing_subscribed_by_default(pg_env: str) -> None:
     _add_global_source(pg_url, "pg-src-list")
     uid = _make_user(pg_url, "list-user")
 
-    client = _api_client(uid, "list-user")
-    try:
+    with _api_client(uid, "list-user") as client:
         resp = client.get("/api/sources")
         assert resp.status_code == 200
         items = resp.json()["items"]
         match = next((i for i in items if i["slug"] == "pg-src-list"), None)
         assert match is not None
         assert match["subscribed"] is True
-    finally:
-        _clear_auth_overrides()
 
 
 def test_pg_sources_listing_after_unsubscribe(pg_env: str) -> None:
@@ -358,15 +359,12 @@ def test_pg_sources_listing_after_unsubscribe(pg_env: str) -> None:
         )
         conn.commit()
 
-    client = _api_client(uid, "unsub-list-user")
-    try:
+    with _api_client(uid, "unsub-list-user") as client:
         resp = client.get("/api/sources")
         assert resp.status_code == 200
         match = next((i for i in resp.json()["items"] if i["slug"] == "pg-src-unsub-list"), None)
         assert match is not None
         assert match["subscribed"] is False
-    finally:
-        _clear_auth_overrides()
 
 
 # ── PATCH /api/sources/{slug}/enabled writes boolean ─────────────────────────
@@ -380,8 +378,7 @@ def test_pg_api_toggle_subscription_writes_boolean(pg_env: str) -> None:
     _add_global_source(pg_url, "pg-src-toggle")
     uid = _make_user(pg_url, "toggle-user")
 
-    client = _api_client(uid, "toggle-user")
-    try:
+    with _api_client(uid, "toggle-user") as client:
         resp = client.patch("/api/sources/pg-src-toggle/enabled", json={"enabled": False})
         assert resp.status_code == 200
         assert resp.json()["subscribed"] is False
@@ -389,8 +386,6 @@ def test_pg_api_toggle_subscription_writes_boolean(pg_env: str) -> None:
         resp2 = client.patch("/api/sources/pg-src-toggle/enabled", json={"enabled": True})
         assert resp2.status_code == 200
         assert resp2.json()["subscribed"] is True
-    finally:
-        _clear_auth_overrides()
 
     # Confirm the DB column holds a proper boolean, not an integer.
     with psycopg.connect(pg_url) as conn:

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -17,7 +18,12 @@ from news_dashboard.push import (
     send_push_for_user,
 )
 
-client = TestClient(app, raise_server_exceptions=True)
+
+@pytest.fixture
+def client() -> Generator[TestClient]:
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
 
 # ── Schema ─────────────────────────────────────────────────────────────────────
 
@@ -284,7 +290,9 @@ def test_send_push_for_user_calls_send_for_each_sub(
 # ── API endpoints ──────────────────────────────────────────────────────────────
 
 
-def test_get_notification_settings_returns_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_notification_settings_returns_defaults(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("VAPID_PUBLIC_KEY", "BExampleKey==")
 
     fake_row: dict[str, Any] = {"briefing_time": "09:00", "briefing_push_enabled": False}
@@ -302,7 +310,7 @@ def test_get_notification_settings_returns_defaults(monkeypatch: pytest.MonkeyPa
     assert data["vapid_public_key"] == "BExampleKey=="
 
 
-def test_put_notification_settings_valid_time() -> None:
+def test_put_notification_settings_valid_time(client: TestClient) -> None:
     fake_row: dict[str, Any] = {"briefing_time": "08:30", "briefing_push_enabled": True}
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -320,12 +328,12 @@ def test_put_notification_settings_valid_time() -> None:
     assert data["push_enabled"] is True
 
 
-def test_put_notification_settings_invalid_time() -> None:
+def test_put_notification_settings_invalid_time(client: TestClient) -> None:
     resp = client.put("/api/settings/notifications", json={"briefing_time": "25:00"})
     assert resp.status_code == 422
 
 
-def test_push_subscribe_endpoint() -> None:
+def test_push_subscribe_endpoint(client: TestClient) -> None:
     with patch("news_dashboard.push.save_push_subscription") as mock_save:
         resp = client.post(
             "/api/notifications/subscribe",
@@ -336,7 +344,7 @@ def test_push_subscribe_endpoint() -> None:
     mock_save.assert_called_once_with(1, "https://ep.example.com", "abc", "xyz")
 
 
-def test_push_unsubscribe_endpoint() -> None:
+def test_push_unsubscribe_endpoint(client: TestClient) -> None:
     with patch("news_dashboard.push.delete_push_subscriptions") as mock_del:
         resp = client.delete("/api/notifications/subscribe")
     assert resp.status_code == 200

--- a/backend/tests/test_run_history_api.py
+++ b/backend/tests/test_run_history_api.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 from news_dashboard.db import connect, init_db
 from news_dashboard.main import app
 
-client = TestClient(app, raise_server_exceptions=True)
+
+@pytest.fixture
+def client() -> Generator[TestClient]:
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
 
 
 def _seed_db(db_path: Path | str) -> tuple[int, int]:
@@ -58,7 +64,9 @@ def _seed_db(db_path: Path | str) -> tuple[int, int]:
     return int(r1), int(r2)
 
 
-def test_list_runs_returns_paginated_response(pg_clean: str, monkeypatch: Any) -> None:
+def test_list_runs_returns_paginated_response(
+    client: TestClient, pg_clean: str, monkeypatch: Any
+) -> None:
     db = pg_clean
     monkeypatch.setenv("DATABASE_URL", db)
     _seed_db(db)
@@ -75,7 +83,7 @@ def test_list_runs_returns_paginated_response(pg_clean: str, monkeypatch: Any) -
     assert ids[0] > ids[1]
 
 
-def test_list_runs_pagination(pg_clean: str, monkeypatch: Any) -> None:
+def test_list_runs_pagination(client: TestClient, pg_clean: str, monkeypatch: Any) -> None:
     db = pg_clean
     monkeypatch.setenv("DATABASE_URL", db)
     _seed_db(db)
@@ -96,7 +104,9 @@ def test_list_runs_pagination(pg_clean: str, monkeypatch: Any) -> None:
     assert body2["items"][0]["id"] != body["items"][0]["id"]
 
 
-def test_get_run_sources_returns_breakdown(pg_clean: str, monkeypatch: Any) -> None:
+def test_get_run_sources_returns_breakdown(
+    client: TestClient, pg_clean: str, monkeypatch: Any
+) -> None:
     db = pg_clean
     monkeypatch.setenv("DATABASE_URL", db)
     r1, _ = _seed_db(db)
@@ -116,7 +126,9 @@ def test_get_run_sources_returns_breakdown(pg_clean: str, monkeypatch: Any) -> N
     assert python_insider["duration_ms"] == 1500
 
 
-def test_get_run_sources_404_for_unknown_id(pg_clean: str, monkeypatch: Any) -> None:
+def test_get_run_sources_404_for_unknown_id(
+    client: TestClient, pg_clean: str, monkeypatch: Any
+) -> None:
     db = pg_clean
     monkeypatch.setenv("DATABASE_URL", db)
     init_db(db)
@@ -125,7 +137,7 @@ def test_get_run_sources_404_for_unknown_id(pg_clean: str, monkeypatch: Any) -> 
     assert resp.status_code == 404
 
 
-def test_list_runs_empty_state(pg_clean: str, monkeypatch: Any) -> None:
+def test_list_runs_empty_state(client: TestClient, pg_clean: str, monkeypatch: Any) -> None:
     db = pg_clean
     monkeypatch.setenv("DATABASE_URL", db)
     init_db(db)

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from fastapi.testclient import TestClient
 
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect, row_to_dict
@@ -167,16 +168,27 @@ def test_unsubscription_is_per_user(tmp_path: Path) -> None:
 # ── API layer ─────────────────────────────────────────────────────────────────
 
 
-def _api_client(db_path: Path | str | str, user_id: int, is_admin: bool = False) -> Any:
-    from fastapi.testclient import TestClient
+def _api_client(db_path: Path | str, user_id: int, is_admin: bool = False) -> Any:
+    from collections.abc import Generator
+    from contextlib import contextmanager
 
     from news_dashboard.auth import require_admin, require_auth
     from news_dashboard.main import app
 
     fake = {"id": user_id, "username": "testuser", "email": None, "is_admin": is_admin}
-    app.dependency_overrides[require_auth] = lambda: fake
-    app.dependency_overrides[require_admin] = lambda: fake
-    return TestClient(app, raise_server_exceptions=True)
+
+    @contextmanager
+    def _ctx() -> Generator[TestClient]:
+        app.dependency_overrides[require_auth] = lambda: fake
+        app.dependency_overrides[require_admin] = lambda: fake
+        try:
+            with TestClient(app, raise_server_exceptions=True) as c:
+                yield c
+        finally:
+            app.dependency_overrides.pop(require_auth, None)
+            app.dependency_overrides.pop(require_admin, None)
+
+    return _ctx()
 
 
 def test_api_list_sources_returns_subscription_status(
@@ -186,20 +198,13 @@ def test_api_list_sources_returns_subscription_status(
     sync_sources(pg_clean)
     uid = _make_user(pg_clean)
 
-    client = _api_client(pg_clean, uid)
-    try:
+    with _api_client(pg_clean, uid) as client:
         resp = client.get("/api/sources")
         assert resp.status_code == 200
         items = resp.json()["items"]
         assert len(items) > 0
         # All global sources are subscribed by default
         assert all(i["subscribed"] for i in items)
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
-
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)
 
 
 def test_api_create_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -207,8 +212,7 @@ def test_api_create_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatc
     sync_sources(pg_clean)
     uid = _make_user(pg_clean)
 
-    client = _api_client(pg_clean, uid)
-    try:
+    with _api_client(pg_clean, uid) as client:
         resp = client.post(
             "/api/sources",
             json={
@@ -227,12 +231,6 @@ def test_api_create_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatc
         resp2 = client.get("/api/sources")
         slugs = [i["slug"] for i in resp2.json()["items"]]
         assert "my-blog" in slugs
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
-
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)
 
 
 def test_api_private_source_not_visible_to_other_user(
@@ -244,8 +242,7 @@ def test_api_private_source_not_visible_to_other_user(
     uid_b = _make_user(pg_clean, "bob")
 
     # Alice creates a private source
-    client_a = _api_client(pg_clean, uid_a)
-    try:
+    with _api_client(pg_clean, uid_a) as client_a:
         resp = client_a.post(
             "/api/sources",
             json={
@@ -255,25 +252,12 @@ def test_api_private_source_not_visible_to_other_user(
             },
         )
         assert resp.status_code == 200
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
-
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)
 
     # Bob doesn't see it
-    client_b = _api_client(pg_clean, uid_b)
-    try:
+    with _api_client(pg_clean, uid_b) as client_b:
         resp2 = client_b.get("/api/sources")
         slugs = [i["slug"] for i in resp2.json()["items"]]
         assert "alice-blog" not in slugs
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
-
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)
 
 
 def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -281,8 +265,7 @@ def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.Monkey
     sync_sources(pg_clean)
     uid = _make_user(pg_clean)
 
-    client = _api_client(pg_clean, uid)
-    try:
+    with _api_client(pg_clean, uid) as client:
         client.post(
             "/api/sources",
             json={
@@ -294,12 +277,6 @@ def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.Monkey
         resp = client.delete("/api/sources/to-delete")
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
-
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)
 
 
 def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -308,8 +285,7 @@ def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.Monk
     uid_a = _make_user(pg_clean, "alice")
     uid_b = _make_user(pg_clean, "bob")
 
-    client_a = _api_client(pg_clean, uid_a)
-    try:
+    with _api_client(pg_clean, uid_a) as client_a:
         client_a.post(
             "/api/sources",
             json={
@@ -318,23 +294,10 @@ def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.Monk
                 "slug": "alice-src",
             },
         )
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
 
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)
-
-    client_b = _api_client(pg_clean, uid_b)
-    try:
+    with _api_client(pg_clean, uid_b) as client_b:
         resp = client_b.delete("/api/sources/alice-src")
         assert resp.status_code == 403
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
-
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)
 
 
 def test_api_toggle_subscription(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -343,8 +306,7 @@ def test_api_toggle_subscription(pg_clean: str, monkeypatch: pytest.MonkeyPatch)
     uid = _make_user(pg_clean)
 
     slug = _global_slug(pg_clean)
-    client = _api_client(pg_clean, uid)
-    try:
+    with _api_client(pg_clean, uid) as client:
         # Unsubscribe
         resp = client.patch(f"/api/sources/{slug}/enabled", json={"enabled": False})
         assert resp.status_code == 200
@@ -354,9 +316,3 @@ def test_api_toggle_subscription(pg_clean: str, monkeypatch: pytest.MonkeyPatch)
         resp2 = client.patch(f"/api/sources/{slug}/enabled", json={"enabled": True})
         assert resp2.status_code == 200
         assert resp2.json()["subscribed"] is True
-    finally:
-        from news_dashboard.auth import require_admin, require_auth
-        from news_dashboard.main import app
-
-        app.dependency_overrides.pop(require_auth, None)
-        app.dependency_overrides.pop(require_admin, None)


### PR DESCRIPTION
## Summary

- Converts module-level `client = TestClient(app)` globals in `test_briefings_api.py`, `test_push_notifications.py`, and `test_run_history_api.py` to `@pytest.fixture` functions that yield from a `with TestClient(app) as c:` context manager
- Converts `_api_client` helper functions in `test_postgres_types.py` and `test_source_subscriptions.py` to return context managers (using `contextmanager`), so callers can use `with _api_client(...) as client:` instead of try/finally cleanup
- Updates `test_auth_extra.py` to use `with TestClient(app) as client:` in all test functions that previously left clients unclosed

Closes #338

## Test plan

- [x] `make lint` — all checks passed
- [x] `make typecheck` — mypy, ty, and pyrefly all clean
- [x] `pytest test_briefings_api.py test_push_notifications.py test_run_history_api.py test_auth_extra.py` — 76 passed
- [x] `pytest test_source_subscriptions.py` — 11 passed
- [x] `pytest test_postgres_types.py -k api` — passes (other tests hit local disk full, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)