### PR TITLE
fix: make digest mark-read links work without a session (#426)

### DIFF
--- a/backend/news_dashboard/digest.py
+++ b/backend/news_dashboard/digest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import html
 import logging
 import os
 import smtplib
@@ -73,10 +74,10 @@ def _render_html(articles: list[dict[str, Any]]) -> str:
     for a in articles:
         token = _make_token(a["id"])
         mark_read_url = f"{base}/api/articles/{a['id']}/read?token={token}"
-        title = a.get("title") or "Untitled"
-        url = a.get("url") or "#"
-        source = a.get("source_name") or ""
-        summary = a.get("summary") or ""
+        title = html.escape(a.get("title") or "Untitled")
+        url = html.escape(a.get("url") or "#", quote=True)
+        source = html.escape(a.get("source_name") or "")
+        summary = html.escape(a.get("summary") or "")
         score = a.get("importance_score", 0)
         rows += f"""
         <tr>

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -379,6 +379,21 @@ def logout(response: Response) -> dict[str, str]:
     return {"status": "logged_out"}
 
 
+@public_router.get("/api/articles/{article_id}/read")
+def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict[str, Any]:
+    from news_dashboard.digest import verify_read_token
+
+    if not verify_read_token(article_id, token):
+        raise HTTPException(status_code=403, detail="invalid or expired token")
+    try:
+        article = set_article_status(article_id, "read")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not article:
+        raise HTTPException(status_code=404, detail="article not found")
+    return {"status": "marked_read", "article": article}
+
+
 app.include_router(public_router)
 
 
@@ -858,21 +873,6 @@ def add_share_message(
     if get_share(share_id, current_user["id"]) is None:
         raise HTTPException(status_code=404, detail="Share not found")
     return add_message(share_id, current_user["id"], payload.message)
-
-
-@api.get("/api/articles/{article_id}/read")
-def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict[str, Any]:
-    from news_dashboard.digest import verify_read_token
-
-    if not verify_read_token(article_id, token):
-        raise HTTPException(status_code=403, detail="invalid or expired token")
-    try:
-        article = set_article_status(article_id, "read")
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if not article:
-        raise HTTPException(status_code=404, detail="article not found")
-    return {"status": "marked_read", "article": article}
 
 
 INTEREST_GROUPS: tuple[dict[str, Any], ...] = (

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import psycopg
 import pytest
+from fastapi.testclient import TestClient
 
 from news_dashboard import digest
 
@@ -182,3 +183,118 @@ def test_send_digest_sends_when_new_articles_exist(pg_clean: str) -> None:
         send.assert_called_once()
         subject = send.call_args.args[0]
         assert "News Digest" in subject
+
+
+# ── HTML escaping ─────────────────────────────────────────────────────────────
+
+
+def test_render_html_escapes_script_in_title() -> None:
+    articles = [
+        {
+            "id": 1,
+            "title": "<script>alert(1)</script>",
+            "url": "https://example.com/1",
+            "source_name": "Src",
+            "summary": "ok",
+            "importance_score": 50,
+        }
+    ]
+    html = digest._render_html(articles)
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_html_escapes_quotes_in_url() -> None:
+    articles = [
+        {
+            "id": 2,
+            "title": "Title",
+            "url": 'https://example.com/?x="evil"',
+            "source_name": "Src",
+            "summary": "",
+            "importance_score": 0,
+        }
+    ]
+    html = digest._render_html(articles)
+    assert '"evil"' not in html
+
+
+def test_render_html_escapes_summary_and_source() -> None:
+    articles = [
+        {
+            "id": 3,
+            "title": "T",
+            "url": "https://example.com/",
+            "source_name": "<b>Bad Source</b>",
+            "summary": "<em>bad summary</em>",
+            "importance_score": 0,
+        }
+    ]
+    html = digest._render_html(articles)
+    assert "<b>" not in html
+    assert "<em>" not in html
+    assert "&lt;b&gt;" in html
+    assert "&lt;em&gt;" in html
+
+
+# ── Public token route (no session required) ──────────────────────────────────
+
+
+def _fresh_client() -> TestClient:
+    from news_dashboard.main import app
+
+    app.dependency_overrides.clear()
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.mark.postgres
+def test_mark_read_via_token_succeeds_without_session(pg_clean: str) -> None:
+    import psycopg
+
+    with psycopg.connect(pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind) VALUES (%s, %s, %s, %s, %s)",
+            ("src", "Src", "https://example.com/feed", "engineering", "rss"),
+        )
+        conn.execute(
+            """
+            INSERT INTO articles(
+                url, canonical_url, title, source_slug, source_name,
+                category, kind, status, importance_score, summary, reason, tags
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'new', 70, 'Sum', '', '')
+            """,
+            (
+                "https://example.com/a",
+                "https://example.com/a",
+                "Headline",
+                "src",
+                "Src",
+                "engineering",
+                "rss",
+            ),
+        )
+        row = conn.execute("SELECT id FROM articles LIMIT 1").fetchone()
+        assert row is not None
+        article_id: int = row[0]
+        conn.commit()
+
+    token = digest._make_token(article_id)
+    client = _fresh_client()
+    resp = client.get(f"/api/articles/{article_id}/read", params={"token": token}, cookies={})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "marked_read"
+
+
+@pytest.mark.postgres
+def test_mark_read_via_token_rejects_bad_token(pg_clean: str) -> None:
+    client = _fresh_client()
+    resp = client.get("/api/articles/999/read", params={"token": "badtoken"}, cookies={})
+    assert resp.status_code == 403
+
+
+@pytest.mark.postgres
+def test_mark_read_via_token_rejects_wrong_article_token(pg_clean: str) -> None:
+    token = digest._make_token(1)
+    client = _fresh_client()
+    resp = client.get("/api/articles/2/read", params={"token": token}, cookies={})
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- Moves `GET /api/articles/{article_id}/read` from the authenticated `api` router to `public_router` so digest email one-click mark-read links work without an `nd_session` cookie
- Adds `html.escape()` to all feed-provided values (title, URL, source, summary) in `digest._render_html()` to prevent XSS from untrusted article data
- Removes the duplicate route from the authenticated router

## Test plan

- [x] `test_mark_read_via_token_succeeds_without_session` — unauthenticated request with valid token returns 200
- [x] `test_mark_read_via_token_rejects_bad_token` — returns 403 for garbage token
- [x] `test_mark_read_via_token_rejects_wrong_article_token` — returns 403 when token is for a different article
- [x] `test_render_html_escapes_script_in_title` — `<script>` in title is escaped
- [x] `test_render_html_escapes_quotes_in_url` — quotes in URL are escaped
- [x] `test_render_html_escapes_summary_and_source` — HTML tags in source/summary are escaped
- [x] All 18 digest tests pass
- [x] `make lint` — clean
- [x] `make typecheck` (mypy strict + ty + pyrefly) — clean

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)