### PR TITLE
feat: add smoke, category, nightly, and smart CI test lanes (#433)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,23 @@ name: CI / CD
 # On push to main: also builds the Docker image, pushes it to GHCR, and
 # deploys to the mini PC via a self-hosted runner running directly on the machine.
 #
+# PR strategy: change-aware routing so small backend-only or frontend-only
+# changes don't run every unrelated test lane. Smoke tests always run.
+# Full suite runs on every push to main and on demand via workflow_dispatch.
+#
 # Branch is 'main'. If you rename it to 'master', update the two filters below.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      full_suite:
+        description: 'Run the full test suite (backend + frontend + coverage)'
+        required: false
+        default: 'true'
+        type: boolean
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -25,8 +36,36 @@ permissions:
   models: read
 
 jobs:
+  # ── 0. DETECT CHANGES ──────────────────────────────────────────────────────
+  # Determine which parts of the codebase changed so later jobs can skip
+  # unrelated test lanes on pull requests.
+  detect-changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'pyproject.toml'
+              - 'scripts/**'
+            frontend:
+              - 'frontend/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'vite.config.ts'
+              - 'index.html'
+              - 'tsconfig*.json'
+
   # ── 1. LINT ────────────────────────────────────────────────────────────────
-  # Static analysis only — fails fast and in parallel with the test job.
+  # Static analysis only — fails fast and in parallel with the test jobs.
   lint:
     name: Lint & typecheck
     runs-on: ubuntu-latest
@@ -55,10 +94,51 @@ jobs:
       - name: prettier (format check)
         run: npm run format:check --silent
 
-  # ── 2. TEST ────────────────────────────────────────────────────────────────
-  test:
-    name: Test & build
+  # ── 2. SMOKE ───────────────────────────────────────────────────────────────
+  # Always runs on PRs and manual dispatches. Fast: no Postgres, no coverage.
+  # Covers app boot, health endpoints, and core frontend render paths.
+  smoke:
+    name: Smoke tests
     runs-on: ubuntu-latest
+    # Skip on push to main — the full test job already covers it.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          cache: pip
+      - run: pip install -e '.[dev]'
+      - name: Backend smoke tests
+        run: |
+          COUNT=$(pytest -m smoke --collect-only -q 2>/dev/null | grep -c "::test_" || true)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "ERROR: smoke test collection returned zero tests — check marker configuration" >&2
+            exit 1
+          fi
+          pytest -m smoke -v
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: npm
+      - run: npm install
+      - name: Frontend smoke tests
+        run: |
+          npm run test:frontend:smoke --silent
+
+  # ── 3. TEST (BACKEND) ──────────────────────────────────────────────────────
+  # On pull requests: runs only when backend files changed (or forced via dispatch).
+  # On push to main: always runs.
+  test-backend:
+    name: Backend tests
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.full_suite == 'true') ||
+      (github.event_name == 'pull_request' && needs.detect-changes.outputs.backend == 'true')
     services:
       postgres:
         image: postgres:16
@@ -81,12 +161,27 @@ jobs:
           python-version: '3.14'
           cache: pip
       - run: pip install -e '.[dev]'
-      - run: >
+      - name: Backend tests
+        run: >
           pytest -v --cov --cov-report=term-missing --durations=20
           -o faulthandler_timeout=120 -o faulthandler_exit_on_timeout=true
         env:
           DATABASE_URL: postgresql://news_dashboard:news_dashboard@127.0.0.1:5432/news_dashboard
           TEST_DATABASE_URL: postgresql://news_dashboard:news_dashboard@127.0.0.1:5432/news_dashboard
+
+  # ── 4. TEST (FRONTEND) ─────────────────────────────────────────────────────
+  # On pull requests: runs only when frontend files changed (or forced via dispatch).
+  # On push to main: always runs (includes build / tsc typecheck).
+  test-frontend:
+    name: Frontend tests & build
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.full_suite == 'true') ||
+      (github.event_name == 'pull_request' && needs.detect-changes.outputs.frontend == 'true')
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -95,9 +190,10 @@ jobs:
       - run: npm install
       - name: vitest (frontend tests)
         run: npm run test:frontend --silent
-      - run: npm run build   # includes tsc -b typecheck
+      - name: build (includes tsc)
+        run: npm run build
 
