### PR TITLE
fix: block private-network fetch targets (#379)

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -18,6 +18,11 @@ from typing import Any
 from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.db import connect, init_db, row_to_dict
 from news_dashboard.scraper import TIMEOUT_SECS, USER_AGENT
+from news_dashboard.url_safety import (
+    UnsafeUrlError,
+    open_server_fetch_url,
+    validate_server_fetch_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,15 +49,19 @@ def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]
     model = os.getenv("OPENAI_BRIEFING_MODEL", _AI_MODEL)
 
     try:
+        validate_server_fetch_url(url)
         import httpx  # lazy import — optional at module load time
 
         resp = httpx.get(
             url,
             timeout=15,
             headers={"User-Agent": USER_AGENT},
-            follow_redirects=True,
+            follow_redirects=False,
         )
         html = resp.text[:_AI_HTML_LIMIT]
+    except UnsafeUrlError as exc:
+        logger.warning("ai_body_fetch: unsafe URL %r: %s", url, exc)
+        return "", "error"
     except Exception as exc:
         logger.warning("ai_body_fetch: HTTP fetch failed for %r: %s", url, exc)
         return "", "error"
@@ -208,16 +217,18 @@ def extract_body(url: str) -> tuple[str, str]:
     (e.g. JS-rendered SPAs).  Returns (body_text, 'ok') on success or
     ('', 'error') on failure.
     """
-    if not url.startswith(("http:", "https:")):
-        return "", "error"
     try:
+        validate_server_fetch_url(url)
         req = urllib.request.Request(  # noqa: S310 - scheme validated above
             url, headers={"User-Agent": USER_AGENT}
         )
-        with urllib.request.urlopen(req, timeout=TIMEOUT_SECS) as resp:  # noqa: S310
+        with open_server_fetch_url(req, timeout=TIMEOUT_SECS) as resp:
             raw: bytes = resp.read(500_000)  # cap at ~500 KB
             charset = resp.headers.get_content_charset("utf-8") or "utf-8"
             html = raw.decode(str(charset), errors="replace")
+    except UnsafeUrlError as exc:
+        logger.warning("body_fetch: unsafe URL %r: %s", url, exc)
+        return "", "error"
     except Exception as exc:
         logger.warning("body_fetch: fetch failed for %r: %s", url, exc)
         return "", "error"

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -22,6 +22,11 @@ from news_dashboard.db import connect, init_db, insert_article_sql, placeholders
 from news_dashboard.ingest_events import ingest_events
 from news_dashboard.recommendations import COLD_START_MODEL_VERSION
 from news_dashboard.sources import DEFAULT_SOURCES, SourceDefinition
+from news_dashboard.url_safety import (
+    UnsafeUrlError,
+    open_server_fetch_url,
+    validate_server_fetch_url,
+)
 
 try:
     from rapidfuzz.distance import Levenshtein
@@ -419,12 +424,13 @@ FEED_FETCH_TIMEOUT_SECS = 15
 
 def _fetch_feed_content(url: str) -> bytes:
     """Fetch raw feed bytes with an explicit timeout. Raises FeedFetchError on failure."""
-    if not url.startswith(("http:", "https:")):
-        msg = f"Refusing to fetch non-HTTP URL: {url!r}"
-        raise FeedFetchError(msg)
+    try:
+        validate_server_fetch_url(url)
+    except UnsafeUrlError as exc:
+        raise FeedFetchError(str(exc)) from exc
     req = urllib.request.Request(url, headers={"User-Agent": _FEED_AGENT})  # noqa: S310
     try:
-        with urllib.request.urlopen(req, timeout=FEED_FETCH_TIMEOUT_SECS) as resp:  # noqa: S310
+        with open_server_fetch_url(req, timeout=FEED_FETCH_TIMEOUT_SECS) as resp:
             return resp.read()  # type: ignore[no-any-return]
     except TimeoutError as exc:
         msg = f"Feed fetch timed out after {FEED_FETCH_TIMEOUT_SECS}s: {url}"

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -101,6 +101,7 @@ from news_dashboard.stats import (
     stats_overview,
     triage_metrics,
 )
+from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
 
 logger = logging.getLogger(__name__)
 
@@ -1219,18 +1220,15 @@ def create_source(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
     """Create a private custom source owned by the current user."""
-    from urllib.parse import urlparse
-
     uid = current_user["id"]
 
     if not payload.name.strip():
         raise HTTPException(status_code=400, detail="name must not be empty")
 
-    parsed = urlparse(payload.url)
-    if parsed.scheme not in ("http", "https"):
-        raise HTTPException(status_code=400, detail="url must use http or https scheme")
-    if not parsed.netloc:
-        raise HTTPException(status_code=400, detail="url must include a valid host")
+    try:
+        validate_server_fetch_url(payload.url)
+    except UnsafeUrlError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     slug = payload.validated_slug(payload.name)
 

--- a/backend/news_dashboard/scraper.py
+++ b/backend/news_dashboard/scraper.py
@@ -11,20 +11,20 @@ import urllib.request
 from html.parser import HTMLParser
 from typing import Any
 
+from news_dashboard.url_safety import open_server_fetch_url, validate_server_fetch_url
+
 USER_AGENT = "news-dashboard/0.1 (personal RSS reader; contact@lihor.ro)"
 TIMEOUT_SECS = 15
 
 
 def _fetch_html(url: str, *, use_selenium: bool = False) -> str:
-    if not url.startswith(("http:", "https:")):
-        message = f"Refusing to fetch non-HTTP URL: {url!r}"
-        raise ValueError(message)
+    validate_server_fetch_url(url)
     if use_selenium:
         from news_dashboard.selenium_client import fetch_spa_html
 
         return fetch_spa_html(url)
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})  # noqa: S310 - scheme validated above
-    with urllib.request.urlopen(req, timeout=TIMEOUT_SECS) as resp:  # noqa: S310 - scheme validated above
+    with open_server_fetch_url(req, timeout=TIMEOUT_SECS) as resp:
         raw: bytes = resp.read()
         charset = resp.headers.get_content_charset("utf-8") or "utf-8"
         return raw.decode(str(charset), errors="replace")

--- a/backend/news_dashboard/url_safety.py
+++ b/backend/news_dashboard/url_safety.py
@@ -1,0 +1,93 @@
+"""Server-side fetch target validation.
+
+The application fetches user-controlled feed and article URLs from backend
+workers.  Validate those targets before network I/O so a malicious source cannot
+reach localhost, private networks, or cloud metadata services from the server.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.request
+from http.client import HTTPMessage
+from typing import IO, Any
+from urllib.parse import urlparse
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when a URL is not safe for server-side fetching."""
+
+
+def validate_server_fetch_url(url: str) -> None:
+    """Raise UnsafeUrlError if ``url`` is not safe for backend network fetches."""
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        msg = f"Refusing to fetch non-HTTP URL: {url!r}"
+        raise UnsafeUrlError(msg)
+
+    hostname = parsed.hostname
+    if not hostname:
+        msg = f"Refusing to fetch URL without a host: {url!r}"
+        raise UnsafeUrlError(msg)
+
+    normalized_host = hostname.rstrip(".").lower()
+    if normalized_host in {"localhost", "localhost.localdomain"} or normalized_host.endswith(
+        ".localhost"
+    ):
+        msg = f"Refusing to fetch local host: {hostname!r}"
+        raise UnsafeUrlError(msg)
+
+    try:
+        addresses = socket.getaddrinfo(normalized_host, parsed.port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        msg = f"Could not resolve fetch host: {hostname!r}"
+        raise UnsafeUrlError(msg) from exc
+
+    for family, _, _, _, sockaddr in addresses:
+        raw_address = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(raw_address)
+        except ValueError as exc:
+            msg = f"Could not classify fetch address: {raw_address!r}"
+            raise UnsafeUrlError(msg) from exc
+
+        if _is_unsafe_ip(ip):
+            msg = f"Refusing to fetch unsafe host address: {ip}"
+            raise UnsafeUrlError(msg)
+
+        if family not in {socket.AF_INET, socket.AF_INET6}:
+            msg = f"Refusing to fetch unsupported address family: {family}"
+            raise UnsafeUrlError(msg)
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        _ = (req, fp, code, msg, headers, newurl)
+        return None
+
+
+def open_server_fetch_url(request: urllib.request.Request, *, timeout: float) -> Any:
+    """Open a prevalidated server-side fetch request without following redirects."""
+    validate_server_fetch_url(request.full_url)
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    return opener.open(request, timeout=timeout)
+
+
+def _is_unsafe_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import http.server
 import threading
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from news_dashboard.body_fetch import (
     extract_body,
@@ -64,6 +69,18 @@ def _start_server(html: bytes) -> tuple[str, threading.Thread]:
     return f"http://127.0.0.1:{port}/", thread
 
 
+@contextmanager
+def _allow_local_body_fetches() -> Iterator[None]:
+    def local_open(req: urllib.request.Request, *, timeout: float) -> object:
+        return urllib.request.urlopen(req, timeout=timeout)  # noqa: S310
+
+    with (
+        patch("news_dashboard.body_fetch.validate_server_fetch_url", return_value=None),
+        patch("news_dashboard.body_fetch.open_server_fetch_url", side_effect=local_open),
+    ):
+        yield
+
+
 # ── extract_body ──────────────────────────────────────────────────────────────
 
 
@@ -79,7 +96,8 @@ def test_extract_body_ok() -> None:
     </body></html>
     """
     url, thread = _start_server(html)
-    body, status = extract_body(url)
+    with _allow_local_body_fetches():
+        body, status = extract_body(url)
     thread.join(timeout=2)
     assert status == "ok"
     assert "long enough paragraph" in body
@@ -100,7 +118,10 @@ def test_extract_body_rejects_non_http() -> None:
 
 def test_extract_body_empty_page_returns_error() -> None:
     url, thread = _start_server(b"<html><body></body></html>")
-    with patch("news_dashboard.body_fetch._selenium_extract_body", return_value=("", "error")):
+    with (
+        _allow_local_body_fetches(),
+        patch("news_dashboard.body_fetch._selenium_extract_body", return_value=("", "error")),
+    ):
         _body, status = extract_body(url)
     thread.join(timeout=2)
     assert status == "error"
@@ -127,7 +148,8 @@ def test_fetch_and_cache_body_success(tmp_path: Path) -> None:
             (url, url, article_id),
         )
 
