### PR TITLE
feat: consolidate AI credentials to FREE_LLM_API_KEY + OPENAI_API_KEY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,8 +246,8 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_BRIEFING_API_KEY: ${{ secrets.OPENAI_BRIEFING_API_KEY }}
-          OPENAI_BRIEFING_BASE_URL: ${{ vars.OPENAI_BRIEFING_BASE_URL }}
+          FREE_LLM_API_KEY: ${{ secrets.FREE_LLM_API_KEY }}
+          FREE_LLM_BASE_URL: ${{ vars.FREE_LLM_BASE_URL }}
           OPENAI_BRIEFING_MODEL: ${{ vars.OPENAI_BRIEFING_MODEL }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
@@ -284,8 +284,8 @@ jobs:
           if [ -n "$OPENAI_API_KEY" ]; then
             ai_secret_args+=(--from-literal=OPENAI_API_KEY="$OPENAI_API_KEY")
           fi
-          if [ -n "$OPENAI_BRIEFING_API_KEY" ]; then
-            ai_secret_args+=(--from-literal=OPENAI_BRIEFING_API_KEY="$OPENAI_BRIEFING_API_KEY")
+          if [ -n "$FREE_LLM_API_KEY" ]; then
+            ai_secret_args+=(--from-literal=FREE_LLM_API_KEY="$FREE_LLM_API_KEY")
           fi
           if [ -n "$LANGFUSE_PUBLIC_KEY" ]; then
             ai_secret_args+=(--from-literal=LANGFUSE_PUBLIC_KEY="$LANGFUSE_PUBLIC_KEY")
@@ -301,8 +301,8 @@ jobs:
               --dry-run=client -o yaml | kubectl apply -f -
             ai_helm_args+=(--set app.ai.existingSecret=news-dashboard-ai)
           fi
-          if [ -n "$OPENAI_BRIEFING_BASE_URL" ]; then
-            ai_helm_args+=(--set-string "app.ai.briefingBaseUrl=$OPENAI_BRIEFING_BASE_URL")
+          if [ -n "$FREE_LLM_BASE_URL" ]; then
+            ai_helm_args+=(--set-string "app.ai.freeLlmBaseUrl=$FREE_LLM_BASE_URL")
           fi
           if [ -n "$OPENAI_BRIEFING_MODEL" ]; then
             ai_helm_args+=(--set-string "app.ai.briefingModel=$OPENAI_BRIEFING_MODEL")

--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -122,6 +122,28 @@ def chat_create(
     return cast("ChatCompletion", completion)
 
 
+def openai_config() -> tuple[str, str | None]:
+    """Return (api_key, base_url) for real-OpenAI-only features (TTS audio, body extraction).
+
+    Uses ``OPENAI_API_KEY`` and ``OPENAI_BASE_URL``. The key may be an empty
+    string when unconfigured — callers that require it must check and raise.
+    """
+    return os.getenv("OPENAI_API_KEY", ""), os.getenv("OPENAI_BASE_URL") or None
+
+
+def free_llm_config() -> tuple[str, str | None]:
+    """Return (api_key, base_url) for the free LLM gateway (chat, embeddings, etc.).
+
+    Uses ``FREE_LLM_API_KEY`` / ``FREE_LLM_BASE_URL`` first, falling back to
+    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` so a single-key setup still works.
+    The key may be an empty string when unconfigured — callers that require it
+    must check and raise.
+    """
+    api_key = os.getenv("FREE_LLM_API_KEY") or os.getenv("OPENAI_API_KEY") or ""
+    base_url = os.getenv("FREE_LLM_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
+    return api_key, base_url
+
+
 def get_openai_client(*, api_key: str, base_url: str | None = None) -> OpenAI:
     """Return an OpenAI client, Langfuse-wrapped when tracing is configured.
 

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -28,23 +28,19 @@ _AI_PROMPT = (
 )
 
 
-def _body_ai_config() -> tuple[str, str | None, str]:
-    """Resolve (api_key, base_url, model) for AI body extraction."""
-    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
-    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
-    model = os.getenv("OPENAI_BRIEFING_MODEL", _AI_MODEL)
-    return api_key or "", base_url, model
-
-
 def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]:
-    """Fallback: fetch raw HTML via httpx and extract body text via AI.
+    """Fallback: fetch raw HTML via httpx and extract body text via the free LLM gateway.
 
-    Returns (text, 'ok') on success or ('', 'error') if OPENAI_API_KEY is
-    absent, the HTTP fetch fails, or the AI call fails.
+    Returns (text, 'ok') on success or ('', 'error') if no API key is
+    configured, the HTTP fetch fails, or the AI call fails.
     """
-    api_key, base_url, model = _body_ai_config()
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
         return "", "error"
+
+    model = os.getenv("OPENAI_BRIEFING_MODEL", _AI_MODEL)
 
     try:
         import httpx  # lazy import — optional at module load time
@@ -327,15 +323,17 @@ def get_article(
 
 
 def translate_body(body: str, from_lang: str) -> str:
-    """Translate the body text to English using OpenAI GPT models."""
-    api_key = os.getenv("OPENAI_API_KEY")
+    """Translate the body text to English using the free LLM gateway."""
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key or not body.strip():
         return body
 
     try:
         from news_dashboard.ai_client import chat_create, get_openai_client
 
-        client = get_openai_client(api_key=api_key)
+        client = get_openai_client(api_key=api_key, base_url=base_url)
         prompt = (
             f"You are a translation assistant. Translate the following body text from "
             f"language code '{from_lang}' to English. Return only the translated plain text, "

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -172,22 +172,16 @@ def _current_day_since_at(until_at: datetime) -> datetime:
 
 
 def _briefing_ai_config() -> tuple[str, str | None]:
-    """Resolve the (api_key, base_url) for briefing generation.
+    """Resolve the (api_key, base_url) for briefing generation via the free LLM gateway."""
+    from news_dashboard.ai_client import free_llm_config
 
-    Briefings can target any OpenAI-compatible endpoint (e.g. a self-hosted
-    gateway) via ``OPENAI_BRIEFING_BASE_URL`` / ``OPENAI_BRIEFING_API_KEY``,
-    falling back to the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` used by
-    the rest of the app. The base URL is optional; when unset the official
-    OpenAI endpoint is used.
-    """
-    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    api_key, base_url = free_llm_config()
     if not api_key:
         msg = (
-            "Briefing generation requires an API key. Set OPENAI_BRIEFING_API_KEY "
+            "Briefing generation requires an API key. Set FREE_LLM_API_KEY "
             "(or OPENAI_API_KEY) in the app environment."
         )
         raise BriefingAINotConfiguredError(msg)
-    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     return api_key, base_url
 
 

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -84,27 +84,16 @@ def embedding_text(
 
 
 def _embeddings_ai_config() -> tuple[str, str | None, str]:
-    """Resolve the (api_key, base_url) for embedding generation.
+    """Resolve the (api_key, base_url, model) for embedding generation via the free LLM gateway."""
+    from news_dashboard.ai_client import free_llm_config
 
-    Embeddings can target any OpenAI-compatible endpoint (e.g. a self-hosted
-    gateway) via ``OPENAI_EMBEDDINGS_BASE_URL`` / ``OPENAI_EMBEDDINGS_API_KEY``,
-    falling back to the briefing gateway and then the shared
-    ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The base URL is optional; when
-    unset the official OpenAI endpoint is used.
-    """
-    api_key = os.getenv("OPENAI_EMBEDDINGS_API_KEY") or os.getenv("OPENAI_API_KEY")
+    api_key, base_url = free_llm_config()
     if not api_key:
         msg = (
-            "Ask AI requires OPENAI_EMBEDDINGS_API_KEY (or OPENAI_API_KEY) to "
+            "Ask AI requires FREE_LLM_API_KEY (or OPENAI_API_KEY) to "
             "generate article embeddings. Set it in the app environment."
         )
         raise MissingAICredentialsError(msg)
-    base_url = (
-        os.getenv("OPENAI_EMBEDDINGS_BASE_URL")
-        or os.getenv("OPENAI_BRIEFING_BASE_URL")
-        or os.getenv("OPENAI_BASE_URL")
-        or None
-    )
     model = os.getenv("OPENAI_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
     return api_key, base_url, model
 
@@ -131,12 +120,11 @@ def _answer(
     prompt: ManagedPrompt | None = None,
 ) -> str:
     """Generate an answer via the free LLM gateway when configured, else OpenAI."""
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, free_llm_config, get_openai_client
 
-    api_key = os.getenv("OPENAI_ANSWER_API_KEY") or _require_env("OPENAI_API_KEY", "use Ask AI")
-    base_url: str | None = (
-        os.getenv("OPENAI_ANSWER_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
-    )
+    api_key, base_url = free_llm_config()
+    if not api_key:
+        _require_env("FREE_LLM_API_KEY", "use Ask AI")
     client = get_openai_client(api_key=api_key, base_url=base_url)
     response = chat_create(
         client,

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -450,7 +450,6 @@ def detect_and_translate_article(
 ) -> tuple[str, str, str, str | None]:
     """Detect language and translate title and summary to English if needed."""
     import json
-    import os
     import re
 
     from news_dashboard.ai_client import chat_create, get_openai_client
@@ -472,12 +471,14 @@ def detect_and_translate_article(
     if not is_non_eng:
         return title, summary, "en", None
 
-    api_key = os.getenv("OPENAI_API_KEY")
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
         return title, summary, source_lang, None
 
     try:
-        client = get_openai_client(api_key=api_key)
+        client = get_openai_client(api_key=api_key, base_url=base_url)
         prompt = (
             "You are a translation assistant. Detect the language of the following text. "
             "If it is not English, translate both the title and the "

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -67,11 +67,12 @@ def _insights_ai_config() -> tuple[str, str | None, str]:
     the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The base URL is
     optional; when unset the official OpenAI endpoint is used.
     """
-    api_key = os.getenv("OPENAI_INSIGHTS_API_KEY") or os.getenv("OPENAI_API_KEY")
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
-        msg = "OPENAI_API_KEY is not configured"
+        msg = "FREE_LLM_API_KEY (or OPENAI_API_KEY) is not configured"
         raise InsightsNotConfiguredError(msg)
-    base_url = os.getenv("OPENAI_INSIGHTS_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     model = os.getenv("OPENAI_INSIGHTS_MODEL", DEFAULT_INSIGHTS_MODEL)
     return api_key, base_url, model
 
@@ -170,11 +171,12 @@ DEFAULT_CLUSTER_MODEL = "gpt-4o-mini"
 
 
 def _cluster_ai_config() -> tuple[str, str | None, str]:
-    api_key = os.getenv("OPENAI_INSIGHTS_API_KEY") or os.getenv("OPENAI_API_KEY")
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
-        msg = "OPENAI_API_KEY is not configured"
+        msg = "FREE_LLM_API_KEY (or OPENAI_API_KEY) is not configured"
         raise InsightsNotConfiguredError(msg)
-    base_url = os.getenv("OPENAI_INSIGHTS_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     model = os.getenv("OPENAI_INSIGHTS_MODEL", DEFAULT_CLUSTER_MODEL)
     return api_key, base_url, model
 

--- a/backend/news_dashboard/perspectives.py
+++ b/backend/news_dashboard/perspectives.py
@@ -71,17 +71,13 @@ def _build_text(article: dict[str, Any], related: list[dict[str, Any]]) -> str:
 
 
 def _perspectives_ai_config() -> tuple[str, str | None, str]:
-    """Resolve (api_key, base_url, model) for perspective analysis.
+    """Resolve (api_key, base_url, model) for perspective analysis via the free LLM gateway."""
+    from news_dashboard.ai_client import free_llm_config
 
-    Can target any OpenAI-compatible endpoint via
-    ``OPENAI_PERSPECTIVES_BASE_URL`` / ``OPENAI_PERSPECTIVES_API_KEY``, falling
-    back to the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``.
-    """
-    api_key = os.getenv("OPENAI_PERSPECTIVES_API_KEY") or os.getenv("OPENAI_API_KEY")
+    api_key, base_url = free_llm_config()
     if not api_key:
-        msg = "OPENAI_API_KEY is not configured"
+        msg = "FREE_LLM_API_KEY (or OPENAI_API_KEY) is not configured"
         raise PerspectivesNotConfiguredError(msg)
-    base_url = os.getenv("OPENAI_PERSPECTIVES_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     model = os.getenv("OPENAI_PERSPECTIVES_MODEL", DEFAULT_PERSPECTIVES_MODEL)
     return api_key, base_url, model
 

--- a/backend/news_dashboard/prompt_optimizer.py
+++ b/backend/news_dashboard/prompt_optimizer.py
@@ -137,23 +137,15 @@ def _optimizer_ai_config() -> tuple[str, str | None]:
     and then the shared ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. The base URL
     is optional; when unset the official OpenAI endpoint is used.
     """
-    api_key = (
-        os.getenv("OPENAI_OPTIMIZER_API_KEY")
-        or os.getenv("OPENAI_BRIEFING_API_KEY")
-        or os.getenv("OPENAI_API_KEY")
-    )
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
         msg = (
-            "Prompt optimization requires an API key. Set OPENAI_OPTIMIZER_API_KEY "
+            "Prompt optimization requires an API key. Set FREE_LLM_API_KEY "
             "(or OPENAI_API_KEY) in the app environment."
         )
         raise PromptOptimizerError(msg)
-    base_url = (
-        os.getenv("OPENAI_OPTIMIZER_BASE_URL")
-        or os.getenv("OPENAI_BRIEFING_BASE_URL")
-        or os.getenv("OPENAI_BASE_URL")
-        or None
-    )
     return api_key, base_url
 
 

--- a/backend/news_dashboard/quiz.py
+++ b/backend/news_dashboard/quiz.py
@@ -112,11 +112,12 @@ def goal_alignment_adjustment(
 
 
 def _quiz_ai_config() -> tuple[str, str | None, str]:
-    api_key = os.getenv("OPENAI_QUIZ_API_KEY") or os.getenv("OPENAI_API_KEY")
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
-        msg = "OPENAI_API_KEY is not configured"
+        msg = "FREE_LLM_API_KEY (or OPENAI_API_KEY) is not configured"
         raise RuntimeError(msg)
-    base_url = os.getenv("OPENAI_QUIZ_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     model = os.getenv("OPENAI_QUIZ_MODEL", DEFAULT_QUIZ_MODEL)
     return api_key, base_url, model
 

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -377,13 +377,12 @@ def generate_recommendation_explanation(
     """
     import os
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, free_llm_config, get_openai_client
 
-    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    api_key, base_url = free_llm_config()
     if not api_key:
         return None
 
-    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
 
     init_db(db_path, database_url=database_url)

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -229,12 +229,13 @@ def generate_share_context(share_id: int) -> str | None:
 
     Returns None if no API key is configured or if the share doesn't exist.
     """
-    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
-        logger.warning("generate_share_context: no OpenAI API key configured, skipping")
+        logger.warning("generate_share_context: no AI API key configured, skipping")
         return None
 
-    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     model = os.getenv("OPENAI_BRIEFING_MODEL", DEFAULT_SHARE_MODEL)
 
     with connect() as conn:

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -26,39 +26,32 @@ class TTSNotConfiguredError(Exception):
 
 
 def _tts_ai_config() -> tuple[str, str | None]:
-    """Resolve the (api_key, base_url) for text-to-speech generation.
+    """Resolve the (api_key, base_url) for TTS audio synthesis (OpenAI only)."""
+    from news_dashboard.ai_client import openai_config
 
-    TTS can target an OpenAI-compatible audio/speech endpoint via
-    ``OPENAI_TTS_BASE_URL`` / ``OPENAI_TTS_API_KEY``, falling back to the shared
-    ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY``. When no base URL is configured the
-    official OpenAI endpoint is used.
-    """
-    api_key = os.getenv("OPENAI_TTS_API_KEY") or os.getenv("OPENAI_API_KEY")
+    api_key, base_url = openai_config()
     if not api_key:
         msg = "OPENAI_API_KEY is not configured"
         raise TTSNotConfiguredError(msg)
-    base_url = os.getenv("OPENAI_TTS_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     return api_key, base_url
 
 
 def _script_ai_config() -> tuple[str, str | None]:
     """Resolve the (api_key, base_url) for podcast script (LLM chat) generation.
 
-    Script generation is a chat-completion call, so it uses the same
-    briefing AI credentials (``OPENAI_BRIEFING_API_KEY`` /
-    ``OPENAI_BRIEFING_BASE_URL``) as every other LLM feature, falling back to
-    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL``. This is intentionally separate
-    from ``_tts_ai_config`` because the free LLM gateway supports chat
-    completions but not the ``audio/speech`` endpoint required for TTS.
+    Script generation is a chat-completion call that works on any OpenAI-compatible
+    gateway, so it uses FREE_LLM_API_KEY. This is intentionally separate from
+    ``_tts_ai_config`` because the free LLM gateway supports chat completions but
+    not the ``audio/speech`` endpoint required for TTS audio synthesis.
     """
-    api_key = os.getenv("OPENAI_BRIEFING_API_KEY") or os.getenv("OPENAI_API_KEY")
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
     if not api_key:
         msg = (
-            "Podcast script generation requires an API key. "
-            "Set OPENAI_BRIEFING_API_KEY or OPENAI_API_KEY"
+            "Podcast script generation requires an API key. Set FREE_LLM_API_KEY or OPENAI_API_KEY"
         )
         raise TTSNotConfiguredError(msg)
-    base_url = os.getenv("OPENAI_BRIEFING_BASE_URL") or os.getenv("OPENAI_BASE_URL") or None
     return api_key, base_url
 
 

--- a/backend/tests/test_ai_credentials.py
+++ b/backend/tests/test_ai_credentials.py
@@ -57,10 +57,10 @@ def test_answer_uses_openai_api_key_and_default_model(
             self.chat = FakeChat()
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_ANSWER_MODEL", raising=False)
-    monkeypatch.delenv("OPENAI_ANSWER_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    monkeypatch.delenv("OPENAI_ANSWER_API_KEY", raising=False)
     import sys
     from types import SimpleNamespace
 
@@ -77,35 +77,33 @@ def test_answer_uses_openai_api_key_and_default_model(
 def test_embeddings_ai_config_raises_when_no_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-    with pytest.raises(MissingAICredentialsError, match="OPENAI_EMBEDDINGS_API_KEY"):
+    with pytest.raises(MissingAICredentialsError, match="FREE_LLM_API_KEY"):
         _embeddings_ai_config()
 
 
-def test_embeddings_ai_config_uses_embeddings_specific_key(
+def test_embeddings_ai_config_uses_free_llm_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("OPENAI_EMBEDDINGS_API_KEY", "embed-key")
+    monkeypatch.setenv("FREE_LLM_API_KEY", "free-llm-key")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     api_key, base_url, _model = _embeddings_ai_config()
 
-    assert api_key == "embed-key"
+    assert api_key == "free-llm-key"
     assert base_url is None
 
 
 def test_embeddings_ai_config_falls_back_to_shared_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "shared-key")
-    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     api_key, base_url, _model = _embeddings_ai_config()
@@ -114,12 +112,11 @@ def test_embeddings_ai_config_falls_back_to_shared_api_key(
     assert base_url is None
 
 
-def test_embeddings_ai_config_uses_embeddings_specific_base_url(
+def test_embeddings_ai_config_uses_free_llm_base_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "key")
-    monkeypatch.setenv("OPENAI_EMBEDDINGS_BASE_URL", "http://gateway:9130/v1")
-    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://gateway:9130/v1")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     _, base_url, _model = _embeddings_ai_config()
@@ -131,8 +128,7 @@ def test_embeddings_ai_config_falls_back_to_shared_base_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "key")
-    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway:9130/v1")
 
     _, base_url, _model = _embeddings_ai_config()
@@ -140,30 +136,16 @@ def test_embeddings_ai_config_falls_back_to_shared_base_url(
     assert base_url == "http://shared-gateway:9130/v1"
 
 
-def test_embeddings_ai_config_specific_base_url_takes_precedence_over_shared(
+def test_embeddings_ai_config_free_llm_base_url_takes_precedence_over_shared(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "key")
-    monkeypatch.setenv("OPENAI_EMBEDDINGS_BASE_URL", "http://embed-gateway/v1")
-    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gateway/v1")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://free-gateway/v1")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway/v1")
 
     _, base_url, _model = _embeddings_ai_config()
 
-    assert base_url == "http://embed-gateway/v1"
-
-
-def test_embeddings_ai_config_falls_back_to_briefing_base_url(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "key")
-    monkeypatch.delenv("OPENAI_EMBEDDINGS_BASE_URL", raising=False)
-    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gateway/v1")
-    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway/v1")
-
-    _, base_url, _model = _embeddings_ai_config()
-
-    assert base_url == "http://briefing-gateway/v1"
+    assert base_url == "http://free-gateway/v1"
 
 
 def test_embeddings_ai_config_uses_model_override(
@@ -192,8 +174,8 @@ def test_answer_uses_no_base_url_when_gateway_not_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-default")
-    monkeypatch.delenv("OPENAI_ANSWER_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_ANSWER_BASE_URL", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     patch_target = "news_dashboard.ai_client.get_openai_client"
@@ -204,8 +186,8 @@ def test_answer_uses_no_base_url_when_gateway_not_configured(
 
 def test_answer_uses_shared_base_url_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-default")
-    monkeypatch.delenv("OPENAI_ANSWER_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_ANSWER_BASE_URL", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "http://gateway:9130/v1")
 
     patch_target = "news_dashboard.ai_client.get_openai_client"
@@ -214,25 +196,27 @@ def test_answer_uses_shared_base_url_when_set(monkeypatch: pytest.MonkeyPatch) -
     mock_factory.assert_called_once_with(api_key="sk-default", base_url="http://gateway:9130/v1")
 
 
-def test_answer_feature_base_url_overrides_shared(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-default")
-    monkeypatch.delenv("OPENAI_ANSWER_API_KEY", raising=False)
-    monkeypatch.setenv("OPENAI_ANSWER_BASE_URL", "http://answer-gw:9130/v1")
-    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gw:9130/v1")
-
-    patch_target = "news_dashboard.ai_client.get_openai_client"
-    with patch(patch_target, return_value=_make_fake_client()) as mock_factory:
-        _answer("sys", "usr")
-    mock_factory.assert_called_once_with(api_key="sk-default", base_url="http://answer-gw:9130/v1")
-
-
-def test_answer_feature_api_key_overrides_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-default")
-    monkeypatch.setenv("OPENAI_ANSWER_API_KEY", "sk-answer-specific")
-    monkeypatch.delenv("OPENAI_ANSWER_BASE_URL", raising=False)
+def test_answer_uses_free_llm_key_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "sk-free-llm")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://free-gw:9130/v1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     patch_target = "news_dashboard.ai_client.get_openai_client"
     with patch(patch_target, return_value=_make_fake_client()) as mock_factory:
         _answer("sys", "usr")
-    mock_factory.assert_called_once_with(api_key="sk-answer-specific", base_url=None)
+    mock_factory.assert_called_once_with(api_key="sk-free-llm", base_url="http://free-gw:9130/v1")
+
+
+def test_answer_free_llm_key_takes_precedence_over_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "sk-free-llm")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    patch_target = "news_dashboard.ai_client.get_openai_client"
+    with patch(patch_target, return_value=_make_fake_client()) as mock_factory:
+        _answer("sys", "usr")
+    mock_factory.assert_called_once_with(api_key="sk-free-llm", base_url=None)

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -698,8 +698,8 @@ def test_current_day_since_at_subtracts_24_hours() -> None:
 
 def test_call_openai_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
-    with pytest.raises(BriefingAINotConfiguredError, match="OPENAI_API_KEY"):
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    with pytest.raises(BriefingAINotConfiguredError, match="FREE_LLM_API_KEY"):
         _call_openai([], model="gpt-x")
 
 
@@ -726,8 +726,8 @@ def _patch_openai(monkeypatch: pytest.MonkeyPatch, content: str) -> type[_FakeOp
 
 def test_call_openai_uses_default_base_url_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
     cls = _patch_openai(monkeypatch, "{}")
     _call_openai([{"id": 1, "title": "A"}], model="gpt-x")
     assert cls.last_kwargs["api_key"] == "sk-test"
@@ -736,10 +736,10 @@ def test_call_openai_uses_default_base_url_when_unset(monkeypatch: pytest.Monkey
     assert cls.last_kwargs.get("base_url") is None
 
 
-def test_call_openai_uses_briefing_endpoint_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_call_openai_uses_free_llm_endpoint_override(monkeypatch: pytest.MonkeyPatch) -> None:
     cls = _patch_openai(monkeypatch, "{}")
-    monkeypatch.setenv("OPENAI_BRIEFING_API_KEY", "freellmapi-key")
-    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://127.0.0.1:9130/v1")
+    monkeypatch.setenv("FREE_LLM_API_KEY", "freellmapi-key")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://127.0.0.1:9130/v1")
     _call_openai([{"id": 1, "title": "A"}], model="auto")
     assert cls.last_kwargs["api_key"] == "freellmapi-key"
     assert cls.last_kwargs["base_url"] == "http://127.0.0.1:9130/v1"
@@ -772,7 +772,7 @@ def test_call_openai_wraps_upstream_error(monkeypatch: pytest.MonkeyPatch) -> No
         raise _UpstreamError(msg)
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://192.168.0.75:9130/v1")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://192.168.0.75:9130/v1")
     cls = type(
         "Patched",
         (_FakeOpenAI,),

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -157,14 +157,14 @@ def test_insights_ai_config_uses_gateway_when_configured(
     assert model == DEFAULT_INSIGHTS_MODEL
 
 
-def test_insights_ai_config_prefers_insights_gateway_settings(
+def test_insights_ai_config_uses_free_llm_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
-    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway/v1")
-    monkeypatch.setenv("OPENAI_INSIGHTS_API_KEY", "freellmapi-key")
-    monkeypatch.setenv("OPENAI_INSIGHTS_BASE_URL", "http://insights-gateway/v1")
+    monkeypatch.setenv("FREE_LLM_API_KEY", "freellmapi-key")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://insights-gateway/v1")
     monkeypatch.setenv("OPENAI_INSIGHTS_MODEL", "gateway-chat-model")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     api_key, base_url, model = _insights_ai_config()
 

--- a/backend/tests/test_perspectives.py
+++ b/backend/tests/test_perspectives.py
@@ -136,30 +136,38 @@ def test_build_text_empty_article_returns_empty() -> None:
 
 def test_perspectives_ai_config_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_PERSPECTIVES_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
     with pytest.raises(PerspectivesNotConfiguredError):
         _perspectives_ai_config()
 
 
-def test_perspectives_ai_config_uses_shared_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_perspectives_ai_config_uses_free_llm_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "sk-free-llm")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://gateway/v1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    api_key, base_url, model = _perspectives_ai_config()
+    assert api_key == "sk-free-llm"
+    assert base_url == "http://gateway/v1"
+    assert model == DEFAULT_PERSPECTIVES_MODEL
+
+
+def test_perspectives_ai_config_falls_back_to_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://gateway/v1")
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
     api_key, base_url, model = _perspectives_ai_config()
     assert api_key == "sk-shared"
     assert base_url == "http://gateway/v1"
     assert model == DEFAULT_PERSPECTIVES_MODEL
 
 
-def test_perspectives_ai_config_prefers_perspectives_settings(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_perspectives_ai_config_uses_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
-    monkeypatch.setenv("OPENAI_PERSPECTIVES_API_KEY", "sk-perspectives")
-    monkeypatch.setenv("OPENAI_PERSPECTIVES_BASE_URL", "http://p-gateway/v1")
     monkeypatch.setenv("OPENAI_PERSPECTIVES_MODEL", "custom-model")
-    api_key, base_url, model = _perspectives_ai_config()
-    assert api_key == "sk-perspectives"
-    assert base_url == "http://p-gateway/v1"
+    _, _, model = _perspectives_ai_config()
     assert model == "custom-model"
 
 
@@ -194,7 +202,7 @@ def test_generate_perspectives_raises_without_api_key() -> None:
     with patch.dict("os.environ", {}, clear=False):
         import os
 
-        os.environ.pop("OPENAI_PERSPECTIVES_API_KEY", None)
+        os.environ.pop("FREE_LLM_API_KEY", None)
         os.environ.pop("OPENAI_API_KEY", None)
         with pytest.raises(PerspectivesNotConfiguredError):
             generate_perspectives(_ARTICLE)

--- a/backend/tests/test_prompt_optimizer.py
+++ b/backend/tests/test_prompt_optimizer.py
@@ -58,56 +58,30 @@ def test_collect_negative_examples_requires_langfuse() -> None:
 
 
 def test_optimizer_ai_config_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in ("OPENAI_OPTIMIZER_API_KEY", "OPENAI_BRIEFING_API_KEY", "OPENAI_API_KEY"):
-        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(PromptOptimizerError, match="API key"):
         _optimizer_ai_config()
 
 
-def test_optimizer_ai_config_uses_optimizer_key_and_base_url(
+def test_optimizer_ai_config_uses_free_llm_key_and_base_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("OPENAI_OPTIMIZER_API_KEY", "opt-key")
-    monkeypatch.setenv("OPENAI_OPTIMIZER_BASE_URL", "http://optimizer-gw/v1")
-    for var in (
-        "OPENAI_BRIEFING_API_KEY",
-        "OPENAI_BRIEFING_BASE_URL",
-        "OPENAI_API_KEY",
-        "OPENAI_BASE_URL",
-    ):
-        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("FREE_LLM_API_KEY", "free-llm-key")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://free-gw/v1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     api_key, base_url = _optimizer_ai_config()
 
-    assert api_key == "opt-key"
-    assert base_url == "http://optimizer-gw/v1"
-
-
-def test_optimizer_ai_config_falls_back_to_briefing_gateway(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    for var in ("OPENAI_OPTIMIZER_API_KEY", "OPENAI_OPTIMIZER_BASE_URL"):
-        monkeypatch.delenv(var, raising=False)
-    monkeypatch.setenv("OPENAI_BRIEFING_API_KEY", "briefing-key")
-    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gw/v1")
-    for var in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
-        monkeypatch.delenv(var, raising=False)
-
-    api_key, base_url = _optimizer_ai_config()
-
-    assert api_key == "briefing-key"
-    assert base_url == "http://briefing-gw/v1"
+    assert api_key == "free-llm-key"
+    assert base_url == "http://free-gw/v1"
 
 
 def test_optimizer_ai_config_falls_back_to_openai(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in (
-        "OPENAI_OPTIMIZER_API_KEY",
-        "OPENAI_OPTIMIZER_BASE_URL",
-        "OPENAI_BRIEFING_API_KEY",
-        "OPENAI_BRIEFING_BASE_URL",
-        "OPENAI_BASE_URL",
-    ):
-        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "plain-key")
 
     api_key, base_url = _optimizer_ai_config()

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -87,23 +87,19 @@ def test_generate_audio_raises_when_no_api_key(tmp_path: Path) -> None:
             generate_audio(42, _ARTICLE, data_dir=tmp_path)
 
 
-def test_tts_ai_config_uses_tts_specific_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
-    monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway:9130/v1")
-    monkeypatch.setenv("OPENAI_TTS_API_KEY", "sk-tts")
-    monkeypatch.setenv("OPENAI_TTS_BASE_URL", "http://tts-gateway:9130/v1")
+def test_tts_ai_config_uses_openai_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://openai-base/v1")
 
     api_key, base_url = _tts_ai_config()
 
-    assert api_key == "sk-tts"
-    assert base_url == "http://tts-gateway:9130/v1"
+    assert api_key == "sk-openai"
+    assert base_url == "http://openai-base/v1"
 
 
 def test_tts_ai_config_uses_shared_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://shared-gateway:9130/v1")
-    monkeypatch.delenv("OPENAI_TTS_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_TTS_BASE_URL", raising=False)
 
     api_key, base_url = _tts_ai_config()
 
@@ -111,11 +107,9 @@ def test_tts_ai_config_uses_shared_gateway(monkeypatch: pytest.MonkeyPatch) -> N
     assert base_url == "http://shared-gateway:9130/v1"
 
 
-def test_tts_ai_config_falls_back_to_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tts_ai_config_no_base_url_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    monkeypatch.delenv("OPENAI_TTS_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_TTS_BASE_URL", raising=False)
 
     api_key, base_url = _tts_ai_config()
 
@@ -247,21 +241,22 @@ def test_generate_audio_creates_audio_directory(tmp_path: Path) -> None:
 # ── _script_ai_config ─────────────────────────────────────────────────────────
 
 
-def test_script_ai_config_uses_briefing_specific_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_BRIEFING_API_KEY", "sk-briefing")
-    monkeypatch.setenv("OPENAI_BRIEFING_BASE_URL", "http://briefing-gw:9130/v1")
+def test_script_ai_config_uses_free_llm_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "sk-free-llm")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://free-gw:9130/v1")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     api_key, base_url = _script_ai_config()
 
-    assert api_key == "sk-briefing"
-    assert base_url == "http://briefing-gw:9130/v1"
+    assert api_key == "sk-free-llm"
+    assert base_url == "http://free-gw:9130/v1"
 
 
 def test_script_ai_config_falls_back_to_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
-    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_BASE_URL", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     api_key, base_url = _script_ai_config()
 
@@ -270,7 +265,7 @@ def test_script_ai_config_falls_back_to_openai_key(monkeypatch: pytest.MonkeyPat
 
 
 def test_script_ai_config_raises_when_no_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     with pytest.raises(TTSNotConfiguredError):
@@ -295,7 +290,7 @@ def test_generate_podcast_script() -> None:
         )
     ]
     with (
-        patch.dict("os.environ", {"OPENAI_BRIEFING_API_KEY": "sk-briefing"}),
+        patch.dict("os.environ", {"FREE_LLM_API_KEY": "sk-free-llm"}),
         patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
     ):
         script = generate_podcast_script(
@@ -314,10 +309,10 @@ def test_generate_podcast_script() -> None:
     assert script[1]["text"] == "Hi Alex!"
 
 
-def test_generate_podcast_script_raises_when_no_briefing_key(
+def test_generate_podcast_script_raises_when_no_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     with pytest.raises(TTSNotConfiguredError):

--- a/backend/tests/test_user_attribution.py
+++ b/backend/tests/test_user_attribution.py
@@ -97,7 +97,7 @@ def test_embed_passes_system_user_id_to_trace_params() -> None:
     mock_tp.assert_called_once_with("article-embedding", tags=["embedding"], user_id="system")
 
 
-def test_embed_uses_briefing_gateway_base_url_when_configured() -> None:
+def test_embed_uses_free_llm_gateway_base_url_when_configured() -> None:
     from news_dashboard.embeddings import _embed
 
     mock_response = MagicMock()
@@ -110,7 +110,7 @@ def test_embed_uses_briefing_gateway_base_url_when_configured() -> None:
             "os.environ",
             {
                 "OPENAI_API_KEY": "sk-test",
-                "OPENAI_BRIEFING_BASE_URL": "http://127.0.0.1:9130/v1",
+                "FREE_LLM_BASE_URL": "http://127.0.0.1:9130/v1",
             },
             clear=True,
         ),
@@ -247,7 +247,7 @@ def test_ai_extract_body_passes_none_user_id_by_default() -> None:
     assert mock_cc.call_args.kwargs["user_id"] is None
 
 
-def test_ai_extract_body_uses_briefing_gateway_config() -> None:
+def test_ai_extract_body_uses_free_llm_gateway_config() -> None:
     from news_dashboard.body_fetch import _ai_extract_body
 
     mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
@@ -258,9 +258,8 @@ def test_ai_extract_body_uses_briefing_gateway_config() -> None:
         patch.dict(
             "os.environ",
             {
-                "OPENAI_API_KEY": "sk-openai",
-                "OPENAI_BRIEFING_API_KEY": "sk-gateway",
-                "OPENAI_BRIEFING_BASE_URL": "http://gateway:9130/v1",
+                "FREE_LLM_API_KEY": "sk-gateway",
+                "FREE_LLM_BASE_URL": "http://gateway:9130/v1",
                 "OPENAI_BRIEFING_MODEL": "gateway-chat-model",
             },
         ),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       POSTGRES_USER: news_dashboard
       POSTGRES_PASSWORD: news-dashboard-local-password
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      FREE_LLM_API_KEY: ${FREE_LLM_API_KEY:-}
+      FREE_LLM_BASE_URL: ${FREE_LLM_BASE_URL:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -88,16 +88,16 @@ spec:
                   name: {{ .Values.app.ai.existingSecret | quote }}
                   key: {{ .Values.app.ai.openaiApiKeyKey | quote }}
                   optional: true
-            - name: OPENAI_BRIEFING_API_KEY
+            - name: FREE_LLM_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.app.ai.existingSecret | quote }}
-                  key: {{ .Values.app.ai.briefingApiKeyKey | quote }}
+                  key: {{ .Values.app.ai.freeLlmApiKeyKey | quote }}
                   optional: true
 {{- end }}
-{{- if .Values.app.ai.briefingBaseUrl }}
-            - name: OPENAI_BRIEFING_BASE_URL
-              value: {{ .Values.app.ai.briefingBaseUrl | quote }}
+{{- if .Values.app.ai.freeLlmBaseUrl }}
+            - name: FREE_LLM_BASE_URL
+              value: {{ .Values.app.ai.freeLlmBaseUrl | quote }}
 {{- end }}
 {{- if .Values.app.ai.briefingModel }}
             - name: OPENAI_BRIEFING_MODEL

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -56,16 +56,17 @@ app:
     # Override in CI/local deploy with a long random string.
     sessionSecret: ""
   ai:
-    # Optional: pre-existing Secret with OPENAI_API_KEY.
+    # Optional: pre-existing Secret with OPENAI_API_KEY and FREE_LLM_API_KEY.
     existingSecret: ""
+    # Key within existingSecret holding the real OpenAI API key (used for TTS audio).
     openaiApiKeyKey: OPENAI_API_KEY
-    # Briefing summarization can target a separate OpenAI-compatible endpoint
-    # (e.g. a self-hosted freellmapi gateway) instead of OpenAI. Leave the
-    # base URL empty to keep using OpenAI for briefings too.
-    briefingBaseUrl: ""
+    # All LLM chat/completion/embedding calls route through the free LLM gateway.
+    # Set freeLlmBaseUrl to your self-hosted OpenAI-compatible proxy base URL.
+    # Leave empty to fall back to OPENAI_API_KEY / official OpenAI endpoint.
+    freeLlmBaseUrl: ""
     briefingModel: ""
-    # Key within `existingSecret` holding the briefing endpoint's API key.
-    briefingApiKeyKey: OPENAI_BRIEFING_API_KEY
+    # Key within existingSecret holding the free LLM gateway API key.
+    freeLlmApiKeyKey: FREE_LLM_API_KEY
     # Langfuse LLM observability. When publicKey + secretKey are present (read
     # from `ai.existingSecret`), every OpenAI call is traced. Leave host empty
     # to disable tracing entirely (app falls back to a plain OpenAI client).


### PR DESCRIPTION
## Summary

Closes #404

- Adds `free_llm_config()` and `openai_config()` helpers in `ai_client.py` to replace 18 per-feature `os.getenv` chains
- Routes all LLM chat/completion/embedding calls through `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL` (falling back to `OPENAI_API_KEY` / `OPENAI_BASE_URL`)
- TTS audio synthesis (`audio/speech`) stays on `OPENAI_API_KEY` only, since the free gateway doesn't expose that endpoint
- Removes all per-feature env vars: `OPENAI_BRIEFING_API_KEY`, `OPENAI_TTS_API_KEY`, `OPENAI_QUIZ_API_KEY`, `OPENAI_EMBEDDINGS_API_KEY`, `OPENAI_ANSWER_API_KEY`, `OPENAI_INSIGHTS_API_KEY`, `OPENAI_PERSPECTIVES_API_KEY`, `OPENAI_OPTIMIZER_API_KEY` and their `*_BASE_URL` counterparts
- Updates Helm chart (`values.yaml`, `deployment.yaml`) and `docker-compose.yml` to expose `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL`
- Updates CI workflow to use the new secret/var names
- Updates all affected tests to use the new env var names

**Embeddings note:** The free LLM gateway at `192.168.0.75:9130` supports the embeddings endpoint — confirmed by the existing gateway config.

## Test plan

- [x] `make lint` passes (ruff + prettier)
- [x] `make typecheck` passes (mypy strict + ty + pyrefly + tsc)
- [x] `source .env && make test` — 957 passed, 5 pre-existing postgres schema type failures (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)