### PR TITLE
feat: add interest-profile onboarding backend (#406)

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -379,17 +379,8 @@ def keycloak_token_request_data(code: str) -> dict[str, str]:
 def subscribe_user_to_default_sources(user_id: int) -> None:
     from news_dashboard.ingest import sync_sources
 
+    _ = user_id
     sync_sources()
-    with connect() as conn:
-        rows = conn.execute("SELECT slug FROM sources WHERE owner_user_id IS NULL").fetchall()
-        for r in rows:
-            slug = row_to_dict(r)["slug"]
-            conn.execute(
-                "INSERT INTO user_sources(user_id, source_slug, enabled) "
-                "VALUES (%s, %s, TRUE) "
-                "ON CONFLICT(user_id, source_slug) DO NOTHING",
-                (user_id, slug),
-            )
 
 
 def ensure_keycloak_user(info: dict[str, Any]) -> dict[str, Any]:

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -279,6 +279,14 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_sources_user ON user_sources(user_id, enabled)",
     """
+    CREATE TABLE IF NOT EXISTS user_interest_profiles (
+      user_id      INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      interests    JSONB NOT NULL DEFAULT '[]'::jsonb,
+      completed_at TIMESTAMPTZ,
+      updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    """
     CREATE TABLE IF NOT EXISTS user_article_state (
       user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       article_id  BIGINT  NOT NULL REFERENCES articles(id) ON DELETE CASCADE,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -22,6 +22,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from psycopg.types.json import Jsonb
 from pydantic import BaseModel, Field
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response as StarletteResponse
@@ -193,6 +194,13 @@ class CreateSourceRequest(BaseModel):
 
 class SourceCleanupRequest(BaseModel):
     source_slugs: list[str]
+
+
+class OnboardingInterestsRequest(BaseModel):
+    interests: list[str]
+    enabled_source_slugs: list[str] = Field(default_factory=list)
+    disabled_source_slugs: list[str] = Field(default_factory=list)
+    completed: bool = True
 
 
 class IntervalUpdate(BaseModel):
@@ -865,6 +873,176 @@ def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict
     if not article:
         raise HTTPException(status_code=404, detail="article not found")
     return {"status": "marked_read", "article": article}
+
+
+INTEREST_GROUPS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "ai",
+        "label": "AI",
+        "options": (
+            {"id": "agents", "label": "Agents"},
+            {"id": "model-releases", "label": "Model releases"},
+            {"id": "evals", "label": "Evals"},
+            {"id": "product-news", "label": "Product news"},
+        ),
+    },
+    {
+        "id": "engineering",
+        "label": "Engineering",
+        "options": (
+            {"id": "python", "label": "Python"},
+            {"id": "infra", "label": "Infrastructure"},
+            {"id": "cloud", "label": "Cloud"},
+            {"id": "security", "label": "Security"},
+        ),
+    },
+)
+
+
+def _interest_options() -> set[str]:
+    return {str(option["id"]) for group in INTEREST_GROUPS for option in group["options"]}
+
+
+def _source_recommendations(user_id: int, interests: list[str]) -> list[dict[str, Any]]:
+    from news_dashboard.ingest import sync_sources
+    from news_dashboard.sources import DEFAULT_SOURCES
+
+    selected = set(interests)
+    sync_sources()
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT source_slug, enabled FROM user_sources WHERE user_id = %s",
+            (user_id,),
+        ).fetchall()
+    subscriptions = {str(row["source_slug"]): bool(row["enabled"]) for row in rows}
+
+    recommendations: list[dict[str, Any]] = []
+    for source in DEFAULT_SOURCES:
+        tags = set(source.interest_tags)
+        matched = sorted(selected & (tags | {source.category}))
+        score = float((len(selected & tags) * 100) + (25 if source.category in selected else 0))
+        score += source.priority / 100
+        recommended = bool(matched)
+        if not selected:
+            score = source.priority / 100
+            recommended = False
+        reason = (
+            f"Matches {', '.join(matched)}" if matched else f"Baseline {source.category} source"
+        )
+        recommendations.append(
+            {
+                "source_slug": source.slug,
+                "source_name": source.name,
+                "category": source.category,
+                "matched_interests": matched,
+                "reason": reason,
+                "recommended": recommended,
+                "subscribed": subscriptions.get(source.slug, False),
+                "_score": score,
+                "_priority": source.priority,
+            }
+        )
+
+    recommendations.sort(
+        key=lambda item: (
+            float(item["_score"]),
+            bool(item["subscribed"]),
+            int(item["_priority"]),
+            str(item["source_name"]),
+        ),
+        reverse=True,
+    )
+    for item in recommendations:
+        item.pop("_score")
+        item.pop("_priority")
+    return recommendations
+
+
+@api.get("/api/onboarding/interests")
+def onboarding_interests(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    _ = current_user
+    return {"groups": list(INTEREST_GROUPS)}
+
+
+@api.get("/api/onboarding/source-recommendations")
+def onboarding_source_recommendations(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    uid = int(current_user["id"])
+    init_db()
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT interests FROM user_interest_profiles WHERE user_id = %s",
+            (uid,),
+        ).fetchone()
+    interests = list(row["interests"]) if row else []
+    return {"items": _source_recommendations(uid, [str(interest) for interest in interests])}
+
+
+@api.post("/api/onboarding/interests")
+def save_onboarding_interests(
+    payload: OnboardingInterestsRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.ingest import sync_sources
+
+    valid_interests = _interest_options()
+    interests = list(dict.fromkeys(payload.interests))
+    invalid = [interest for interest in interests if interest not in valid_interests]
+    if invalid:
+        raise HTTPException(status_code=400, detail=f"unknown interests: {', '.join(invalid)}")
+
+    uid = int(current_user["id"])
+    requested = list(dict.fromkeys(payload.enabled_source_slugs + payload.disabled_source_slugs))
+    sync_sources()
+    with connect() as conn:
+        if requested:
+            rows = conn.execute(
+                "SELECT slug FROM sources WHERE owner_user_id IS NULL AND slug = ANY(%s)",
+                (requested,),
+            ).fetchall()
+            allowed = {str(row["slug"]) for row in rows}
+            missing = [slug for slug in requested if slug not in allowed]
+            if missing:
+                detail = f"unknown global sources: {', '.join(missing)}"
+                raise HTTPException(status_code=404, detail=detail)
+
+        conn.execute(
+            """
+            INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
+            VALUES (%s, %s, CASE WHEN %s THEN NOW() ELSE NULL END, NOW())
+            ON CONFLICT(user_id) DO UPDATE SET
+              interests = excluded.interests,
+              completed_at = excluded.completed_at,
+              updated_at = NOW()
+            """,
+            (uid, Jsonb(interests), payload.completed),
+        )
+        for slug in payload.enabled_source_slugs:
+            conn.execute(
+                """
+                INSERT INTO user_sources(user_id, source_slug, enabled)
+                VALUES (%s, %s, TRUE)
+                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = TRUE
+                """,
+                (uid, slug),
+            )
+        for slug in payload.disabled_source_slugs:
+            conn.execute(
+                """
+                INSERT INTO user_sources(user_id, source_slug, enabled)
+                VALUES (%s, %s, FALSE)
+                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = FALSE
+                """,
+                (uid, slug),
+            )
+
+    return {
+        "interests": interests,
+        "items": _source_recommendations(uid, interests),
+    }
 
 
 @api.get("/api/sources")

--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -13,6 +13,8 @@ class SourceDefinition:
     priority: int = 50
     enabled: bool = True
     lang: str = "en"
+    interest_tags: tuple[str, ...] = ()
+    description: str | None = None
 
 
 DEFAULT_SOURCES: list[SourceDefinition] = [
@@ -23,9 +25,15 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://blog.python.org/feeds/posts/default",
         "python",
         priority=90,
+        interest_tags=("python", "product-news"),
     ),
     SourceDefinition(
-        "astral-blog", "Astral Blog", "https://astral.sh/blog/rss.xml", "python", priority=85
+        "astral-blog",
+        "Astral Blog",
+        "https://astral.sh/blog/rss.xml",
+        "python",
+        priority=85,
+        interest_tags=("python", "infra"),
     ),
     SourceDefinition(
         "ruff-releases",
@@ -34,6 +42,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "python",
         "github_release_feed",
         85,
+        interest_tags=("python", "infra", "model-releases"),
     ),
     SourceDefinition(
         "uv-releases",
@@ -42,6 +51,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "python",
         "github_release_feed",
         85,
+        interest_tags=("python", "infra", "model-releases"),
     ),
     SourceDefinition(
         "mypy-releases",
@@ -50,6 +60,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "python",
         "github_release_feed",
         80,
+        interest_tags=("python", "infra", "model-releases"),
     ),
     SourceDefinition(
         "pyright-releases",
@@ -58,6 +69,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "python",
         "github_release_feed",
         80,
+        interest_tags=("python", "infra", "model-releases"),
     ),
     SourceDefinition(
         "scikit-learn-releases",
@@ -66,6 +78,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "python",
         "github_release_feed",
         75,
+        interest_tags=("python", "model-releases"),
     ),
     SourceDefinition(
         "scipy-releases",
@@ -74,9 +87,15 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "python",
         "github_release_feed",
         75,
+        interest_tags=("python", "model-releases"),
     ),
     SourceDefinition(
-        "pytorch-blog", "PyTorch Blog", "https://pytorch.org/blog/feed.xml", "python", priority=80
+        "pytorch-blog",
+        "PyTorch Blog",
+        "https://pytorch.org/blog/feed.xml",
+        "python",
+        priority=80,
+        interest_tags=("python", "model-releases", "infra"),
     ),
     SourceDefinition(
         "tensorflow-blog",
@@ -84,6 +103,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://blog.tensorflow.org/feeds/posts/default",
         "python",
         priority=70,
+        interest_tags=("python", "model-releases", "infra"),
     ),
     # ── AI / LLM / agents ───────────────────────────────────────────────────
     SourceDefinition(
@@ -93,9 +113,15 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "ai-llm",
         "scraped_page",
         90,
+        interest_tags=("agents", "model-releases", "evals", "product-news"),
     ),
     SourceDefinition(
-        "openai-blog", "OpenAI Blog", "https://openai.com/news/rss.xml", "ai-llm", priority=85
+        "openai-blog",
+        "OpenAI Blog",
+        "https://openai.com/news/rss.xml",
+        "ai-llm",
+        priority=85,
+        interest_tags=("agents", "model-releases", "evals", "product-news"),
     ),
     SourceDefinition(
         "google-ai-blog",
@@ -103,6 +129,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://blog.google/technology/ai/rss/",
         "ai-llm",
         priority=75,
+        interest_tags=("model-releases", "product-news", "cloud"),
     ),
     SourceDefinition(
         "huggingface-blog",
@@ -110,6 +137,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://huggingface.co/blog/feed.xml",
         "ai-llm",
         priority=80,
+        interest_tags=("model-releases", "infra", "evals"),
     ),
     SourceDefinition(
         "augment-code-blog",
@@ -117,6 +145,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://www.augmentcode.com/blog/rss.xml",
         "ai-llm",
         priority=70,
+        interest_tags=("agents", "product-news"),
     ),
     SourceDefinition(
         "simon-willison",
@@ -124,12 +153,23 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://simonwillison.net/atom/everything/",
         "ai-llm",
         priority=85,
+        interest_tags=("agents", "model-releases", "evals", "python"),
     ),
     SourceDefinition(
-        "latent-space", "Latent Space", "https://www.latent.space/feed", "ai-llm", priority=65
+        "latent-space",
+        "Latent Space",
+        "https://www.latent.space/feed",
+        "ai-llm",
+        priority=65,
+        interest_tags=("agents", "model-releases", "product-news"),
     ),
     SourceDefinition(
-        "import-ai", "Import AI", "https://importai.substack.com/feed", "ai-llm", priority=65
+        "import-ai",
+        "Import AI",
+        "https://importai.substack.com/feed",
+        "ai-llm",
+        priority=65,
+        interest_tags=("evals", "model-releases"),
     ),
     SourceDefinition(
         "infoq-ai-ml",
@@ -137,6 +177,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://feed.infoq.com/ai-ml-data-eng",
         "ai-llm",
         priority=60,
+        interest_tags=("infra", "cloud", "model-releases"),
     ),
     SourceDefinition(
         "langchain-releases",
@@ -145,6 +186,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "agents",
         "github_release_feed",
         80,
+        interest_tags=("agents", "python", "model-releases"),
     ),
     SourceDefinition(
         "langgraph-releases",
@@ -153,6 +195,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "agents",
         "github_release_feed",
         85,
+        interest_tags=("agents", "python", "model-releases"),
     ),
     SourceDefinition(
         "langfuse-releases",
@@ -161,6 +204,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "agents",
         "github_release_feed",
         80,
+        interest_tags=("agents", "infra", "model-releases"),
     ),
     # ── Cloud / infra ────────────────────────────────────────────────────────
     SourceDefinition(
@@ -169,6 +213,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://kubernetes.io/feed.xml",
         "cloud-infra",
         priority=65,
+        interest_tags=("cloud", "infra"),
     ),
     SourceDefinition(
         "docker-blog",
@@ -176,6 +221,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://www.docker.com/blog/feed/",
         "cloud-infra",
         priority=65,
+        interest_tags=("cloud", "infra"),
     ),
     SourceDefinition(
         "aws-ml-blog",
@@ -183,6 +229,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://aws.amazon.com/blogs/machine-learning/feed/",
         "cloud-infra",
         priority=60,
+        interest_tags=("cloud", "infra", "model-releases"),
     ),
     # ── Engineering ──────────────────────────────────────────────────────────
     SourceDefinition(
@@ -191,6 +238,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://newsletter.pragmaticengineer.com/feed",
         "engineering",
         priority=60,
+        interest_tags=("product-news", "infra"),
     ),
     SourceDefinition(
         "github-changelog",
@@ -198,6 +246,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://github.blog/changelog/feed/",
         "engineering",
         priority=65,
+        interest_tags=("product-news", "infra"),
     ),
     SourceDefinition(
         "github-engineering",
@@ -205,6 +254,7 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         "https://github.blog/engineering/feed/",
         "engineering",
         priority=55,
+        interest_tags=("infra", "cloud"),
     ),
     # ── Trending / repositories ───────────────────────────────────────────────
     SourceDefinition(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -129,8 +129,9 @@ def pg_clean(pg_url: str) -> str:
     with psycopg.connect(pg_url, autocommit=True) as conn:
         conn.execute(
             "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
-            " user_settings, user_push_subscriptions, article_shares, user_events,"
-            " briefing_articles, briefings, ingest_run_sources, ingest_runs, articles,"
-            " sources, users RESTART IDENTITY CASCADE"
+            " user_interest_profiles, user_settings, user_push_subscriptions,"
+            " article_shares, user_events, briefing_articles, briefings,"
+            " ingest_run_sources, ingest_runs, articles, sources, users"
+            " RESTART IDENTITY CASCADE"
         )
     return pg_url

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -440,7 +440,7 @@ def test_health_details_requires_admin(tmp_db: str) -> None:
     assert resp.status_code in (401, 403)
 
 
-def test_ensure_keycloak_user_provisions_default_sources(
+def test_ensure_keycloak_user_does_not_provision_default_sources(
     tmp_db: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Keycloak auth enabled to run ensure_keycloak_user
@@ -454,20 +454,19 @@ def test_ensure_keycloak_user_provisions_default_sources(
     )
     assert user["username"] == "newkeycloakuser"
 
-    # Verify that the user is subscribed to all sources in the sources table.
+    # Verify that the catalog is synced but no global subscriptions are enabled
+    # until the user completes onboarding.
     with connect() as conn:
-        # Get count of default sources
         default_sources_count = conn.execute(
             "SELECT COUNT(*) AS count FROM sources WHERE owner_user_id IS NULL"
         ).fetchone()["count"]
-        # Get count of user subscriptions
         user_subs_count = conn.execute(
             "SELECT COUNT(*) AS count FROM user_sources WHERE user_id = %s AND enabled IS TRUE",
             (user["id"],),
         ).fetchone()["count"]
 
         assert default_sources_count > 0
-        assert user_subs_count == default_sources_count
+        assert user_subs_count == 0
 
 
 def test_keycloak_registration_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_onboarding_interests.py
+++ b/backend/tests/test_onboarding_interests.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import create_user, require_admin, require_auth
+from news_dashboard.db import connect
+from news_dashboard.ingest import sync_sources
+from news_dashboard.main import app
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    user = create_user(username, "pw", db_path=database_url)
+    return int(user["id"])
+
+
+@contextmanager
+def _api_client(user_id: int) -> Generator[TestClient]:
+    fake = {"id": user_id, "username": "testuser", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake
+    app.dependency_overrides[require_admin] = lambda: fake
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_onboarding_interest_options_are_stable(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.get("/api/onboarding/interests")
+
+    assert response.status_code == 200
+    groups = response.json()["groups"]
+    option_ids = {option["id"] for group in groups for option in group["options"]}
+    assert {"agents", "model-releases", "evals", "infra", "python", "cloud"} <= option_ids
+
+
+def test_onboarding_recommendations_rank_matches_and_subscription_state(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    user_id = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_interest_profiles(user_id, interests)
+            VALUES (%s, '["agents", "python"]'::jsonb)
+            """,
+            (user_id,),
+        )
+        conn.execute(
+            """
+            INSERT INTO user_sources(user_id, source_slug, enabled)
+            VALUES (%s, 'langgraph-releases', TRUE)
+            """,
+            (user_id,),
+        )
+
+    with _api_client(user_id) as client:
+        response = client.get("/api/onboarding/source-recommendations")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    langgraph = next(item for item in items if item["source_slug"] == "langgraph-releases")
+    assert langgraph["recommended"] is True
+    assert langgraph["subscribed"] is True
+    assert langgraph["matched_interests"] == ["agents", "python"]
+    assert items.index(langgraph) < 5
+
+
+def test_save_onboarding_interests_persists_profile_and_source_choices(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.post(
+            "/api/onboarding/interests",
+            json={
+                "interests": ["agents", "python"],
+                "enabled_source_slugs": ["langgraph-releases"],
+                "disabled_source_slugs": ["openai-blog"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["interests"] == ["agents", "python"]
+    with connect(pg_clean) as conn:
+        profile = conn.execute(
+            "SELECT interests, completed_at FROM user_interest_profiles WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()
+        subscriptions = conn.execute(
+            """
+            SELECT source_slug, enabled
+            FROM user_sources
+            WHERE user_id = %s AND source_slug IN ('langgraph-releases', 'openai-blog')
+            """,
+            (user_id,),
+        ).fetchall()
+
+    assert profile is not None
+    assert profile["interests"] == ["agents", "python"]
+    assert profile["completed_at"] is not None
+    assert {row["source_slug"]: row["enabled"] for row in subscriptions} == {
+        "langgraph-releases": True,
+        "openai-blog": False,
+    }
+
+
+def test_new_user_has_no_explicit_global_source_subscriptions(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with connect(pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM user_sources WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()["count"]
+
+    assert count == 0

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -9,6 +9,7 @@ Covered scenarios
 - COALESCE(uas.starred, false)     — list_articles starred filter
 - COALESCE(us_src.enabled, true)   — source subscription filter in list_articles
 - COALESCE(us.enabled, true)       — sources listing CASE expression in main.py
+- user_interest_profiles.interests — onboarding profile JSONB storage
 - Writing user_sources.enabled as a Python bool (not 0/1) via PATCH API
 - State isolation between users on PostgreSQL
 - Private source visibility on PostgreSQL
@@ -159,6 +160,24 @@ def test_pg_list_articles_starred_filter(pg_env: str) -> None:
     assert all(a["starred"] is True for a in results if a["id"] == aid)
 
 
+def test_pg_user_interest_profiles_interests_is_jsonb(pg_env: str) -> None:
+    import psycopg
+
+    with psycopg.connect(pg_env) as conn:
+        row = conn.execute(
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'user_interest_profiles'
+              AND column_name = 'interests'
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "jsonb"
+
+
 def test_pg_list_articles_unstarred_filter(pg_env: str) -> None:
     """Starred=False filter must correctly exclude starred articles on PostgreSQL."""
     from news_dashboard.ingest import list_articles, set_article_starred
@@ -279,7 +298,7 @@ def test_pg_list_articles_respects_source_subscription(pg_env: str) -> None:
     uid = _make_user(pg_url, "sub-user")
     aid = _add_article(pg_url, source_slug="pg-src-sub", url_suffix="sub1")
 
-    # Default: no user_sources row → source is visible.
+    # Default: no user_sources row means the source is visible.
     results = list_articles(state="today", user_id=uid)
     assert any(a["id"] == aid for a in results)
 


### PR DESCRIPTION
Closes #406

## Summary
- add a PostgreSQL JSONB user_interest_profiles table and source interest metadata
- add onboarding interest options, source recommendations, and save/apply endpoints
- stop Keycloak provisioning from inserting every global source subscription row

## Tests
- make lint
- make typecheck
- pytest backend/tests/test_onboarding_interests.py backend/tests/test_auth.py::test_ensure_keycloak_user_does_not_provision_default_sources backend/tests/test_postgres_types.py::test_pg_user_interest_profiles_interests_is_jsonb -q

Note: full local make test could not complete because the local PostgreSQL service entered recovery mode; GitHub CI should run on a fresh database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)