### PR TITLE
security: add noopener,noreferrer to article shortcut opens (#451)

### DIFF
--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -352,6 +352,31 @@ describe('ArticlePage — back navigation', () => {
   });
 });
 
+// ─── Keyboard shortcuts ───────────────────────────────────────────────────────
+
+describe('ArticlePage — keyboard shortcuts', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Text' })
+    );
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Text' })
+    );
+  });
+
+  it('o opens article URL in new tab with noopener,noreferrer', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    fireEvent.keyDown(window, { key: 'o' });
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://example.com/article',
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+});
+
 // ─── Touch gesture handling ────────────────────────────────────────────────────
 
 describe('ArticlePage — touch gesture state', () => {

--- a/frontend/src/__tests__/keyboard.test.ts
+++ b/frontend/src/__tests__/keyboard.test.ts
@@ -146,11 +146,11 @@ describe('useArticleListNav — action keys', () => {
     expect(mutations.setState).toHaveBeenCalledWith(article, 'archived', 'Archived');
   });
 
-  it('o opens original URL in new tab', () => {
+  it('o opens original URL in new tab with noopener,noreferrer', () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
     act(() => fireKey('o'));
-    expect(openSpy).toHaveBeenCalledWith(article.url, '_blank');
+    expect(openSpy).toHaveBeenCalledWith(article.url, '_blank', 'noopener,noreferrer');
   });
 
   it('Enter calls openArticle', () => {

--- a/frontend/src/hooks/useArticleListNav.ts
+++ b/frontend/src/hooks/useArticleListNav.ts
@@ -42,7 +42,7 @@ export function useArticleListNav(
       } else if (e.key === 'e' && cur) {
         mutations.setState(cur, 'archived', 'Archived');
       } else if (e.key === 'o' && cur) {
-        window.open(cur.url, '_blank');
+        window.open(cur.url, '_blank', 'noopener,noreferrer');
       }
     };
 

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -363,7 +363,7 @@ export function ArticlePage() {
       else if (e.key === 's' && article) void doStar();
       else if (e.key === 'x' && article) void doAction('skipped', 'Skipped');
       else if (e.key === 'e' && article) void doAction('archived', 'Archived');
-      else if (e.key === 'o' && article) window.open(article.url, '_blank');
+      else if (e.key === 'o' && article) window.open(article.url, '_blank', 'noopener,noreferrer');
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);


### PR DESCRIPTION
## Summary

- Updated `window.open` in `frontend/src/hooks/useArticleListNav.ts` (`o` shortcut from list view) to include `noopener,noreferrer` window features
- Updated `window.open` in `frontend/src/pages/ArticlePage.tsx` (`o` shortcut from article reader) to include `noopener,noreferrer` window features
- Updated existing keyboard test to assert the new third argument
- Added new test in `articleReader.test.tsx` covering the reader `o` shortcut

Closes #451

## Test plan

- [x] `frontend/src/__tests__/keyboard.test.ts` — updated `o opens original URL` test now asserts `noopener,noreferrer`
- [x] `frontend/src/__tests__/articleReader.test.tsx` — new test `o opens article URL in new tab with noopener,noreferrer`
- [x] All 64 tests pass (`vitest run` on both test files)
- [x] Pre-commit hooks pass (eslint, prettier, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)