### PR TITLE
fix: deliver desktop daily brief notifications via Electron IPC (#445)

### DIFF
--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -100,11 +100,24 @@ function createWindow() {
 
 // ── Native notification IPC ───────────────────────────────────────────────────
 
-ipcMain.on('notification:show', (_event, { title, body }) => {
+// Keep a reference to the most-recently focused window so notification clicks
+// can bring it forward and load the target route.
+let mainWindow = null;
+
+ipcMain.on('notification:show', (_event, { title, body, targetUrl }) => {
   const { Notification } = require('electron');
-  if (Notification.isSupported()) {
-    new Notification({ title: String(title), body: String(body) }).show();
+  if (!Notification.isSupported()) return;
+  const n = new Notification({ title: String(title), body: String(body) });
+  if (targetUrl && typeof targetUrl === 'string') {
+    n.on('click', () => {
+      if (mainWindow) {
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.focus();
+        mainWindow.webContents.send('notification:clicked', targetUrl);
+      }
+    });
   }
+  n.show();
 });
 
 // ── Auto-updater IPC bridge ───────────────────────────────────────────────────
@@ -225,12 +238,14 @@ ipcMain.on('get-app-version', (event) => {
 
 app.whenReady().then(() => {
   const win = createWindow();
+  mainWindow = win;
   Menu.setApplicationMenu(buildMenu(win));
   setupUpdater(win);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       const w = createWindow();
+      mainWindow = w;
       Menu.setApplicationMenu(buildMenu(w));
       setupUpdater(w);
     }

--- a/desktop/src/preload.js
+++ b/desktop/src/preload.js
@@ -49,5 +49,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // ── Native notifications ──────────────────────────────────────────────────
 
-  showNotification: (title, body) => ipcRenderer.send('notification:show', { title, body }),
+  showNotification: (title, body, targetUrl) =>
+    ipcRenderer.send('notification:show', { title, body, targetUrl }),
+
+  onNotificationClick: (cb) =>
+    ipcRenderer.on('notification:clicked', (_e, url) => cb(url)),
+
+  removeNotificationClickListener: () =>
+    ipcRenderer.removeAllListeners('notification:clicked'),
 });

--- a/frontend/src/__tests__/useElectronBriefNotifier.test.tsx
+++ b/frontend/src/__tests__/useElectronBriefNotifier.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const { mockFetchSettings, mockFetchLatestBriefing } = vi.hoisted(() => ({
+  mockFetchSettings: vi.fn(),
+  mockFetchLatestBriefing: vi.fn(),
+}));
+
+vi.mock('@/api', () => ({
+  fetchNotificationSettings: mockFetchSettings,
+  fetchLatestBriefing: mockFetchLatestBriefing,
+}));
+
+import { useElectronBriefNotifier } from '../hooks/useElectronBriefNotifier';
+
+const completeBriefing = {
+  id: 42,
+  status: 'complete' as const,
+  title: 'Morning Brief',
+  summary: 'Headlines for today',
+  created_at: '',
+  scope: 'global',
+  since_at: '',
+  until_at: '',
+  content: null,
+  model: 'gpt-4',
+  error: null,
+  articles: [],
+};
+
+function makeElectronAPI() {
+  return {
+    platform: 'electron' as const,
+    appVersion: '1.0.0',
+    checkForUpdate: vi.fn(),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+    onUpdateAvailable: vi.fn(),
+    onUpdateNotAvailable: vi.fn(),
+    onUpdateDownloaded: vi.fn(),
+    onUpdateError: vi.fn(),
+    onDownloadProgress: vi.fn(),
+    removeUpdateListeners: vi.fn(),
+    showNotification: vi.fn(),
+    onNotificationClick: vi.fn(),
+    removeNotificationClickListener: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockFetchSettings.mockResolvedValue({
+    briefing_time: '09:00',
+    push_enabled: true,
+    vapid_public_key: null,
+  });
+  mockFetchLatestBriefing.mockResolvedValue(completeBriefing);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  localStorage.clear();
+});
+
+describe('useElectronBriefNotifier', () => {
+  it('does nothing when not running in Electron', async () => {
+    const navigate = vi.fn();
+    renderHook(() => useElectronBriefNotifier(navigate));
+    await vi.waitFor(() => expect(mockFetchSettings).not.toHaveBeenCalled());
+    expect(mockFetchLatestBriefing).not.toHaveBeenCalled();
+  });
+
+  it('shows a notification for a new complete briefing', async () => {
+    const api = makeElectronAPI();
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+
+    const navigate = vi.fn();
+    renderHook(() => useElectronBriefNotifier(navigate));
+
+    await vi.waitFor(() => expect(api.showNotification).toHaveBeenCalledOnce());
+    expect(api.showNotification).toHaveBeenCalledWith(
+      'Morning Brief',
+      'Headlines for today',
+      '/briefs/42'
+    );
+  });
+
+  it('does not notify twice for the same briefing id', async () => {
+    localStorage.setItem('nd_electron_last_brief_id', '42');
+    const api = makeElectronAPI();
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+
+    const navigate = vi.fn();
+    renderHook(() => useElectronBriefNotifier(navigate));
+
+    // Give it time to poll
+    await new Promise((r) => setTimeout(r, 50));
+    expect(api.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not show a notification when push_enabled is false', async () => {
+    mockFetchSettings.mockResolvedValue({
+      briefing_time: '09:00',
+      push_enabled: false,
+      vapid_public_key: null,
+    });
+    const api = makeElectronAPI();
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+
+    const navigate = vi.fn();
+    renderHook(() => useElectronBriefNotifier(navigate));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(api.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not show a notification when the latest briefing is empty', async () => {
+    mockFetchLatestBriefing.mockResolvedValue({ status: 'empty' });
+    const api = makeElectronAPI();
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+
+    const navigate = vi.fn();
+    renderHook(() => useElectronBriefNotifier(navigate));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(api.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('registers onNotificationClick and navigates on click', async () => {
+    const api = makeElectronAPI();
+    let clickHandler: ((url: string) => void) | undefined;
+    api.onNotificationClick = vi.fn((cb: (url: string) => void) => {
+      clickHandler = cb;
+    });
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+
+    const navigate = vi.fn();
+    renderHook(() => useElectronBriefNotifier(navigate));
+
+    await vi.waitFor(() => expect(api.onNotificationClick).toHaveBeenCalled());
+    clickHandler?.('/briefs/42');
+    expect(navigate).toHaveBeenCalledWith('/briefs/42');
+  });
+
+  it('removes notification click listener on unmount', () => {
+    const api = makeElectronAPI();
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+
+    const navigate = vi.fn();
+    const { unmount } = renderHook(() => useElectronBriefNotifier(navigate));
+    unmount();
+
+    expect(api.removeNotificationClickListener).toHaveBeenCalled();
+  });
+
+  it('stores the notified briefing id in localStorage', async () => {
+    const api = makeElectronAPI();
+    (window as unknown as { electronAPI: unknown }).electronAPI = api;
+
+    const navigate = vi.fn();
+    renderHook(() => useElectronBriefNotifier(navigate));
+
+    await vi.waitFor(() => expect(api.showNotification).toHaveBeenCalledOnce());
+    expect(localStorage.getItem('nd_electron_last_brief_id')).toBe('42');
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { WhatsNewDialog } from './WhatsNewDialog';
 import { OnboardingWizard } from './OnboardingWizard';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
 import { useOnboardingWizard } from '@/hooks/useOnboardingWizard';
+import { useElectronBriefNotifier } from '@/hooks/useElectronBriefNotifier';
 import { cn } from '@/lib/utils';
 import { fetchSummary, fetchSharesUnreadCount, logoutUser } from '@/api';
 import { startAnalytics, stopAnalytics, trackRoute } from '@/lib/analytics';
@@ -138,6 +139,7 @@ export function AppShell() {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const whatsNew = useWhatsNew();
   const onboarding = useOnboardingWizard();
+  useElectronBriefNotifier(navigate);
 
   async function handleLogout() {
     await logoutUser();

--- a/frontend/src/hooks/useElectronBriefNotifier.ts
+++ b/frontend/src/hooks/useElectronBriefNotifier.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { fetchLatestBriefing, fetchNotificationSettings } from '@/api';
+
+const LAST_NOTIFIED_KEY = 'nd_electron_last_brief_id';
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Polls for new daily briefings while the Electron app is open.
+ * Fires a native OS notification the first time a new complete briefing appears.
+ * Each briefing ID is notified at most once (tracked in localStorage).
+ *
+ * Must only be called when the user is authenticated (AppShell context).
+ */
+export function useElectronBriefNotifier(navigate: (path: string) => void): void {
+  useEffect(() => {
+    if (!window.electronAPI) return;
+
+    window.electronAPI.onNotificationClick((url) => navigate(url));
+
+    let active = true;
+
+    async function poll() {
+      if (!active) return;
+      try {
+        const settings = await fetchNotificationSettings();
+        if (!settings.push_enabled) return;
+
+        const latest = await fetchLatestBriefing();
+        if (!('id' in latest) || latest.status !== 'complete') return;
+
+        const lastId = localStorage.getItem(LAST_NOTIFIED_KEY);
+        if (lastId === String(latest.id)) return;
+
+        localStorage.setItem(LAST_NOTIFIED_KEY, String(latest.id));
+        window.electronAPI!.showNotification(
+          latest.title,
+          latest.summary ?? '',
+          `/briefs/${latest.id}`
+        );
+      } catch {
+        // non-critical — silent fail
+      }
+    }
+
+    void poll();
+    const timer = setInterval(() => void poll(), POLL_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      clearInterval(timer);
+      window.electronAPI?.removeNotificationClickListener();
+    };
+  }, [navigate]);
+}

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -24,7 +24,11 @@ interface Window {
     onUpdateError(cb: (message: string) => void): void;
     onDownloadProgress(cb: (progress: ElectronDownloadProgress) => void): void;
     removeUpdateListeners(): void;
-    /** Show a native OS notification (Electron only). */
-    showNotification(title: string, body: string): void;
+    /** Show a native OS notification. `targetUrl` is forwarded to main so a click can open the route. */
+    showNotification(title: string, body: string, targetUrl?: string): void;
+    /** Register a callback that fires when the user clicks a notification that carries a target URL. */
+    onNotificationClick(cb: (url: string) => void): void;
+    /** Remove the notification-click listener registered by `onNotificationClick`. */
+    removeNotificationClickListener(): void;
   };
 }


### PR DESCRIPTION
## Summary

Closes #445

- **`useElectronBriefNotifier` hook** (`frontend/src/hooks/useElectronBriefNotifier.ts`): polls `/api/briefings/latest` every 5 minutes while the Electron app is open. When a new `complete` briefing appears, fires a native OS notification via `window.electronAPI.showNotification()`. Each briefing ID is notified at most once, tracked in `localStorage`.
- **Electron IPC extension** (`desktop/src/main.js`, `desktop/src/preload.js`): the `notification:show` handler now accepts an optional `targetUrl`. On notification click, main focuses the window and sends `notification:clicked` to the renderer. The preload exposes `onNotificationClick` and `removeNotificationClickListener`.
- **AppShell wiring** (`frontend/src/components/AppShell.tsx`): hook is mounted for all authenticated sessions so the notification path is active whenever the app is open.
- **Type declarations** (`frontend/src/types/electron.d.ts`): updated `showNotification` signature and added `onNotificationClick` / `removeNotificationClickListener`.
- **Browser/PWA Web Push unchanged** — the service worker path in `public/push-handler.js` is not touched.

## Test results

8 new unit tests in `frontend/src/__tests__/useElectronBriefNotifier.test.tsx`:
- Notification fires for a new complete briefing
- Same briefing ID not notified twice (localStorage dedup)
- No notification when `push_enabled = false`
- No notification for empty/non-complete briefing
- Click handler calls `navigate` with the correct route
- Cleanup on unmount removes the IPC listener
- localStorage is updated with the notified ID

All 556 frontend tests pass, TypeScript clean, ESLint/Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)