### PR TITLE
fix: replace in-app RD placeholder with app logo

### DIFF
--- a/frontend/src/__tests__/appLogo.test.tsx
+++ b/frontend/src/__tests__/appLogo.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+/**
+ * Tests for #414 — replace in-app RD placeholder with real app logo.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AppLogo } from '../components/AppLogo';
+import { LoginPage } from '../pages/LoginPage';
+import * as api from '../api';
+import { AuthProvider } from '../contexts/auth';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+// ── AppLogo component ──────────────────────────────────────────────────────────
+
+describe('AppLogo', () => {
+  it('renders an image element pointing to the favicon', () => {
+    render(<AppLogo />);
+    const img = screen.getByRole('img');
+    expect(img).toBeTruthy();
+    expect(img.getAttribute('src')).toBe('/favicon.svg');
+  });
+
+  it('has an accessible alt text by default', () => {
+    render(<AppLogo />);
+    const img = screen.getByRole('img');
+    expect(img.getAttribute('alt')).toBeTruthy();
+    expect(img.getAttribute('alt')).not.toBe('');
+  });
+
+  it('accepts a custom className', () => {
+    render(<AppLogo className="size-10" />);
+    const img = screen.getByRole('img');
+    expect(img.className).toContain('size-10');
+  });
+
+  it('does not render "RD" text', () => {
+    render(<AppLogo />);
+    expect(screen.queryByText('RD')).toBeNull();
+  });
+});
+
+// ── AppShell source-level check ────────────────────────────────────────────────
+
+describe('AppShell', () => {
+  const src = readFileSync(join(import.meta.dirname, '../components/AppShell.tsx'), 'utf8');
+
+  it('does not contain the hardcoded RD logo text badge', () => {
+    // The old pattern was: ...grid place-items-center text-background...>RD</div>
+    // Ensure no text node containing exactly "RD" remains inside a div used as logo
+    expect(src).not.toMatch(/>[\s]*RD[\s]*</);
+  });
+
+  it('uses the AppLogo component in the header', () => {
+    expect(src).toContain('AppLogo');
+  });
+});
+
+// ── LoginPage ──────────────────────────────────────────────────────────────────
+
+function makeQc() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not render a visible RD logo badge', async () => {
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'password',
+      keycloak_enabled: false,
+      login_url: null,
+      logout_url: '/api/auth/logout',
+    });
+    vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401'));
+
+    render(
+      <QueryClientProvider client={makeQc()}>
+        <AuthProvider>
+          <MemoryRouter>
+            <LoginPage />
+          </MemoryRouter>
+        </AuthProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('form')).toBeDefined();
+    });
+
+    // The old RD text badge must not appear
+    expect(screen.queryByText('RD')).toBeNull();
+  });
+
+  it('renders the app logo image on the login page', async () => {
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'password',
+      keycloak_enabled: false,
+      login_url: null,
+      logout_url: '/api/auth/logout',
+    });
+    vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401'));
+
+    render(
+      <QueryClientProvider client={makeQc()}>
+        <AuthProvider>
+          <MemoryRouter>
+            <LoginPage />
+          </MemoryRouter>
+        </AuthProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      const img = screen.getByRole('img', { name: /readingdna/i });
+      expect(img.getAttribute('src')).toBe('/favicon.svg');
+    });
+  });
+});

--- a/frontend/src/components/AppLogo.tsx
+++ b/frontend/src/components/AppLogo.tsx
@@ -1,0 +1,8 @@
+interface AppLogoProps {
+  className?: string;
+  alt?: string;
+}
+
+export function AppLogo({ className = 'size-6', alt = 'ReadingDNA' }: AppLogoProps) {
+  return <img src="/favicon.svg" alt={alt} className={className} />;
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { LogOut, MoreHorizontal, Search } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { AppLogo } from './AppLogo';
 import { CommandPalette } from './CommandPalette';
 import { ShortcutOverlay } from './ShortcutOverlay';
 import { WhatsNewDialog } from './WhatsNewDialog';
@@ -209,9 +210,7 @@ export function AppShell() {
       <header className="sticky top-0 z-30 border-b border-border bg-background/85 backdrop-blur">
         <div className="mx-auto max-w-6xl flex h-12 items-center justify-between px-4">
           <div className="flex items-center gap-2 min-w-0">
-            <div className="size-6 rounded-md bg-foreground/90 grid place-items-center text-background text-[10px] font-bold tracking-tight">
-              RD
-            </div>
+            <AppLogo className="size-6 rounded-md" />
             <h1 className="text-[13px] font-semibold tracking-tight truncate">{title}</h1>
           </div>
           <div className="flex items-center gap-1">

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type FormEvent } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { fetchAuthConfig, loginUser, type AuthConfig } from '@/api';
 import { useAuth } from '@/contexts/auth';
+import { AppLogo } from '@/components/AppLogo';
 
 export function LoginPage() {
   const { setUser } = useAuth();
@@ -50,9 +51,7 @@ export function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-sm">
         <div className="mb-6 text-center space-y-2">
-          <div className="mx-auto size-10 rounded-xl bg-foreground/90 grid place-items-center text-background text-sm font-bold tracking-tight">
-            RD
-          </div>
+          <AppLogo className="mx-auto size-10 rounded-xl" />
           <div>
             <h1 className="text-xl font-semibold text-foreground">Sign in</h1>
             <p className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
Closes #414

## Summary
- Added `AppLogo` component (`frontend/src/components/AppLogo.tsx`) that renders `/favicon.svg` with a proper `alt="ReadingDNA"` attribute
- Replaced hardcoded `RD` text badge in `AppShell` header with `<AppLogo className="size-6 rounded-md" />`
- Replaced hardcoded `RD` text badge in `LoginPage` with `<AppLogo className="mx-auto size-10 rounded-xl" />`
- Added 8 tests in `appLogo.test.tsx` covering component rendering, accessibility, and absence of old RD placeholder in both AppShell and LoginPage

## Tests
- 521 tests pass (47 test files)
- TypeScript, ESLint, and Prettier all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)