### PR TITLE
ops: prevent overlapping ingest CronJobs (#427)

### DIFF
--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -30,6 +30,47 @@ def test_helm_template_default() -> None:
     # Check that it renders standard postgres config
     assert "name: POSTGRES_HOST" in output
     assert 'value: "news-dashboard-news-dashboard-postgres"' in output
+    assert "concurrencyPolicy: Forbid" in output
+    assert "startingDeadlineSeconds: 1800" in output
+    assert "activeDeadlineSeconds: 3600" in output
+    assert "backoffLimit: 1" in output
+    assert "successfulJobsHistoryLimit: 2" in output
+    assert "failedJobsHistoryLimit: 3" in output
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_ingest_cronjob_operational_overrides() -> None:
+    assert HELM_BIN is not None
+    res = subprocess.run(  # noqa: S603
+        [
+            HELM_BIN,
+            "template",
+            "news-dashboard",
+            str(CHART_DIR),
+            "--set",
+            "app.auth.sessionSecret=dummy-session-secret",
+            "--set",
+            "ingestCronJob.concurrencyPolicy=Replace",
+            "--set",
+            "ingestCronJob.startingDeadlineSeconds=900",
+            "--set",
+            "ingestCronJob.activeDeadlineSeconds=1200",
+            "--set",
+            "ingestCronJob.backoffLimit=2",
+            "--set",
+            "ingestCronJob.ttlSecondsAfterFinished=86400",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0, f"helm template failed: {res.stderr}"
+    output = res.stdout
+    assert "concurrencyPolicy: Replace" in output
+    assert "startingDeadlineSeconds: 900" in output
+    assert "activeDeadlineSeconds: 1200" in output
+    assert "backoffLimit: 2" in output
+    assert "ttlSecondsAfterFinished: 86400" in output
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")

--- a/helm/news-dashboard/templates/cronjob.yaml
+++ b/helm/news-dashboard/templates/cronjob.yaml
@@ -5,10 +5,23 @@ metadata:
   name: {{ include "news-dashboard.fullname" . }}-ingest
 spec:
   schedule: {{ .Values.ingestCronJob.schedule | quote }}
+  concurrencyPolicy: {{ .Values.ingestCronJob.concurrencyPolicy | default "Forbid" }}
+  {{- with .Values.ingestCronJob.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ . }}
+  {{- end }}
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      {{- with .Values.ingestCronJob.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ . }}
+      {{- end }}
+      {{- with .Values.ingestCronJob.backoffLimit }}
+      backoffLimit: {{ . }}
+      {{- end }}
+      {{- with .Values.ingestCronJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end }}
       template:
         spec:
           restartPolicy: OnFailure

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -86,6 +86,16 @@ app:
 ingestCronJob:
   enabled: true
   schedule: "17 */6 * * *"
+  # Keep private single-node ingestion serialized; skip new runs while one is active.
+  concurrencyPolicy: Forbid
+  # Allow one missed schedule window after node downtime, but avoid stale catch-up storms.
+  startingDeadlineSeconds: 1800
+  # Fail stuck ingest jobs visibly before the next six-hour schedule window.
+  activeDeadlineSeconds: 3600
+  # Retry once for transient pod failures without hiding persistent ingest problems.
+  backoffLimit: 1
+  # Optional cluster cleanup for finished Jobs. Leave empty to preserve history limits.
+  ttlSecondsAfterFinished: ""
 
 postgresql:
   enabled: true


### PR DESCRIPTION
Closes #427

## Summary
- add explicit ingest CronJob concurrency, missed-start, runtime, retry, and optional TTL controls
- document conservative defaults under `ingestCronJob` in Helm values
- cover default render output and override propagation in chart-render tests

## Tests
- `python -m pytest backend/tests/test_chart_render.py -q`
- `helm template news-dashboard ./helm/news-dashboard --set app.auth.sessionSecret=dummy-session-secret`
- `make lint`
- `make typecheck`
- `source .env && make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)