-    result = fetch_and_cache_body(article_id, db_path=db_path)
+    with _allow_local_body_fetches():
+        result = fetch_and_cache_body(article_id, db_path=db_path)
     thread.join(timeout=2)
 
     assert result is not None
@@ -382,7 +404,8 @@ def test_prefetch_article_bodies_fetches_missing(tmp_path: Path) -> None:
             (url, url, article_id),
         )
 
-    count = prefetch_article_bodies(db_path=db_path)
+    with _allow_local_body_fetches():
+        count = prefetch_article_bodies(db_path=db_path)
     thread.join(timeout=2)
 
     assert count == 1
@@ -430,6 +453,46 @@ def test_ai_extract_body_skipped_without_api_key(tmp_path: Path) -> None:
 
     assert status == "error"
     assert body == ""
+
+
+def test_extract_body_rejects_private_network_url_before_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.body_fetch import extract_body
+
+    called = False
+
+    def fake_urlopen(_req: object, timeout: float) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    body, status = extract_body("http://127.0.0.1/admin")
+
+    assert status == "error"
+    assert body == ""
+    assert called is False
+
+
+def test_ai_extract_body_rejects_private_network_url_before_fetch() -> None:
+    from news_dashboard.body_fetch import _ai_extract_body
+
+    called = False
+
+    def fake_get(*_: object, **__: object) -> None:
+        nonlocal called
+        called = True
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("httpx.get", side_effect=fake_get),
+    ):
+        body, status = _ai_extract_body("http://169.254.169.254/latest/meta-data")
+
+    assert status == "error"
+    assert body == ""
+    assert called is False
 
 
 def test_ai_extract_body_calls_openai_on_html(tmp_path: Path) -> None:
