### PR TITLE
feat: runtime free-LLM→OpenAI fallback for chat and embeddings

### DIFF
--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -166,6 +166,99 @@ def get_openai_client(*, api_key: str, base_url: str | None = None) -> OpenAI:
     from openai import OpenAI as PlainOpenAI
 
     return PlainOpenAI(**kwargs)
+
+
+# ── Runtime free-LLM → OpenAI fallback ─────────────────────────────────────
+
+
+def _invoke[T](
+    primary: OpenAI,
+    fallback: tuple[str, str | None] | None,
+    call: Callable[[OpenAI], T],
+) -> T:
+    """Run *call* against *primary*; on OpenAIError retry once on the OpenAI fallback.
+
+    The same request is replayed verbatim (same model and kwargs) against a
+    lazily-built OpenAI client, so the fallback is only constructed when the free
+    LLM gateway actually fails. When no distinct fallback is configured, the call
+    runs directly against *primary* and any error propagates unchanged.
+    """
+    if fallback is None:
+        return call(primary)
+
+    from openai import OpenAIError  # lazy import — optional dep at import time
+
+    try:
+        return call(primary)
+    except OpenAIError as exc:
+        api_key, base_url = fallback
+        logger.warning("free LLM request failed (%s); retrying on OpenAI fallback", exc)
+        return call(get_openai_client(api_key=api_key, base_url=base_url))
+
+
+class _FallbackCompletions:
+    """``chat.completions`` shim that routes ``create`` through :func:`_invoke`."""
+
+    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+        self._primary = primary
+        self._fallback = fallback
+
+    def create(self, **kwargs: Any) -> Any:
+        return _invoke(self._primary, self._fallback, lambda c: c.chat.completions.create(**kwargs))
+
+
+class _FallbackChat:
+    """``chat`` namespace exposing a fallback-aware ``completions``."""
+
+    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+        self.completions = _FallbackCompletions(primary, fallback)
+
+
+class _FallbackEmbeddings:
+    """``embeddings`` shim that routes ``create`` through :func:`_invoke`."""
+
+    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+        self._primary = primary
+        self._fallback = fallback
+
+    def create(self, **kwargs: Any) -> Any:
+        return _invoke(self._primary, self._fallback, lambda c: c.embeddings.create(**kwargs))
+
+
+class _FallbackClient:
+    """Chat/embedding client that prefers the free LLM gateway, then OpenAI.
+
+    Exposes only the ``chat.completions.create`` and ``embeddings.create``
+    surfaces the backend uses through it; each request prefers the primary (free
+    LLM) client and falls back to OpenAI on failure (see :func:`get_chat_client`).
+    """
+
+    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+        self.chat = _FallbackChat(primary, fallback)
+        self.embeddings = _FallbackEmbeddings(primary, fallback)
+
+
+def get_chat_client(*, api_key: str, base_url: str | None = None) -> OpenAI:
+    """Return a chat/embedding client that prefers the free LLM gateway.
+
+    *api_key* / *base_url* are the primary (free LLM) credentials, as resolved by
+    :func:`free_llm_config`. When a distinct, configured OpenAI endpoint exists —
+    a non-empty ``OPENAI_API_KEY`` whose ``(key, base_url)`` differs from the
+    primary — any chat or embedding request that raises ``openai.OpenAIError`` is
+    retried once against OpenAI with the same model and arguments. For single-key
+    setups, where the free config already *is* the OpenAI endpoint, no fallback
+    is attempted and errors propagate unchanged.
+
+    The returned object is API-compatible with ``openai.OpenAI`` for the
+    ``chat.completions.create`` and ``embeddings.create`` calls made through it.
+    The OpenAI fallback client is built lazily, only on the first failure.
+    """
+    primary = get_openai_client(api_key=api_key, base_url=base_url)
+    openai_key, openai_base = openai_config()
+    fallback: tuple[str, str | None] | None = None
+    if openai_key and (openai_key, openai_base) != (api_key, base_url):
+        fallback = (openai_key, openai_base)
+    return cast("OpenAI", _FallbackClient(primary, fallback))
 
 
 # ── Trace context ────────────────────────────────────────────────────────

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -57,9 +57,9 @@ def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]
         return "", "error"
 
     try:
-        from news_dashboard.ai_client import chat_create, get_openai_client
+        from news_dashboard.ai_client import chat_create, get_chat_client
 
