### PR TITLE
fix: show backend triage error details in reverted-action toast

### DIFF
--- a/frontend/src/__tests__/useTriageMutations.test.tsx
+++ b/frontend/src/__tests__/useTriageMutations.test.tsx
@@ -252,6 +252,112 @@ describe('useTriageMutations — undo calls the API to revert server state', () 
   });
 });
 
+describe('useTriageMutations — surfaces backend error details in error toast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    patchArticleStatePromise = Promise.resolve({});
+  });
+
+  it('setState shows backend error detail and reverted message on API failure', async () => {
+    patchArticleStatePromise = Promise.reject(
+      new Error("transition 'later' → 'skipped' is not allowed")
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    const article = makeArticle({ state: 'later', starred: false });
+
+    await act(async () => {
+      result.current.setState(article, 'skipped', 'Skipped');
+      await patchArticleStatePromise.catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(toast).error).toHaveBeenCalledWith(
+        "Action failed — transition 'later' → 'skipped' is not allowed. Changes reverted.",
+        { id: 'triage' }
+      );
+    });
+  });
+
+  it('setState falls back to generic message when error has no detail', async () => {
+    patchArticleStatePromise = Promise.reject(new Error(''));
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    const article = makeArticle({ state: 'today', starred: false });
+
+    await act(async () => {
+      result.current.setState(article, 'done', 'Marked as read');
+      await patchArticleStatePromise.catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(toast).error).toHaveBeenCalledWith('Action failed — changes reverted', {
+        id: 'triage',
+      });
+    });
+  });
+
+  it('setState restores cache after error with backend detail message', async () => {
+    patchArticleStatePromise = Promise.reject(new Error('some backend error'));
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    const article = makeArticle({ state: 'today' });
+    queryClient.setQueryData([ARTICLES_KEY, 'today'], [article]);
+
+    await act(async () => {
+      result.current.setState(article, 'done', 'Marked as read');
+      await patchArticleStatePromise.catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<WorkflowArticle[]>([ARTICLES_KEY, 'today']);
+      expect(cached?.some((a) => a.id === article.id)).toBe(true);
+    });
+  });
+
+  it('starMutation surfaces backend error detail', async () => {
+    vi.mocked(workflowApi.patchArticleStar).mockRejectedValueOnce(
+      new Error('star update rejected by server')
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    const article = makeArticle({ starred: false });
+
+    await act(async () => {
+      result.current.toggleStar(article);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(toast).error).toHaveBeenCalledWith(
+        'Action failed — star update rejected by server. Changes reverted.',
+        { id: 'triage' }
+      );
+    });
+  });
+
+  it('sendLaterMutation surfaces backend error detail', async () => {
+    vi.mocked(workflowApi.patchArticleLater).mockRejectedValueOnce(
+      new Error('snooze window not allowed')
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    const article = makeArticle({ state: 'today' });
+
+    await act(async () => {
+      result.current.sendLater(article, 1);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(toast).error).toHaveBeenCalledWith(
+        'Action failed — snooze window not allowed. Changes reverted.',
+        { id: 'triage' }
+      );
+    });
+  });
+});
+
 describe('useTriageMutations — settles caches without a full article refetch', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/hooks/useTriageMutations.ts
+++ b/frontend/src/hooks/useTriageMutations.ts
@@ -102,6 +102,13 @@ function settleArticleCaches(queryClient: ReturnType<typeof useQueryClient>) {
   void queryClient.invalidateQueries({ queryKey: ['summary'] });
 }
 
+function triageErrorMessage(err: unknown): string {
+  const detail = err instanceof Error && err.message ? err.message : null;
+  return detail
+    ? `Action failed — ${detail}. Changes reverted.`
+    : 'Action failed — changes reverted';
+}
+
 // ─── Hook ───────────────────────────────────────────────────────────────────
 
 export function useTriageMutations() {
@@ -128,10 +135,10 @@ export function useTriageMutations() {
       return { snap, querySnapshots };
     },
 
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
       if (context?.querySnapshots) restoreQuerySnapshots(queryClient, context.querySnapshots);
       else if (context?.snap) restoreToCache(queryClient, context.snap.article);
-      toast.error('Action failed — changes reverted', { id: TRIAGE_TOAST_ID });
+      toast.error(triageErrorMessage(err), { id: TRIAGE_TOAST_ID });
     },
 
     onSettled: () => {
@@ -154,10 +161,10 @@ export function useTriageMutations() {
       return { snap, querySnapshots };
     },
 
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
       if (context?.querySnapshots) restoreQuerySnapshots(queryClient, context.querySnapshots);
       else if (context?.snap) restoreToCache(queryClient, context.snap.article);
-      toast.error('Action failed — changes reverted', { id: TRIAGE_TOAST_ID });
+      toast.error(triageErrorMessage(err), { id: TRIAGE_TOAST_ID });
     },
 
     onSettled: () => {
@@ -179,10 +186,10 @@ export function useTriageMutations() {
       return { snap, querySnapshots };
     },
 
-    onError: (_err, _vars, context) => {
+    onError: (err, _vars, context) => {
       if (context?.querySnapshots) restoreQuerySnapshots(queryClient, context.querySnapshots);
       else if (context?.snap) restoreToCache(queryClient, context.snap.article);
-      toast.error('Action failed — changes reverted', { id: TRIAGE_TOAST_ID });
+      toast.error(triageErrorMessage(err), { id: TRIAGE_TOAST_ID });
     },
 
     onSettled: () => {


### PR DESCRIPTION
Closes #421

## Summary
- Added `triageErrorMessage(err)` helper in `useTriageMutations.ts` that extracts the `Error.message` when available or falls back to a generic message
- Updated all three mutation `onError` handlers (`setStateMutation`, `starMutation`, `sendLaterMutation`) to use the helper
- Toast format: `Action failed — <backend detail>. Changes reverted.` or `Action failed — changes reverted` for empty-message errors

## Tests
- Added 5 new tests covering: backend detail surfacing for setState, generic fallback for empty-message errors, cache rollback after error, starMutation error detail, sendLaterMutation error detail
- All 532 existing tests continue to pass; all pre-commit hooks passed

## Test plan
- [ ] All 532 frontend tests pass (`npm run test:frontend`)
- [ ] Lint clean (`npm run lint`)
- [ ] Type check clean (`npm run typecheck`)
- [ ] Format check clean (`npm run format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)