### PR TITLE
fix: unregister analytics pagehide listener (#452)

### DIFF
--- a/frontend/src/__tests__/analytics.test.ts
+++ b/frontend/src/__tests__/analytics.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   flush,
+  startAnalytics,
+  stopAnalytics,
   trackArticleClose,
   trackArticleOpen,
   trackFeature,
@@ -70,6 +72,90 @@ describe('analytics tracker', () => {
     trackArticleClose(999);
     flush();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('analytics pagehide lifecycle', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const registered: EventListener[] = [];
+  const unregistered: EventListener[] = [];
+  let origAdd: typeof window.addEventListener;
+  let origRemove: typeof window.removeEventListener;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('MODE', 'production');
+    registered.length = 0;
+    unregistered.length = 0;
+    origAdd = window.addEventListener.bind(window);
+    origRemove = window.removeEventListener.bind(window);
+    window.addEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ): void => {
+      if (type === 'pagehide') registered.push(listener as EventListener);
+      origAdd(type, listener, options);
+    };
+    window.removeEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions
+    ): void => {
+      if (type === 'pagehide') unregistered.push(listener as EventListener);
+      origRemove(type, listener, options);
+    };
+  });
+
+  afterEach(() => {
+    window.addEventListener = origAdd;
+    window.removeEventListener = origRemove;
+    stopAnalytics();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('registers a pagehide listener on start', () => {
+    startAnalytics();
+    expect(registered).toHaveLength(1);
+    expect(typeof registered[0]).toBe('function');
+  });
+
+  it('removes the same pagehide handler on stop', () => {
+    startAnalytics();
+    const added = registered[0];
+    stopAnalytics();
+    expect(unregistered[0]).toBe(added);
+  });
+
+  it('does not accumulate pagehide listeners across start/stop cycles', () => {
+    startAnalytics();
+    stopAnalytics();
+    registered.length = 0;
+    startAnalytics();
+    expect(registered).toHaveLength(1);
+  });
+
+  it('fires flush via beacon on pagehide after start', () => {
+    const beaconMock = vi.fn().mockReturnValue(true);
+    vi.stubGlobal('navigator', { sendBeacon: beaconMock });
+    trackRoute('/test');
+    startAnalytics();
+    window.dispatchEvent(new Event('pagehide'));
+    expect(beaconMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire flush on pagehide after stop', () => {
+    const beaconMock = vi.fn().mockReturnValue(true);
+    vi.stubGlobal('navigator', { sendBeacon: beaconMock });
+    startAnalytics();
+    stopAnalytics();
+    // beacon called once by stopAnalytics flush; reset counter
+    beaconMock.mockClear();
+    trackRoute('/test');
+    window.dispatchEvent(new Event('pagehide'));
+    expect(beaconMock).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -103,6 +103,10 @@ function handleVisibility(): void {
   }
 }
 
+function handlePageHide(): void {
+  flush(true);
+}
+
 export function startAnalytics(): void {
   // Never emit telemetry under the test runner — it would issue real network
   // calls from any component test that mounts the app shell.
@@ -112,7 +116,7 @@ export function startAnalytics(): void {
   heartbeatTimer = setInterval(beat, HEARTBEAT_MS);
   flushTimer = setInterval(() => flush(), FLUSH_MS);
   document.addEventListener('visibilitychange', handleVisibility);
-  window.addEventListener('pagehide', () => flush(true));
+  window.addEventListener('pagehide', handlePageHide);
 }
 
 export function stopAnalytics(): void {
@@ -123,5 +127,6 @@ export function stopAnalytics(): void {
   heartbeatTimer = null;
   flushTimer = null;
   document.removeEventListener('visibilitychange', handleVisibility);
+  window.removeEventListener('pagehide', handlePageHide);
   flush(true);
 }


### PR DESCRIPTION
## Summary

- Extracts a stable `handlePageHide` function in `analytics.ts` so `stopAnalytics()` can remove the exact same reference that `startAnalytics()` registered
- Prevents `pagehide` listener accumulation when the app shell is mounted and unmounted multiple times in the same browser session
- Adds 5 new lifecycle tests: registration, removal (same reference), no-accumulation across cycles, beacon fires on pagehide after start, and beacon does NOT fire after stop

## Test results

All 10 tests pass (5 new lifecycle + 5 existing).

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)