### PR TITLE
fix: pass AI env into ingest CronJob (#446)

### DIFF
--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -1,5 +1,6 @@
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -8,24 +9,69 @@ HELM_BIN = shutil.which("helm")
 CHART_DIR = Path(__file__).resolve().parents[2] / "helm" / "news-dashboard"
 
 
-@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
-def test_helm_template_default() -> None:
+def _render_chart(*set_values: str) -> str:
     assert HELM_BIN is not None
+    args = [
+        HELM_BIN,
+        "template",
+        "news-dashboard",
+        str(CHART_DIR),
+        "--set",
+        "app.auth.sessionSecret=dummy-session-secret",
+    ]
+    for value in set_values:
+        args.extend(("--set", value))
+
     res = subprocess.run(  # noqa: S603
-        [
-            HELM_BIN,
-            "template",
-            "news-dashboard",
-            str(CHART_DIR),
-            "--set",
-            "app.auth.sessionSecret=dummy-session-secret",
-        ],
+        args,
         capture_output=True,
         text=True,
         check=False,
     )
     assert res.returncode == 0, f"helm template failed: {res.stderr}"
-    output = res.stdout
+    return res.stdout
+
+
+def _manifest_for_kind(output: str, kind: str) -> str:
+    for manifest in output.split("---"):
+        if f"\nkind: {kind}\n" in f"\n{manifest}\n":
+            return manifest
+    msg = f"Rendered chart did not include {kind}"
+    raise AssertionError(msg)
+
+
+def _env_block(manifest: str) -> str:
+    lines = manifest.splitlines()
+    env_index = next(index for index, line in enumerate(lines) if line.strip() == "env:")
+    env_indent = len(lines[env_index]) - len(lines[env_index].lstrip())
+    block: list[str] = []
+    for line in lines[env_index + 1 :]:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        if stripped and indent <= env_indent:
+            break
+        block.append(line)
+    return "\n".join(block)
+
+
+def _env_entry(env: str, name: str) -> str:
+    lines = env.splitlines()
+    needle = f"- name: {name}"
+    start = next(index for index, line in enumerate(lines) if line.strip() == needle)
+    entry_indent = len(lines[start]) - len(lines[start].lstrip())
+    entry: list[str] = [lines[start]]
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        if stripped.startswith("- name: ") and indent == entry_indent:
+            break
+        entry.append(line)
+    return textwrap.dedent("\n".join(entry))
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_default() -> None:
+    output = _render_chart()
     assert "NEWS_DASHBOARD_DB" not in output
     # Check that it renders standard postgres config
     assert "name: POSTGRES_HOST" in output
@@ -40,32 +86,13 @@ def test_helm_template_default() -> None:
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
 def test_helm_template_ingest_cronjob_operational_overrides() -> None:
-    assert HELM_BIN is not None
-    res = subprocess.run(  # noqa: S603
-        [
-            HELM_BIN,
-            "template",
-            "news-dashboard",
-            str(CHART_DIR),
-            "--set",
-            "app.auth.sessionSecret=dummy-session-secret",
-            "--set",
-            "ingestCronJob.concurrencyPolicy=Replace",
-            "--set",
-            "ingestCronJob.startingDeadlineSeconds=900",
-            "--set",
-            "ingestCronJob.activeDeadlineSeconds=1200",
-            "--set",
-            "ingestCronJob.backoffLimit=2",
-            "--set",
-            "ingestCronJob.ttlSecondsAfterFinished=86400",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
+    output = _render_chart(
+        "ingestCronJob.concurrencyPolicy=Replace",
+        "ingestCronJob.startingDeadlineSeconds=900",
+        "ingestCronJob.activeDeadlineSeconds=1200",
+        "ingestCronJob.backoffLimit=2",
+        "ingestCronJob.ttlSecondsAfterFinished=86400",
     )
-    assert res.returncode == 0, f"helm template failed: {res.stderr}"
-    output = res.stdout
     assert "concurrencyPolicy: Replace" in output
     assert "startingDeadlineSeconds: 900" in output
     assert "activeDeadlineSeconds: 1200" in output
@@ -74,31 +101,41 @@ def test_helm_template_ingest_cronjob_operational_overrides() -> None:
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
-def test_helm_template_external_postgres() -> None:
-    assert HELM_BIN is not None
-    res = subprocess.run(  # noqa: S603
-        [
-            HELM_BIN,
-            "template",
-            "news-dashboard",
-            str(CHART_DIR),
-            "--set",
-            "app.auth.sessionSecret=dummy-session-secret",
-            "--set",
-            "postgresql.enabled=false",
-            "--set",
-            "app.postgresExternal.host=ext-postgres.internal",
-            "--set",
-            "app.postgresExternal.database=ext_db",
-            "--set",
-            "app.postgresExternal.username=ext_user",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
+def test_helm_template_ingest_cronjob_receives_ai_env() -> None:
+    output = _render_chart(
+        "app.ai.existingSecret=ai-credentials",
+        "app.ai.openaiApiKeyKey=CUSTOM_OPENAI_API_KEY",
+        "app.ai.freeLlmApiKeyKey=CUSTOM_FREE_LLM_API_KEY",
+        "app.ai.freeLlmBaseUrl=https://llm.example.test/v1",
+        "app.ai.briefingModel=briefing-model",
+        "app.ai.langfuse.host=https://langfuse.example.test",
+        "app.ai.langfuse.publicKeyKey=CUSTOM_LANGFUSE_PUBLIC_KEY",
+        "app.ai.langfuse.secretKeyKey=CUSTOM_LANGFUSE_SECRET_KEY",
     )
-    assert res.returncode == 0, f"helm template failed: {res.stderr}"
-    output = res.stdout
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+    cronjob_env = _env_block(_manifest_for_kind(output, "CronJob"))
+
+    ai_env_names = [
+        "OPENAI_API_KEY",
+        "FREE_LLM_API_KEY",
+        "FREE_LLM_BASE_URL",
+        "OPENAI_BRIEFING_MODEL",
+        "LANGFUSE_HOST",
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+    ]
+    for name in ai_env_names:
+        assert _env_entry(cronjob_env, name) == _env_entry(deployment_env, name)
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_external_postgres() -> None:
+    output = _render_chart(
+        "postgresql.enabled=false",
+        "app.postgresExternal.host=ext-postgres.internal",
+        "app.postgresExternal.database=ext_db",
+        "app.postgresExternal.username=ext_user",
+    )
     assert "NEWS_DASHBOARD_DB" not in output
     assert "name: POSTGRES_HOST" in output
     assert 'value: "ext-postgres.internal"' in output
@@ -110,26 +147,10 @@ def test_helm_template_external_postgres() -> None:
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
 def test_helm_template_external_database_url() -> None:
-    assert HELM_BIN is not None
-    res = subprocess.run(  # noqa: S603
-        [
-            HELM_BIN,
-            "template",
-            "news-dashboard",
-            str(CHART_DIR),
-            "--set",
-            "app.auth.sessionSecret=dummy-session-secret",
-            "--set",
-            "postgresql.enabled=false",
-            "--set",
-            "app.databaseUrl.existingSecret=my-db-secret",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
+    output = _render_chart(
+        "postgresql.enabled=false",
+        "app.databaseUrl.existingSecret=my-db-secret",
     )
-    assert res.returncode == 0, f"helm template failed: {res.stderr}"
-    output = res.stdout
     assert "NEWS_DASHBOARD_DB" not in output
     assert "name: DATABASE_URL" in output
     assert 'name: "my-db-secret"' in output

--- a/backend/tests/test_novelty_freshness.py
+++ b/backend/tests/test_novelty_freshness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import struct
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -130,6 +131,10 @@ def _insert_article(
     return int(row["id"])
 
 
+def _hours_ago(hours: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+
 def _set_state(
     db_path: str, user_id: int, article_id: int, *, state: str, starred: bool = False
 ) -> None:
@@ -166,12 +171,8 @@ def test_freshness_lifts_recent_article_over_older_twin(
     user_id = _make_user(db_path, "alice")
 
     # Two articles identical except for age; the recent one should score higher.
-    recent = _insert_article(
-        db_path, "src", "recent", importance=90, discovered_at="2026-06-21T09:00:00+00:00"
-    )
-    old = _insert_article(
-        db_path, "src", "old", importance=90, discovered_at="2026-05-01T09:00:00+00:00"
-    )
+    recent = _insert_article(db_path, "src", "recent", importance=90, discovered_at=_hours_ago(2))
+    old = _insert_article(db_path, "src", "old", importance=90, discovered_at=_hours_ago(1000))
 
     recompute_user_recommendations(user_id, db_path=db_path)
 
@@ -198,7 +199,7 @@ def test_novelty_contributes_positively_and_relevance_does_not_dominate(
         "src",
         "surprising",
         importance=95,
-        discovered_at="2026-06-21T09:30:00+00:00",
+        discovered_at=_hours_ago(2),
         embedding=[0.0, 1.0],
     )
 

--- a/helm/news-dashboard/templates/_helpers.tpl
+++ b/helm/news-dashboard/templates/_helpers.tpl
@@ -5,3 +5,46 @@
 {{- define "news-dashboard.fullname" -}}
 {{- printf "%s-%s" .Release.Name (include "news-dashboard.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "news-dashboard.aiEnv" -}}
+{{- if .Values.app.ai.existingSecret }}
+- name: OPENAI_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.ai.existingSecret | quote }}
+      key: {{ .Values.app.ai.openaiApiKeyKey | quote }}
+      optional: true
+- name: FREE_LLM_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.ai.existingSecret | quote }}
+      key: {{ .Values.app.ai.freeLlmApiKeyKey | quote }}
+      optional: true
+{{- end }}
+{{- if .Values.app.ai.freeLlmBaseUrl }}
+- name: FREE_LLM_BASE_URL
+  value: {{ .Values.app.ai.freeLlmBaseUrl | quote }}
+{{- end }}
+{{- if .Values.app.ai.briefingModel }}
+- name: OPENAI_BRIEFING_MODEL
+  value: {{ .Values.app.ai.briefingModel | quote }}
+{{- end }}
+{{- if .Values.app.ai.langfuse.host }}
+- name: LANGFUSE_HOST
+  value: {{ .Values.app.ai.langfuse.host | quote }}
+{{- if .Values.app.ai.existingSecret }}
+- name: LANGFUSE_PUBLIC_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.ai.existingSecret | quote }}
+      key: {{ .Values.app.ai.langfuse.publicKeyKey | default "LANGFUSE_PUBLIC_KEY" | quote }}
+      optional: true
+- name: LANGFUSE_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.ai.existingSecret | quote }}
+      key: {{ .Values.app.ai.langfuse.secretKeyKey | default "LANGFUSE_SECRET_KEY" | quote }}
+      optional: true
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/helm/news-dashboard/templates/cronjob.yaml
+++ b/helm/news-dashboard/templates/cronjob.yaml
@@ -88,4 +88,5 @@ spec:
     {{- fail "External PostgreSQL configuration is required when postgresql.enabled=false. Provide app.postgresExternal or app.databaseUrl." }}
   {{- end }}
 {{- end }}
+{{ include "news-dashboard.aiEnv" . | indent 16 }}
 {{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -81,46 +81,7 @@ spec:
     {{- fail "External PostgreSQL configuration is required when postgresql.enabled=false. Provide app.postgresExternal or app.databaseUrl." }}
   {{- end }}
 {{- end }}
-{{- if .Values.app.ai.existingSecret }}
-            - name: OPENAI_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.ai.existingSecret | quote }}
-                  key: {{ .Values.app.ai.openaiApiKeyKey | quote }}
-                  optional: true
-            - name: FREE_LLM_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.ai.existingSecret | quote }}
-                  key: {{ .Values.app.ai.freeLlmApiKeyKey | quote }}
-                  optional: true
-{{- end }}
-{{- if .Values.app.ai.freeLlmBaseUrl }}
-            - name: FREE_LLM_BASE_URL
-              value: {{ .Values.app.ai.freeLlmBaseUrl | quote }}
-{{- end }}
-{{- if .Values.app.ai.briefingModel }}
-            - name: OPENAI_BRIEFING_MODEL
-              value: {{ .Values.app.ai.briefingModel | quote }}
-{{- end }}
-{{- if .Values.app.ai.langfuse.host }}
-            - name: LANGFUSE_HOST
-              value: {{ .Values.app.ai.langfuse.host | quote }}
-{{- if .Values.app.ai.existingSecret }}
-            - name: LANGFUSE_PUBLIC_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.ai.existingSecret | quote }}
-                  key: {{ .Values.app.ai.langfuse.publicKeyKey | default "LANGFUSE_PUBLIC_KEY" | quote }}
-                  optional: true
-            - name: LANGFUSE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.ai.existingSecret | quote }}
-                  key: {{ .Values.app.ai.langfuse.secretKeyKey | default "LANGFUSE_SECRET_KEY" | quote }}
-                  optional: true
-{{- end }}
-{{- end }}
+{{ include "news-dashboard.aiEnv" . | indent 12 }}
 {{- if .Values.app.push }}
 {{- if .Values.app.push.existingSecret }}
             - name: VAPID_PUBLIC_KEY


### PR DESCRIPTION
Closes #446

## Summary
- Moved the Deployment AI/Langfuse env rendering into a shared Helm helper.
- Included the same optional AI/Langfuse env block in the ingest CronJob.
- Added chart-render coverage that compares Deployment and CronJob AI env entries.
- Made an existing freshness test date-relative so the full gate remains stable after June 2026.

## Test results
- `pytest backend/tests/test_chart_render.py::test_helm_template_ingest_cronjob_receives_ai_env -q` (red before implementation: CronJob missing `OPENAI_API_KEY`)
- `pytest backend/tests/test_chart_render.py -q`
- `ruff check backend/tests/test_novelty_freshness.py backend/tests/test_chart_render.py && ruff format --check backend/tests/test_novelty_freshness.py backend/tests/test_chart_render.py && source .env && pytest backend/tests/test_novelty_freshness.py backend/tests/test_chart_render.py -q`
- `source .env && make check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
