### PR TITLE
fix: align Feeds controls with admin permissions

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -479,7 +479,7 @@ def auth_me(current_user: Annotated[dict[str, Any], Depends(require_auth)]) -> d
     }
 
 
-@api.post("/api/ingest")
+@api.post("/api/ingest", dependencies=[Depends(require_admin)])
 def ingest(background_tasks: BackgroundTasks) -> dict[str, Any]:
     results = ingest_all()
     inserted = sum(v for v in results.values() if v > 0)

--- a/backend/tests/test_ingest_route_auth.py
+++ b/backend/tests/test_ingest_route_auth.py
@@ -1,0 +1,58 @@
+"""Tests that POST /api/ingest is restricted to admin users."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import app
+
+
+@pytest.fixture
+def client() -> Generator[TestClient]:
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+_FAKE_ADMIN = {
+    "id": 1,
+    "username": "adminuser",
+    "email": None,
+    "is_admin": True,
+}
+
+
+def test_ingest_requires_admin(client: TestClient) -> None:
+    from news_dashboard.auth import require_admin, require_auth
+
+    def _non_admin_require_admin() -> None:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 2,
+        "username": "regularuser",
+        "email": None,
+        "is_admin": False,
+    }
+    app.dependency_overrides[require_admin] = _non_admin_require_admin
+    try:
+        resp = client.post("/api/ingest")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_ingest_succeeds_for_admin(client: TestClient) -> None:
+    with (
+        patch("news_dashboard.main.ingest_all", return_value={"feed1": 3, "feed2": 0}),
+        patch("news_dashboard.main.prefetch_article_bodies"),
+    ):
+        resp = client.post("/api/ingest")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["inserted"] == 3

--- a/frontend/src/__tests__/commandPalette.test.tsx
+++ b/frontend/src/__tests__/commandPalette.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import { AuthProvider } from '../contexts/auth';
 import { CommandPalette } from '../components/CommandPalette';
 import * as api from '../api';
 import type { Article } from '../types';
@@ -53,21 +54,23 @@ function renderPalette() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/search']}>
-        <FocusedArticleProvider>
-          <Routes>
-            <Route
-              path="*"
-              element={
-                <>
-                  <LocationProbe />
-                  <CommandPalette open={true} onOpenChange={vi.fn()} />
-                </>
-              }
-            />
-          </Routes>
-        </FocusedArticleProvider>
-      </MemoryRouter>
+      <AuthProvider>
+        <MemoryRouter initialEntries={['/search']}>
+          <FocusedArticleProvider>
+            <Routes>
+              <Route
+                path="*"
+                element={
+                  <>
+                    <LocationProbe />
+                    <CommandPalette open={true} onOpenChange={vi.fn()} />
+                  </>
+                }
+              />
+            </Routes>
+          </FocusedArticleProvider>
+        </MemoryRouter>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -3,8 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { ReactElement, ReactNode } from 'react';
-import type { Source } from '../types';
+import { useEffect, type ReactElement, type ReactNode } from 'react';
+import type { Source, User } from '../types';
+import { AuthProvider, useAuth } from '../contexts/auth';
 
 // ── Shared API mock ──────────────────────────────────────────────────────────
 // SourcesPage imports from '@/api', SchedulerPage from '../api'; both resolve to
@@ -39,13 +40,23 @@ import { FeedsLogsPage } from '../pages/FeedsLogsPage';
 import { SourcesPage } from '../pages/SourcesPage';
 import { SchedulerPage } from '../pages/SchedulerPage';
 
-function withProviders(ui: ReactElement, route = '/') {
+function SetUser({ user, children }: { user: User | null; children: ReactNode }) {
+  const { setUser } = useAuth();
+  useEffect(() => setUser(user), [user, setUser]);
+  return <>{children}</>;
+}
+
+function withProviders(ui: ReactElement, route = '/', user: User | null = null) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>
-      <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+      <AuthProvider>
+        <SetUser user={user}>
+          <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+        </SetUser>
+      </AuthProvider>
     </QueryClientProvider>
   );
   return render(ui, { wrapper });
@@ -73,6 +84,9 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+const adminUser: User = { id: 1, username: 'admin', is_admin: true };
+const regularUser: User = { id: 2, username: 'user', is_admin: false };
+
 // ── FeedsPage (pure layout) ──────────────────────────────────────────────────
 
 describe('FeedsPage', () => {
@@ -83,12 +97,45 @@ describe('FeedsPage', () => {
           <Route index element={<div>child content</div>} />
         </Route>
       </Routes>,
-      '/feeds'
+      '/feeds',
+      adminUser
     );
     expect(screen.getByRole('heading', { name: 'Feeds' })).toBeTruthy();
     expect(screen.getByText('Sources')).toBeTruthy();
     expect(screen.getByText('Schedule')).toBeTruthy();
     expect(screen.getByText('child content')).toBeTruthy();
+  });
+
+  it('shows all tabs to admin users', () => {
+    withProviders(
+      <Routes>
+        <Route path="/feeds" element={<FeedsPage />}>
+          <Route index element={<div>child content</div>} />
+        </Route>
+      </Routes>,
+      '/feeds',
+      adminUser
+    );
+    expect(screen.getByText('Sources')).toBeTruthy();
+    expect(screen.getByText('Schedule')).toBeTruthy();
+    expect(screen.getByText('Runs')).toBeTruthy();
+    expect(screen.getByText('Logs')).toBeTruthy();
+  });
+
+  it('hides Schedule, Runs, and Logs tabs from non-admin users', () => {
+    withProviders(
+      <Routes>
+        <Route path="/feeds" element={<FeedsPage />}>
+          <Route index element={<div>child content</div>} />
+        </Route>
+      </Routes>,
+      '/feeds',
+      regularUser
+    );
+    expect(screen.getByText('Sources')).toBeTruthy();
+    expect(screen.queryByText('Schedule')).toBeNull();
+    expect(screen.queryByText('Runs')).toBeNull();
+    expect(screen.queryByText('Logs')).toBeNull();
   });
 });
 

--- a/frontend/src/__tests__/palette.test.tsx
+++ b/frontend/src/__tests__/palette.test.tsx
@@ -4,8 +4,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect, type ReactNode } from 'react';
 import { CommandPalette } from '../components/CommandPalette';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import { AuthProvider, useAuth } from '../contexts/auth';
+import type { User } from '../types';
 import * as api from '../api';
 
 // Silence sonner in tests
@@ -27,16 +30,29 @@ vi.mock('../hooks/useTriageMutations', () => ({
   ARTICLES_KEY: 'articles',
 }));
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function SetUser({ user, children }: { user: User | null; children: ReactNode }) {
+  const { setUser } = useAuth();
+  useEffect(() => setUser(user), [user, setUser]);
+  return <>{children}</>;
+}
+
+function Wrapper({ children, user = null }: { children: React.ReactNode; user?: User | null }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return (
     <QueryClientProvider client={qc}>
-      <MemoryRouter>
-        <FocusedArticleProvider>{children}</FocusedArticleProvider>
-      </MemoryRouter>
+      <AuthProvider>
+        <SetUser user={user}>
+          <MemoryRouter>
+            <FocusedArticleProvider>{children}</FocusedArticleProvider>
+          </MemoryRouter>
+        </SetUser>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }
+
+const adminUser: User = { id: 1, username: 'admin', is_admin: true };
+const regularUser: User = { id: 2, username: 'user', is_admin: false };
 
 // ─── CommandPalette ───────────────────────────────────────────────────────────
 
@@ -85,13 +101,22 @@ describe('CommandPalette — navigation items', () => {
     expect(screen.getByText('Archive')).toBeTruthy();
   });
 
-  it('shows "Refresh feeds now" action', () => {
+  it('shows "Refresh feeds now" action to admin users', () => {
     render(
-      <Wrapper>
+      <Wrapper user={adminUser}>
         <CommandPalette open={true} onOpenChange={vi.fn()} />
       </Wrapper>
     );
     expect(screen.getByText(/refresh feeds now/i)).toBeTruthy();
+  });
+
+  it('hides "Refresh feeds now" action from non-admin users', () => {
+    render(
+      <Wrapper user={regularUser}>
+        <CommandPalette open={true} onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+    expect(screen.queryByText(/refresh feeds now/i)).toBeNull();
   });
 
   it('shows keyboard shortcuts item when onShortcuts provided', () => {
@@ -157,11 +182,11 @@ describe('CommandPalette — article search', () => {
 });
 
 describe('CommandPalette — ingest action', () => {
-  it('calls ingestNow when "Refresh feeds now" is selected', async () => {
+  it('calls ingestNow when "Refresh feeds now" is selected by admin', async () => {
     const ingestSpy = vi.spyOn(api, 'ingestNow').mockResolvedValue({ inserted: 3, results: {} });
     const onOpenChange = vi.fn();
     render(
-      <Wrapper>
+      <Wrapper user={adminUser}>
         <CommandPalette open={true} onOpenChange={onOpenChange} />
       </Wrapper>
     );

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -72,11 +72,13 @@ function renderPalette(open = true) {
   const qc = makeQc();
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter>
-        <FocusedArticleProvider>
-          <CommandPalette open={open} onOpenChange={vi.fn()} />
-        </FocusedArticleProvider>
-      </MemoryRouter>
+      <AuthProvider>
+        <MemoryRouter>
+          <FocusedArticleProvider>
+            <CommandPalette open={open} onOpenChange={vi.fn()} />
+          </FocusedArticleProvider>
+        </MemoryRouter>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -20,6 +20,7 @@ import { searchArticles, ingestNow } from '@/api';
 import { adaptArticle } from '@/api/workflowApi';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { useFocusedArticle } from '@/contexts/focusedArticle';
+import { useAuth } from '@/contexts/auth';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
 import { commandNavigationItems } from '@/lib/navigation';
 import { trackFeature } from '@/lib/analytics';
@@ -40,6 +41,7 @@ export function CommandPalette({ open, onOpenChange, onShortcuts }: Props) {
   const navigate = useNavigate();
   const mutations = useTriageMutations();
   const { article: focusedArticle } = useFocusedArticle();
+  const { user } = useAuth();
 
   const [q, setQ] = useState('');
   const [searchResults, setSearchResults] = useState<WorkflowArticle[]>([]);
@@ -252,15 +254,17 @@ export function CommandPalette({ open, onOpenChange, onShortcuts }: Props) {
 
             {/* App actions */}
             <Command.Group heading="Actions" className={GROUP_CLS}>
-              <Command.Item
-                onSelect={() => {
-                  void handleIngest();
-                }}
-                className={ITEM_CLS}
-              >
-                <RefreshCw className="size-4 text-muted-foreground" />
-                <span className="text-sm">Refresh feeds now</span>
-              </Command.Item>
+              {user?.is_admin && (
+                <Command.Item
+                  onSelect={() => {
+                    void handleIngest();
+                  }}
+                  className={ITEM_CLS}
+                >
+                  <RefreshCw className="size-4 text-muted-foreground" />
+                  <span className="text-sm">Refresh feeds now</span>
+                </Command.Item>
+              )}
               {onShortcuts && (
                 <Command.Item
                   onSelect={() => {

--- a/frontend/src/pages/FeedsPage.tsx
+++ b/frontend/src/pages/FeedsPage.tsx
@@ -1,15 +1,18 @@
 import { Outlet, NavLink, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/utils';
+import { useAuth } from '@/contexts/auth';
 
-const TABS = [
-  { to: '/feeds', label: 'Sources', exact: true },
-  { to: '/feeds/schedule', label: 'Schedule' },
-  { to: '/feeds/runs', label: 'Runs' },
-  { to: '/feeds/logs', label: 'Logs' },
+const ALL_TABS = [
+  { to: '/feeds', label: 'Sources', exact: true, adminOnly: false },
+  { to: '/feeds/schedule', label: 'Schedule', adminOnly: true },
+  { to: '/feeds/runs', label: 'Runs', adminOnly: true },
+  { to: '/feeds/logs', label: 'Logs', adminOnly: true },
 ];
 
 export function FeedsPage() {
   const { pathname } = useLocation();
+  const { user } = useAuth();
+  const tabs = ALL_TABS.filter((t) => !t.adminOnly || user?.is_admin);
   return (
     <div>
       <div className="px-4 md:px-5 pt-4">
@@ -20,7 +23,7 @@ export function FeedsPage() {
       </div>
       <div className="px-4 md:px-5 mt-3 border-b border-border overflow-x-auto">
         <div className="flex gap-1">
-          {TABS.map((t) => {
+          {tabs.map((t) => {
             const active = t.exact ? pathname === t.to : pathname === t.to;
             return (
               <NavLink


### PR DESCRIPTION
Closes #436

## Summary

- `POST /api/ingest` now requires admin access (using the same `require_admin` dependency pattern as the scheduler endpoints)
- `FeedsPage` filters Schedule, Runs, and Logs tabs — only shown to admin users
- `CommandPalette` hides "Refresh feeds now" action from non-admin users

## Tests

- New backend test file `test_ingest_route_auth.py`: asserts 403 for non-admin on `POST /api/ingest` and 200 for admin
- Updated `feedsPages.test.tsx`: adds admin/non-admin tab visibility assertions
- Updated `palette.test.tsx`: adds admin/non-admin "Refresh feeds now" visibility assertions
- Fixed `commandPalette.test.tsx` and `routing.test.tsx`: added `AuthProvider` to wrappers that render `CommandPalette` (required now that the component calls `useAuth`)

All 538 frontend tests, 2 new backend tests, and all pre-commit hooks (ruff, mypy, ty, pyrefly, eslint, prettier, tsc) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)