### PR TITLE
fix: sanitize article body markdown links (#425)

### DIFF
--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -107,6 +107,54 @@ describe('ArticlePage — rendering', () => {
       expect(screen.getByText('Listen')).toBeTruthy();
     });
   });
+
+  it('renders safe article body markdown links as external anchors', async () => {
+    const body = 'Read [the original report](https://example.org/report?from=reader&ok=1).';
+    const article = makeArticle({ body_status: 'ok', body });
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(article);
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(article);
+
+    renderReader('42', article);
+
+    const link = await screen.findByRole('link', { name: 'the original report' });
+    expect(link).toHaveAttribute('href', 'https://example.org/report?from=reader&ok=1');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders unsafe article body markdown links as plain text', async () => {
+    const body = [
+      '[run script](javascript:alert(1))',
+      '[data url](data:text/html,<script>alert(1)</script>)',
+      '[vbscript url](vbscript:msgbox(1))',
+      '[broken url](https://example.com/" onclick="alert(1))',
+    ].join('\n\n');
+    const article = makeArticle({ body_status: 'ok', body });
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(article);
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(article);
+
+    renderReader('42', article);
+
+    await screen.findByText('run script');
+    expect(screen.queryByRole('link', { name: 'run script' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'data url' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'vbscript url' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'broken url' })).toBeNull();
+  });
+
+  it('escapes article body markdown link labels and href attributes', async () => {
+    const body = '[<img src=x onerror=alert(1)>](https://example.org/report?quote="&tag=<tag>)';
+    const article = makeArticle({ body_status: 'ok', body });
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(article);
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(article);
+
+    renderReader('42', article);
+
+    const link = await screen.findByRole('link', { name: '<img src=x onerror=alert(1)>' });
+    expect(link.innerHTML).toBe('&lt;img src=x onerror=alert(1)&gt;');
+    expect(link).toHaveAttribute('href', 'https://example.org/report?quote=%22&tag=%3Ctag%3E');
+    expect(link).not.toHaveAttribute('onerror');
+  });
 });
 
 // ─── Open original link ───────────────────────────────────────────────────────

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -57,6 +57,23 @@ const LANGUAGE_NAMES: Record<string, string> = {
 function renderBody(md: string): string {
   const escape = (s: string) =>
     s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]!);
+  const decodeEscapedMarkdown = (s: string) =>
+    s
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
+  const safeHref = (rawHref: string): string | null => {
+    const href = decodeEscapedMarkdown(rawHref).trim();
+    if (!href || /[\s\p{Cc}]/u.test(href)) return null;
+
+    try {
+      const url = new URL(href);
+      return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
+    } catch {
+      return null;
+    }
+  };
   const lines = md.split('\n');
   let html = '';
   let inCode = false;
@@ -74,7 +91,12 @@ function renderBody(md: string): string {
     s
       .replace(/`([^`]+)`/g, (_, t: string) => `<code>${escape(t)}</code>`)
       .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+      .replace(/\[([^\]]+)\]\((.+)\)/g, (_, label: string, rawHref: string) => {
+        const href = safeHref(rawHref);
+        return href
+          ? `<a href="${escape(href)}" target="_blank" rel="noopener noreferrer">${label}</a>`
+          : label;
+      });
 
   for (const raw of lines) {
     if (raw.startsWith('```')) {


### PR DESCRIPTION
Closes #425

## Summary
- sanitize article body markdown hrefs before rendering dangerous HTML
- allow only absolute http/https article-body links and add noopener noreferrer
- render unsafe markdown links as plain text labels
- add reader tests for safe links, unsafe schemes, and quote/attribute escaping

## Test results
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test:frontend
- npm run build