### PR TITLE
feat: add weekly quiz history (#410)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1817,6 +1817,17 @@ def get_latest_quiz_endpoint(
     return quiz
 
 
+@api.get("/api/quizzes")
+def list_quizzes_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    limit: Annotated[int, Query(ge=1, le=50)] = 12,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    from news_dashboard.quiz import list_quizzes
+
+    return {"items": list_quizzes(current_user["id"], limit=limit, offset=offset)}
+
+
 @api.post("/api/quizzes/generate")
 def generate_quiz_endpoint(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],

--- a/backend/news_dashboard/quiz.py
+++ b/backend/news_dashboard/quiz.py
@@ -307,6 +307,30 @@ def get_latest_quiz(
     return quiz
 
 
+def list_quizzes(
+    user_id: int,
+    limit: int = 12,
+    offset: int = 0,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, user_id, created_at, score, submitted_at,
+                   jsonb_array_length(questions) AS total,
+                   (submitted_at IS NOT NULL OR score IS NOT NULL) AS completed
+            FROM user_quizzes
+            WHERE user_id = %s
+            ORDER BY created_at DESC, id DESC
+            LIMIT %s OFFSET %s
+            """,
+            (user_id, limit, offset),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
 def submit_quiz(
     quiz_id: int,
     user_id: int,

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi.testclient import TestClient
 
+from news_dashboard.auth import require_auth
 from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
 from news_dashboard.quiz import (
     create_goal,
     delete_goal,
@@ -17,14 +21,23 @@ from news_dashboard.quiz import (
     get_latest_quiz,
     goal_alignment_adjustment,
     list_goals,
+    list_quizzes,
     submit_quiz,
 )
 
 
-def _seed(db_path: Path) -> tuple[int, int]:
+def _db_url(value: Path | str) -> str | None:
+    text = str(value)
+    if text.startswith(("postgres://", "postgresql://")):
+        return text
+    return None
+
+
+def _seed(db_path: Path | str) -> tuple[int, int]:
     """Create one user, source, and article; return (user_id, article_id)."""
-    init_db(db_path)
-    with connect(db_path) as conn:
+    database_url = _db_url(db_path)
+    init_db(None if database_url else db_path, database_url=database_url)
+    with connect(None if database_url else db_path, database_url=database_url) as conn:
         conn.execute(
             "INSERT INTO users(id, username, password_hash, is_admin)"
             " VALUES (1, 'reader', 'x', FALSE)"
@@ -217,8 +230,6 @@ def test_generate_weekly_quiz_with_articles(tmp_path: Path) -> None:
     user_id, article_id = _seed(db_path)
     _seed_done_article(db_path, user_id, article_id)
 
-    import json
-
     mock_response = MagicMock()
     mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
 
@@ -242,12 +253,113 @@ def test_get_latest_quiz_empty(tmp_path: Path) -> None:
     assert get_latest_quiz(1, db_path=db_path) is None
 
 
+def _insert_quiz(
+    db_path: Path | str,
+    *,
+    user_id: int,
+    created_at: datetime,
+    score: int | None = None,
+    submitted_at: datetime | None = None,
+) -> int:
+    database_url = _db_url(db_path)
+    with connect(None if database_url else db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_quizzes (user_id, created_at, questions, score, submitted_at)
+            VALUES (%s, %s, %s::jsonb, %s, %s)
+            RETURNING id
+            """,
+            (user_id, created_at, json.dumps(_MOCK_QUESTIONS), score, submitted_at),
+        ).fetchone()
+    return int(row["id"])
+
+
+def test_list_quizzes_newest_first_with_metadata(pg_clean: str) -> None:
+    _seed(pg_clean)
+    old = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    new = datetime(2026, 1, 8, tzinfo=timezone.utc)
+    old_id = _insert_quiz(pg_clean, user_id=1, created_at=old)
+    new_id = _insert_quiz(
+        pg_clean,
+        user_id=1,
+        created_at=new,
+        score=2,
+        submitted_at=new + timedelta(minutes=5),
+    )
+
+    items = list_quizzes(1, database_url=pg_clean)
+
+    assert [item["id"] for item in items] == [new_id, old_id]
+    assert items[0]["score"] == 2
+    assert items[0]["total"] == 3
+    assert items[0]["completed"] is True
+    assert items[0]["submitted_at"] is not None
+    assert items[1]["completed"] is False
+
+
+def test_list_quizzes_limits_and_offsets(pg_clean: str) -> None:
+    _seed(pg_clean)
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    ids = [
+        _insert_quiz(pg_clean, user_id=1, created_at=base + timedelta(days=days))
+        for days in range(3)
+    ]
+
+    items = list_quizzes(1, limit=1, offset=1, database_url=pg_clean)
+
+    assert [item["id"] for item in items] == [ids[1]]
+
+
+def test_list_quizzes_is_user_scoped(pg_clean: str) -> None:
+    _seed(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash, is_admin)"
+            " VALUES (2, 'other', 'x', FALSE)"
+        )
+    mine = _insert_quiz(
+        pg_clean,
+        user_id=1,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    _insert_quiz(
+        pg_clean,
+        user_id=2,
+        created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+
+    items = list_quizzes(1, database_url=pg_clean)
+
+    assert [item["id"] for item in items] == [mine]
+
+
+def test_list_quizzes_endpoint_returns_current_user_history(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed(pg_clean)
+    _insert_quiz(
+        pg_clean,
+        user_id=1,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        score=3,
+        submitted_at=datetime(2026, 1, 1, 1, tzinfo=timezone.utc),
+    )
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    app.dependency_overrides[require_auth] = lambda: {"id": 1, "username": "reader"}
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            response = client.get("/api/quizzes")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["total"] == 3
+
+
 def test_submit_quiz_scoring(tmp_path: Path) -> None:
     db_path = tmp_path / "q.db"
     user_id, article_id = _seed(db_path)
     _seed_done_article(db_path, user_id, article_id)
-
-    import json
 
     mock_response = MagicMock()
     mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)

--- a/frontend/src/__tests__/readingDnaQuizHistory.test.tsx
+++ b/frontend/src/__tests__/readingDnaQuizHistory.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReadingDnaPage } from '../pages/ReadingDnaPage';
+import * as api from '../api';
+import type { Quiz, QuizHistoryItem, QuizResult, ReadingDna } from '../types';
+
+const dna: ReadingDna = {
+  range_days: 30,
+  generated_at: '2026-06-21T10:00:00Z',
+  categories: [],
+  sources: [],
+  monthly_time: [],
+  average_dwell_seconds: 0,
+};
+
+const quiz: Quiz = {
+  id: 7,
+  user_id: 1,
+  created_at: '2026-06-21T10:00:00Z',
+  score: null,
+  questions: [
+    {
+      question: 'Which model uses attention?',
+      options: ['Transformer', 'Database', 'Queue', 'Cache'],
+      correct_index: 0,
+      explanation: 'Transformers use attention.',
+      article_id: 10,
+    },
+  ],
+};
+
+const quizResult: QuizResult = {
+  quiz_id: 7,
+  score: 1,
+  total: 1,
+  questions: [{ ...quiz.questions[0], your_answer: 0 }],
+};
+
+const history: QuizHistoryItem[] = [
+  {
+    id: 7,
+    user_id: 1,
+    created_at: '2026-06-21T10:00:00Z',
+    score: 1,
+    total: 1,
+    completed: true,
+    submitted_at: '2026-06-21T10:05:00Z',
+  },
+  {
+    id: 6,
+    user_id: 1,
+    created_at: '2026-06-14T10:00:00Z',
+    score: null,
+    total: 3,
+    completed: false,
+    submitted_at: null,
+  },
+];
+
+function mockBasics() {
+  vi.spyOn(api, 'fetchReadingDna').mockResolvedValue(dna);
+  vi.spyOn(api, 'fetchRecommendationPreferences').mockResolvedValue({
+    category_weights: {},
+    novelty_weight: 1,
+  });
+  vi.spyOn(api, 'fetchGoals').mockResolvedValue([]);
+  vi.spyOn(api, 'fetchLatestQuiz').mockResolvedValue(null);
+  vi.spyOn(api, 'fetchQuizHistory').mockResolvedValue([]);
+}
+
+async function renderLearningCenter() {
+  render(<ReadingDnaPage />);
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Learning Center' })).toBeTruthy());
+  await userEvent.click(screen.getByRole('button', { name: 'Learning Center' }));
+}
+
+describe('ReadingDnaPage quiz history', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockBasics();
+  });
+
+  it('renders quiz progress when history exists', async () => {
+    vi.spyOn(api, 'fetchQuizHistory').mockResolvedValue(history);
+
+    await renderLearningCenter();
+
+    await waitFor(() => expect(screen.getByText('Quiz Progress')).toBeTruthy());
+    expect(screen.getByText('Attempts')).toBeTruthy();
+    expect(screen.getByText('Average')).toBeTruthy();
+    expect(screen.getByText('1/1')).toBeTruthy();
+    expect(screen.getByText('—/3')).toBeTruthy();
+  });
+
+  it('does not render quiz progress for empty history', async () => {
+    await renderLearningCenter();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No quiz yet. Generate one based on your recent reading.')
+      ).toBeTruthy()
+    );
+    expect(screen.queryByText('Quiz Progress')).toBeNull();
+  });
+
+  it('refreshes quiz history after generating a quiz', async () => {
+    const fetchHistory = vi
+      .spyOn(api, 'fetchQuizHistory')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(history);
+    vi.spyOn(api, 'generateQuiz').mockResolvedValue(quiz);
+
+    await renderLearningCenter();
+    await userEvent.click(screen.getByRole('button', { name: 'Generate quiz' }));
+
+    await waitFor(() => expect(fetchHistory).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Quiz Progress')).toBeTruthy();
+  });
+
+  it('refreshes quiz history after submitting a quiz', async () => {
+    const fetchHistory = vi
+      .spyOn(api, 'fetchQuizHistory')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(history);
+    vi.spyOn(api, 'fetchLatestQuiz').mockResolvedValue(quiz);
+    vi.spyOn(api, 'submitQuiz').mockResolvedValue(quizResult);
+
+    await renderLearningCenter();
+    await userEvent.click(await screen.findByLabelText('Transformer'));
+    await userEvent.click(screen.getByRole('button', { name: 'Submit answers' }));
+
+    await waitFor(() => expect(fetchHistory).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Quiz Progress')).toBeTruthy();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -18,6 +18,7 @@ import type {
   PersonalizationNudge,
   PushSubscribeRequest,
   Quiz,
+  QuizHistoryItem,
   QuizResult,
   ReadingDna,
   ReadingGoal,
@@ -519,6 +520,11 @@ export async function fetchLatestQuiz(): Promise<Quiz | null> {
   } catch {
     return null;
   }
+}
+
+export async function fetchQuizHistory(): Promise<QuizHistoryItem[]> {
+  const data = await requestJson<{ items: QuizHistoryItem[] }>('/api/quizzes');
+  return data.items;
 }
 
 export async function generateQuiz(): Promise<Quiz> {

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -6,6 +6,7 @@ import {
   deleteGoal,
   fetchGoals,
   fetchLatestQuiz,
+  fetchQuizHistory,
   fetchReadingDna,
   fetchRecommendationPreferences,
   generateQuiz,
@@ -14,6 +15,7 @@ import {
 } from '../api';
 import type {
   Quiz,
+  QuizHistoryItem,
   QuizQuestion,
   QuizResult,
   ReadingDna,
@@ -218,6 +220,7 @@ export function ReadingDnaPage() {
 function LearningCenter() {
   const [goals, setGoals] = useState<ReadingGoal[]>([]);
   const [quiz, setQuiz] = useState<Quiz | null>(null);
+  const [quizHistory, setQuizHistory] = useState<QuizHistoryItem[]>([]);
   const [result, setResult] = useState<QuizResult | null>(null);
   const [answers, setAnswers] = useState<Record<number, number>>({});
   const [loadingGoals, setLoadingGoals] = useState(true);
@@ -229,6 +232,14 @@ function LearningCenter() {
   const [newKeywords, setNewKeywords] = useState('');
   const [addingGoal, setAddingGoal] = useState(false);
   const [showGoalForm, setShowGoalForm] = useState(false);
+
+  const refreshQuizHistory = async () => {
+    try {
+      setQuizHistory(await fetchQuizHistory());
+    } catch {
+      setQuizHistory([]);
+    }
+  };
 
   useEffect(() => {
     fetchGoals()
@@ -244,6 +255,7 @@ function LearningCenter() {
       })
       .catch(() => setQuiz(null))
       .finally(() => setLoadingQuiz(false));
+    void refreshQuizHistory();
   }, []);
 
   async function handleAddGoal() {
@@ -280,6 +292,7 @@ function LearningCenter() {
     try {
       const newQuiz = await generateQuiz();
       setQuiz(newQuiz);
+      await refreshQuizHistory();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate quiz');
     } finally {
@@ -295,6 +308,7 @@ function LearningCenter() {
     try {
       const quizResult = await submitQuiz(quiz.id, answerList);
       setResult(quizResult);
+      await refreshQuizHistory();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to submit quiz');
     } finally {
@@ -441,6 +455,64 @@ function LearningCenter() {
           </div>
         )}
       </Panel>
+
+      {quizHistory.length > 0 && <QuizHistoryPanel items={quizHistory} />}
+    </div>
+  );
+}
+
+function QuizHistoryPanel({ items }: { items: QuizHistoryItem[] }) {
+  const completed = items.filter((item) => item.completed && item.score !== null);
+  const average =
+    completed.length > 0
+      ? Math.round(
+          (completed.reduce((sum, item) => sum + (item.score ?? 0) / item.total, 0) /
+            completed.length) *
+            100
+        )
+      : null;
+  const streak = items.findIndex((item) => !item.completed);
+  const currentStreak = streak === -1 ? items.length : streak;
+
+  return (
+    <Panel title="Quiz Progress">
+      <div className="space-y-3">
+        <div className="grid gap-2 sm:grid-cols-3">
+          <ProgressStat label="Attempts" value={String(items.length)} />
+          <ProgressStat label="Average" value={average === null ? '—' : `${average}%`} />
+          <ProgressStat label="Streak" value={String(currentStreak)} />
+        </div>
+        <ul className="divide-y divide-border rounded border border-border">
+          {items.map((item) => (
+            <li key={item.id} className="flex items-center justify-between gap-3 px-3 py-2">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">
+                  {new Date(item.created_at).toLocaleDateString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {item.completed ? 'Completed' : 'Not completed'}
+                </div>
+              </div>
+              <div className="shrink-0 text-sm font-semibold tabular-nums">
+                {item.score === null ? `—/${item.total}` : `${item.score}/${item.total}`}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Panel>
+  );
+}
+
+function ProgressStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-border px-3 py-2">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold tabular-nums">{value}</div>
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -395,6 +395,16 @@ export interface Quiz {
   completed_result?: QuizResult | null;
 }
 
+export interface QuizHistoryItem {
+  id: number;
+  user_id: number;
+  created_at: string;
+  score: number | null;
+  total: number;
+  completed: boolean;
+  submitted_at?: string | null;
+}
+
 export interface QuizResult {
   quiz_id: number;
   score: number;


### PR DESCRIPTION
Closes #410

## Summary
- add `GET /api/quizzes` with authenticated, newest-first quiz history metadata
- expose `fetchQuizHistory()` and `QuizHistoryItem` on the frontend
- render compact quiz progress/history in the Reading DNA Learning Center and refresh it after quiz generation/submission

## Tests
- `source .env && pytest backend/tests/test_quiz.py -q` passed before the local PostgreSQL service entered recovery mode: 24 passed, 1 warning
- `npm run test:frontend -- frontend/src/__tests__/readingDnaQuizHistory.test.tsx` passed: 4 passed
- `make lint` passed
- `make typecheck` passed
- `npm run build` passed
- `source .env && make test` could not complete locally because PostgreSQL at localhost:55432 entered recovery mode (`psycopg.OperationalError: database system is in recovery mode`) across unrelated DB-heavy tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)