### PR TITLE
feat: expose shared article workspace UI (#467)

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -9,6 +9,7 @@ import { LoginPage } from './pages/LoginPage';
 import { BriefPage } from './pages/BriefPage';
 import { InboxPage } from './pages/InboxPage';
 import { SharedPage } from './pages/SharedPage';
+import { SharedDetailPage } from './pages/SharedDetailPage';
 import { LaterPage } from './pages/LaterPage';
 import { StarredPage } from './pages/StarredPage';
 import { FeedsPage } from './pages/FeedsPage';
@@ -113,6 +114,7 @@ export const routes: RouteObject[] = [
       { path: 'later', element: <LaterPage /> },
       { path: 'starred', element: <StarredPage /> },
       { path: 'shared', element: <SharedPage /> },
+      { path: 'shared/:shareId', element: <SharedDetailPage /> },
       { path: 'search', element: withSuspense(SearchPage) },
       { path: 'ask', element: withSuspense(AskPage) },
       {

--- a/frontend/src/__tests__/shared.test.tsx
+++ b/frontend/src/__tests__/shared.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+
+// ── API mock ─────────────────────────────────────────────────────────────────
+const apiMock = vi.hoisted(() => ({
+  fetchReceivedShares: vi.fn(),
+  markShareRead: vi.fn(),
+  fetchShareDetail: vi.fn(),
+  fetchShareMessages: vi.fn(),
+  postShareMessage: vi.fn(),
+}));
+vi.mock('../api', () => apiMock);
+vi.mock('@/api', () => apiMock);
+
+// Auth context — provides a logged-in user
+vi.mock('../contexts/auth', () => ({
+  useAuth: () => ({ user: { id: 1, username: 'alice', is_admin: false }, setUser: vi.fn() }),
+}));
+
+import { SharedPage } from '../pages/SharedPage';
+import { SharedDetailPage } from '../pages/SharedDetailPage';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeShare(overrides = {}) {
+  return {
+    id: 42,
+    note: 'Check this out',
+    context_summary: null,
+    created_at: new Date(Date.now() - 60_000).toISOString(),
+    read_at: null,
+    from_user_id: 2,
+    from_username: 'bob',
+    article_id: 99,
+    article_title: 'The Future of TypeScript',
+    article_url: 'https://example.com/ts',
+    article_source_name: 'Tech Blog',
+    article_summary: null,
+    annotations: [],
+    messages: [],
+    ...overrides,
+  };
+}
+
+function renderWithRouter(ui: ReactElement, { path = '/', route = '/' } = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[route]}>
+        <Routes>
+          <Route path={path} element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ── SharedPage ────────────────────────────────────────────────────────────────
+
+describe('SharedPage', () => {
+  beforeEach(() => {
+    apiMock.markShareRead.mockResolvedValue(true);
+  });
+
+  it('shows empty state when no shares', async () => {
+    apiMock.fetchReceivedShares.mockResolvedValue({ items: [] });
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+    await waitFor(() => expect(screen.getByText('Nothing shared yet')).toBeTruthy());
+  });
+
+  it('renders a share item with title linking to the detail view', async () => {
+    apiMock.fetchReceivedShares.mockResolvedValue({ items: [makeShare()] });
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+    await waitFor(() => expect(screen.getByText('The Future of TypeScript')).toBeTruthy());
+
+    const titleLink = screen.getByRole('link', { name: 'The Future of TypeScript' });
+    expect(titleLink.getAttribute('href')).toBe('/shared/42');
+
+    const viewLink = screen.getByRole('link', { name: 'View' });
+    expect(viewLink.getAttribute('href')).toBe('/shared/42');
+  });
+
+  it('still shows the Original external link', async () => {
+    apiMock.fetchReceivedShares.mockResolvedValue({ items: [makeShare()] });
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+    await waitFor(() => expect(screen.getByText('The Future of TypeScript')).toBeTruthy());
+    const original = screen.getByRole('link', { name: /Original/ });
+    expect(original.getAttribute('href')).toBe('https://example.com/ts');
+  });
+});
+
+// ── SharedDetailPage ──────────────────────────────────────────────────────────
+
+describe('SharedDetailPage', () => {
+  it('shows a loading skeleton while fetching', () => {
+    apiMock.fetchShareDetail.mockReturnValue(new Promise(vi.fn()));
+    renderWithRouter(<SharedDetailPage />, { path: '/shared/:shareId', route: '/shared/42' });
+    // skeleton divs are rendered during loading
+    expect(screen.getByText('Shared with me')).toBeTruthy();
+  });
+
+  it('renders article metadata, sender note, and context summary', async () => {
+    apiMock.fetchShareDetail.mockResolvedValue(
+      makeShare({ context_summary: 'This matters because TypeScript ships faster now.' })
+    );
+    renderWithRouter(<SharedDetailPage />, { path: '/shared/:shareId', route: '/shared/42' });
+    await waitFor(() => expect(screen.getByText('The Future of TypeScript')).toBeTruthy());
+
+    expect(screen.getByText('Tech Blog')).toBeTruthy();
+    expect(screen.getByText(/Check this out/)).toBeTruthy();
+    expect(screen.getByText('This matters because TypeScript ships faster now.')).toBeTruthy();
+
+    const readLink = screen.getByRole('link', { name: 'Read article' });
+    expect(readLink.getAttribute('href')).toBe('/a/99');
+
+    const origLink = screen.getByRole('link', { name: /Original/ });
+    expect(origLink.getAttribute('href')).toBe('https://example.com/ts');
+  });
+
+  it('renders annotations as a highlight list', async () => {
+    const annotations = [
+      {
+        id: 1,
+        share_id: 42,
+        highlighted_text: 'TypeScript is amazing',
+        offset_chars: 0,
+        note: 'Key insight',
+        created_at: new Date().toISOString(),
+      },
+    ];
+    apiMock.fetchShareDetail.mockResolvedValue(makeShare({ annotations }));
+    renderWithRouter(<SharedDetailPage />, { path: '/shared/:shareId', route: '/shared/42' });
+    await waitFor(() => expect(screen.getByText(/"TypeScript is amazing"/)).toBeTruthy());
+    expect(screen.getByText('Key insight')).toBeTruthy();
+  });
+
+  it('renders the message thread', async () => {
+    const messages = [
+      {
+        id: 1,
+        share_id: 42,
+        user_id: 2,
+        username: 'bob',
+        message: 'What do you think?',
+        created_at: new Date().toISOString(),
+      },
+    ];
+    apiMock.fetchShareDetail.mockResolvedValue(makeShare({ messages }));
+    renderWithRouter(<SharedDetailPage />, { path: '/shared/:shareId', route: '/shared/42' });
+    await waitFor(() => expect(screen.getByText('What do you think?')).toBeTruthy());
+    // 'bob' appears as sender in the header and as message author — both should be present
+    expect(screen.getAllByText('bob').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('submits a new message and refreshes the thread', async () => {
+    apiMock.fetchShareDetail.mockResolvedValue(makeShare());
+    apiMock.postShareMessage.mockResolvedValue({
+      id: 10,
+      share_id: 42,
+      user_id: 1,
+      username: 'alice',
+      message: 'Great article!',
+      created_at: new Date().toISOString(),
+    });
+
+    renderWithRouter(<SharedDetailPage />, { path: '/shared/:shareId', route: '/shared/42' });
+    await waitFor(() => expect(screen.getByPlaceholderText('Add a message…')).toBeTruthy());
+
+    const textarea = screen.getByPlaceholderText('Add a message…');
+    fireEvent.change(textarea, { target: { value: 'Great article!' } });
+    fireEvent.click(screen.getByRole('button', { name: /Send/ }));
+
+    await waitFor(() =>
+      expect(apiMock.postShareMessage).toHaveBeenCalledWith(42, 'Great article!')
+    );
+  });
+
+  it('shows an error state when the share cannot be loaded', async () => {
+    apiMock.fetchShareDetail.mockRejectedValue(new Error('Share not found.'));
+    renderWithRouter(<SharedDetailPage />, { path: '/shared/:shareId', route: '/shared/42' });
+    await waitFor(() => expect(screen.getByText('Share not found.')).toBeTruthy());
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -25,6 +25,8 @@ import type {
   ReadingGoal,
   RecommendationPreferences,
   ReceivedShare,
+  ShareDetail,
+  ShareMessage,
   SaveOnboardingProfileRequest,
   ShareableUser,
   Source,
@@ -564,6 +566,21 @@ export async function submitQuiz(quizId: number, answers: number[]): Promise<Qui
 
 export async function markShareRead(shareId: number): Promise<void> {
   await requestJson(`/api/shares/${shareId}/read`, { method: 'POST' });
+}
+
+export async function fetchShareDetail(shareId: number): Promise<ShareDetail> {
+  return requestJson<ShareDetail>(`/api/shares/${shareId}`);
+}
+
+export async function fetchShareMessages(shareId: number): Promise<{ items: ShareMessage[] }> {
+  return requestJson<{ items: ShareMessage[] }>(`/api/shares/${shareId}/messages`);
+}
+
+export async function postShareMessage(shareId: number, message: string): Promise<ShareMessage> {
+  return requestJson<ShareMessage>(`/api/shares/${shareId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({ message }),
+  });
 }
 
 export async function fetchTopicMap(): Promise<TopicMapResponse> {

--- a/frontend/src/pages/SharedDetailPage.tsx
+++ b/frontend/src/pages/SharedDetailPage.tsx
@@ -1,0 +1,232 @@
+import { useState, useRef, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, ExternalLink, Sparkles, MessageSquare, Highlighter, Send } from 'lucide-react';
+import { fetchShareDetail, postShareMessage } from '@/api';
+import { relativeTime } from '@/lib/format';
+import { useAuth } from '@/contexts/auth';
+
+function BackLink() {
+  return (
+    <Link
+      to="/shared"
+      className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <ArrowLeft className="size-3.5" />
+      Shared with me
+    </Link>
+  );
+}
+
+export function SharedDetailPage() {
+  const { shareId } = useParams<{ shareId: string }>();
+  const id = shareId ? parseInt(shareId, 10) : NaN;
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const [draft, setDraft] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const {
+    data: share,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['share', id],
+    queryFn: () => fetchShareDetail(id),
+    enabled: !isNaN(id),
+    retry: false,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (message: string) => postShareMessage(id, message),
+    onSuccess: () => {
+      setDraft('');
+      void queryClient.invalidateQueries({ queryKey: ['share', id] });
+    },
+  });
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const msg = draft.trim();
+    if (!msg || mutation.isPending) return;
+    mutation.mutate(msg);
+  }
+
+  if (isNaN(id)) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-6">
+        <BackLink />
+        <p className="mt-4 text-sm text-destructive">Invalid share link.</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-6">
+        <BackLink />
+        <div className="mt-6 space-y-3">
+          {[1, 2, 3].map((n) => (
+            <div key={n} className="h-5 animate-pulse rounded bg-surface-2" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !share) {
+    const msg = error instanceof Error ? error.message : 'Share not found.';
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-6">
+        <BackLink />
+        <p className="mt-4 text-sm text-destructive">{msg}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-6 space-y-5">
+      <BackLink />
+
+      {/* Article header */}
+      <div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
+          <span className="font-medium text-foreground">{share.from_username}</span>
+          <span>shared · {relativeTime(share.created_at)}</span>
+        </div>
+        <h1 className="text-lg font-semibold text-foreground leading-snug">
+          {share.article_title}
+        </h1>
+        <p className="mt-0.5 text-xs text-muted-foreground">{share.article_source_name}</p>
+
+        <div className="mt-3 flex items-center gap-4 text-xs">
+          <Link to={`/a/${share.article_id}`} className="text-accent-foreground hover:underline">
+            Read article
+          </Link>
+          <a
+            href={share.article_url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+          >
+            Original <ExternalLink className="size-3" />
+          </a>
+        </div>
+      </div>
+
+      {/* Sender note */}
+      {share.note ? (
+        <div className="rounded-md border border-border bg-surface-2 px-3 py-2.5 text-sm text-foreground">
+          <p className="mb-0.5 text-xs font-medium text-muted-foreground">
+            Note from {share.from_username}
+          </p>
+          <p>"{share.note}"</p>
+        </div>
+      ) : null}
+
+      {/* AI context summary */}
+      {share.context_summary ? (
+        <div className="rounded-md border border-border bg-surface px-3 py-2.5 text-sm text-foreground">
+          <div className="flex items-center gap-1.5 mb-1 text-xs font-medium text-muted-foreground">
+            <Sparkles className="size-3.5" />
+            Why this is relevant to you
+          </div>
+          <p>{share.context_summary}</p>
+        </div>
+      ) : null}
+
+      {/* Annotations */}
+      {share.annotations && share.annotations.length > 0 ? (
+        <div>
+          <div className="flex items-center gap-1.5 mb-2 text-xs font-medium text-muted-foreground">
+            <Highlighter className="size-3.5" />
+            Highlights
+          </div>
+          <ul className="space-y-2">
+            {share.annotations.map((ann) => (
+              <li key={ann.id} className="rounded-md border border-border bg-surface px-3 py-2">
+                <p className="text-sm text-foreground border-l-2 border-accent-foreground pl-2">
+                  "{ann.highlighted_text}"
+                </p>
+                {ann.note ? <p className="mt-1 text-xs text-muted-foreground">{ann.note}</p> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* Message thread */}
+      <div>
+        <div className="flex items-center gap-1.5 mb-2 text-xs font-medium text-muted-foreground">
+          <MessageSquare className="size-3.5" />
+          Discussion
+        </div>
+
+        {share.messages && share.messages.length > 0 ? (
+          <ul className="space-y-2 mb-3">
+            {share.messages.map((msg) => {
+              const isMe = user?.username === msg.username;
+              return (
+                <li
+                  key={msg.id}
+                  className={`rounded-md border border-border px-3 py-2 text-sm ${isMe ? 'bg-surface-2' : 'bg-surface'}`}
+                >
+                  <div className="flex items-center gap-1.5 mb-0.5 text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{msg.username}</span>
+                    <span>· {relativeTime(msg.created_at)}</span>
+                  </div>
+                  <p className="text-foreground">{msg.message}</p>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="text-xs text-muted-foreground mb-3">
+            No messages yet. Start the conversation.
+          </p>
+        )}
+
+        {/* Compose */}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Add a message…"
+            rows={2}
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                handleSubmit(e);
+              }
+            }}
+          />
+          <div className="flex items-center justify-between">
+            {mutation.isError ? (
+              <p className="text-xs text-destructive">
+                {mutation.error instanceof Error
+                  ? mutation.error.message
+                  : 'Failed to send message.'}
+              </p>
+            ) : (
+              <span className="text-xs text-muted-foreground">⌘↵ to send</span>
+            )}
+            <button
+              type="submit"
+              disabled={!draft.trim() || mutation.isPending}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-opacity disabled:opacity-50"
+            >
+              <Send className="size-3" />
+              {mutation.isPending ? 'Sending…' : 'Send'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SharedPage.tsx
+++ b/frontend/src/pages/SharedPage.tsx
@@ -68,7 +68,7 @@ export function SharedPage() {
               </div>
 
               <Link
-                to={`/a/${s.article_id}`}
+                to={`/shared/${s.id}`}
                 className="mt-1 block font-medium text-foreground hover:underline"
               >
                 {s.article_title}
@@ -77,13 +77,13 @@ export function SharedPage() {
 
               {s.note ? (
                 <div className="mt-2 rounded-md bg-surface-2 px-2.5 py-1.5 text-sm text-foreground">
-                  “{s.note}”
+                  "{s.note}"
                 </div>
               ) : null}
 
               <div className="mt-2 flex items-center gap-3 text-xs">
-                <Link to={`/a/${s.article_id}`} className="text-accent-foreground hover:underline">
-                  Read
+                <Link to={`/shared/${s.id}`} className="text-accent-foreground hover:underline">
+                  View
                 </Link>
                 <a
                   href={s.article_url}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -58,6 +58,7 @@ export interface ShareableUser {
 export interface ReceivedShare {
   id: number;
   note?: string | null;
+  context_summary?: string | null;
   created_at: string;
   read_at?: string | null;
   from_user_id: number;
@@ -67,6 +68,29 @@ export interface ReceivedShare {
   article_url: string;
   article_source_name: string;
   article_summary?: string | null;
+}
+
+export interface ShareAnnotation {
+  id: number;
+  share_id: number;
+  highlighted_text: string;
+  offset_chars: number;
+  note?: string | null;
+  created_at: string;
+}
+
+export interface ShareMessage {
+  id: number;
+  share_id: number;
+  user_id: number;
+  username: string;
+  message: string;
+  created_at: string;
+}
+
+export interface ShareDetail extends ReceivedShare {
+  annotations: ShareAnnotation[];
+  messages: ShareMessage[];
 }
 
 export interface Source {


### PR DESCRIPTION
## Summary

Closes #467

- Add `SharedDetailPage` at `/shared/:shareId` showing sender note, AI context summary, highlight annotations, and message thread with compose box
- Route SharedPage title links and "View" button to `/shared/:id` instead of directly to the article
- Add `fetchShareDetail`, `fetchShareMessages`, `postShareMessage` API helpers and `ShareDetail`, `ShareAnnotation`, `ShareMessage` types
- Keep "Read article" and "Original" links on the detail page so existing navigation is preserved

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npm run test:frontend` — 576/576 tests pass (9 new tests in `shared.test.tsx`)
- [x] `npm run build` — builds cleanly

New tests cover: SharedPage routes to detail view, SharedDetailPage renders metadata/note/context/annotations/messages, message submission, error state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)