-  # ── 3. PUBLISH ─────────────────────────────────────────────────────────────
+  # ── 5. PUBLISH ─────────────────────────────────────────────────────────────
   # Builds one image and pushes two tags:
   #   :<sha>    — immutable, pinned to this exact commit; used by the deploy step
   #   :latest   — floating convenience tag for manual pulls / rollback reference
@@ -110,7 +206,7 @@ jobs:
   # packages:write by default for the repo that owns the package.
   publish:
     name: Build & push image
-    needs: [lint, test]
+    needs: [lint, test-backend, test-frontend]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
@@ -204,7 +300,7 @@ jobs:
             ${{ env.IMAGE }}:${{ github.sha }}
             ${{ env.IMAGE }}:latest
 
-  # ── 4. DEPLOY ──────────────────────────────────────────────────────────────
+  # ── 6. DEPLOY ──────────────────────────────────────────────────────────────
   # Runs directly on the self-hosted runner (the mini PC itself) — no SSH hop
   # needed. The runner process on the mini PC picks up the job and executes
   # the deploy commands locally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,29 @@ jobs:
       - name: build (includes tsc)
         run: npm run build
 
-  # ── 5. PUBLISH ─────────────────────────────────────────────────────────────
+  # ── 5. TEST ROLLUP ─────────────────────────────────────────────────────────
+  # Satisfies the "Test & build" required status check while the component jobs
+  # use the new change-aware names. Skips if either component job is skipped
+  # (both-skipped = no relevant files changed, so the check still passes).
+  test:
+    name: Test & build
+    needs: [test-backend, test-frontend]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Aggregate test results
+        run: |
+          backend="${{ needs.test-backend.result }}"
+          frontend="${{ needs.test-frontend.result }}"
+          if [[ "$backend" == "failure" || "$backend" == "cancelled" ]]; then
+            echo "Backend tests failed or were cancelled ($backend)" && exit 1
+          fi
+          if [[ "$frontend" == "failure" || "$frontend" == "cancelled" ]]; then
+            echo "Frontend tests failed or were cancelled ($frontend)" && exit 1
+          fi
+          echo "All test lanes passed (backend=$backend, frontend=$frontend)"
+
+  # ── 6. PUBLISH ─────────────────────────────────────────────────────────────
   # Builds one image and pushes two tags:
   #   :<sha>    — immutable, pinned to this exact commit; used by the deploy step
   #   :latest   — floating convenience tag for manual pulls / rollback reference
@@ -206,7 +228,7 @@ jobs:
   # packages:write by default for the repo that owns the package.
   publish:
     name: Build & push image
-    needs: [lint, test-backend, test-frontend]
+    needs: [lint, test]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
@@ -300,7 +322,7 @@ jobs:
             ${{ env.IMAGE }}:${{ github.sha }}
             ${{ env.IMAGE }}:latest
 
-  # ── 6. DEPLOY ──────────────────────────────────────────────────────────────
+  # ── 7. DEPLOY ──────────────────────────────────────────────────────────────
   # Runs directly on the self-hosted runner (the mini PC itself) — no SSH hop
   # needed. The runner process on the mini PC picks up the job and executes
   # the deploy commands locally.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,76 @@
+name: Nightly full suite
+
+# Runs the complete test suite with coverage every night and on demand.
+# Use this to catch regressions that don't surface in the faster per-PR lanes.
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # 02:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to test (default: main)'
+        required: false
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Full backend suite with coverage ───────────────────────────────────────
+  backend-full:
+    name: Backend (full + coverage)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: news_dashboard
+          POSTGRES_USER: news_dashboard
+          POSTGRES_PASSWORD: news_dashboard
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          cache: pip
+      - run: pip install -e '.[dev]'
+
+      - name: Run full backend suite with coverage
+        run: >
+          pytest -v --cov --cov-report=term-missing --durations=20
+          -o faulthandler_timeout=120 -o faulthandler_exit_on_timeout=true
+        env:
+          DATABASE_URL: postgresql://news_dashboard:news_dashboard@127.0.0.1:5432/news_dashboard
+          TEST_DATABASE_URL: postgresql://news_dashboard:news_dashboard@127.0.0.1:5432/news_dashboard
+
+  # ── Full frontend suite with coverage ──────────────────────────────────────
+  frontend-full:
+    name: Frontend (full + coverage)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: npm
+      - run: npm install
+
+      - name: Run full frontend suite with coverage
+        run: npm run test:frontend:coverage --silent
+
+      - name: Build (includes tsc)
+        run: npm run build

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -5,6 +5,11 @@ name: PR test metrics
 # diffs the two. Lets you see at a glance whether a PR moves coverage or makes
 # the suite slower before you merge.
 #