@@ -602,10 +665,13 @@ def test_fetch_and_cache_body_ai_fallback_result_is_cached(tmp_path: Path) -> No
 def test_extract_body_falls_back_to_selenium_when_static_empty() -> None:
     url, thread = _start_server(b"<html><body></body></html>")
     spa_content = "SPA article content rendered by JavaScript and extracted by headless browser."
-    with patch(
-        "news_dashboard.body_fetch._selenium_extract_body",
-        return_value=(spa_content, "ok"),
-    ) as mock_sel:
+    with (
+        _allow_local_body_fetches(),
+        patch(
+            "news_dashboard.body_fetch._selenium_extract_body",
+            return_value=(spa_content, "ok"),
+        ) as mock_sel,
+    ):
         body, status = extract_body(url)
     thread.join(timeout=2)
     mock_sel.assert_called_once_with(url)
@@ -620,7 +686,10 @@ def test_extract_body_does_not_call_selenium_when_static_ok() -> None:
     </body></html>
     """
     url, thread = _start_server(html)
-    with patch("news_dashboard.body_fetch._selenium_extract_body") as mock_sel:
+    with (
+        _allow_local_body_fetches(),
+        patch("news_dashboard.body_fetch._selenium_extract_body") as mock_sel,
+    ):
         _body, status = extract_body(url)
     thread.join(timeout=2)
     mock_sel.assert_not_called()

--- a/backend/tests/test_hf_blog_ingest.py
+++ b/backend/tests/test_hf_blog_ingest.py
@@ -68,6 +68,7 @@ def test_hf_blog_empty_description_triggers_snippet_fetch(tmp_path: Path, monkey
     """New HF blog articles with no feed description should get a snippet from the page."""
     db_path = tmp_path / "hf_snippet.db"
     monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [_hf_source()])
+    monkeypatch.setattr(ingest_module, "_fetch_feed_content", lambda _url: b"")
 
     monkeypatch.setattr(
         feedparser,
@@ -97,6 +98,7 @@ def test_hf_blog_non_empty_feed_description_skips_snippet_fetch(
     """If the feed does provide a description, no extra HTTP request is made."""
     db_path = tmp_path / "hf_has_desc.db"
     monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [_hf_source()])
+    monkeypatch.setattr(ingest_module, "_fetch_feed_content", lambda _url: b"")
 
     entry_with_desc = _feed_entry("some-article")
     entry_with_desc["summary"] = "Feed-provided description already here."
@@ -131,6 +133,7 @@ def test_hf_blog_snippet_fetch_skipped_for_existing_articles(
     """Snippet fetch must not happen for articles already stored (repeat ingest run)."""
     db_path = tmp_path / "hf_repeat.db"
     monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [_hf_source()])
+    monkeypatch.setattr(ingest_module, "_fetch_feed_content", lambda _url: b"")
 
     monkeypatch.setattr(
         feedparser,
@@ -160,6 +163,7 @@ def test_hf_blog_snippet_fetch_capped_per_run(tmp_path: Path, monkeypatch: Any) 
     """Snippet fetches must not exceed _MAX_SNIPPET_FETCHES_PER_RUN per ingest run."""
     db_path = tmp_path / "hf_cap.db"
     monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [_hf_source()])
+    monkeypatch.setattr(ingest_module, "_fetch_feed_content", lambda _url: b"")
 
     # Produce more entries than the cap
     entries = [_feed_entry(f"article-{i}") for i in range(_MAX_SNIPPET_FETCHES_PER_RUN + 5)]
@@ -188,6 +192,7 @@ def test_hf_blog_snippet_fetch_failure_still_inserts_article(
     """A snippet fetch error must not prevent article insertion."""
     db_path = tmp_path / "hf_fail.db"
     monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [_hf_source()])
+    monkeypatch.setattr(ingest_module, "_fetch_feed_content", lambda _url: b"")
 
     monkeypatch.setattr(
         feedparser,
@@ -215,6 +220,7 @@ def test_other_sources_not_affected_by_snippet_fetch(tmp_path: Path, monkeypatch
         "openai-blog", "OpenAI Blog", "https://openai.com/news/rss.xml", "ai-llm", "rss_feed", 85
     )
     monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [other])
+    monkeypatch.setattr(ingest_module, "_fetch_feed_content", lambda _url: b"")
 
     monkeypatch.setattr(
         feedparser,

--- a/backend/tests/test_nitter_feed.py
+++ b/backend/tests/test_nitter_feed.py
@@ -75,6 +75,23 @@ def test_fetch_feed_content_rejects_file_url(monkeypatch: pytest.MonkeyPatch) ->
         _fetch_feed_content("file:///etc/passwd")
 
 
+def test_fetch_feed_content_rejects_private_network_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    def fake_open(_req: object, *, timeout: float) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
+
+    with pytest.raises(FeedFetchError, match="unsafe host"):
+        _fetch_feed_content("http://127.0.0.1/feed.xml")
+
+    assert called is False
+
+
 def test_fetch_feed_content_sends_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[str | None] = []
 
@@ -88,7 +105,7 @@ def test_fetch_feed_content_sends_user_agent(monkeypatch: pytest.MonkeyPatch) ->
         def __exit__(self, *_: object) -> None:
             pass
 
-    def fake_urlopen(req: object, timeout: float) -> _FakeResp:
+    def fake_open(req: object, *, timeout: float) -> _FakeResp:
         import urllib.request as ur
 
         assert isinstance(req, ur.Request)
@@ -96,27 +113,27 @@ def test_fetch_feed_content_sends_user_agent(monkeypatch: pytest.MonkeyPatch) ->
         assert timeout == FEED_FETCH_TIMEOUT_SECS
         return _FakeResp()
 
-    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
     _fetch_feed_content("https://example.com/feed.xml")
     assert captured == [_FEED_AGENT]
 
 
 def test_fetch_feed_content_converts_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_urlopen(_req: object, timeout: float) -> None:
+    def fake_open(_req: object, *, timeout: float) -> None:
         msg = "timed out"
         raise TimeoutError(msg)
 
-    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
     with pytest.raises(FeedFetchError, match="timed out"):
         _fetch_feed_content("https://example.com/feed.xml")
 
 
 def test_fetch_feed_content_converts_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_urlopen(_req: object, timeout: float) -> None:
+    def fake_open(_req: object, *, timeout: float) -> None:
         msg = "Name or service not known"
         raise urllib.error.URLError(msg)
 
-    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
     with pytest.raises(FeedFetchError, match="network error"):
         _fetch_feed_content("https://example.com/feed.xml")
 

--- a/backend/tests/test_scraper.py
+++ b/backend/tests/test_scraper.py
@@ -73,6 +73,23 @@ def test_scrape_source_uses_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(entries) >= 2
 
 
+def test_fetch_html_rejects_private_network_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.scraper import _fetch_html
+
+    called = False
+
+    def fake_urlopen(_req: object, timeout: float) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="unsafe host"):
+        _fetch_html("http://127.0.0.1/admin")
+
+    assert called is False
+
+
 def test_scrape_source_unknown_slug_raises() -> None:
     source = SourceDefinition(
         "no-scraper", "No Scraper", "https://example.com", "python", "scraped_page", 50

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -233,6 +233,28 @@ def test_api_create_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatc
         assert "my-blog" in slugs
 
 
+def test_api_create_private_source_rejects_unsafe_url(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources",
+            json={
+                "url": "http://127.0.0.1/admin",
+                "name": "Local Admin",
+                "category": "tech",
+                "slug": "local-admin",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "unsafe" in resp.json()["detail"]
+
+
 def test_api_private_source_not_visible_to_other_user(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -246,7 +268,7 @@ def test_api_private_source_not_visible_to_other_user(
         resp = client_a.post(
             "/api/sources",
             json={
-                "url": "https://private.example.com/feed",
+                "url": "https://example.com/alice-feed.xml",
                 "name": "Alice Blog",
                 "slug": "alice-blog",
             },
@@ -269,7 +291,7 @@ def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.Monkey
         client.post(
             "/api/sources",
             json={
-                "url": "https://delete.example.com/feed",
+                "url": "https://example.com/delete-feed.xml",
                 "name": "To Delete",
                 "slug": "to-delete",
             },
@@ -289,7 +311,7 @@ def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.Monk
         client_a.post(
             "/api/sources",
             json={
-                "url": "https://alices.example.com/feed",
+                "url": "https://example.com/alices-feed.xml",
                 "name": "Alice Source",
                 "slug": "alice-src",
             },

--- a/backend/tests/test_url_safety.py
+++ b/backend/tests/test_url_safety.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
+
+
+def _fake_getaddrinfo(addresses: list[str]) -> object:
+    def fake_getaddrinfo(
+        _host: str, _port: int | None, **kwargs: int
+    ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+        family = socket.AF_INET6 if ":" in addresses[0] else socket.AF_INET
+        socket_type = kwargs["type"]
+        return [(family, socket_type, 6, "", (address, 443)) for address in addresses]
+
+    return fake_getaddrinfo
+
+
+@pytest.mark.parametrize(
+    ("url", "address"),
+    [
+        ("http://127.0.0.1/feed.xml", "127.0.0.1"),
+        ("http://localhost/feed.xml", "127.0.0.1"),
+        ("http://10.0.0.1/feed.xml", "10.0.0.1"),
+        ("http://169.254.169.254/latest/meta-data", "169.254.169.254"),
+        ("http://[::1]/feed.xml", "::1"),
+        ("http://[fc00::1]/feed.xml", "fc00::1"),
+    ],
+)
+def test_validate_server_fetch_url_rejects_unsafe_targets(
+    url: str, address: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo([address]))
+
+    with pytest.raises(UnsafeUrlError):
+        validate_server_fetch_url(url)
+
+
+def test_validate_server_fetch_url_accepts_public_https(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo(["93.184.216.34"]))
+
+    validate_server_fetch_url("https://example.com/feed.xml")
+
+
+def test_validate_server_fetch_url_rejects_any_unsafe_resolved_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo(["93.184.216.34", "10.0.0.1"]))
+
+    with pytest.raises(UnsafeUrlError):
+        validate_server_fetch_url("https://example.com/feed.xml")


### PR DESCRIPTION
Closes #379

## Summary
- Add a shared server-side URL safety helper for backend fetch targets.
- Reject localhost, loopback, private, link-local, multicast, reserved, unspecified, and metadata IP targets before network I/O.
- Apply the policy to custom source creation, feed fetching, scraped pages, article body extraction, and AI fallback body extraction.
- Disable automatic redirects for urllib and httpx server-side fetches.

## Tests
- `pytest backend/tests/test_url_safety.py backend/tests/test_nitter_feed.py backend/tests/test_scraper.py backend/tests/test_body_fetch.py::test_extract_body_ok backend/tests/test_body_fetch.py::test_extract_body_empty_page_returns_error backend/tests/test_body_fetch.py::test_extract_body_rejects_private_network_url_before_fetch backend/tests/test_body_fetch.py::test_ai_extract_body_rejects_private_network_url_before_fetch backend/tests/test_body_fetch.py::test_extract_body_falls_back_to_selenium_when_static_empty backend/tests/test_body_fetch.py::test_extract_body_does_not_call_selenium_when_static_ok -q`
- `make lint`
- `make typecheck`

Note: the fuller local Postgres-backed focused test run could not complete because local PostgreSQL on `localhost:55432` is in recovery mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)