### PR TITLE
fix: persist quiz completion so result survives page refresh (#409)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -461,6 +461,8 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_nudge_dismissals_user"
     " ON user_nudge_dismissals(user_id, cooldown_until)",
+    "ALTER TABLE user_quizzes ADD COLUMN IF NOT EXISTS submitted_answers JSONB",
+    "ALTER TABLE user_quizzes ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ",
 ]
 
 

--- a/backend/news_dashboard/quiz.py
+++ b/backend/news_dashboard/quiz.py
@@ -290,13 +290,21 @@ def get_latest_quiz(
     init_db(db_path, database_url=database_url)
     with connect(db_path, database_url=database_url) as conn:
         row = conn.execute(
-            "SELECT id, user_id, created_at, questions, score"
+            "SELECT id, user_id, created_at, questions, score, submitted_answers, submitted_at"
             " FROM user_quizzes WHERE user_id = %s ORDER BY created_at DESC LIMIT 1",
             (user_id,),
         ).fetchone()
     if not row:
         return None
-    return dict(row)
+    quiz = dict(row)
+    if quiz.get("submitted_at") and quiz.get("submitted_answers") and quiz.get("score") is not None:
+        quiz["completed_result"] = {
+            "quiz_id": quiz["id"],
+            "score": quiz["score"],
+            "total": len(quiz["submitted_answers"]),
+            "questions": quiz["submitted_answers"],
+        }
+    return quiz
 
 
 def submit_quiz(
@@ -325,17 +333,19 @@ def submit_quiz(
         )
         score = correct
 
+        submitted_answers = [
+            {**q, "your_answer": answers[i] if i < len(answers) else None}
+            for i, q in enumerate(questions)
+        ]
         conn.execute(
-            "UPDATE user_quizzes SET score = %s WHERE id = %s AND user_id = %s",
-            (score, quiz_id, user_id),
+            "UPDATE user_quizzes SET score = %s, submitted_answers = %s::jsonb,"
+            " submitted_at = NOW() WHERE id = %s AND user_id = %s",
+            (score, json.dumps(submitted_answers), quiz_id, user_id),
         )
 
     return {
         "quiz_id": quiz_id,
         "score": score,
         "total": len(questions),
-        "questions": [
-            {**q, "your_answer": answers[i] if i < len(answers) else None}
-            for i, q in enumerate(questions)
-        ],
+        "questions": submitted_answers,
     }

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -300,3 +300,79 @@ def test_submit_quiz_not_found(tmp_path: Path) -> None:
     _seed(db_path)
     with pytest.raises(ValueError, match="not found"):
         submit_quiz(9999, 1, [0, 0, 0], db_path=db_path)
+
+
+def _generate_quiz_with_mock(user_id: int, db_path: Path) -> dict[str, Any]:
+    import json
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
+        patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
+    ):
+        mock_client_factory.return_value = MagicMock()
+        quiz = generate_weekly_quiz(user_id, db_path=db_path)
+    assert quiz is not None
+    return quiz
+
+
+def test_submit_quiz_persists_submitted_answers(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+    quiz = _generate_quiz_with_mock(user_id, db_path)
+
+    answers = [q["correct_index"] for q in _MOCK_QUESTIONS]
+    submit_quiz(quiz["id"], user_id, answers, db_path=db_path)
+
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT submitted_answers, submitted_at FROM user_quizzes WHERE id = %s",
+            (quiz["id"],),
+        ).fetchone()
+
+    assert row is not None
+    assert row["submitted_at"] is not None
+    assert row["submitted_answers"] is not None
+    assert len(row["submitted_answers"]) == 3
+    # Each question should have your_answer populated
+    for i, q in enumerate(row["submitted_answers"]):
+        assert q["your_answer"] == answers[i]
+
+
+def test_get_latest_quiz_returns_completed_result_after_submit(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+    quiz = _generate_quiz_with_mock(user_id, db_path)
+
+    # Before submit: no completed_result
+    latest = get_latest_quiz(user_id, db_path=db_path)
+    assert latest is not None
+    assert latest.get("completed_result") is None
+
+    answers = [q["correct_index"] for q in _MOCK_QUESTIONS]
+    submit_quiz(quiz["id"], user_id, answers, db_path=db_path)
+
+    # After submit: completed_result is populated
+    latest = get_latest_quiz(user_id, db_path=db_path)
+    assert latest is not None
+    cr = latest.get("completed_result")
+    assert cr is not None
+    assert cr["quiz_id"] == quiz["id"]
+    assert cr["score"] == 3
+    assert cr["total"] == 3
+    assert len(cr["questions"]) == 3
+
+
+def test_get_latest_quiz_unanswered_has_no_completed_result(tmp_path: Path) -> None:
+    db_path = tmp_path / "q.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+    _generate_quiz_with_mock(user_id, db_path)
+
+    latest = get_latest_quiz(user_id, db_path=db_path)
+    assert latest is not None
+    assert latest.get("completed_result") is None

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -236,7 +236,12 @@ function LearningCenter() {
       .catch(() => setGoals([]))
       .finally(() => setLoadingGoals(false));
     fetchLatestQuiz()
-      .then(setQuiz)
+      .then((q) => {
+        setQuiz(q);
+        if (q?.completed_result) {
+          setResult(q.completed_result);
+        }
+      })
       .catch(() => setQuiz(null))
       .finally(() => setLoadingQuiz(false));
   }, []);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -390,6 +390,9 @@ export interface Quiz {
   created_at: string;
   questions: QuizQuestion[];
   score: number | null;
+  submitted_at?: string | null;
+  submitted_answers?: QuizQuestion[] | null;
+  completed_result?: QuizResult | null;
 }
 
 export interface QuizResult {


### PR DESCRIPTION
## Summary

Closes #409

- Added `submitted_answers JSONB` and `submitted_at TIMESTAMPTZ` columns to `user_quizzes` via `IF NOT EXISTS` migrations in `db.py`
- Updated `submit_quiz()` to persist submitted answers (questions with `your_answer` merged in) and set `submitted_at = NOW()`
- Updated `get_latest_quiz()` to select the new columns and return a `completed_result` dict (matching the existing `QuizResult` shape) when the quiz has been submitted
- Extended the `Quiz` frontend type with `submitted_at?`, `submitted_answers?`, and `completed_result?` fields
- On initial quiz load in `ReadingDnaPage`, if the fetched quiz includes a `completed_result`, it is used to set `result` state — so `QuizResultView` renders immediately without requiring a re-submit
- Regenerating a quiz clears `result` state and creates a fresh unanswered quiz (existing `handleGenerateQuiz` already calls `setResult(null)`)

## Test plan

- [x] 3 new backend tests in `test_quiz.py`: persist submitted answers, `get_latest_quiz` returns `completed_result` after submit, unanswered quiz has no `completed_result`
- [x] All 20 quiz tests pass (`pytest backend/tests/test_quiz.py`)
- [x] `make lint`, `make typecheck` both green
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)