### PR TITLE
fix: route shared push notifications to inbox (#458)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -779,6 +779,8 @@ def _notify_share_recipient(*, to_user_id: int, sender: str, article_title: str)
         to_user_id,
         f"{sender} shared an article",
         article_title,
+        target_url="/shared",
+        tag="shared-article",
     )
 
 

--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -103,6 +103,7 @@ def send_push_notification(
     title: str,
     body: str,
     target_url: str | None = None,
+    tag: str | None = None,
 ) -> PushDeliveryResult:
     """Send a single Web Push notification to the given subscription."""
     try:
@@ -114,6 +115,8 @@ def send_push_notification(
     data: dict[str, str] = {"title": title, "body": body}
     if target_url is not None:
         data["url"] = target_url
+    if tag is not None:
+        data["tag"] = tag
     payload = json.dumps(data)
     try:
         webpush(
@@ -210,6 +213,7 @@ def send_push_for_user(
     body: str,
     *,
     target_url: str | None = None,
+    tag: str | None = None,
     database_url: str | None = None,
 ) -> None:
     """Send a push notification to all subscriptions registered by a user."""
@@ -222,6 +226,7 @@ def send_push_for_user(
             title=title,
             body=body,
             target_url=target_url,
+            tag=tag,
         )
         if result == "gone":
             delete_push_subscriptions(

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -227,6 +227,37 @@ def test_send_push_notification_payload_with_url(monkeypatch: pytest.MonkeyPatch
     assert payload == {"title": "T", "body": "B", "url": "/briefs/42"}
 
 
+def test_send_push_notification_payload_with_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    import news_dashboard.push as push_mod
+
+    monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
+
+    mock_webpush = MagicMock()
+
+    class _FakeWebPushError(Exception):
+        pass
+
+    fake_module: dict[str, Any] = {
+        "webpush": mock_webpush,
+        "WebPushException": _FakeWebPushError,
+    }
+    with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
+        push_mod.send_push_notification(
+            endpoint="https://ep.example.com",
+            p256dh="abc",
+            auth="xyz",
+            title="T",
+            body="B",
+            target_url="/shared",
+            tag="shared-article",
+        )
+
+    payload = json.loads(mock_webpush.call_args.kwargs["data"])
+    assert payload == {"title": "T", "body": "B", "url": "/shared", "tag": "shared-article"}
+
+
 def test_send_push_notification_logs_on_webpush_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -286,6 +317,25 @@ def test_send_push_for_user_calls_send_for_each_sub(
         send_push_for_user(uid, "Brief ready", "", database_url=pg_clean)
 
     assert mock_send.call_count == 2
+
+
+def test_notify_share_recipient_routes_push_to_shared_inbox() -> None:
+    from news_dashboard.main import _notify_share_recipient
+
+    with patch("news_dashboard.push.send_push_for_user") as mock_send:
+        _notify_share_recipient(
+            to_user_id=42,
+            sender="alice",
+            article_title="Interesting article",
+        )
+
+    mock_send.assert_called_once_with(
+        42,
+        "alice shared an article",
+        "Interesting article",
+        target_url="/shared",
+        tag="shared-article",
+    )
 
 
 # ── API endpoints ──────────────────────────────────────────────────────────────

--- a/frontend/src/__tests__/pushHandler.test.ts
+++ b/frontend/src/__tests__/pushHandler.test.ts
@@ -114,6 +114,38 @@ describe('push event — payload handling', () => {
       expect.objectContaining({ data: { url: '/' } })
     );
   });
+
+  it('uses explicit notification tag from payload', () => {
+    const ev = makePushEvent({
+      title: 'Shared',
+      body: 'Article',
+      url: '/shared',
+      tag: 'shared-article',
+    });
+    fireEvent('push', ev);
+    expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+      'Shared',
+      expect.objectContaining({ tag: 'shared-article', data: { url: '/shared' } })
+    );
+  });
+
+  it('keeps daily brief tag when payload has no tag', () => {
+    const ev = makePushEvent({ title: 'Brief', body: 'Ready', url: '/briefs/99' });
+    fireEvent('push', ev);
+    expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+      'Brief',
+      expect.objectContaining({ tag: 'daily-brief' })
+    );
+  });
+
+  it('rejects unsafe notification tag and falls back to daily brief', () => {
+    const ev = makePushEvent({ title: 'T', body: 'B', tag: '../../bad' });
+    fireEvent('push', ev);
+    expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+      'T',
+      expect.objectContaining({ tag: 'daily-brief' })
+    );
+  });
 });
 
 // ── notificationclick event tests ─────────────────────────────────────────────

--- a/public/push-handler.js
+++ b/public/push-handler.js
@@ -7,15 +7,22 @@ function _safeUrl(url) {
   return '/';
 }
 
+function _safeTag(tag) {
+  if (typeof tag !== 'string' || !/^[A-Za-z0-9_-]{1,64}$/.test(tag)) return 'daily-brief';
+  return tag;
+}
+
 self.addEventListener('push', function (event) {
   let title = 'Daily Brief';
   let body = 'Your daily brief is ready.';
   let targetUrl = '/';
+  let tag = 'daily-brief';
   try {
     const data = event.data ? event.data.json() : {};
     if (data.title) title = data.title;
     if (data.body) body = data.body;
     if (data.url) targetUrl = _safeUrl(data.url);
+    if (data.tag) tag = _safeTag(data.tag);
   } catch {
     // keep defaults if payload is not valid JSON
   }
@@ -24,7 +31,7 @@ self.addEventListener('push', function (event) {
       body,
       icon: '/icons/icon-192.png',
       badge: '/icons/icon-monochrome-512.png',
-      tag: 'daily-brief',
+      tag,
       renotify: true,
       data: { url: targetUrl },
     })
@@ -34,22 +41,18 @@ self.addEventListener('push', function (event) {
 self.addEventListener('notificationclick', function (event) {
   event.notification.close();
   const targetUrl = _safeUrl(
-    event.notification.data && event.notification.data.url
-      ? event.notification.data.url
-      : '/'
+    event.notification.data && event.notification.data.url ? event.notification.data.url : '/'
   );
   event.waitUntil(
-    clients
-      .matchAll({ type: 'window', includeUncontrolled: true })
-      .then(function (windowClients) {
-        for (const client of windowClients) {
-          if (client.url.endsWith(targetUrl) && 'focus' in client) {
-            return client.focus();
-          }
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (windowClients) {
+      for (const client of windowClients) {
+        if (client.url.endsWith(targetUrl) && 'focus' in client) {
+          return client.focus();
         }
-        if (clients.openWindow) {
-          return clients.openWindow(targetUrl);
-        }
-      })
+      }
+      if (clients.openWindow) {
+        return clients.openWindow(targetUrl);
+      }
+    })
   );
 });


### PR DESCRIPTION
Closes #458

## Summary
- add optional push notification tags to backend payload serialization and fanout
- route shared article push notifications to `/shared` with a distinct `shared-article` tag
- let the service worker use safe explicit tags while keeping `daily-brief` as the default

## Tests
- `pytest backend/tests/test_push_notifications.py`
- `npm run test:frontend -- --run frontend/src/__tests__/pushHandler.test.ts`
- `make lint`
- `make typecheck`

Generated by codex automation.