+# This workflow measures the FULL backend + frontend suites (same as the
+# nightly lane) so coverage numbers are comprehensive. The per-PR CI (ci.yml)
+# uses change-aware routing; metrics here intentionally run everything for an
+# accurate diff regardless of which files changed.
+#
 # Strategy: a 2-entry matrix runs the suite once per ref and uploads a small
 # metrics artifact; a final job downloads both and renders the comparison.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: install ci-install lint format typecheck test check build
+.PHONY: install ci-install lint format typecheck \
+        test test-smoke test-backend test-frontend test-e2e test-nightly test-full \
+        check build
 
 ## install: install backend (editable + dev tools) and update local frontend dependencies
 install:
@@ -33,10 +35,35 @@ typecheck:
 	pyrefly check backend
 	npm run typecheck --silent
 
-## test: run backend + frontend test suites
+## test: run backend + frontend test suites (everyday development loop)
 test:
 	pytest --cov --cov-report=term-missing
 	npm run test:frontend --silent
+
+## test-smoke: fast smoke tests — backend health + core API paths, frontend app render
+test-smoke:
+	pytest -m smoke -v
+	npm run test:frontend:smoke --silent
+
+## test-backend: all backend pytest tests
+test-backend:
+	pytest -v
+
+## test-frontend: all frontend Vitest tests
+test-frontend:
+	npm run test:frontend --silent
+
+## test-e2e: Playwright end-to-end tests
+test-e2e:
+	npm run test:e2e --silent
+
+## test-nightly: full suite with coverage — same as what the nightly CI runs
+test-nightly:
+	pytest --cov --cov-report=term-missing --cov-report=html -v
+	npm run test:frontend:coverage --silent
+
+## test-full: alias for test-nightly (complete suite with coverage)
+test-full: test-nightly
 
 ## check: everything CI runs — lint, typecheck, test, build
 check: lint typecheck test build

