### PR TITLE
feat: allow later articles to be skipped (#422)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -58,6 +58,7 @@ _ALLOWED_TRANSITIONS: frozenset[tuple[str, str]] = frozenset(
         ("today", "archived"),
         ("later", "today"),
         ("later", "done"),
+        ("later", "skipped"),
         ("later", "archived"),
         ("done", "archived"),
         ("skipped", "today"),

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -163,11 +163,55 @@ def test_invalid_transition_raises(tmp_path: Path) -> None:
         transition_article_state(aid, "skipped", db_path=db, user_id=uid)
 
 
+def test_later_to_skipped_with_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    send_article_later(aid, days=2, db_path=db, user_id=uid)
+    result = transition_article_state(aid, "skipped", db_path=db, user_id=uid)
+    assert result is not None
+    assert result["state"] == "skipped"
+    assert result["skipped_at"] is not None
+
+
+def test_later_to_skipped_is_per_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid_a = _make_user(db, "alice")
+    uid_b = _make_user(db, "bob")
+    aid = _insert_article(db)
+
+    # Both users snooze the article so both have a UAS row in 'later' state.
+    send_article_later(aid, days=2, db_path=db, user_id=uid_a)
+    send_article_later(aid, days=2, db_path=db, user_id=uid_b)
+
+    # Alice skips it from 'later'.
+    transition_article_state(aid, "skipped", db_path=db, user_id=uid_a)
+
+    skipped = list_articles(state="skipped", db_path=db, user_id=uid_a)
+    assert any(a["id"] == aid for a in skipped)
+
+    # Bob's view is unchanged — still in 'later'.
+    later = list_articles(state="later", db_path=db, user_id=uid_b)
+    assert any(a["id"] == aid for a in later)
+
+
 def test_starred_cannot_be_skipped(tmp_path: Path) -> None:
     db = _setup_db(tmp_path)
     uid = _make_user(db)
     aid = _insert_article(db)
 
+    set_article_starred(aid, True, db_path=db, user_id=uid)
+    with pytest.raises(ValueError, match="starred"):
+        transition_article_state(aid, "skipped", db_path=db, user_id=uid)
+
+
+def test_starred_later_cannot_be_skipped_with_user(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    uid = _make_user(db)
+    aid = _insert_article(db)
+
+    send_article_later(aid, days=2, db_path=db, user_id=uid)
     set_article_starred(aid, True, db_path=db, user_id=uid)
     with pytest.raises(ValueError, match="starred"):
         transition_article_state(aid, "skipped", db_path=db, user_id=uid)

--- a/backend/tests/test_workflow_state.py
+++ b/backend/tests/test_workflow_state.py
@@ -120,6 +120,29 @@ def test_later_to_archived(tmp_path: Path) -> None:
     assert updated["state"] == "archived"
 
 
+def test_later_to_skipped(tmp_path: Path) -> None:
+    db = tmp_path / "news.db"
+    sync_sources(db)
+    aid = _insert_article(db, state="later")
+    updated = transition_article_state(aid, "skipped", db_path=db)
+    assert updated is not None
+    assert updated["state"] == "skipped"
+    assert updated["skipped_at"] is not None
+
+
+def test_later_resnooze_updates_later_until(tmp_path: Path) -> None:
+    db = tmp_path / "news.db"
+    sync_sources(db)
+    aid = _insert_article(db, state="later")
+    updated = send_article_later(aid, days=3, db_path=db)
+    assert updated is not None
+    assert updated["state"] == "later"
+    assert updated["later_until"] is not None
+    until = datetime.fromisoformat(updated["later_until"])
+    delta = until - datetime.now(timezone.utc)
+    assert 2 < delta.total_seconds() / 3600 < 75
+
+
 def test_done_to_archived(tmp_path: Path) -> None:
     db = tmp_path / "news.db"
     sync_sources(db)
@@ -197,6 +220,14 @@ def test_starred_cannot_be_skipped(tmp_path: Path) -> None:
     db = tmp_path / "news.db"
     sync_sources(db)
     aid = _insert_article(db, state="today", starred=True)
+    with pytest.raises(ValueError, match="starred articles cannot be skipped"):
+        transition_article_state(aid, "skipped", db_path=db)
+
+
+def test_starred_later_cannot_be_skipped(tmp_path: Path) -> None:
+    db = tmp_path / "news.db"
+    sync_sources(db)
+    aid = _insert_article(db, state="later", starred=True)
     with pytest.raises(ValueError, match="starred articles cannot be skipped"):
         transition_article_state(aid, "skipped", db_path=db)
 


### PR DESCRIPTION
Closes #422

## Summary

- Added `("later", "skipped")` to `_ALLOWED_TRANSITIONS` in `backend/news_dashboard/ingest.py` so non-starred articles in the `later` state can be transitioned to `skipped` via `PATCH /api/articles/{id}/state`.
- The existing starred-cannot-skip guard at transition time already covers the `later` case — starred later articles are still rejected with the same error.
- Re-snoozing from `later` already worked; `send_article_later()` accepts `today` or `later` state.

## Tests added

- `test_later_to_skipped` — verifies state and `skipped_at` are set
- `test_starred_later_cannot_be_skipped` — starred later article is still rejected
- `test_later_resnooze_updates_later_until` — re-snooze from later updates `later_until`
- `test_later_to_skipped_with_user` — per-user path sets UAS correctly
- `test_later_to_skipped_is_per_user` — skipping for one user doesn't affect another
- `test_starred_later_cannot_be_skipped_with_user` — starred guard works in per-user path

All 57 backend workflow/per-user tests pass. Ruff, mypy, ty, pyrefly all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)