### PR TITLE
fix: bound analytics ingestion and retention (#380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Runtime storage is PostgreSQL only. Set `DATABASE_URL` or the split
 | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` | VAPID public and private keys for Web Push notifications. Generate using `npx web-push generate-vapid-keys`. |
 | `VAPID_EMAIL` | Contact email address used in VAPID claims mailto link. Defaults to `admin@example.com` if unset. |
 | `CORS_ORIGINS` | Comma-separated browser dev origins. |
+| `ANALYTICS_RETENTION_DAYS` | Days to retain `user_events` before the daily cleanup job prunes them. Defaults to `180`. |
 
 SQLite is supported only as a legacy import source for
 `news-dashboard-migrate sqlite-to-postgres`.

--- a/backend/news_dashboard/analytics.py
+++ b/backend/news_dashboard/analytics.py
@@ -18,6 +18,9 @@ from news_dashboard.db import connect, init_db
 logger = logging.getLogger(__name__)
 
 ALLOWED_EVENT_TYPES = frozenset({"heartbeat", "route", "article_open", "article_close", "feature"})
+# Backend ingestion cap for one telemetry request or direct record_events() call.
+MAX_EVENTS_PER_BATCH = 250
+DEFAULT_EVENT_RETENTION_DAYS = 180
 # Clamp a single heartbeat's reported active time so a misbehaving or malicious
 # client cannot inflate time-on-app. The tracker beats every 15s; 5 min is slack.
 MAX_HEARTBEAT_MS = 5 * 60 * 1000
@@ -34,7 +37,7 @@ def record_events(
     """Bulk-insert validated telemetry events for ``user_id``; return the count stored."""
     init_db(db_path, database_url=database_url)
     rows: list[tuple[int, str, str | None, int | None, str | None, int | None]] = []
-    for event in events:
+    for event in events[:MAX_EVENTS_PER_BATCH]:
         event_type = str(event.get("type") or "")
         if event_type not in ALLOWED_EVENT_TYPES:
             continue
@@ -59,6 +62,20 @@ def record_events(
             rows,
         )
     return len(rows)
+
+
+def prune_old_events(
+    retention_days: int = DEFAULT_EVENT_RETENTION_DAYS,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> int:
+    """Delete telemetry older than the retention window; return deleted rows."""
+    init_db(db_path, database_url=database_url)
+    retention_days = max(1, retention_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    with connect(db_path, database_url=database_url) as conn:
+        result = conn.execute("DELETE FROM user_events WHERE created_at < %s", (cutoff,))
+        return int(result.rowcount or 0)
 
 
 def admin_analytics(

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -22,11 +22,16 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response as StarletteResponse
 
-from news_dashboard.analytics import admin_analytics, reading_dna, record_events
+from news_dashboard.analytics import (
+    MAX_EVENTS_PER_BATCH,
+    admin_analytics,
+    reading_dna,
+    record_events,
+)
 from news_dashboard.auth import (
     _session_days,
     authenticate,
@@ -225,7 +230,7 @@ class AnalyticsEvent(BaseModel):
 
 
 class AnalyticsEventsRequest(BaseModel):
-    events: list[AnalyticsEvent]
+    events: list[AnalyticsEvent] = Field(max_length=MAX_EVENTS_PER_BATCH)
 
 
 # ── Public auth routes (no session required) ──────────────────────────────────

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -74,6 +74,21 @@ def _run_daily_recommendation_recalc() -> None:
         logger.exception("Daily recommendation recalculation failed")
 
 
+def _run_analytics_retention() -> None:
+    from news_dashboard.analytics import DEFAULT_EVENT_RETENTION_DAYS, prune_old_events
+
+    retention_days = int(os.getenv("ANALYTICS_RETENTION_DAYS", str(DEFAULT_EVENT_RETENTION_DAYS)))
+    try:
+        deleted = prune_old_events(retention_days=retention_days)
+        logger.info(
+            "Analytics retention pruned %d events older than %d days",
+            deleted,
+            retention_days,
+        )
+    except Exception:
+        logger.exception("Analytics retention failed")
+
+
 def _run_briefing() -> None:
     from news_dashboard.briefings import (
         BriefingAINotConfiguredError,
@@ -248,6 +263,15 @@ def start_scheduler() -> None:
         hour=r_hour,
         minute=r_minute,
         id="recommendations",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _run_analytics_retention,
+        trigger="cron",
+        hour="3",
+        minute="0",
+        id="analytics_retention",
         replace_existing=True,
     )
 

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -1,16 +1,33 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
-from news_dashboard.analytics import admin_analytics, record_events
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.analytics import (
+    MAX_EVENTS_PER_BATCH,
+    admin_analytics,
+    prune_old_events,
+    record_events,
+)
 from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
 
 
-def _seed(db_path: Path) -> int:
+@pytest.fixture
+def client(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        yield test_client
+
+
+def _seed(database_url: str) -> int:
     """Create one user, source, and article; return the article id."""
-    init_db(db_path)
-    with connect(db_path) as conn:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
         conn.execute(
             "INSERT INTO users(id, username, password_hash, is_admin)"
             " VALUES (1, 'reader', 'x', FALSE)"
@@ -30,9 +47,17 @@ def _seed(db_path: Path) -> int:
     return 10
 
 
-def test_record_events_filters_invalid_and_clamps(tmp_path: Path) -> None:
-    db_path = tmp_path / "a.db"
-    article_id = _seed(db_path)
+def test_events_endpoint_rejects_oversized_batch(client: TestClient) -> None:
+    response = client.post(
+        "/api/events",
+        json={"events": [{"type": "heartbeat", "duration_ms": 1}] * (MAX_EVENTS_PER_BATCH + 1)},
+    )
+
+    assert response.status_code == 422
+
+
+def test_record_events_filters_invalid_and_clamps(pg_clean: str) -> None:
+    article_id = _seed(pg_clean)
 
     stored = record_events(
         1,
@@ -44,11 +69,11 @@ def test_record_events_filters_invalid_and_clamps(tmp_path: Path) -> None:
             {"type": "feature", "feature": "ask"},
             {"type": "bogus", "route": "/x"},  # dropped
         ],
-        db_path=db_path,
+        database_url=pg_clean,
     )
     assert stored == 5
 
-    with connect(db_path) as conn:
+    with connect(database_url=pg_clean) as conn:
         total = conn.execute(
             "SELECT COALESCE(SUM(duration_ms), 0) AS s FROM user_events"
             " WHERE event_type = 'heartbeat'"
@@ -57,9 +82,57 @@ def test_record_events_filters_invalid_and_clamps(tmp_path: Path) -> None:
     assert total == 310_000
 
 
-def test_admin_analytics_aggregates_behavior(tmp_path: Path) -> None:
-    db_path = tmp_path / "b.db"
-    article_id = _seed(db_path)
+def test_record_events_defensively_caps_direct_batches(pg_clean: str) -> None:
+    _seed(pg_clean)
+
+    stored = record_events(
+        1,
+        [{"type": "route", "route": f"/item/{index}"} for index in range(MAX_EVENTS_PER_BATCH + 1)],
+        database_url=pg_clean,
+    )
+
+    assert stored == MAX_EVENTS_PER_BATCH
+    with connect(database_url=pg_clean) as conn:
+        total = conn.execute("SELECT COUNT(*) AS count FROM user_events").fetchone()["count"]
+    assert total == MAX_EVENTS_PER_BATCH
+
+
+def test_prune_old_events_deletes_only_expired_rows(pg_clean: str) -> None:
+    _seed(pg_clean)
+    now = datetime.now(timezone.utc)
+    record_events(
+        1,
+        [
+            {"type": "route", "route": "/old"},
+            {"type": "route", "route": "/recent"},
+        ],
+        database_url=pg_clean,
+    )
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            UPDATE user_events
+            SET created_at = CASE route
+                WHEN '/old' THEN %s
+                ELSE %s
+            END
+            """,
+            (now - timedelta(days=181), now - timedelta(days=10)),
+        )
+
+    deleted = prune_old_events(database_url=pg_clean)
+
+    assert deleted == 1
+    with connect(database_url=pg_clean) as conn:
+        routes = [
+            row["route"]
+            for row in conn.execute("SELECT route FROM user_events ORDER BY route").fetchall()
+        ]
+    assert routes == ["/recent"]
+
+
+def test_admin_analytics_aggregates_behavior(pg_clean: str) -> None:
+    article_id = _seed(pg_clean)
     now = datetime.now(timezone.utc)
 
     record_events(
@@ -71,16 +144,16 @@ def test_admin_analytics_aggregates_behavior(tmp_path: Path) -> None:
             {"type": "feature", "feature": "ask"},
             {"type": "article_close", "article_id": article_id, "duration_ms": 30_000},
         ],
-        db_path=db_path,
+        database_url=pg_clean,
     )
-    with connect(db_path) as conn:
+    with connect(database_url=pg_clean) as conn:
         conn.execute(
             "INSERT INTO user_article_state(user_id, article_id, state, done_at)"
             " VALUES (1, %s, 'done', %s)",
             (article_id, now - timedelta(hours=1)),
         )
 
-    result = admin_analytics(days=30, db_path=db_path)
+    result = admin_analytics(days=30, database_url=pg_clean)
 
     assert result["summary"]["mau"] == 1
     assert result["summary"]["total_minutes"] == 1.0
@@ -100,10 +173,9 @@ def test_admin_analytics_aggregates_behavior(tmp_path: Path) -> None:
     assert categories["tech"] == 1
 
 
-def test_admin_analytics_empty_db(tmp_path: Path) -> None:
-    db_path = tmp_path / "c.db"
-    init_db(db_path)
-    result = admin_analytics(days=7, db_path=db_path)
+def test_admin_analytics_empty_db(pg_clean: str) -> None:
+    init_db(database_url=pg_clean)
+    result = admin_analytics(days=7, database_url=pg_clean)
     assert result["summary"]["mau"] == 0
     assert result["summary"]["stickiness"] == 0.0
     assert result["users"] == []

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -173,6 +173,18 @@ def test_start_scheduler_briefing_uses_cron_trigger(monkeypatch: pytest.MonkeyPa
     assert briefing_call.kwargs["trigger"] == "cron"
 
 
+def test_start_scheduler_registers_analytics_retention_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_sched = _start_with_env(monkeypatch)
+    retention_call = next(
+        c for c in mock_sched.add_job.call_args_list if c.kwargs.get("id") == "analytics_retention"
+    )
+    assert retention_call.kwargs["trigger"] == "cron"
+    assert retention_call.kwargs["hour"] == "3"
+    assert retention_call.kwargs["minute"] == "0"
+
+
 def test_start_scheduler_briefing_fn_is_run_briefing(monkeypatch: pytest.MonkeyPatch) -> None:
     from news_dashboard.scheduler import _run_briefing as expected_fn
 


### PR DESCRIPTION
Closes #380

## Summary
- enforce a backend telemetry batch cap at the FastAPI schema boundary
- defensively cap direct `record_events()` calls and add `prune_old_events()` retention cleanup
- schedule daily analytics retention cleanup and document `ANALYTICS_RETENTION_DAYS` defaulting to 180 days
- convert analytics tests to the PostgreSQL fixture and cover oversized batches, direct-call caps, pruning, and scheduler wiring

## Tests
- `source .env && pytest backend/tests/test_analytics.py backend/tests/test_scheduler.py -q` passed: 59 passed, 1 warning
- `make lint` passed
- `make typecheck` passed
- `npm run test:frontend --silent` passed: 42 files / 479 tests
- `npm run build --silent` passed
- `source .env && make test` could not complete locally because the shared PostgreSQL service at localhost:55432 entered recovery mode mid-run (`FATAL: the database system is in recovery mode`); focused changed tests had passed before the service failure.

Generated by codex automation.