### PR TITLE
feat: preview quiz source articles before generation (closes #411)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1805,6 +1805,16 @@ def delete_goal_endpoint(
     return {"deleted": True}
 
 
+@api.get("/api/quizzes/candidates")
+def get_quiz_candidates_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.quiz import get_quiz_candidate_articles
+
+    candidates = get_quiz_candidate_articles(current_user["id"])
+    return {"candidates": candidates}
+
+
 @api.get("/api/quizzes/latest")
 def get_latest_quiz_endpoint(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],

--- a/backend/news_dashboard/quiz.py
+++ b/backend/news_dashboard/quiz.py
@@ -162,6 +162,104 @@ def _parse_questions(response_text: str) -> list[dict[str, Any]]:
         return []
 
 
+def get_quiz_candidate_articles(
+    user_id: int,
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+    days: int = 7,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Return candidate articles for quiz generation without invoking any LLM.
+
+    Each returned dict contains: id, title, category, source_name, done_at,
+    goal_matched (bool), matched_keywords (list[str]).  No body text is included.
+    """
+    init_db(db_path, database_url=database_url)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    with connect(db_path, database_url=database_url) as conn:
+        goals = conn.execute(
+            "SELECT description, keywords FROM user_goals WHERE user_id = %s",
+            (user_id,),
+        ).fetchall()
+        goal_list = [dict(g) for g in goals]
+
+        keyword_terms: list[str] = []
+        for g in goal_list:
+            kw_str = g.get("keywords") or g.get("description") or ""
+            keyword_terms.extend(kw_str.lower().split())
+
+        goal_candidates: list[dict[str, Any]] = []
+        if keyword_terms:
+            ilike_clauses = " OR ".join(
+                "(LOWER(a.title) LIKE %s OR LOWER(a.category) LIKE %s)" for _ in keyword_terms
+            )
+            params: list[Any] = []
+            for kw in keyword_terms:
+                params.extend([f"%{kw}%", f"%{kw}%"])
+            params.extend([user_id, cutoff])
+            rows = conn.execute(
+                f"""
+                SELECT a.id, a.title, a.category, a.source_name, s.done_at
+                FROM articles a
+                JOIN user_article_state s ON s.article_id = a.id
+                WHERE ({ilike_clauses})
+                  AND s.user_id = %s
+                  AND s.state = 'done'
+                  AND s.done_at >= %s
+                ORDER BY s.done_at DESC
+                LIMIT {limit}
+                """,
+                params,
+            ).fetchall()
+            for row in rows:
+                r = dict(row)
+                article_text = " ".join(filter(None, [r.get("title"), r.get("category")])).lower()
+                matched = [kw for kw in keyword_terms if kw and kw in article_text]
+                goal_candidates.append(
+                    {
+                        "id": r["id"],
+                        "title": r["title"],
+                        "category": r.get("category"),
+                        "source_name": r.get("source_name"),
+                        "done_at": r["done_at"].isoformat() if r.get("done_at") else None,
+                        "goal_matched": True,
+                        "matched_keywords": matched,
+                    }
+                )
+
+        if goal_candidates:
+            return goal_candidates
+
+        # Fall back to any recently done articles when no goal keywords match.
+        rows = conn.execute(
+            """
+            SELECT a.id, a.title, a.category, a.source_name, s.done_at
+            FROM articles a
+            JOIN user_article_state s ON s.article_id = a.id
+            WHERE s.user_id = %s
+              AND s.state = 'done'
+              AND s.done_at >= %s
+            ORDER BY s.done_at DESC
+            LIMIT %s
+            """,
+            (user_id, cutoff, limit),
+        ).fetchall()
+        return [
+            {
+                "id": r["id"],
+                "title": r["title"],
+                "category": r.get("category"),
+                "source_name": r.get("source_name"),
+                "done_at": r["done_at"].isoformat() if r.get("done_at") else None,
+                "goal_matched": False,
+                "matched_keywords": [],
+            }
+            for r in rows
+        ]
+
+
 def generate_weekly_quiz(
     user_id: int,
     *,
@@ -176,74 +274,24 @@ def generate_weekly_quiz(
 
     Returns the saved quiz row, or None when no eligible articles are found.
     """
-    init_db(db_path, database_url=database_url)
-    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
-
-    with connect(db_path, database_url=database_url) as conn:
-        goals = conn.execute(
-            "SELECT description, keywords FROM user_goals WHERE user_id = %s",
-            (user_id,),
-        ).fetchall()
-        goal_list = [dict(g) for g in goals]
-
-        # Build keyword filter for the SQL query when goals are present.
-        articles: list[dict[str, Any]]
-        if goal_list:
-            keyword_terms: list[str] = []
-            for g in goal_list:
-                kw_str = g.get("keywords") or g.get("description") or ""
-                keyword_terms.extend(kw_str.lower().split())
-            if keyword_terms:
-                ilike_clauses = " OR ".join(
-                    "(LOWER(a.title) LIKE %s OR LOWER(a.category) LIKE %s)" for _ in keyword_terms
-                )
-                params: list[Any] = []
-                for kw in keyword_terms:
-                    params.extend([f"%{kw}%", f"%{kw}%"])
-                params.extend([user_id, cutoff])
-                rows = conn.execute(
-                    f"""
-                    SELECT a.id, a.title, a.body, a.summary, a.category
-                    FROM articles a
-                    JOIN user_article_state s ON s.article_id = a.id
-                    WHERE ({ilike_clauses})
-                      AND s.user_id = %s
-                      AND s.state = 'done'
-                      AND s.done_at >= %s
-                    ORDER BY s.done_at DESC
-                    LIMIT 10
-                    """,
-                    params,
-                ).fetchall()
-                articles = [dict(r) for r in rows]
-            else:
-                articles = []
-        else:
-            articles = []
-
-        # Fall back to any recently-read articles when no goal matches.
-        if not articles:
-            rows = conn.execute(
-                """
-                SELECT a.id, a.title, a.body, a.summary, a.category
-                FROM articles a
-                JOIN user_article_state s ON s.article_id = a.id
-                WHERE s.user_id = %s
-                  AND s.state = 'done'
-                  AND s.done_at >= %s
-                ORDER BY s.done_at DESC
-                LIMIT 10
-                """,
-                (user_id, cutoff),
-            ).fetchall()
-            articles = [dict(r) for r in rows]
-
-    if not articles:
+    candidates = get_quiz_candidate_articles(user_id, db_path=db_path, database_url=database_url)
+    if not candidates:
         logger.info("No eligible articles for quiz generation for user %s", user_id)
         return None
 
+    # Fetch full article bodies for the LLM; candidate objects only carry metadata.
+    candidate_ids = [c["id"] for c in candidates[:5]]
+    placeholders = ", ".join("%s" for _ in candidate_ids)
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            f"SELECT id, title, body, summary, category FROM articles WHERE id IN ({placeholders})",
+            candidate_ids,
+        ).fetchall()
+    articles = [dict(r) for r in rows]
+
     api_key, base_url, model = _quiz_ai_config()
-    blurbs = "\n\n---\n\n".join(_build_article_blurb(a) for a in articles[:5])
+    blurbs = "\n\n---\n\n".join(_build_article_blurb(a) for a in articles)
     messages = [{"role": "user", "content": f"{_QUIZ_PROMPT}\n\nArticles:\n{blurbs}"}]
 
     from news_dashboard.ai_client import chat_create, get_chat_client

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -15,6 +15,7 @@ from news_dashboard.quiz import (
     delete_goal,
     generate_weekly_quiz,
     get_latest_quiz,
+    get_quiz_candidate_articles,
     goal_alignment_adjustment,
     list_goals,
     submit_quiz,
@@ -376,3 +377,62 @@ def test_get_latest_quiz_unanswered_has_no_completed_result(tmp_path: Path) -> N
     latest = get_latest_quiz(user_id, db_path=db_path)
     assert latest is not None
     assert latest.get("completed_result") is None
+
+
+# ── get_quiz_candidate_articles tests ────────────────────────────────────────
+
+
+def test_candidates_empty_when_no_done_articles(tmp_path: Path) -> None:
+    db_path = tmp_path / "c.db"
+    _seed(db_path)
+    candidates = get_quiz_candidate_articles(1, db_path=db_path)
+    assert candidates == []
+
+
+def test_candidates_fallback_to_recent_done(tmp_path: Path) -> None:
+    db_path = tmp_path / "c.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+
+    candidates = get_quiz_candidate_articles(user_id, db_path=db_path)
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c["id"] == article_id
+    assert c["title"] == "AI Transformer Deep Dive"
+    assert c["goal_matched"] is False
+    assert c["matched_keywords"] == []
+    assert "body" not in c
+
+
+def test_candidates_goal_matched(tmp_path: Path) -> None:
+    db_path = tmp_path / "c.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+    create_goal(user_id, "Deep learning", keywords="transformer ai", db_path=db_path)
+
+    candidates = get_quiz_candidate_articles(user_id, db_path=db_path)
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c["goal_matched"] is True
+    assert "transformer" in c["matched_keywords"] or "ai" in c["matched_keywords"]
+
+
+def test_candidates_user_isolation(tmp_path: Path) -> None:
+    db_path = tmp_path / "c.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+
+    # User 2 should see no candidates
+    candidates = get_quiz_candidate_articles(999, db_path=db_path)
+    assert candidates == []
+
+
+def test_candidates_no_body_text(tmp_path: Path) -> None:
+    db_path = tmp_path / "c.db"
+    user_id, article_id = _seed(db_path)
+    _seed_done_article(db_path, user_id, article_id)
+
+    candidates = get_quiz_candidate_articles(user_id, db_path=db_path)
+    for c in candidates:
+        assert "body" not in c
+        assert "summary" not in c

--- a/frontend/src/__tests__/quizCandidates.test.tsx
+++ b/frontend/src/__tests__/quizCandidates.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ReadingDnaPage } from '../pages/ReadingDnaPage';
+import * as api from '../api';
+
+vi.mock('../api', () => ({
+  fetchGoals: vi.fn(),
+  fetchLatestQuiz: vi.fn(),
+  fetchQuizCandidates: vi.fn(),
+  fetchReadingDna: vi.fn(),
+  fetchRecommendationPreferences: vi.fn(),
+  createGoal: vi.fn(),
+  deleteGoal: vi.fn(),
+  generateQuiz: vi.fn(),
+  submitQuiz: vi.fn(),
+  saveRecommendationPreferences: vi.fn(),
+}));
+
+const mockedApi = vi.mocked(api, true);
+
+async function renderLearningTab() {
+  render(
+    <MemoryRouter>
+      <ReadingDnaPage />
+    </MemoryRouter>
+  );
+  // Wait for the top-level page to finish loading, then switch to the Learning tab.
+  await waitFor(() => {
+    expect(screen.getByText('Learning Center')).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByText('Learning Center'));
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockedApi.fetchGoals.mockResolvedValue([]);
+  mockedApi.fetchLatestQuiz.mockResolvedValue(null);
+  mockedApi.fetchReadingDna.mockResolvedValue({
+    range_days: 30,
+    generated_at: '2026-06-27T00:00:00Z',
+    categories: [],
+    sources: [],
+    monthly_time: [],
+    average_dwell_seconds: 0,
+  });
+  mockedApi.fetchRecommendationPreferences.mockResolvedValue({
+    category_weights: {},
+    novelty_weight: 0.5,
+  });
+});
+
+describe('quiz candidate preview', () => {
+  it('shows candidate articles before generation when candidates exist', async () => {
+    mockedApi.fetchQuizCandidates.mockResolvedValue([
+      {
+        id: 1,
+        title: 'AI Transformer Deep Dive',
+        category: 'tech',
+        source_name: 'Source One',
+        done_at: '2026-06-27T10:00:00Z',
+        goal_matched: false,
+        matched_keywords: [],
+      },
+    ]);
+
+    await renderLearningTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('AI Transformer Deep Dive')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/quiz will draw from/i)).toBeInTheDocument();
+  });
+
+  it('shows goal match indicator when candidate matches a goal', async () => {
+    mockedApi.fetchQuizCandidates.mockResolvedValue([
+      {
+        id: 2,
+        title: 'Quantum Computing Basics',
+        category: 'science',
+        source_name: 'Science Weekly',
+        done_at: '2026-06-27T09:00:00Z',
+        goal_matched: true,
+        matched_keywords: ['quantum'],
+      },
+    ]);
+
+    await renderLearningTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Quantum Computing Basics')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/✓ goal/)).toBeInTheDocument();
+  });
+
+  it('shows empty state explaining how to create quiz material when no candidates', async () => {
+    mockedApi.fetchQuizCandidates.mockResolvedValue([]);
+
+    await renderLearningTab();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Mark articles as done/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Generate quiz/)).not.toBeInTheDocument();
+  });
+
+  it('shows generate button alongside candidate preview when candidates exist', async () => {
+    mockedApi.fetchQuizCandidates.mockResolvedValue([
+      {
+        id: 3,
+        title: 'Some Article',
+        category: 'tech',
+        source_name: null,
+        done_at: '2026-06-27T08:00:00Z',
+        goal_matched: false,
+        matched_keywords: [],
+      },
+    ]);
+
+    await renderLearningTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Some Article')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /Generate quiz/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -18,6 +18,7 @@ import type {
   PersonalizationNudge,
   PushSubscribeRequest,
   Quiz,
+  QuizCandidate,
   QuizResult,
   ReadingDna,
   ReadingGoal,
@@ -511,6 +512,11 @@ export async function createGoal(description: string, keywords: string): Promise
 
 export async function deleteGoal(goalId: number): Promise<void> {
   await requestJson(`/api/goals/${goalId}`, { method: 'DELETE' });
+}
+
+export async function fetchQuizCandidates(): Promise<QuizCandidate[]> {
+  const data = await requestJson<{ candidates: QuizCandidate[] }>('/api/quizzes/candidates');
+  return data.candidates;
 }
 
 export async function fetchLatestQuiz(): Promise<Quiz | null> {

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -6,6 +6,7 @@ import {
   deleteGoal,
   fetchGoals,
   fetchLatestQuiz,
+  fetchQuizCandidates,
   fetchReadingDna,
   fetchRecommendationPreferences,
   generateQuiz,
@@ -14,6 +15,7 @@ import {
 } from '../api';
 import type {
   Quiz,
+  QuizCandidate,
   QuizQuestion,
   QuizResult,
   ReadingDna,
@@ -229,6 +231,7 @@ function LearningCenter() {
   const [newKeywords, setNewKeywords] = useState('');
   const [addingGoal, setAddingGoal] = useState(false);
   const [showGoalForm, setShowGoalForm] = useState(false);
+  const [candidates, setCandidates] = useState<QuizCandidate[] | null>(null);
 
   useEffect(() => {
     fetchGoals()
@@ -244,6 +247,9 @@ function LearningCenter() {
       })
       .catch(() => setQuiz(null))
       .finally(() => setLoadingQuiz(false));
+    fetchQuizCandidates()
+      .then(setCandidates)
+      .catch(() => setCandidates([]));
   }, []);
 
   async function handleAddGoal() {
@@ -409,8 +415,42 @@ function LearningCenter() {
             onSubmit={() => void handleSubmitQuiz()}
             submitting={submitting}
           />
+        ) : candidates !== null && candidates.length === 0 ? (
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              No quiz material yet. Mark articles as done while reading to build up quiz content.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Quizzes draw from articles you finished in the last 7 days.
+            </p>
+          </div>
         ) : (
           <div className="space-y-3">
+            {candidates && candidates.length > 0 && (
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Quiz will draw from
+                </p>
+                <ul className="space-y-1">
+                  {candidates.slice(0, 5).map((c) => (
+                    <li key={c.id} className="flex items-start gap-2 text-xs">
+                      <span className="mt-0.5 shrink-0 text-muted-foreground">·</span>
+                      <span className="min-w-0">
+                        <span className="font-medium">{c.title}</span>
+                        {(c.source_name ?? c.category) && (
+                          <span className="ml-1 text-muted-foreground">
+                            {[c.source_name ?? null, c.category ?? null]
+                              .filter(Boolean)
+                              .join(' · ')}
+                          </span>
+                        )}
+                        {c.goal_matched && <span className="ml-1 text-primary">✓ goal</span>}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <p className="text-sm text-muted-foreground">
               No quiz yet. Generate one based on your recent reading.
             </p>

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -260,7 +260,9 @@ function LearningCenter() {
       .finally(() => setLoadingQuiz(false));
     fetchQuizCandidates()
       .then(setCandidates)
-      .catch(() => setCandidates([]));
+      .catch(() => {
+        // leave candidates null so the default UI renders when the endpoint is unavailable
+      });
     void refreshQuizHistory();
   }, []);
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -375,6 +375,16 @@ export interface ReadingGoal {
   created_at: string;
 }
 
+export interface QuizCandidate {
+  id: number;
+  title: string;
+  category: string | null;
+  source_name: string | null;
+  done_at: string | null;
+  goal_matched: boolean;
+  matched_keywords: string[];
+}
+
 export interface QuizQuestion {
   question: string;
   options: string[];


### PR DESCRIPTION
## Summary

- Extracts article-selection logic from `generate_weekly_quiz()` into a reusable `get_quiz_candidate_articles()` helper in `backend/news_dashboard/quiz.py` — returns metadata-only rows (id, title, category, source_name, done_at, goal_matched, matched_keywords) without body text
- Adds `GET /api/quizzes/candidates` endpoint in `backend/news_dashboard/main.py` scoped to the authenticated user
- Adds `QuizCandidate` type to `frontend/src/types.ts` and `fetchQuizCandidates()` to `frontend/src/api.ts`
- Updates the Weekly Knowledge Quiz panel in `ReadingDnaPage.tsx` to show a compact "quiz will draw from" list before generation, and a clear empty state ("Mark articles as done…") when no candidates exist instead of a failed generate action

Closes #411

## Test results

- Backend: all existing quiz unit tests pass; 5 new `get_quiz_candidate_articles` tests added covering empty state, fallback to recent done articles, goal keyword matching, user isolation, and no-body-text guarantee
- Frontend: 4 new vitest tests in `quizCandidates.test.tsx` covering candidate preview, goal match indicator, empty state, and generate button visibility
- All pre-commit hooks passed (ruff, mypy, ty, pyrefly, eslint, prettier, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)