### PR TITLE
feat: steerable daily briefings with focus_prompt (#341)

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -186,7 +186,11 @@ def _briefing_ai_config() -> tuple[str, str | None]:
 
 
 def _call_openai(
-    candidates: list[dict[str, Any]], model: str, *, user_id: int | None = None
+    candidates: list[dict[str, Any]],
+    model: str,
+    *,
+    user_id: int | None = None,
+    focus_prompt: str | None = None,
 ) -> dict[str, Any]:
     """Call an OpenAI-compatible API to generate structured briefing JSON."""
 
@@ -206,6 +210,10 @@ def _call_openai(
 
     prompt = get_prompt("briefing-system", fallback=_BRIEFING_SYSTEM_PROMPT)
     system = prompt.text
+    if focus_prompt:
+        system += (
+            f"\n\nFocus the briefing on the following user-directed topic/style: {focus_prompt}"
+        )
     user = "Articles:\n\n" + "\n\n".join(article_lines)
 
     client = get_openai_client(api_key=api_key, base_url=base_url)
@@ -273,7 +281,7 @@ def _validate_content(raw: dict[str, Any], candidate_ids: set[int]) -> dict[str,
     }
 
 
-def _save_briefing(
+def _save_briefing(  # noqa: PLR0913
     since_at: datetime,
     until_at: datetime,
     content: dict[str, Any],
@@ -281,6 +289,7 @@ def _save_briefing(
     model: str,
     database_url: str | None = None,
     user_id: int | None = None,
+    focus_prompt: str | None = None,
 ) -> dict[str, Any]:
     """Insert briefing + article links; return the full briefing dict."""
     title = content.get("title") or ""
@@ -294,9 +303,10 @@ def _save_briefing(
         row = conn.execute(
             """
             INSERT INTO briefings(
-                scope, since_at, until_at, status, title, summary, content, model, user_id
+                scope, since_at, until_at, status,
+                title, summary, content, model, user_id, focus_prompt
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -309,6 +319,7 @@ def _save_briefing(
                 json.dumps(content_blob),
                 model,
                 user_id,
+                focus_prompt,
             ),
         ).fetchone()
         if row is None:
@@ -356,6 +367,7 @@ def _find_recent_briefing(
     window_minutes: int,
     database_url: str | None = None,
     user_id: int | None = None,
+    focus_prompt: str | None = None,
 ) -> dict[str, Any] | None:
     """Return the most recent complete briefing if created within window_minutes, else None."""
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
@@ -365,20 +377,22 @@ def _find_recent_briefing(
                 """
                 SELECT id FROM briefings
                 WHERE status = 'complete' AND created_at >= %s AND user_id = %s
+                  AND focus_prompt IS NOT DISTINCT FROM %s
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
-                (cutoff, user_id),
+                (cutoff, user_id, focus_prompt),
             ).fetchone()
         else:
             row = conn.execute(
                 """
                 SELECT id FROM briefings
                 WHERE status = 'complete' AND created_at >= %s AND user_id IS NULL
+                  AND focus_prompt IS NOT DISTINCT FROM %s
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
-                (cutoff,),
+                (cutoff, focus_prompt),
             ).fetchone()
     if row is None:
         return None
@@ -392,16 +406,28 @@ def _save_failed_briefing(
     model: str,
     database_url: str | None = None,
     user_id: int | None = None,
+    focus_prompt: str | None = None,
 ) -> None:
     """Persist a failed-status row for observability; DB errors are swallowed."""
     try:
         with connect(database_url=database_url) as conn:
             conn.execute(
                 """
-                INSERT INTO briefings(scope, since_at, until_at, status, model, error, user_id)
-                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                INSERT INTO briefings(
+                    scope, since_at, until_at, status, model, error, user_id, focus_prompt
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 """,
-                (CURRENT_DAY_SCOPE, since_at, until_at, "failed", model, str(exc), user_id),
+                (
+                    CURRENT_DAY_SCOPE,
+                    since_at,
+                    until_at,
+                    "failed",
+                    model,
+                    str(exc),
+                    user_id,
+                    focus_prompt,
+                ),
             )
     except Exception:
         logger.exception("Failed to persist failed-briefing row — original error follows")
@@ -436,7 +462,25 @@ def select_candidates(
         return [row_to_dict(r) for r in rows]
 
 
-def generate_briefing(
+def _keyword_score(article: dict[str, Any], keywords: list[str]) -> float:
+    if not keywords:
+        return 0.0
+    title = (article.get("title") or "").lower()
+    category = (article.get("category") or "").lower()
+    summary = (article.get("summary") or "").lower()
+
+    score = 0.0
+    for kw in keywords:
+        if kw in title:
+            score += 10.0
+        if kw in category:
+            score += 5.0
+        if kw in summary:
+            score += 2.0
+    return score
+
+
+def generate_briefing(  # noqa: PLR0913
     database_url: str | None = None,
     *,
     model: str | None = None,
@@ -445,6 +489,7 @@ def generate_briefing(
     user_id: int | None = None,
     max_attempts: int = BRIEFING_MAX_ATTEMPTS,
     retry_base_delay_seconds: float = BRIEFING_RETRY_BASE_DELAY_SECONDS,
+    focus_prompt: str | None = None,
 ) -> dict[str, Any]:
     """Generate and persist a briefing from eligible Today articles.
 
@@ -465,7 +510,9 @@ def generate_briefing(
         BriefingGenerationError: AI returned an invalid or unparseable response
             on every attempt.
     """
-    recent = _find_recent_briefing(idempotency_window_minutes, database_url, user_id=user_id)
+    recent = _find_recent_briefing(
+        idempotency_window_minutes, database_url, user_id=user_id, focus_prompt=focus_prompt
+    )
     if recent is not None:
         return recent
 
@@ -480,8 +527,27 @@ def generate_briefing(
     if not candidates:
         return {"status": "no_candidates"}
 
+    keywords = []
+    if focus_prompt:
+        cleaned = "".join(c if c.isalnum() else " " for c in focus_prompt.lower())
+        keywords = [w for w in cleaned.split() if len(w) >= 3]
+
+    if keywords:
+        candidates = sorted(
+            candidates,
+            key=lambda a: (
+                _keyword_score(a, keywords),
+                -float(a["importance_score"]) if a.get("importance_score") is not None else -50.0,
+            ),
+            reverse=True,
+        )
+
     candidate_ids = {int(a["id"]) for a in candidates}
-    call_ai: AiFn = ai_fn if ai_fn is not None else partial(_call_openai, user_id=user_id)
+    call_ai: AiFn = (
+        ai_fn
+        if ai_fn is not None
+        else partial(_call_openai, user_id=user_id, focus_prompt=focus_prompt)
+    )
     attempts = max(1, max_attempts)
     content: dict[str, Any] | None = None
     for attempt in range(1, attempts + 1):
@@ -492,13 +558,25 @@ def generate_briefing(
         except BriefingAINotConfiguredError as exc:
             # Misconfiguration won't fix itself on retry — fail fast.
             _save_failed_briefing(
-                since_at, until_at, exc, resolved_model, database_url, user_id=user_id
+                since_at,
+                until_at,
+                exc,
+                resolved_model,
+                database_url,
+                user_id=user_id,
+                focus_prompt=focus_prompt,
             )
             raise
         except BriefingGenerationError as exc:
             if attempt >= attempts:
                 _save_failed_briefing(
-                    since_at, until_at, exc, resolved_model, database_url, user_id=user_id
+                    since_at,
+                    until_at,
+                    exc,
+                    resolved_model,
+                    database_url,
+                    user_id=user_id,
+                    focus_prompt=focus_prompt,
                 )
                 raise
             delay = retry_base_delay_seconds * (2 ** (attempt - 1))
@@ -516,7 +594,14 @@ def generate_briefing(
         msg = "Briefing generation produced no content"
         raise BriefingGenerationError(msg)
     return _save_briefing(
-        since_at, until_at, content, candidate_ids, resolved_model, database_url, user_id=user_id
+        since_at,
+        until_at,
+        content,
+        candidate_ids,
+        resolved_model,
+        database_url,
+        user_id=user_id,
+        focus_prompt=focus_prompt,
     )
 
 
@@ -531,7 +616,7 @@ def get_latest_briefing(
             row = conn.execute(
                 """
                 SELECT id, created_at, scope, since_at, until_at, status,
-                       title, summary, content, model, error, script
+                       title, summary, content, model, error, script, focus_prompt
                 FROM briefings
                 WHERE user_id = %s
                 ORDER BY created_at DESC
@@ -543,7 +628,7 @@ def get_latest_briefing(
             row = conn.execute(
                 """
                 SELECT id, created_at, scope, since_at, until_at, status,
-                       title, summary, content, model, error, script
+                       title, summary, content, model, error, script, focus_prompt
                 FROM briefings
                 WHERE user_id IS NULL
                 ORDER BY created_at DESC
@@ -573,7 +658,7 @@ def list_briefings(
             rows = conn.execute(
                 """
                 SELECT id, created_at, scope, since_at, until_at, status,
-                       title, summary, model, error
+                       title, summary, model, error, focus_prompt
                 FROM briefings
                 WHERE user_id = %s
                 ORDER BY created_at DESC
@@ -585,7 +670,7 @@ def list_briefings(
             rows = conn.execute(
                 """
                 SELECT id, created_at, scope, since_at, until_at, status,
-                       title, summary, model, error
+                       title, summary, model, error, focus_prompt
                 FROM briefings
                 WHERE user_id IS NULL
                 ORDER BY created_at DESC
@@ -608,7 +693,7 @@ def get_briefing(
             row = conn.execute(
                 """
                 SELECT id, created_at, scope, since_at, until_at, status,
-                       title, summary, content, model, error, script
+                       title, summary, content, model, error, script, focus_prompt
                 FROM briefings
                 WHERE id = %s AND user_id = %s
                 """,
@@ -618,7 +703,7 @@ def get_briefing(
             row = conn.execute(
                 """
                 SELECT id, created_at, scope, since_at, until_at, status,
-                       title, summary, content, model, error, script
+                       title, summary, content, model, error, script, focus_prompt
                 FROM briefings
                 WHERE id = %s AND user_id IS NULL
                 """,

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -248,6 +248,7 @@ POSTGRES_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_briefings_user ON briefings(user_id, created_at DESC)",
     "ALTER TABLE briefings ADD COLUMN IF NOT EXISTS script JSONB",
     "ALTER TABLE ingest_run_sources ADD COLUMN IF NOT EXISTS duration_ms INTEGER",
+    "ALTER TABLE briefings ADD COLUMN IF NOT EXISTS focus_prompt TEXT",
 ]
 
 POSTGRES_MULTIUSER_SCHEMA = [

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1280,12 +1280,18 @@ def get_podcast_audio_endpoint(
     return FileResponse(audio_path, media_type="audio/mpeg", filename=f"podcast-{briefing_id}.mp3")
 
 
+class BriefingCreateRequest(BaseModel):
+    focus_prompt: str | None = None
+
+
 @api.post("/api/briefings")
 def briefings_create(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    payload: BriefingCreateRequest | None = None,
 ) -> dict[str, Any]:
     try:
-        return generate_briefing(user_id=current_user["id"])
+        focus = payload.focus_prompt if payload is not None else None
+        return generate_briefing(user_id=current_user["id"], focus_prompt=focus)
     except BriefingAINotConfiguredError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except BriefingGenerationError as exc:

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -1132,3 +1132,133 @@ def test_generate_briefing_does_not_retry_when_ai_not_configured(pg_clean: str) 
 
     # Misconfiguration fails fast — no retries.
     assert calls["n"] == 1
+
+
+# ── Steerable briefings tests ───────────────────────────────────────────────
+
+
+def test_generate_briefing_re_ranks_candidates_based_on_focus_prompt(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    a1 = _seed_article(
+        pg_clean,
+        url="https://example.com/art1",
+        title="Exploring deep space exploration",
+        state="today",
+        importance_score=50,
+    )
+    a2 = _seed_article(
+        pg_clean,
+        url="https://example.com/art2",
+        title="Unlocking nuclear fusion energy",
+        state="today",
+        importance_score=10,
+    )
+    _seed_article(
+        pg_clean,
+        url="https://example.com/art3",
+        title="Standard news article on agriculture",
+        state="today",
+        importance_score=90,
+    )
+
+    called_candidates = []
+
+    def _ai_spy(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        nonlocal called_candidates
+        called_candidates = list(candidates)
+        return {
+            "title": "Fusion Briefing",
+            "summary": "Nuclear fusion news.",
+            "sections": [{"title": "Energy", "body": "Fusion update.", "citations": [a2]}],
+            "worth_opening": [a2],
+        }
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_ai_spy, focus_prompt="fusion energy")
+    assert result["title"] == "Fusion Briefing"
+    assert called_candidates[0]["id"] == a2
+    assert called_candidates[1]["id"] == a1
+
+
+def test_call_openai_includes_focus_prompt_in_system_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    captured_messages = []
+
+    def _mock_chat_create(*args: Any, messages: list[dict[str, str]], **kwargs: Any) -> Any:
+        nonlocal captured_messages
+        captured_messages = messages
+        message = SimpleNamespace(content='{"title": "T", "sections": []}')
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice])
+
+    import news_dashboard.ai_client as ai_client_mod
+
+    monkeypatch.setattr(ai_client_mod, "chat_create", _mock_chat_create)
+
+    _call_openai([{"id": 1, "title": "A"}], model="gpt-x", focus_prompt="FUSION ENERGY")
+    assert any("FUSION ENERGY" in msg.get("content", "") for msg in captured_messages)
+
+
+def test_generate_briefing_idempotency_respects_focus_prompt(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(
+        pg_clean, url="https://example.com/art1", title="Nuclear fusion energy", state="today"
+    )
+
+    calls = {"n": 0}
+
+    def _ai_fn(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        calls["n"] += 1
+        return {
+            "title": f"Briefing {calls['n']}",
+            "summary": "Summary",
+            "sections": [],
+            "worth_opening": [],
+        }
+
+    res1 = generate_briefing(database_url=pg_clean, ai_fn=_ai_fn, focus_prompt="fusion")
+    assert res1["title"] == "Briefing 1"
+    assert calls["n"] == 1
+
+    res2 = generate_briefing(database_url=pg_clean, ai_fn=_ai_fn, focus_prompt="fusion")
+    assert res2["title"] == "Briefing 1"
+    assert calls["n"] == 1
+
+    res3 = generate_briefing(database_url=pg_clean, ai_fn=_ai_fn, focus_prompt="space")
+    assert res3["title"] == "Briefing 2"
+    assert calls["n"] == 2
+
+    res4 = generate_briefing(database_url=pg_clean, ai_fn=_ai_fn, focus_prompt=None)
+    assert res4["title"] == "Briefing 3"
+    assert calls["n"] == 3
+
+
+def test_get_latest_briefing_and_list_returns_focus_prompt(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(
+        pg_clean, url="https://example.com/art1", title="Nuclear fusion energy", state="today"
+    )
+
+    def _ai_fn(candidates: list[dict[str, Any]], model: str) -> dict[str, Any]:
+        return {
+            "title": "Fusion Brief",
+            "summary": "Summary",
+            "sections": [],
+            "worth_opening": [],
+        }
+
+    res = generate_briefing(database_url=pg_clean, ai_fn=_ai_fn, focus_prompt="fusion")
+    assert res["focus_prompt"] == "fusion"
+
+    latest = get_latest_briefing(database_url=pg_clean)
+    assert latest is not None
+    assert latest["focus_prompt"] == "fusion"
+
+    detail = get_briefing(latest["id"], database_url=pg_clean)
+    assert detail is not None
+    assert detail["focus_prompt"] == "fusion"
+
+    history = list_briefings(database_url=pg_clean)
+    assert len(history) == 1
+    assert history[0]["focus_prompt"] == "fusion"

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -356,6 +356,12 @@ describe('ingest runs & briefings', () => {
     expect(calls[0].init?.method).toBe('POST');
   });
 
+  it('createBriefing sends focus_prompt when provided', async () => {
+    const { calls } = stubFetch(() => jsonOk({ id: 1 }));
+    await api.createBriefing('tech policy');
+    expect(calls[0].init?.body).toBe(JSON.stringify({ focus_prompt: 'tech policy' }));
+  });
+
   it('fetchBriefing GETs by id', async () => {
     const { calls } = stubFetch(() => jsonOk({ id: 4 }));
     await api.fetchBriefing(4);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -300,8 +300,11 @@ export async function fetchLatestBriefing(): Promise<BriefingLatestResponse> {
   return requestJson<BriefingLatestResponse>('/api/briefings/latest');
 }
 
-export async function createBriefing(): Promise<BriefingCreateResponse> {
-  return requestJson<BriefingCreateResponse>('/api/briefings', { method: 'POST' });
+export async function createBriefing(focusPrompt?: string): Promise<BriefingCreateResponse> {
+  return requestJson<BriefingCreateResponse>('/api/briefings', {
+    method: 'POST',
+    ...(focusPrompt ? { body: JSON.stringify({ focus_prompt: focusPrompt }) } : {}),
+  });
 }
 
 export async function fetchBriefing(id: number): Promise<Briefing> {

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Newspaper, RefreshCw, AlertCircle, Inbox, History } from 'lucide-react';
+import { Newspaper, RefreshCw, AlertCircle, Inbox, History, Wand2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { fetchLatestBriefing, createBriefing } from '@/api';
 import { BriefingView, BriefSkeleton } from '@/components/BriefingView';
 import { BriefingChat } from '@/components/BriefingChat';
@@ -23,23 +24,28 @@ export function BriefPage() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generateError, setGenerateError] = useState<GenerateError | null>(null);
   const [noCandidates, setNoCandidates] = useState<NoCandidates>({ shown: false });
+  const [focusInput, setFocusInput] = useState('');
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['briefings', 'latest'],
     queryFn: fetchLatestBriefing,
   });
 
-  function generate() {
+  function generate(focusPrompt?: string) {
+    void handleGenerate(focusPrompt);
+  }
+
+  function generateDefault() {
     void handleGenerate();
   }
 
-  async function handleGenerate() {
+  async function handleGenerate(focusPrompt?: string) {
     trackFeature('generate_briefing');
     setIsGenerating(true);
     setGenerateError(null);
     setNoCandidates({ shown: false });
     try {
-      const result = await createBriefing();
+      const result = await createBriefing(focusPrompt);
       if ('status' in result && result.status === 'no_candidates') {
         setNoCandidates({ shown: true });
       } else {
@@ -83,7 +89,7 @@ export function BriefPage() {
         </div>
         <div className="flex gap-2 flex-wrap">
           {generateError.kind === 'failed' && (
-            <Button size="sm" onClick={generate} disabled={isGenerating}>
+            <Button size="sm" onClick={generateDefault} disabled={isGenerating}>
               <RefreshCw className={isGenerating ? 'animate-spin' : ''} />
               {isGenerating ? 'Retrying…' : 'Retry'}
             </Button>
@@ -131,7 +137,7 @@ export function BriefPage() {
           </div>
         </div>
         <div className="flex gap-2 justify-center flex-wrap">
-          <Button size="sm" onClick={generate} disabled={isGenerating}>
+          <Button size="sm" onClick={generateDefault} disabled={isGenerating}>
             <RefreshCw className={isGenerating ? 'animate-spin' : ''} />
             {isGenerating ? 'Generating…' : 'Generate briefing'}
           </Button>
@@ -158,7 +164,7 @@ export function BriefPage() {
           </div>
         </div>
         <div className="flex gap-2 flex-wrap">
-          <Button size="sm" onClick={generate} disabled={isGenerating}>
+          <Button size="sm" onClick={generateDefault} disabled={isGenerating}>
             <RefreshCw className={isGenerating ? 'animate-spin' : ''} />
             {isGenerating ? 'Retrying…' : 'Retry'}
           </Button>
@@ -172,25 +178,49 @@ export function BriefPage() {
   }
 
   return (
-    <BriefingView
-      briefing={data}
-      onGenerate={generate}
-      isGenerating={isGenerating}
-      onRefreshBriefing={() => {
-        void refetch();
-      }}
-      afterMeta={
-        <div className="flex items-center gap-2 mt-1">
-          <Link
-            to="/briefs"
-            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+    <div>
+      <div className="px-4 md:px-5 pt-4 pb-2">
+        <div className="flex gap-2 items-center">
+          <Input
+            placeholder="Focus on… (e.g. AI safety, tech policy)"
+            value={focusInput}
+            onChange={(e) => setFocusInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && focusInput.trim()) generate(focusInput.trim());
+            }}
+            className="h-8 text-sm"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={isGenerating || !focusInput.trim()}
+            onClick={() => generate(focusInput.trim())}
           >
-            <History className="size-3" />
-            View history
-          </Link>
-          <BriefingChat briefingId={data.id} />
+            <Wand2 className="size-3.5 mr-1" />
+            Generate
+          </Button>
         </div>
-      }
-    />
+      </div>
+      <BriefingView
+        briefing={data}
+        onGenerate={generateDefault}
+        isGenerating={isGenerating}
+        onRefreshBriefing={() => {
+          void refetch();
+        }}
+        afterMeta={
+          <div className="flex items-center gap-2 mt-1">
+            <Link
+              to="/briefs"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <History className="size-3" />
+              View history
+            </Link>
+            <BriefingChat briefingId={data.id} />
+          </div>
+        }
+      />
+    </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -257,6 +257,7 @@ export interface Briefing {
   error: string | null;
   articles: BriefingArticle[];
   script?: PodcastTurn[] | null;
+  focus_prompt?: string | null;
 }
 
 export type BriefingLatestResponse = Briefing | { status: 'empty' };


### PR DESCRIPTION
Closes #341

## Summary

- **Backend**: `POST /api/briefings` now accepts an optional `focus_prompt` field. When provided, the LLM system prompt is extended with the user's focus/style instruction, and article candidates are re-ranked by keyword relevance so the most topically relevant articles appear first in the prompt.
- **Database**: A `focus_prompt TEXT` column is added to the `briefings` table via the existing `POSTGRES_SCHEMA` migration list. Idempotency checks now distinguish briefings by their `focus_prompt` value.
- **Frontend**: A "Steer Briefing" input bar is added above the daily brief on `BriefPage`. Users type a topic/tone focus, press Enter or click Generate, and the focused briefing is generated via the updated API.
- **Types**: `Briefing` interface gains optional `focus_prompt` field; `createBriefing()` accepts an optional `focusPrompt` argument.

## Test plan

- [ ] Backend integration tests in `test_briefings_db.py`:
  - Candidates are re-ranked when `focus_prompt` is set
  - `focus_prompt` is appended to the LLM system instruction
  - Idempotency window is keyed per `focus_prompt` value
  - `get_latest_briefing`, `get_briefing`, `list_briefings` all return `focus_prompt`
- [ ] Frontend unit test: `createBriefing('tech policy')` serialises `focus_prompt` in the request body
- [ ] All pre-commit hooks pass: ruff, mypy, ty, pyrefly, eslint, prettier, tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)