### PR TITLE
fix: pass dummy sessionSecret in helm-validate defaults render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,8 @@ jobs:
         run: |
           helm template news-dashboard ./helm/news-dashboard \
             --set "postgresql.enabled=false" \
-            --set "app.databaseUrl.existingSecret=news-dashboard-db"
+            --set "app.databaseUrl.existingSecret=news-dashboard-db" \
+            --set-string "app.auth.sessionSecret=dummy-session-secret-for-render-only"
 
   # ── 7. PUBLISH ─────────────────────────────────────────────────────────────
   # Builds one image and pushes two tags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,9 @@ jobs:
         run: helm lint ./helm/news-dashboard
 
       - name: helm template (defaults)
-        run: helm template news-dashboard ./helm/news-dashboard
+        run: |
+          helm template news-dashboard ./helm/news-dashboard \
+            --set-string "app.auth.sessionSecret=dummy-session-secret-for-render-only"
 
       - name: helm template (production-like overrides)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ helm-validate:
 		--set "postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data"
 	helm template news-dashboard ./helm/news-dashboard \
 		--set "postgresql.enabled=false" \
-		--set "app.databaseUrl.existingSecret=news-dashboard-db"
+		--set "app.databaseUrl.existingSecret=news-dashboard-db" \
+		--set-string "app.auth.sessionSecret=dummy-session-secret-for-render-only"
 
 ## check: everything CI runs — lint, typecheck, test, build
 check: lint typecheck test build

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ test-full: test-nightly
 ## helm-validate: lint and render the Helm chart with default and production-like values
 helm-validate:
 	helm lint ./helm/news-dashboard
-	helm template news-dashboard ./helm/news-dashboard
+	helm template news-dashboard ./helm/news-dashboard \
+		--set-string "app.auth.sessionSecret=dummy-session-secret-for-render-only"
 	helm template news-dashboard ./helm/news-dashboard \
 		--set "image.tag=abc1234" \
 		--set "image.pullSecretName=ghcr-pull-secret" \


### PR DESCRIPTION
## Summary

Follow-up to #513 / #463.

The `helm-validate` CI job added in #513 fails on the defaults render step because the Helm chart's `auth-secret.yaml` uses `{{ required ... .Values.app.auth.sessionSecret }}`, which errors when the value is empty — even in a render-only context.

Pass a harmless dummy string for both the CI defaults render and the local `make helm-validate` defaults step so the check passes correctly.

## Test plan

- [ ] `Helm chart validation` CI job passes on this PR (all three render steps: defaults, production-like overrides, external postgresql)

🤖 Generated with [Claude Code](https://claude.com/claude-code)