### PR TITLE
fix: keep Later reachable on mobile via More sheet (#461)

### DIFF
--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -60,9 +60,11 @@ test.describe('Mobile — navigation', () => {
     await expect(page.locator('h1').filter({ hasText: 'Today' })).toBeVisible();
   });
 
-  test('tapping Later in mobile nav goes to /later', async ({ page }) => {
+  test('Later is reachable from the More sheet', async ({ page }) => {
     await page.goto('/');
-    await page.locator('nav.fixed a[href="/later"]').first().click();
+    await page.getByRole('button', { name: 'More' }).click();
+    const sheet = page.getByRole('dialog');
+    await sheet.getByRole('link', { name: 'Later' }).click();
     await expect(page).toHaveURL('/later');
   });
 
@@ -98,6 +100,13 @@ test.describe('Mobile — header', () => {
     await expect(sheet.getByText('Stats')).toBeVisible();
     await expect(sheet.getByText('Archive')).toBeVisible();
     await expect(sheet.getByText('Settings')).toBeVisible();
+  });
+
+  test('More sheet exposes Later in primary overflow', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'More' }).click();
+    const sheet = page.getByRole('dialog');
+    await expect(sheet.getByRole('link', { name: 'Later' })).toBeVisible();
   });
 });
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -126,10 +126,14 @@ test.describe('Mobile bottom navigation', () => {
     await expect(todayLink).toBeVisible();
   });
 
-  test('shows Later in mobile nav', async ({ page }) => {
+  test('Later is absent from fixed mobile nav but reachable from More sheet', async ({ page }) => {
     await page.goto('/');
-    const laterLink = page.locator('nav.fixed a[href="/later"]').first();
-    await expect(laterLink).toBeVisible();
+    // Later must not be in the fixed bottom bar.
+    await expect(page.locator('nav.fixed a[href="/later"]')).toHaveCount(0);
+    // Later must be reachable via the More sheet.
+    await page.getByRole('button', { name: 'More' }).click();
+    const sheet = page.getByRole('dialog');
+    await expect(sheet.getByRole('link', { name: 'Later' })).toBeVisible();
   });
 
   test('shows Starred in mobile nav', async ({ page }) => {

--- a/frontend/src/__tests__/navigation.test.ts
+++ b/frontend/src/__tests__/navigation.test.ts
@@ -4,6 +4,7 @@ import {
   getPageTitle,
   getShortcutTarget,
   isNavigationItemActive,
+  mobilePrimaryOverflowItems,
   mobileNavigationItems,
   primaryNavigationItems,
   secondaryNavigationItems,
@@ -38,6 +39,15 @@ describe('navigation metadata', () => {
     expect(mobileTargets).toEqual(['/', '/today', '/shared', '/starred', '/search']);
     expect(mobileTargets).toContain('/shared');
     expect(mobileTargets).not.toContain('/later');
+  });
+
+  it('puts Later (and Ask) in the mobile primary overflow for the More sheet', () => {
+    const overflowTargets = mobilePrimaryOverflowItems.map((item) => item.to);
+    expect(overflowTargets).toContain('/later');
+    expect(overflowTargets).toContain('/ask');
+    // Overflow must not duplicate items already in the bottom bar.
+    expect(overflowTargets).not.toContain('/shared');
+    expect(overflowTargets).not.toContain('/');
   });
 
   it('matches exact roots but prefix-matches nested families', () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -19,6 +19,7 @@ import {
   getPageTitle,
   getShortcutTarget,
   isNavigationItemActive,
+  mobilePrimaryOverflowItems,
   mobileNavigationItems,
   primaryNavigationItems,
   secondaryNavigationItemsFor,
@@ -241,6 +242,29 @@ export function AppShell() {
                   )}
                 </SheetHeader>
                 <nav className="p-2">
+                  {mobilePrimaryOverflowItems.map((m) => {
+                    const Icon = m.icon;
+                    const active = isNavigationItemActive(m.to, pathname);
+                    return (
+                      <Link
+                        key={m.to}
+                        to={m.to}
+                        onClick={() => setMoreOpen(false)}
+                        className={cn(
+                          'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm',
+                          active
+                            ? 'bg-surface-2 text-foreground'
+                            : 'text-muted-foreground hover:bg-surface hover:text-foreground'
+                        )}
+                      >
+                        <Icon className="size-4" />
+                        {m.label}
+                      </Link>
+                    );
+                  })}
+                  {mobilePrimaryOverflowItems.length > 0 && (
+                    <div className="mx-1 my-1 h-px bg-border" />
+                  )}
                   {secondaryNavigationItemsFor(Boolean(user?.is_admin)).map((m) => {
                     const Icon = m.icon;
                     const active = isNavigationItemActive(m.to, pathname);

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -63,11 +63,18 @@ export function secondaryNavigationItemsFor(isAdmin: boolean): NavigationItem[] 
 // bar. Mobile surfaces Shared (articles sent to you by other people) here in
 // place of Later, which remains reachable on desktop.
 const mobileNavigationOrder = ['/', '/today', '/shared', '/starred', '/search'];
+const mobileNavigationSet = new Set(mobileNavigationOrder);
 const primaryNavigationByTo = new Map(primaryNavigationItems.map((item) => [item.to, item]));
 export const mobileNavigationItems = mobileNavigationOrder.flatMap((to) => {
   const item = primaryNavigationByTo.get(to);
   return item ? [item] : [];
 });
+
+// Primary destinations omitted from the mobile bottom bar (e.g. Later, Ask).
+// Rendered in the mobile More sheet so they remain reachable on small screens.
+export const mobilePrimaryOverflowItems = primaryNavigationItems.filter(
+  (item) => !mobileNavigationSet.has(item.to)
+);
 
 export const commandNavigationItems = [...primaryNavigationItems, ...secondaryNavigationItems].map(
   (item) => ({


### PR DESCRIPTION
## Summary

- Adds a `mobilePrimaryOverflowItems` export to `navigation.ts` — primary nav destinations excluded from the 5-slot mobile bottom bar (currently `/later` and `/ask`).
- Renders those items as a short overflow group at the top of the More sheet in `AppShell.tsx`, separated from secondary nav by a divider.
- The fixed mobile bottom bar remains unchanged (Brief / Today / Shared / Starred / Search).
- Desktop rail behavior is unchanged.

## Test results

- Unit tests: 6/6 pass (`mobilePrimaryOverflowItems` contains `/later` and `/ask`, not `/shared`)
- ESLint, Prettier, TypeScript: all pass
- Updated `mobile.spec.ts` and `navigation.spec.ts` to assert Later is absent from `nav.fixed` but visible in the More sheet

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)