### PR TITLE
fix: surface briefing-not-found error in Ask Assistant chat (#417)

### DIFF
--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -421,6 +421,7 @@ def test_chat_returns_404_when_briefing_missing(client: TestClient, monkeypatch:
     monkeypatch.setattr(main_mod, "chat_with_briefing", _raise)
     resp = client.post("/api/briefings/99/chat", json={"message": "hello", "history": []})
     assert resp.status_code == 404
+    assert resp.json()["detail"] == "briefing not found"
 
 
 def test_chat_returns_503_when_ai_not_configured(client: TestClient, monkeypatch: Any) -> None:

--- a/frontend/src/__tests__/BriefingChat.test.tsx
+++ b/frontend/src/__tests__/BriefingChat.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { BriefingChat } from '../components/BriefingChat';
+import * as api from '../api';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+function renderChat(briefingId = 42) {
+  render(
+    <MemoryRouter>
+      <BriefingChat briefingId={briefingId} />
+    </MemoryRouter>
+  );
+}
+
+async function openChat() {
+  await userEvent.click(screen.getByRole('button', { name: 'Ask assistant' }));
+}
+
+async function sendMessage(text: string) {
+  await userEvent.type(screen.getByRole('textbox', { name: 'Chat input' }), text);
+  await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BriefingChat', () => {
+  it('appends assistant reply on successful send', async () => {
+    vi.spyOn(api, 'chatWithBriefing').mockResolvedValue({ reply: 'AI reply here' });
+
+    renderChat();
+    await openChat();
+    await sendMessage('What is this about?');
+
+    await waitFor(() => expect(screen.getByText('AI reply here')).toBeTruthy());
+    expect(screen.getByText('What is this about?')).toBeTruthy();
+  });
+
+  it('shows recovery message and links on 404 briefing not found', async () => {
+    vi.spyOn(api, 'chatWithBriefing').mockRejectedValue(new Error('briefing not found'));
+
+    renderChat();
+    await openChat();
+    await sendMessage('Hello?');
+
+    await waitFor(() => expect(screen.getByTestId('briefing-unavailable')).toBeTruthy());
+    expect(screen.getByText('This briefing is no longer available.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Latest briefing' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Briefing history' })).toBeTruthy();
+  });
+
+  it('shows generic fallback for non-404 errors', async () => {
+    vi.spyOn(api, 'chatWithBriefing').mockRejectedValue(new Error('500 Internal Server Error'));
+
+    renderChat();
+    await openChat();
+    await sendMessage('Hello?');
+
+    await waitFor(() =>
+      expect(screen.getByText('Sorry, something went wrong. Please try again.')).toBeTruthy()
+    );
+    expect(screen.queryByTestId('briefing-unavailable')).toBeNull();
+  });
+});

--- a/frontend/src/components/BriefingChat.tsx
+++ b/frontend/src/components/BriefingChat.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { MessageCircle, Send, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -25,6 +26,7 @@ export function BriefingChat({ briefingId }: { briefingId: number }) {
   const [history, setHistory] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [briefingUnavailable, setBriefingUnavailable] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -46,11 +48,15 @@ export function BriefingChat({ briefingId }: { briefingId: number }) {
     try {
       const { reply } = await chatWithBriefing(briefingId, text, history);
       setHistory([...nextHistory, { role: 'assistant', content: reply }]);
-    } catch {
-      setHistory([
-        ...nextHistory,
-        { role: 'assistant', content: 'Sorry, something went wrong. Please try again.' },
-      ]);
+    } catch (err) {
+      if (err instanceof Error && err.message === 'briefing not found') {
+        setBriefingUnavailable(true);
+      } else {
+        setHistory([
+          ...nextHistory,
+          { role: 'assistant', content: 'Sorry, something went wrong. Please try again.' },
+        ]);
+      }
     } finally {
       setLoading(false);
     }
@@ -91,7 +97,7 @@ export function BriefingChat({ briefingId }: { briefingId: number }) {
         </SheetHeader>
 
         <div className="flex-1 overflow-y-auto px-4 py-3 min-h-0">
-          {history.length === 0 && (
+          {history.length === 0 && !briefingUnavailable && (
             <p className="text-xs text-muted-foreground text-center mt-8">
               Ask anything about today&apos;s briefing or the articles it covers.
             </p>
@@ -106,6 +112,29 @@ export function BriefingChat({ briefingId }: { briefingId: number }) {
               </div>
             </div>
           )}
+          {briefingUnavailable && (
+            <div
+              className="mt-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm"
+              data-testid="briefing-unavailable"
+            >
+              <p className="font-medium text-foreground">This briefing is no longer available.</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Refresh the briefing or open it from history.
+              </p>
+              <div className="flex gap-2 mt-3 flex-wrap">
+                <Link to="/brief">
+                  <Button size="sm" variant="outline" onClick={() => setOpen(false)}>
+                    Latest briefing
+                  </Button>
+                </Link>
+                <Link to="/briefs">
+                  <Button size="sm" variant="outline" onClick={() => setOpen(false)}>
+                    Briefing history
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          )}
           <div ref={bottomRef} />
         </div>
 
@@ -115,14 +144,14 @@ export function BriefingChat({ briefingId }: { briefingId: number }) {
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Ask a question…"
-            disabled={loading}
+            disabled={loading || briefingUnavailable}
             className="flex-1"
             aria-label="Chat input"
           />
           <Button
             size="icon"
             onClick={() => void sendMessage()}
-            disabled={loading || !input.trim()}
+            disabled={loading || !input.trim() || briefingUnavailable}
             aria-label="Send"
           >
             <Send className="size-4" />


### PR DESCRIPTION
## Summary

- Fixes #417
- `BriefingChat` now catches 404 `"briefing not found"` responses and shows a specific recovery banner ("This briefing is no longer available.") instead of the generic "something went wrong" message
- The banner includes action links to the latest briefing (`/brief`) and briefing history (`/briefs`), and disables the chat input while unavailable
- Generic server errors (503, 500, etc.) still render the original generic fallback message — no regression on AI-not-configured path
- Backend test for the 404 chat path now asserts `resp.json()["detail"] == "briefing not found"` per the issue spec

## Changes

- `frontend/src/components/BriefingChat.tsx` — error inspection in `sendMessage`, `briefingUnavailable` state, recovery banner UI
- `frontend/src/__tests__/BriefingChat.test.tsx` — new vitest suite (3 tests: success, 404 recovery, generic fallback)
- `backend/tests/test_briefings_api.py` — added `detail` assertion to existing 404 test

## Test results

```
✓ BriefingChat > appends assistant reply on successful send
✓ BriefingChat > shows recovery message and links on 404 briefing not found
✓ BriefingChat > shows generic fallback for non-404 errors
✓ backend::test_chat_returns_404_when_briefing_missing
Test Files: 49 passed | Tests: 527 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)