-        client = get_openai_client(api_key=api_key, base_url=base_url)
+        client = get_chat_client(api_key=api_key, base_url=base_url)
         result = chat_create(
             client,
             name="ai-body-fetch",
@@ -331,9 +331,9 @@ def translate_body(body: str, from_lang: str) -> str:
         return body
 
     try:
-        from news_dashboard.ai_client import chat_create, get_openai_client
+        from news_dashboard.ai_client import chat_create, get_chat_client
 
-        client = get_openai_client(api_key=api_key, base_url=base_url)
+        client = get_chat_client(api_key=api_key, base_url=base_url)
         prompt = (
             f"You are a translation assistant. Translate the following body text from "
             f"language code '{from_lang}' to English. Return only the translated plain text, "

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -206,7 +206,7 @@ def _call_openai(
 
     from openai import OpenAIError  # lazy import — optional dep at import time
 
-    from news_dashboard.ai_client import chat_create, get_openai_client, get_prompt
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     prompt = get_prompt("briefing-system", fallback=_BRIEFING_SYSTEM_PROMPT)
     system = prompt.text
@@ -216,7 +216,7 @@ def _call_openai(
         )
     user = "Articles:\n\n" + "\n\n".join(article_lines)
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     try:
         response = chat_create(
             client,
@@ -783,9 +783,9 @@ def chat_with_briefing(
         articles_context=articles_context,
     )
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_chat_client
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     messages: list[dict[str, str]] = [{"role": "system", "content": system}]
     messages.extend(history)
     messages.append({"role": "user", "content": message})

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -100,10 +100,10 @@ def _embeddings_ai_config() -> tuple[str, str | None, str]:
 
 def _embed(text: str) -> list[float]:
     """Embed *text* via the configured OpenAI-compatible endpoint."""
-    from news_dashboard.ai_client import get_openai_client, trace_params
+    from news_dashboard.ai_client import get_chat_client, trace_params
 
     api_key, base_url, model = _embeddings_ai_config()
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     response = client.embeddings.create(
         model=model,
         input=text,
@@ -120,12 +120,12 @@ def _answer(
     prompt: ManagedPrompt | None = None,
 ) -> str:
     """Generate an answer via the free LLM gateway when configured, else OpenAI."""
-    from news_dashboard.ai_client import chat_create, free_llm_config, get_openai_client
+    from news_dashboard.ai_client import chat_create, free_llm_config, get_chat_client
 
     api_key, base_url = free_llm_config()
     if not api_key:
         _require_env("FREE_LLM_API_KEY", "use Ask AI")
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     response = chat_create(
         client,
         name="ask-ai",

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -452,7 +452,7 @@ def detect_and_translate_article(
     import json
     import re
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_chat_client
 
     is_non_eng = source_lang != "en"
     if not is_non_eng:
@@ -478,7 +478,7 @@ def detect_and_translate_article(
         return title, summary, source_lang, None
 
     try:
-        client = get_openai_client(api_key=api_key, base_url=base_url)
+        client = get_chat_client(api_key=api_key, base_url=base_url)
         prompt = (
             "You are a translation assistant. Detect the language of the following text. "
             "If it is not English, translate both the title and the "

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -89,9 +89,9 @@ def generate_insights(article: dict[str, Any], *, user_id: int | None = None) ->
     if not text.strip():
         return []
 
-    from news_dashboard.ai_client import chat_create, get_openai_client, get_prompt
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     prompt = get_prompt("article-insights", fallback=_PROMPT)
     logger.info("Generating insights for article %s", article.get("id"))
     result = chat_create(
@@ -300,9 +300,9 @@ def _generate_cluster_label(
         f"- Title: {a.get('title', '')}\n  Summary: {a.get('summary', '')}" for a in articles[:10]
     )
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_chat_client
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     result = chat_create(
         client,
         name="topic-cluster-label",

--- a/backend/news_dashboard/perspectives.py
+++ b/backend/news_dashboard/perspectives.py
@@ -144,9 +144,9 @@ def generate_perspectives(
     if not text.strip():
         return {"verified_facts": [], "omissions": [], "alternative_perspectives": []}
 
-    from news_dashboard.ai_client import chat_create, get_openai_client, get_prompt
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     prompt = get_prompt("article-perspectives", fallback=_PROMPT)
     logger.info("Generating perspectives for article %s", article.get("id"))
     result = chat_create(

--- a/backend/news_dashboard/prompt_optimizer.py
+++ b/backend/news_dashboard/prompt_optimizer.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from news_dashboard.ai_client import _client, chat_create, get_openai_client, langfuse_enabled
+from news_dashboard.ai_client import _client, chat_create, get_chat_client, langfuse_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,7 @@ def _optimizer_ai_config() -> tuple[str, str | None]:
 def _propose_revision(current_text: str, examples: list[NegativeExample], *, model: str) -> str:
     """Call the LLM to draft an improved prompt. Traced like any other call."""
     api_key, base_url = _optimizer_ai_config()
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     response = chat_create(
         client,
         name="prompt-optimizer",

--- a/backend/news_dashboard/quiz.py
+++ b/backend/news_dashboard/quiz.py
@@ -246,9 +246,9 @@ def generate_weekly_quiz(
     blurbs = "\n\n---\n\n".join(_build_article_blurb(a) for a in articles[:5])
     messages = [{"role": "user", "content": f"{_QUIZ_PROMPT}\n\nArticles:\n{blurbs}"}]
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_chat_client
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     logger.info("Generating weekly quiz for user %s from %d articles", user_id, len(articles))
     result = chat_create(
         client,

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -377,7 +377,7 @@ def generate_recommendation_explanation(
     """
     import os
 
-    from news_dashboard.ai_client import chat_create, free_llm_config, get_openai_client
+    from news_dashboard.ai_client import chat_create, free_llm_config, get_chat_client
 
     api_key, base_url = free_llm_config()
     if not api_key:
@@ -435,7 +435,7 @@ def generate_recommendation_explanation(
     )
 
     try:
-        client = get_openai_client(api_key=api_key, base_url=base_url)
+        client = get_chat_client(api_key=api_key, base_url=base_url)
         response = chat_create(
             client,
             name="recommendation-explanation",

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -297,9 +297,9 @@ def generate_share_context(share_id: int) -> str | None:
         "Be specific and personal, not generic."
     )
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_chat_client
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
     try:
         completion = chat_create(
             client,

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -195,10 +195,10 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
     """Generate a conversational podcast script from briefing content using LLM."""
     api_key, base_url = _script_ai_config()
 
-    from news_dashboard.ai_client import chat_create, get_openai_client
+    from news_dashboard.ai_client import chat_create, get_chat_client
 
     model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_chat_client(api_key=api_key, base_url=base_url)
 
     title = briefing_content.get("title", "")
     summary = briefing_content.get("summary", "")

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -157,3 +158,157 @@ def test_fetch_metrics_disabled_returns_enabled_false() -> None:
 def test_compile_fallback_substitutes_double_brace_vars() -> None:
     assert _compile_fallback("Hi {{name}}, {{name}}!", {"name": "Sam"}) == "Hi Sam, Sam!"
     assert _compile_fallback("no vars here", {}) == "no vars here"
+
+
+# ── get_chat_client runtime free-LLM→OpenAI fallback ───────────────────────
+
+
+def _raising_client(exc: Exception) -> MagicMock:
+    client = MagicMock()
+    client.chat.completions.create.side_effect = exc
+    client.embeddings.create.side_effect = exc
+    return client
+
+
+def _ok_client(result: object) -> MagicMock:
+    client = MagicMock()
+    client.chat.completions.create.return_value = result
+    client.embeddings.create.return_value = result
+    return client
+
+
+def _clear_ai_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("FREE_LLM_API_KEY", "FREE_LLM_BASE_URL", "OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_get_chat_client_falls_back_to_openai_on_chat_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    from openai import OpenAIError
+
+    from news_dashboard.ai_client import get_chat_client
+
+    class _UpstreamError(OpenAIError):
+        pass
+
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("FREE_LLM_API_KEY", "free-key")
+    monkeypatch.setenv("FREE_LLM_BASE_URL", "http://gw/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "oa-key")
+
+    primary = _raising_client(_UpstreamError("gateway down"))
+    fallback = _ok_client("fallback-result")
+    with patch(
+        "news_dashboard.ai_client.get_openai_client", side_effect=[primary, fallback]
+    ) as factory:
+        client = get_chat_client(api_key="free-key", base_url="http://gw/v1")
+        result: object = client.chat.completions.create(model="m", messages=[])
+
+    assert result == "fallback-result"
+    assert factory.call_args_list[0].kwargs == {"api_key": "free-key", "base_url": "http://gw/v1"}
+    assert factory.call_args_list[1].kwargs == {"api_key": "oa-key", "base_url": None}
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_get_chat_client_falls_back_to_openai_on_embedding_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    from openai import OpenAIError
+
+    from news_dashboard.ai_client import get_chat_client
+
+    class _UpstreamError(OpenAIError):
+        pass
+
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("FREE_LLM_API_KEY", "free-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "oa-key")
+
+    primary = _raising_client(_UpstreamError("gateway down"))
+    fallback = _ok_client("embedding-result")
+    with patch(
+        "news_dashboard.ai_client.get_openai_client", side_effect=[primary, fallback]
+    ) as factory:
+        client = get_chat_client(api_key="free-key", base_url=None)
+        result: object = client.embeddings.create(model="m", input="x")
+
+    assert result == "embedding-result"
+    assert factory.call_count == 2
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_get_chat_client_no_fallback_when_single_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    from openai import OpenAIError
+
+    from news_dashboard.ai_client import get_chat_client
+
+    class _UpstreamError(OpenAIError):
+        pass
+
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "oa-key")
+
+    primary = _raising_client(_UpstreamError("boom"))
+    with patch("news_dashboard.ai_client.get_openai_client", side_effect=[primary]) as factory:
+        client = get_chat_client(api_key="oa-key", base_url=None)
+        with pytest.raises(OpenAIError):
+            client.chat.completions.create(model="m", messages=[])
+
+    assert factory.call_count == 1
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_get_chat_client_no_fallback_when_openai_key_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    from openai import OpenAIError
+
+    from news_dashboard.ai_client import get_chat_client
+
+    class _UpstreamError(OpenAIError):
+        pass
+
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("FREE_LLM_API_KEY", "free-key")
+
+    primary = _raising_client(_UpstreamError("boom"))
+    with patch("news_dashboard.ai_client.get_openai_client", side_effect=[primary]) as factory:
+        client = get_chat_client(api_key="free-key", base_url=None)
+        with pytest.raises(OpenAIError):
+            client.chat.completions.create(model="m", messages=[])
+
+    assert factory.call_count == 1
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_get_chat_client_happy_path_builds_one_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    from news_dashboard.ai_client import get_chat_client
+
+    _clear_ai_env(monkeypatch)
+    monkeypatch.setenv("FREE_LLM_API_KEY", "free-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "oa-key")
+
+    primary = _ok_client("primary-result")
+    # Only one client provided: if the fallback were built eagerly, StopIteration would raise.
+    with patch("news_dashboard.ai_client.get_openai_client", side_effect=[primary]) as factory:
+        client = get_chat_client(api_key="free-key", base_url=None)
+        result: object = client.chat.completions.create(model="m", messages=[])
+
+    assert result == "primary-result"
+    assert factory.call_count == 1


### PR DESCRIPTION
Closes #440

## Summary

Adds a **runtime** free-LLM→OpenAI fallback for every chat and embedding call. PR #439 consolidated credentials to `FREE_LLM_*` / `OPENAI_*` with a *config-time* fallback (use OpenAI only when `FREE_LLM_API_KEY` is unset). This adds the missing *runtime* piece: actually try the free LLM gateway, and if the call fails, retry against OpenAI.

- New `get_chat_client(api_key=, base_url=)` in `ai_client.py` returns a thin wrapper that prefers the free LLM gateway and, when a **distinct** configured `OPENAI_API_KEY` endpoint exists, retries any chat/embedding request that raises `openai.OpenAIError` against OpenAI — same model, same arguments. The OpenAI fallback client is built **lazily**, only on the first failure.
- Single-key setups (free config == OpenAI config) get no retry; errors propagate unchanged.
- Swapped all 15 `free_llm_config`-backed call sites from `get_openai_client` to `get_chat_client`: briefings (×2), quiz, insights (×2), perspectives, recommendations, prompt_optimizer, embeddings (`_embed` + `_answer`), shares, body_fetch (×2), ingest, and the TTS podcast **script**.
- TTS **audio/speech** (`generate_audio`, `generate_podcast_audio`) intentionally stays on `get_openai_client` — the free gateway has no `audio/speech` endpoint.

## Test plan

- [x] TDD: 5 new `get_chat_client` tests in `test_ai_client.py` (chat fallback, embedding fallback, no-fallback when single endpoint, no-fallback when `OPENAI_API_KEY` absent, lazy/one-client happy path) — written red, then green.
- [x] `make lint` (ruff + prettier) passes
- [x] `make typecheck` (mypy strict + ty + pyrefly + tsc) passes
- [x] All affected-module test files pass: 336 passed (`test_ai_client`, `test_ai_credentials`, `test_article_shares`, `test_body_fetch`, `test_briefings_*`, `test_ingest*`, `test_insights`, `test_perspectives`, `test_prompt_optimizer`, `test_quiz`, `test_recommendation*`, `test_today_recommendations`, `test_tts`, `test_user_attribution`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)