### PR TITLE
fix: route Topic Map before article detail (#435)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -543,6 +543,20 @@ def search(  # noqa: PLR0913
     }
 
 
+@api.get("/api/articles/topic-map")
+def articles_topic_map(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.insights import InsightsNotConfiguredError, cluster_recent_articles
+
+    try:
+        clusters = cluster_recent_articles(user_id=current_user["id"])
+    except InsightsNotConfiguredError as exc:
+        raise HTTPException(status_code=501, detail=str(exc)) from exc
+
+    return {"clusters": clusters}
+
+
 @api.get("/api/articles/{article_id}")
 def get_article_by_id(
     article_id: int,
@@ -600,20 +614,6 @@ def article_insights(
         raise HTTPException(status_code=404, detail="article not found")
 
     return {"bullets": bullets}
-
-
-@api.get("/api/articles/topic-map")
-def articles_topic_map(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.insights import InsightsNotConfiguredError, cluster_recent_articles
-
-    try:
-        clusters = cluster_recent_articles(user_id=current_user["id"])
-    except InsightsNotConfiguredError as exc:
-        raise HTTPException(status_code=501, detail=str(exc)) from exc
-
-    return {"clusters": clusters}
 
 
 @api.get("/api/articles/{article_id}/perspectives")

--- a/backend/tests/test_topic_map_api.py
+++ b/backend/tests/test_topic_map_api.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.main import app
+
+
+def _client() -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 42,
+        "username": "reader",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_topic_map_static_route_is_not_parsed_as_article_id(monkeypatch: Any) -> None:
+    def fake_cluster_recent_articles(*, user_id: int) -> list[dict[str, Any]]:
+        assert user_id == 42
+        return [
+            {
+                "id": 1,
+                "headline": "Topic arc",
+                "trend_summary": "Related articles are moving together.",
+                "x": 0.0,
+                "y": 0.0,
+                "article_ids": [7],
+                "articles": [{"id": 7, "title": "Article 7", "source": "Example"}],
+            }
+        ]
+
+    monkeypatch.setattr(
+        "news_dashboard.insights.cluster_recent_articles",
+        fake_cluster_recent_articles,
+    )
+
+    response = _client().get("/api/articles/topic-map")
+
+    assert response.status_code == 200
+    assert response.json()["clusters"][0]["headline"] == "Topic arc"
+
+
+def test_numeric_article_detail_route_still_resolves(monkeypatch: Any) -> None:
+    def fake_get_article(article_id: int, *, user_id: int) -> dict[str, Any]:
+        assert article_id == 7
+        assert user_id == 42
+        return {"id": 7, "title": "Article 7"}
+
+    monkeypatch.setattr("news_dashboard.main.get_article", fake_get_article)
+
+    response = _client().get("/api/articles/7")
+
+    assert response.status_code == 200
+    assert response.json() == {"id": 7, "title": "Article 7"}


### PR DESCRIPTION
Closes #435

## Summary
- Move the static `/api/articles/topic-map` handler before `/api/articles/{article_id}` so FastAPI does not parse `topic-map` as an integer article id.
- Add API regression coverage for the Topic Map route and numeric article detail route.

## Test results
- `pytest backend/tests/test_topic_map_api.py`
- `make lint`
- `make typecheck`
- `set -a; source .env; set +a; make test`
- `npm run build --silent`

Generated by codex automation.