--- a/README.md
+++ b/README.md
@@ -126,10 +126,31 @@ Open [http://localhost:5173](http://localhost:5173).
 make lint        # ruff, eslint, prettier checks
 make format      # auto-format backend and frontend
 make typecheck   # mypy and TypeScript
-make test        # backend and frontend tests
+make test        # backend and frontend tests (everyday development loop)
 make build       # production frontend build
 make check       # full CI suite
 ```
+
+### Test lanes
+
+| Command | What it runs | When to use |
+|---|---|---|
+| `make test-smoke` | Backend `smoke`-marked tests + frontend smoke files | Quick sanity check, ~seconds |
+| `make test-backend` | Full `pytest` suite | Before pushing backend changes |
+| `make test-frontend` | Full Vitest suite | Before pushing frontend changes |
+| `make test-e2e` | Playwright end-to-end tests | Before pushing UI/routing changes |
+| `make test-full` | Everything with coverage | Same as nightly CI; use before major releases |
+
+**Local development loop:** run `make test-smoke` during active development, `make test-backend` or `make test-frontend` depending on what you changed, then `make check` before opening a PR.
+
+**Pre-push / pre-release:** run `make test-full` for comprehensive coverage including slow and DB-heavy tests.
+
+Pytest markers:
+- `smoke` — fast tests with no external services
+- `db` — auto-applied to any test using `pg_url` / `pg_clean`; requires PostgreSQL
+- `slow` — expensive tests reserved for the nightly schedule
+
+Run a specific lane with `pytest -m smoke`, `pytest -m "not db"`, or `pytest -m db`.
 
 ## Project Layout
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,11 +39,18 @@ if _env_file.exists():
 os.environ.setdefault("TEST_SESSION_SECRET", "test-secret-key-not-for-production")
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line(
-        "markers",
-        "postgres: marks tests that require a live PostgreSQL instance",
-    )
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-apply markers based on fixture usage.
+
+    Any test that requests ``pg_url`` or ``pg_clean`` is tagged ``db`` so
+    ``pytest -m "not db"`` reliably excludes all Postgres-dependent tests
+    without requiring manual marker decoration in every test file.
+    """
+    db_mark = pytest.mark.db
+    for item in items:
+        fixtures: list[str] = getattr(item, "fixturenames", [])
+        if "pg_url" in fixtures or "pg_clean" in fixtures:
+            item.add_marker(db_mark, append=True)
 
 
 _FAKE_ADMIN = {

--- a/backend/tests/test_health_endpoints.py
+++ b/backend/tests/test_health_endpoints.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from news_dashboard.main import app
@@ -16,6 +17,7 @@ def _client() -> TestClient:
     return TestClient(app, follow_redirects=False)
 
 
+@pytest.mark.smoke
 def test_live_returns_200_without_db() -> None:
     with patch("news_dashboard.main.connect") as mock_connect:
         resp = _client().get("/api/live")
@@ -24,6 +26,7 @@ def test_live_returns_200_without_db() -> None:
     mock_connect.assert_not_called()
 
 
+@pytest.mark.smoke
 def test_ready_returns_200_when_db_ok() -> None:
     @contextmanager
     def fake_connect() -> Iterator[object]:
@@ -39,6 +42,7 @@ def test_ready_returns_200_when_db_ok() -> None:
     assert resp.json() == {"status": "ok"}
 
 
+@pytest.mark.smoke
 def test_ready_returns_503_when_db_unavailable() -> None:
     @contextmanager
     def broken_connect() -> Iterator[object]:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "format": "prettier --write frontend/src vite.config.ts index.html",
     "format:check": "prettier --check frontend/src vite.config.ts index.html",
     "test:frontend": "vitest run",
-    "test:frontend:coverage": "vitest run --coverage"
+    "test:frontend:smoke": "vitest run frontend/src/__tests__/appRouter.test.tsx frontend/src/__tests__/routing.test.tsx frontend/src/__tests__/navigation.test.ts frontend/src/__tests__/auth.test.tsx",
+    "test:frontend:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ pythonpath = ["backend"]
 testpaths = ["backend/tests", "scripts"]
 addopts = "-ra --strict-markers --strict-config"
 filterwarnings = ["error::DeprecationWarning:news_dashboard.*"]
+markers = [
+  "smoke: fast, high-signal tests covering app boot, health, and core API paths (no external services required)",
+  "db: tests requiring a live PostgreSQL instance (testcontainers or CI service container)",
+  "slow: expensive or long-running tests reserved for the nightly suite",
+  "postgres: alias for db — marks tests that require a live PostgreSQL instance",
+]
 
 [tool.coverage.run]
 source = ["news_dashboard"]


### PR DESCRIPTION
## Summary

Closes #433

- **pytest markers**: `smoke`, `db`, `slow`, `postgres` registered in `pyproject.toml`; `db` marker auto-applied in conftest via `pytest_collection_modifyitems` (tags 258 Postgres-dependent tests without touching each file)
- **Smoke tests**: `@pytest.mark.smoke` on health endpoint tests; 3 fast tests run in ~0.3s with no external services
- **Frontend smoke script**: `test:frontend:smoke` runs 4 lightweight test files; `test:e2e` for Playwright
- **Makefile lanes**: `test-smoke`, `test-backend`, `test-frontend`, `test-e2e`, `test-nightly`, `test-full`
- **CI restructure**: new `detect-changes` job (dorny/paths-filter); separate `test-backend` and `test-frontend` jobs conditional on which files changed on PRs; `smoke` job always runs on PRs; full suite on push to main; `workflow_dispatch` with `full_suite` input for on-demand runs
- **Nightly workflow** (`nightly.yml`): scheduled 02:00 UTC daily, full backend + frontend with coverage, also manually dispatchable with optional `ref` input
- **README**: test lane table, local development loop, pre-push guidance, pytest marker reference

## Test plan

- [x] `pytest --markers` shows all 4 new markers
- [x] `pytest -m smoke --collect-only` collects 3 tests
- [x] `pytest -m db --collect-only` collects 258 tests (auto-marked via fixture detection)
- [x] `pytest -m smoke -v` — all 3 pass in ~0.3s
- [x] All pre-commit hooks pass (ruff, mypy, ty, pyrefly, prettier, yaml check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)