### PR TITLE
fix: align onboarding wizard API contract (#457)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -948,11 +948,14 @@ def _source_recommendations(user_id: int, interests: list[str]) -> list[dict[str
             {
                 "source_slug": source.slug,
                 "source_name": source.name,
+                "kind": source.kind,
+                "url": source.url,
                 "category": source.category,
                 "matched_interests": matched,
                 "reason": reason,
                 "recommended": recommended,
                 "subscribed": subscriptions.get(source.slug, False),
+                "priority": source.priority,
                 "_score": score,
                 "_priority": source.priority,
             }
@@ -973,12 +976,123 @@ def _source_recommendations(user_id: int, interests: list[str]) -> list[dict[str
     return recommendations
 
 
+@api.get("/api/onboarding/status")
+def onboarding_status(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    uid = int(current_user["id"])
+    init_db()
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT completed_at FROM user_interest_profiles WHERE user_id = %s",
+            (uid,),
+        ).fetchone()
+    completed = row is not None and row["completed_at"] is not None
+    return {"completed": completed}
+
+
 @api.get("/api/onboarding/interests")
 def onboarding_interests(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
+) -> list[dict[str, Any]]:
     _ = current_user
-    return {"groups": list(INTEREST_GROUPS)}
+    return [
+        {"id": option["id"], "label": option["label"], "description": option.get("description", "")}
+        for group in INTEREST_GROUPS
+        for option in group["options"]
+    ]
+
+
+class OnboardingRecommendationsRequest(BaseModel):
+    interest_ids: list[str]
+
+
+class OnboardingProfileRequest(BaseModel):
+    interest_ids: list[str]
+    enabled_slugs: list[str] = Field(default_factory=list)
+
+
+def _frontend_recommendations(user_id: int, interests: list[str]) -> list[dict[str, Any]]:
+    """Return source recommendations using the frontend field-name contract (slug, name)."""
+    raw = _source_recommendations(user_id, interests)
+    return [
+        {
+            "slug": item["source_slug"],
+            "name": item["source_name"],
+            "category": item["category"],
+            "kind": item["kind"],
+            "url": item["url"],
+            "matched_interests": item["matched_interests"],
+            "reason": item["reason"],
+            "recommended": item["recommended"],
+            "enabled": 1 if item["subscribed"] else 0,
+            "priority": item["priority"],
+        }
+        for item in raw
+    ]
+
+
+@api.post("/api/onboarding/recommendations")
+def onboarding_recommendations(
+    payload: OnboardingRecommendationsRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> list[dict[str, Any]]:
+    uid = int(current_user["id"])
+    init_db()
+    return _frontend_recommendations(uid, payload.interest_ids)
+
+
+@api.post("/api/onboarding/profile")
+def save_onboarding_profile(
+    payload: OnboardingProfileRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.ingest import sync_sources
+
+    valid_interests = _interest_options()
+    interests = list(dict.fromkeys(payload.interest_ids))
+    invalid = [i for i in interests if i not in valid_interests]
+    if invalid:
+        raise HTTPException(status_code=400, detail=f"unknown interests: {', '.join(invalid)}")
+
+    uid = int(current_user["id"])
+    enabled_slugs = list(dict.fromkeys(payload.enabled_slugs))
+    sync_sources()
+    with connect() as conn:
+        if enabled_slugs:
+            rows = conn.execute(
+                "SELECT slug FROM sources WHERE owner_user_id IS NULL AND slug = ANY(%s)",
+                (enabled_slugs,),
+            ).fetchall()
+            allowed = {str(row["slug"]) for row in rows}
+            missing = [slug for slug in enabled_slugs if slug not in allowed]
+            if missing:
+                raise HTTPException(
+                    status_code=404, detail=f"unknown global sources: {', '.join(missing)}"
+                )
+
+        conn.execute(
+            """
+            INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
+            VALUES (%s, %s, NOW(), NOW())
+            ON CONFLICT(user_id) DO UPDATE SET
+              interests = excluded.interests,
+              completed_at = NOW(),
+              updated_at = NOW()
+            """,
+            (uid, Jsonb(interests)),
+        )
+        for slug in enabled_slugs:
+            conn.execute(
+                """
+                INSERT INTO user_sources(user_id, source_slug, enabled)
+                VALUES (%s, %s, TRUE)
+                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = TRUE
+                """,
+                (uid, slug),
+            )
+
+    return {"completed": True}
 
 
 @api.get("/api/onboarding/source-recommendations")

--- a/backend/tests/test_onboarding_interests.py
+++ b/backend/tests/test_onboarding_interests.py
@@ -40,9 +40,102 @@ def test_onboarding_interest_options_are_stable(
         response = client.get("/api/onboarding/interests")
 
     assert response.status_code == 200
-    groups = response.json()["groups"]
-    option_ids = {option["id"] for group in groups for option in group["options"]}
+    items = response.json()
+    assert isinstance(items, list)
+    option_ids = {item["id"] for item in items}
     assert {"agents", "model-releases", "evals", "infra", "python", "cloud"} <= option_ids
+    for item in items:
+        assert "id" in item
+        assert "label" in item
+        assert "description" in item
+
+
+def test_onboarding_status_incomplete_for_new_user(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.get("/api/onboarding/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"completed": False}
+
+
+def test_onboarding_status_complete_after_profile_save(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        client.post(
+            "/api/onboarding/profile",
+            json={"interest_ids": ["agents"], "enabled_slugs": []},
+        )
+        response = client.get("/api/onboarding/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"completed": True}
+
+
+def test_onboarding_recommendations_post_returns_ranked_sources(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.post(
+            "/api/onboarding/recommendations",
+            json={"interest_ids": ["agents", "python"]},
+        )
+
+    assert response.status_code == 200
+    items = response.json()
+    assert isinstance(items, list)
+    assert len(items) > 0
+    slugs = {item["slug"] for item in items}
+    assert "langgraph-releases" in slugs
+    first = items[0]
+    assert "slug" in first
+    assert "name" in first
+    assert "recommended" in first
+
+
+def test_save_onboarding_profile_persists_and_marks_complete(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.post(
+            "/api/onboarding/profile",
+            json={"interest_ids": ["agents", "python"], "enabled_slugs": ["langgraph-releases"]},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"completed": True}
+    with connect(pg_clean) as conn:
+        profile = conn.execute(
+            "SELECT interests, completed_at FROM user_interest_profiles WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()
+        sub = conn.execute(
+            "SELECT enabled FROM user_sources"
+            " WHERE user_id = %s AND source_slug = 'langgraph-releases'",
+            (user_id,),
+        ).fetchone()
+    assert profile is not None
+    assert profile["interests"] == ["agents", "python"]
+    assert profile["completed_at"] is not None
+    assert sub is not None
+    assert sub["enabled"] is True
 
 
 def test_onboarding_recommendations_rank_matches_and_subscription_state(

--- a/frontend/src/__tests__/onboardingWizard.test.tsx
+++ b/frontend/src/__tests__/onboardingWizard.test.tsx
@@ -243,6 +243,29 @@ describe('OnboardingWizard', () => {
     // Loading state should be visible
     expect(screen.getByTestId('onboarding-loading')).toBeTruthy();
   });
+
+  it('preselects recommended sources after recommendation data loads on step 2', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    vi.spyOn(api, 'fetchOnboardingSourceRecommendations').mockResolvedValue(MOCK_RECOMMENDATIONS);
+    const save = vi.spyOn(api, 'saveOnboardingInterests').mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps({ onClose })} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    fireEvent.click(screen.getByText('Technology'));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => expect(screen.getByText('Hacker News')).toBeTruthy());
+    // Apply without manually selecting — recommended sources should already be selected
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+    await waitFor(() => expect(save).toHaveBeenCalled());
+    const payload = save.mock.calls[0][0];
+    // Both recommended sources should be in the enabled list
+    expect(payload.enabled_slugs).toContain('hn');
+    expect(payload.enabled_slugs).toContain('arxiv');
+  });
 });
 
 // ── API functions ─────────────────────────────────────────────────────────────

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 import {
@@ -29,6 +29,7 @@ export function OnboardingWizard({ open, onClose }: Props) {
   const [step, setStep] = useState<Step>('interests');
   const [selectedInterests, setSelectedInterests] = useState<Set<string>>(new Set());
   const [selectedSlugs, setSelectedSlugs] = useState<Set<string>>(new Set());
+  const didPreselect = useRef(false);
 
   const { data: interests, isLoading: loadingInterests } = useQuery({
     queryKey: ['onboarding-interests'],
@@ -43,6 +44,13 @@ export function OnboardingWizard({ open, onClose }: Props) {
     enabled: step === 'recommendations' && selectedInterests.size > 0,
     staleTime: Infinity,
   });
+
+  useEffect(() => {
+    if (step === 'recommendations' && !didPreselect.current && recommendations.length > 0) {
+      didPreselect.current = true;
+      setSelectedSlugs(new Set(recommendations.filter((r) => r.recommended).map((r) => r.slug)));
+    }
+  }, [step, recommendations]);
 
   const saveMutation = useMutation({
     mutationFn: saveOnboardingInterests,
@@ -85,10 +93,8 @@ export function OnboardingWizard({ open, onClose }: Props) {
     setStep('interests');
   }
 
-  // Pre-select recommended sources when moving to step 2
   function handleGoToRecommendations() {
-    const preselected = recommendations.filter((r) => r.recommended).map((r) => r.slug);
-    setSelectedSlugs(new Set(preselected));
+    didPreselect.current = false;
     setStep('recommendations');
   }
 


### PR DESCRIPTION
Closes #457

## Summary

- **Add `GET /api/onboarding/status`** — returns `{completed: bool}` by checking whether the user has a `completed_at` timestamp in their interest profile.
- **Change `GET /api/onboarding/interests`** — now returns a flat `[{id, label, description}]` list instead of the grouped `{groups:[...]}` shape, matching the `OnboardingInterest[]` type the frontend already expects.
- **Add `POST /api/onboarding/recommendations`** — accepts `{interest_ids: [...]}` and returns source recommendations using the frontend field-name contract (`slug`, `name`) instead of `source_slug`/`source_name`.
- **Add `POST /api/onboarding/profile`** — accepts `{interest_ids: [...], enabled_slugs: [...]}` and persists the interest profile with `completed_at` set.
- **Fix preselection bug in `OnboardingWizard`** — recommended sources are now preselected via a `useEffect` that fires once recommendation data loads, rather than at "Next" click time when the query has not yet run.

## Test plan

- [x] `pytest backend/tests/test_onboarding_interests.py` — 8 tests pass (4 new tests added for status, POST recommendations, POST profile)
- [x] `npm run test:frontend -- --run frontend/src/__tests__/onboardingWizard.test.tsx` — 19 tests pass (1 new preselection test added)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `make typecheck` (mypy + ty + pyrefly) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)