### PR TITLE
feat: expose source filtering in Search (#438)

### DIFF
--- a/frontend/src/__tests__/search.test.tsx
+++ b/frontend/src/__tests__/search.test.tsx
@@ -6,13 +6,29 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SearchPage } from '../pages/SearchPage';
 import * as workflowApi from '../api/workflowApi';
+import * as api from '../api';
 import type { WorkflowArticle } from '../lib/workflowTypes';
+import type { Source } from '../types';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
 
 vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
+function makeSource(overrides: Partial<Source> = {}): Source {
+  return {
+    slug: 'test-source',
+    name: 'Test Source',
+    url: 'https://example.com',
+    category: 'engineering',
+    kind: 'rss',
+    priority: 1,
+    enabled: 1,
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(api, 'fetchSources').mockResolvedValue([]);
 });
 
 function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
@@ -183,5 +199,75 @@ describe('SearchPage — reader navigation', () => {
 
     const link = screen.getByRole('link');
     expect(link.getAttribute('href')).toContain('/a/42');
+  });
+});
+
+// ─── Source filter ────────────────────────────────────────────────────────────
+
+describe('SearchPage — source filter', () => {
+  it('renders Source filter group when sources are available', async () => {
+    vi.spyOn(api, 'fetchSources').mockResolvedValue([
+      makeSource({ slug: 'hn', name: 'Hacker News' }),
+      makeSource({ slug: 'openai-blog', name: 'OpenAI Blog' }),
+    ]);
+
+    renderSearch();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Source/i })).toBeTruthy();
+    });
+  });
+
+  it('does not render Source filter group when no sources available', async () => {
+    vi.spyOn(api, 'fetchSources').mockResolvedValue([]);
+    renderSearch();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /^Source/i })).toBeNull();
+    });
+  });
+
+  it('shows source names in dropdown when Source button is clicked', async () => {
+    vi.spyOn(api, 'fetchSources').mockResolvedValue([
+      makeSource({ slug: 'hn', name: 'Hacker News' }),
+      makeSource({ slug: 'openai-blog', name: 'OpenAI Blog' }),
+    ]);
+
+    renderSearch();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Source/i })).toBeTruthy();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /^Source/i }));
+
+    expect(screen.getByText('Hacker News')).toBeTruthy();
+    expect(screen.getByText('OpenAI Blog')).toBeTruthy();
+  });
+
+  it('passes selected sources to searchArticlesFiltered', async () => {
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    vi.spyOn(api, 'fetchSources').mockResolvedValue([
+      makeSource({ slug: 'hn', name: 'Hacker News' }),
+    ]);
+
+    renderSearch('?q=test&sources=hn');
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ sources: ['hn'] }));
+    });
+  });
+
+  it('preselects sources from URL params', async () => {
+    vi.spyOn(api, 'fetchSources').mockResolvedValue([
+      makeSource({ slug: 'hn', name: 'Hacker News' }),
+      makeSource({ slug: 'openai-blog', name: 'OpenAI Blog' }),
+    ]);
+
+    renderSearch('?q=test&sources=hn');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Source · 1/i })).toBeTruthy();
+    });
   });
 });

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -9,6 +9,7 @@ import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { useFocusedArticle } from '@/contexts/focusedArticle';
 import { setReaderList } from '@/lib/readerList';
 import { searchArticlesFiltered } from '@/api/workflowApi';
+import { fetchSources } from '@/api';
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { cn } from '@/lib/utils';
 
@@ -124,6 +125,12 @@ export function SearchPage() {
     includeArchived ||
     dateRange !== 'all';
 
+  const { data: availableSources = [] } = useQuery({
+    queryKey: ['sources'],
+    queryFn: fetchSources,
+    staleTime: 5 * 60_000,
+  });
+
   const { data: results = [], isLoading } = useQuery({
     queryKey: ['search', q, states, categories, sources, starredOnly, includeArchived, dateRange],
     queryFn: () =>
@@ -222,6 +229,17 @@ export function SearchPage() {
             render={(v) => DATE_OPTIONS.find((d) => d.value === v)?.label ?? v}
             single
           />
+
+          {/* Source group */}
+          {availableSources.length > 0 && (
+            <FilterGroup
+              label="Source"
+              all={availableSources.map((s) => s.slug)}
+              selected={sources}
+              onChange={(next) => updateParams({ sources: next })}
+              render={(slug) => availableSources.find((s) => s.slug === slug)?.name ?? slug}
+            />
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Closes #438

- Fetches the user's visible sources via `fetchSources` and renders a **Source** `FilterGroup` next to the existing State/Category/Date chips in `SearchPage.tsx`
- Selected source slugs are written as repeated `sources=<slug>` URL params and read back on load, so the filter survives refresh/back navigation and can be shared as a URL
- Delegates filtering to the existing `/api/search` contract — no backend changes required
- The Source group is hidden when the sources list is empty (loading/error states do not block text search or other filters)
- Long source names truncate inside the dropdown (`truncate text-left` via the existing `FilterGroup` style)

## Test plan

- [x] `frontend/src/__tests__/search.test.tsx` — 5 new tests: Source group renders when sources available, hidden when empty, shows names in dropdown, passes selected slugs to `searchArticlesFiltered`, preselects sources from URL params
- [x] All 15 search tests pass (`vitest run`)
- [x] `tsc --noEmit` clean
- [x] eslint + prettier clean (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)