### PR TITLE
feat: add interest onboarding wizard for feed personalization

### DIFF
--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -19,6 +19,10 @@ const apiMock = vi.hoisted(() => ({
   pauseScheduler: vi.fn(),
   resumeScheduler: vi.fn(),
   ingestNow: vi.fn(),
+  fetchOnboardingInterests: vi.fn().mockResolvedValue([]),
+  fetchOnboardingSourceRecommendations: vi.fn().mockResolvedValue([]),
+  fetchOnboardingStatus: vi.fn().mockResolvedValue({ completed: true }),
+  saveOnboardingInterests: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@/api', () => apiMock);
 vi.mock('../api', () => apiMock);

--- a/frontend/src/__tests__/onboardingWizard.test.tsx
+++ b/frontend/src/__tests__/onboardingWizard.test.tsx
@@ -1,0 +1,313 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, fireEvent, waitFor, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as api from '../api';
+import { useOnboardingWizard } from '../hooks/useOnboardingWizard';
+import { OnboardingWizard } from '../components/OnboardingWizard';
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function makeQc() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={makeQc()}>{children}</QueryClientProvider>;
+}
+
+const MOCK_INTERESTS = [
+  { id: 'tech', label: 'Technology', description: 'Software and hardware news' },
+  { id: 'science', label: 'Science', description: 'Research and discoveries' },
+  { id: 'finance', label: 'Finance', description: 'Markets and economics' },
+];
+
+const MOCK_RECOMMENDATIONS = [
+  {
+    slug: 'hn',
+    name: 'Hacker News',
+    category: 'tech',
+    kind: 'rss_feed',
+    url: 'https://news.ycombinator.com/rss',
+    matched_interests: ['tech'],
+    reason: 'Top source for tech discussion',
+    recommended: true,
+    enabled: 0,
+    priority: 1,
+  },
+  {
+    slug: 'arxiv',
+    name: 'arXiv',
+    category: 'science',
+    kind: 'rss_feed',
+    url: 'https://arxiv.org/rss',
+    matched_interests: ['science'],
+    reason: 'Primary preprint server for research',
+    recommended: true,
+    enabled: 0,
+    priority: 1,
+  },
+];
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+  );
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  sessionStorage.clear();
+});
+
+// ── useOnboardingWizard ───────────────────────────────────────────────────────
+
+describe('useOnboardingWizard', () => {
+  it('opens when the backend indicates onboarding is not completed', async () => {
+    vi.spyOn(api, 'fetchOnboardingStatus').mockResolvedValue({ completed: false });
+    const { result } = renderHook(() => useOnboardingWizard(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.open).toBe(true));
+  });
+
+  it('stays closed when onboarding is already completed', async () => {
+    vi.spyOn(api, 'fetchOnboardingStatus').mockResolvedValue({ completed: true });
+    const { result } = renderHook(() => useOnboardingWizard(), { wrapper: Wrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.open).toBe(false);
+  });
+
+  it('stays closed when dismissed for current session (skip)', async () => {
+    vi.spyOn(api, 'fetchOnboardingStatus').mockResolvedValue({ completed: false });
+    const { result } = renderHook(() => useOnboardingWizard(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.open).toBe(true));
+    act(() => result.current.skip());
+    expect(result.current.open).toBe(false);
+    expect(sessionStorage.getItem('onboarding-skipped')).toBe('1');
+  });
+
+  it('stays closed for the session after skip even if backend says incomplete', async () => {
+    sessionStorage.setItem('onboarding-skipped', '1');
+    vi.spyOn(api, 'fetchOnboardingStatus').mockResolvedValue({ completed: false });
+    const { result } = renderHook(() => useOnboardingWizard(), { wrapper: Wrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.open).toBe(false);
+  });
+
+  it('stays closed on fetch error (non-critical)', async () => {
+    vi.spyOn(api, 'fetchOnboardingStatus').mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useOnboardingWizard(), { wrapper: Wrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.open).toBe(false);
+  });
+
+  it('exposes openWizard to manually trigger the wizard', async () => {
+    vi.spyOn(api, 'fetchOnboardingStatus').mockResolvedValue({ completed: true });
+    const { result } = renderHook(() => useOnboardingWizard(), { wrapper: Wrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.open).toBe(false);
+    act(() => result.current.openWizard());
+    expect(result.current.open).toBe(true);
+  });
+});
+
+// ── OnboardingWizard component ────────────────────────────────────────────────
+
+describe('OnboardingWizard', () => {
+  function makeProps(overrides?: Partial<Parameters<typeof OnboardingWizard>[0]>) {
+    return {
+      open: true,
+      onClose: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it('renders step 1 interest selection when open', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps()} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    expect(screen.getByText('Science')).toBeTruthy();
+    expect(screen.getByText('Finance')).toBeTruthy();
+  });
+
+  it('does not render when open is false', () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps({ open: false })} />
+      </Wrapper>
+    );
+    expect(screen.queryByText('Technology')).toBeNull();
+  });
+
+  it('calls onClose (without saving) when Skip for now is clicked', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    const saveInterests = vi.spyOn(api, 'saveOnboardingInterests');
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps({ onClose })} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(saveInterests).not.toHaveBeenCalled();
+  });
+
+  it('moves to step 2 (recommendations) when Next is clicked with selected interests', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    vi.spyOn(api, 'fetchOnboardingSourceRecommendations').mockResolvedValue(MOCK_RECOMMENDATIONS);
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps()} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    // Select the "Technology" interest
+    fireEvent.click(screen.getByText('Technology'));
+    // Click Next
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => expect(screen.getByText('Hacker News')).toBeTruthy());
+    expect(screen.getByText('Top source for tech discussion')).toBeTruthy();
+  });
+
+  it('shows recommendation reasons on step 2', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    vi.spyOn(api, 'fetchOnboardingSourceRecommendations').mockResolvedValue(MOCK_RECOMMENDATIONS);
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps()} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    fireEvent.click(screen.getByText('Technology'));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => expect(screen.getByText('Top source for tech discussion')).toBeTruthy());
+  });
+
+  it('calls saveOnboardingInterests and onClose when Apply is clicked', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    vi.spyOn(api, 'fetchOnboardingSourceRecommendations').mockResolvedValue(MOCK_RECOMMENDATIONS);
+    const save = vi.spyOn(api, 'saveOnboardingInterests').mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps({ onClose })} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    fireEvent.click(screen.getByText('Technology'));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => expect(screen.getByText('Hacker News')).toBeTruthy());
+    // Click Apply
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+    await waitFor(() => expect(save).toHaveBeenCalled());
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('does not call save on Apply when no interests are selected', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    vi.spyOn(api, 'fetchOnboardingSourceRecommendations').mockResolvedValue([]);
+    const save = vi.spyOn(api, 'saveOnboardingInterests').mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps({ onClose })} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    // Don't select any interest, still click next (button may be disabled, let's check)
+    const nextBtn = screen.getByRole('button', { name: /next/i });
+    expect(nextBtn.hasAttribute('disabled')).toBe(true);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('shows loading skeleton while interests are fetching', () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockReturnValue(new Promise(() => undefined));
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps()} />
+      </Wrapper>
+    );
+    // Loading state should be visible
+    expect(screen.getByTestId('onboarding-loading')).toBeTruthy();
+  });
+});
+
+// ── API functions ─────────────────────────────────────────────────────────────
+
+describe('onboarding API functions', () => {
+  function stubFetch(body: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) }))
+    );
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetchOnboardingStatus calls /api/onboarding/status', async () => {
+    stubFetch({ completed: false });
+    const result = await api.fetchOnboardingStatus();
+    expect(result).toEqual({ completed: false });
+  });
+
+  it('fetchOnboardingInterests calls /api/onboarding/interests', async () => {
+    stubFetch([{ id: 'tech', label: 'Technology', description: 'desc' }]);
+    const result = await api.fetchOnboardingInterests();
+    expect(result).toEqual([{ id: 'tech', label: 'Technology', description: 'desc' }]);
+  });
+
+  it('fetchOnboardingSourceRecommendations POSTs interests to /api/onboarding/recommendations', async () => {
+    const calls: { url: string; init?: RequestInit }[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(MOCK_RECOMMENDATIONS),
+        });
+      })
+    );
+    await api.fetchOnboardingSourceRecommendations(['tech', 'science']);
+    expect(calls[0].url).toBe('/api/onboarding/recommendations');
+    expect(calls[0].init?.method).toBe('POST');
+    const body = JSON.parse(calls[0].init?.body as string) as { interest_ids: string[] };
+    expect(body.interest_ids).toEqual(['tech', 'science']);
+  });
+
+  it('saveOnboardingInterests POSTs to /api/onboarding/profile', async () => {
+    const calls: { url: string; init?: RequestInit }[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+      })
+    );
+    await api.saveOnboardingInterests({ interest_ids: ['tech'], enabled_slugs: ['hn'] });
+    expect(calls[0].url).toBe('/api/onboarding/profile');
+    expect(calls[0].init?.method).toBe('POST');
+    const body = JSON.parse(calls[0].init?.body as string) as {
+      interest_ids: string[];
+      enabled_slugs: string[];
+    };
+    expect(body.interest_ids).toEqual(['tech']);
+    expect(body.enabled_slugs).toEqual(['hn']);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,6 +12,9 @@ import type {
   IngestedVsHandledPoint,
   NotificationSettings,
   NotificationSettingsUpdate,
+  OnboardingInterest,
+  OnboardingSourceRecommendation,
+  OnboardingStatus,
   PushSubscribeRequest,
   Quiz,
   QuizResult,
@@ -19,6 +22,7 @@ import type {
   ReadingGoal,
   RecommendationPreferences,
   ReceivedShare,
+  SaveOnboardingProfileRequest,
   ShareableUser,
   Source,
   SourceCleanupSuggestion,
@@ -533,4 +537,30 @@ export async function markShareRead(shareId: number): Promise<void> {
 
 export async function fetchTopicMap(): Promise<TopicMapResponse> {
   return requestJson<TopicMapResponse>('/api/articles/topic-map');
+}
+
+export async function fetchOnboardingStatus(): Promise<OnboardingStatus> {
+  return requestJson<OnboardingStatus>('/api/onboarding/status');
+}
+
+export async function fetchOnboardingInterests(): Promise<OnboardingInterest[]> {
+  return requestJson<OnboardingInterest[]>('/api/onboarding/interests');
+}
+
+export async function fetchOnboardingSourceRecommendations(
+  interestIds: string[]
+): Promise<OnboardingSourceRecommendation[]> {
+  return requestJson<OnboardingSourceRecommendation[]>('/api/onboarding/recommendations', {
+    method: 'POST',
+    body: JSON.stringify({ interest_ids: interestIds }),
+  });
+}
+
+export async function saveOnboardingInterests(
+  payload: SaveOnboardingProfileRequest
+): Promise<void> {
+  await requestJson('/api/onboarding/profile', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -6,7 +6,9 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/co
 import { CommandPalette } from './CommandPalette';
 import { ShortcutOverlay } from './ShortcutOverlay';
 import { WhatsNewDialog } from './WhatsNewDialog';
+import { OnboardingWizard } from './OnboardingWizard';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
+import { useOnboardingWizard } from '@/hooks/useOnboardingWizard';
 import { cn } from '@/lib/utils';
 import { fetchSummary, fetchSharesUnreadCount, logoutUser } from '@/api';
 import { startAnalytics, stopAnalytics, trackRoute } from '@/lib/analytics';
@@ -134,6 +136,7 @@ export function AppShell() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const whatsNew = useWhatsNew();
+  const onboarding = useOnboardingWizard();
 
   async function handleLogout() {
     await logoutUser();
@@ -314,6 +317,7 @@ export function AppShell() {
       />
       <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
       <WhatsNewDialog state={whatsNew} />
+      <OnboardingWizard open={onboarding.open} onClose={onboarding.skip} />
     </div>
   );
 }

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -1,0 +1,278 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+  fetchOnboardingInterests,
+  fetchOnboardingSourceRecommendations,
+  saveOnboardingInterests,
+} from '@/api';
+import type { OnboardingSourceRecommendation } from '@/types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Step = 'interests' | 'recommendations' | 'saving';
+
+export function OnboardingWizard({ open, onClose }: Props) {
+  const qc = useQueryClient();
+  const [step, setStep] = useState<Step>('interests');
+  const [selectedInterests, setSelectedInterests] = useState<Set<string>>(new Set());
+  const [selectedSlugs, setSelectedSlugs] = useState<Set<string>>(new Set());
+
+  const { data: interests, isLoading: loadingInterests } = useQuery({
+    queryKey: ['onboarding-interests'],
+    queryFn: fetchOnboardingInterests,
+    enabled: open,
+    staleTime: Infinity,
+  });
+
+  const { data: recommendations = [], isLoading: loadingRecs } = useQuery({
+    queryKey: ['onboarding-recommendations', [...selectedInterests].sort().join(',')],
+    queryFn: () => fetchOnboardingSourceRecommendations([...selectedInterests]),
+    enabled: step === 'recommendations' && selectedInterests.size > 0,
+    staleTime: Infinity,
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: saveOnboardingInterests,
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['sources'] });
+      onClose();
+    },
+  });
+
+  function toggleInterest(id: string) {
+    setSelectedInterests((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSlug(slug: string) {
+    setSelectedSlugs((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }
+
+  function handleApply() {
+    saveMutation.mutate({
+      interest_ids: [...selectedInterests],
+      enabled_slugs: [...selectedSlugs],
+    });
+  }
+
+  function handleSkip() {
+    onClose();
+  }
+
+  function handleBack() {
+    setStep('interests');
+  }
+
+  // Pre-select recommended sources when moving to step 2
+  function handleGoToRecommendations() {
+    const preselected = recommendations.filter((r) => r.recommended).map((r) => r.slug);
+    setSelectedSlugs(new Set(preselected));
+    setStep('recommendations');
+  }
+
+  const isLoading = step === 'interests' ? loadingInterests : loadingRecs;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) onClose();
+      }}
+    >
+      <DialogContent className="max-w-lg w-full">
+        <DialogHeader>
+          <DialogTitle>
+            {step === 'interests' ? 'What are you interested in?' : 'Recommended sources'}
+          </DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12" data-testid="onboarding-loading">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : step === 'interests' ? (
+          <InterestStep
+            interests={interests ?? []}
+            selected={selectedInterests}
+            onToggle={toggleInterest}
+          />
+        ) : (
+          <RecommendationsStep
+            recommendations={recommendations}
+            selected={selectedSlugs}
+            onToggle={toggleSlug}
+            loading={loadingRecs}
+          />
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          {step === 'interests' ? (
+            <>
+              <Button variant="ghost" size="sm" onClick={handleSkip}>
+                Skip for now
+              </Button>
+              <Button
+                size="sm"
+                disabled={selectedInterests.size === 0 || loadingInterests}
+                onClick={handleGoToRecommendations}
+              >
+                Next
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="ghost" size="sm" onClick={handleBack}>
+                Back
+              </Button>
+              <Button
+                size="sm"
+                disabled={saveMutation.isPending || loadingRecs}
+                onClick={handleApply}
+              >
+                {saveMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : 'Apply'}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+
+        {saveMutation.isError && (
+          <p className="text-xs text-destructive text-center -mt-2">
+            Failed to save. Please try again.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── sub-components ────────────────────────────────────────────────────────────
+
+interface InterestStepProps {
+  interests: { id: string; label: string; description: string }[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+}
+
+function InterestStep({ interests, selected, onToggle }: InterestStepProps) {
+  if (interests.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        No interest categories available.
+      </p>
+    );
+  }
+  return (
+    <div className="grid gap-2 max-h-72 overflow-y-auto pr-1">
+      {interests.map((interest) => {
+        const isSelected = selected.has(interest.id);
+        return (
+          <button
+            key={interest.id}
+            onClick={() => onToggle(interest.id)}
+            className={cn(
+              'flex flex-col gap-0.5 rounded-md border px-3 py-2.5 text-left transition-colors',
+              isSelected
+                ? 'border-primary bg-primary/5 text-foreground'
+                : 'border-border bg-background text-foreground hover:bg-surface'
+            )}
+          >
+            <span className="text-sm font-medium">{interest.label}</span>
+            {interest.description && (
+              <span className="text-xs text-muted-foreground">{interest.description}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface RecommendationsStepProps {
+  recommendations: OnboardingSourceRecommendation[];
+  selected: Set<string>;
+  onToggle: (slug: string) => void;
+  loading: boolean;
+}
+
+function RecommendationsStep({
+  recommendations,
+  selected,
+  onToggle,
+  loading,
+}: RecommendationsStepProps) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (recommendations.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        No recommendations for your selected interests.
+      </p>
+    );
+  }
+  return (
+    <div className="grid gap-2 max-h-72 overflow-y-auto pr-1">
+      {recommendations.map((rec) => {
+        const isSelected = selected.has(rec.slug);
+        return (
+          <button
+            key={rec.slug}
+            onClick={() => onToggle(rec.slug)}
+            className={cn(
+              'flex flex-col gap-0.5 rounded-md border px-3 py-2.5 text-left transition-colors',
+              isSelected
+                ? 'border-primary bg-primary/5 text-foreground'
+                : 'border-border bg-background text-foreground hover:bg-surface'
+            )}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-medium">{rec.name}</span>
+              <span className="text-[10px] text-muted-foreground uppercase tracking-wide shrink-0">
+                {rec.category}
+              </span>
+            </div>
+            {rec.reason && <span className="text-xs text-muted-foreground">{rec.reason}</span>}
+            {rec.matched_interests.length > 0 && (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {rec.matched_interests.map((id) => (
+                  <span
+                    key={id}
+                    className="inline-block rounded-sm bg-surface-2 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                  >
+                    {id}
+                  </span>
+                ))}
+              </div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useOnboardingWizard.ts
+++ b/frontend/src/hooks/useOnboardingWizard.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchOnboardingStatus } from '@/api';
+
+const SESSION_KEY = 'onboarding-skipped';
+
+export interface OnboardingWizardState {
+  open: boolean;
+  skip: () => void;
+  openWizard: () => void;
+  close: () => void;
+}
+
+export function useOnboardingWizard(): OnboardingWizardState {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (sessionStorage.getItem(SESSION_KEY)) return;
+    let cancelled = false;
+    fetchOnboardingStatus()
+      .then((status) => {
+        if (cancelled) return;
+        if (!status.completed) setOpen(true);
+      })
+      .catch(() => {
+        // non-critical, stay closed
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const skip = useCallback(() => {
+    sessionStorage.setItem(SESSION_KEY, '1');
+    setOpen(false);
+  }, []);
+
+  const openWizard = useCallback(() => {
+    setOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return { open, skip, openWizard, close };
+}

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, AlertTriangle, AlertCircle, Sparkles, Trash2 } from 'lucide-react';
+import { CheckCircle2, AlertTriangle, AlertCircle, Sparkles, Trash2, Wand2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
@@ -11,6 +12,7 @@ import {
 } from '@/api';
 import { relativeTime } from '@/lib/format';
 import type { Source, SourceCleanupSuggestion } from '@/types';
+import { OnboardingWizard } from '@/components/OnboardingWizard';
 
 type HealthState = 'ok' | 'stale' | 'error';
 
@@ -61,6 +63,7 @@ function formatSuggestionMeta(suggestion: SourceCleanupSuggestion): string {
 }
 
 export function SourcesPage() {
+  const [wizardOpen, setWizardOpen] = useState(false);
   const qc = useQueryClient();
   const { data: sources = [], isLoading } = useQuery({
     queryKey: [SOURCES_KEY],
@@ -128,6 +131,20 @@ export function SourcesPage() {
 
   return (
     <div>
+      <section className="border-b border-border px-4 py-3 md:px-5 flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">Manage your feed subscriptions</span>
+        <Button size="sm" variant="outline" onClick={() => setWizardOpen(true)}>
+          <Wand2 className="size-4" />
+          Personalize
+        </Button>
+      </section>
+      <OnboardingWizard
+        open={wizardOpen}
+        onClose={() => {
+          setWizardOpen(false);
+          void qc.invalidateQueries({ queryKey: [SOURCES_KEY] });
+        }}
+      />
       {cleanupSuggestions.length > 0 && (
         <section className="border-b border-border bg-muted/25 px-4 py-4 md:px-5">
           <div className="flex flex-col gap-3">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -406,3 +406,31 @@ export interface TopicCluster {
 export interface TopicMapResponse {
   clusters: TopicCluster[];
 }
+
+export interface OnboardingInterest {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface OnboardingSourceRecommendation {
+  slug: string;
+  name: string;
+  category: string;
+  kind: string;
+  url: string;
+  matched_interests: string[];
+  reason: string;
+  recommended: boolean;
+  enabled: number;
+  priority: number;
+}
+
+export interface OnboardingStatus {
+  completed: boolean;
+}
+
+export interface SaveOnboardingProfileRequest {
+  interest_ids: string[];
+  enabled_slugs: string[];
+}


### PR DESCRIPTION
Closes #407

## Summary

- **New types** (`OnboardingInterest`, `OnboardingSourceRecommendation`, `OnboardingStatus`, `SaveOnboardingProfileRequest`) and **4 API functions** targeting `/api/onboarding/*` endpoints (ready for the backend in #406)
- **`useOnboardingWizard` hook** — auto-prompts users whose profile is incomplete on app load; session-only skip via `sessionStorage`; `openWizard()` for manual trigger
- **`OnboardingWizard` component** — 2-step dialog: interest selection → source recommendations grouped by matched interest with reason labels; "Apply" calls `saveOnboardingInterests` and invalidates the `sources` query; "Skip for now" closes without saving
- **`AppShell`** mounts the wizard for auto-prompt on every authenticated page load
- **`SourcesPage`** gains a "Personalize" button for manual wizard trigger
- **18 new tests** covering hook auto-open/skip/session-gate/manual-open, component steps, skip-without-save, apply, disabled Next when nothing selected, loading state, and all 4 API functions
- Existing `feedsPages` tests extended to include new mock exports

## Test plan
- [ ] All 497 vitest tests pass
- [ ] ESLint 0 warnings, tsc clean (enforced by pre-commit hook)
- [ ] New user (profile incomplete): wizard auto-opens on login
- [ ] Skip closes wizard for session; re-load opens it again
- [ ] Select interests → Next → see recommended sources with reasons → Apply → sources invalidated
- [ ] Existing source switches on SourcesPage still work
- [ ] "Personalize" button on SourcesPage reopens wizard manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)