### PR TITLE
ops: add scheduled PostgreSQL backup CronJob to Helm chart (#473)

### DIFF
--- a/docs/POSTGRES_BACKUP.md
+++ b/docs/POSTGRES_BACKUP.md
@@ -1,0 +1,119 @@
+# PostgreSQL Backup and Restore
+
+The Helm chart ships an optional scheduled backup CronJob that creates timestamped
+compressed PostgreSQL logical dumps (pg_dump custom format) and prunes old files
+according to a configurable retention policy.
+
+## Enabling backups
+
+Set the following values (override in your `values.yaml` or via `--set`):
+
+```yaml
+postgresql:
+  backup:
+    enabled: true
+    schedule: "0 2 * * *"      # daily at 02:00 UTC (cron syntax)
+    retentionDays: 7            # delete dumps older than this many days
+    hostPath: /home/ioachim-minipc/news-dashboard-postgres-backups
+```
+
+> **Important:** `hostPath` must be different from `postgresql.persistence.hostPath`
+> (the live data directory).  The CronJob mounts the backup directory separately
+> to prevent the retention cleanup from touching live data.
+
+Apply with:
+
+```bash
+helm upgrade news-dashboard ./helm/news-dashboard \
+  --set postgresql.backup.enabled=true \
+  --set postgresql.backup.hostPath=/home/ioachim-minipc/news-dashboard-postgres-backups \
+  --reuse-values
+```
+
+## Where dumps are stored
+
+Dumps are written to the configured `hostPath` directory on the cluster node with
+filenames of the form:
+
+```
+news_dashboard_20260628T020001Z.dump
+```
+
+Each dump uses `pg_dump -Fc` (custom binary format), which is compact, parallel-
+restore capable, and safe for long-term storage.
+
+## Triggering a manual backup
+
+You can run the backup job immediately without waiting for the schedule:
+
+```bash
+kubectl -n news-dashboard create job \
+  --from=cronjob/news-dashboard-news-dashboard-postgres-backup \
+  manual-backup-$(date +%Y%m%d)
+```
+
+Watch the job logs:
+
+```bash
+kubectl -n news-dashboard logs -l job-name=manual-backup-... -f
+```
+
+## Restoring a dump
+
+### 1. Copy the dump to a local machine (optional)
+
+```bash
+# From the node host, copy via scp or mount the backup directory directly.
+scp ioachim-minipc:/home/ioachim-minipc/news-dashboard-postgres-backups/news_dashboard_20260628T020001Z.dump .
+```
+
+### 2. Restore into the running Helm PostgreSQL pod
+
+```bash
+# Find the postgres pod name:
+POD=$(kubectl -n news-dashboard get pod -l app.kubernetes.io/name=news-dashboard-postgres -o jsonpath='{.items[0].metadata.name}')
+
+# Copy the dump into the pod:
+kubectl -n news-dashboard cp news_dashboard_20260628T020001Z.dump "${POD}:/tmp/restore.dump"
+
+# Drop and recreate the target database, then restore:
+kubectl -n news-dashboard exec -it "${POD}" -- bash -c "
+  psql -U news_dashboard -d postgres -c 'DROP DATABASE IF EXISTS news_dashboard;'
+  psql -U news_dashboard -d postgres -c 'CREATE DATABASE news_dashboard;'
+  pg_restore -U news_dashboard -d news_dashboard /tmp/restore.dump
+"
+```
+
+### 3. Restore into a fresh Helm deployment
+
+Deploy the chart without the application (or with replicas=0), then follow step 2.
+Once the restore is confirmed, scale the application back up:
+
+```bash
+kubectl -n news-dashboard scale deployment news-dashboard --replicas=1
+```
+
+## Verifying a dump (without restoring to production)
+
+```bash
+# Inspect the dump table of contents:
+pg_restore --list news_dashboard_20260628T020001Z.dump | head -40
+
+# Restore into a throwaway local container:
+docker run --rm -e POSTGRES_PASSWORD=test -p 5433:5432 -d --name pg-verify postgres:16-alpine
+sleep 3
+pg_restore -h 127.0.0.1 -p 5433 -U postgres -d postgres \
+  --create news_dashboard_20260628T020001Z.dump
+docker stop pg-verify
+```
+
+## Disabling backups
+
+```bash
+helm upgrade news-dashboard ./helm/news-dashboard \
+  --set postgresql.backup.enabled=false \
+  --reuse-values
+```
+
+This removes the CronJob from the cluster; existing dump files on the host are
+not deleted.

--- a/helm/news-dashboard/templates/postgres-backup-cronjob.yaml
+++ b/helm/news-dashboard/templates/postgres-backup-cronjob.yaml
@@ -1,0 +1,77 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.backup.enabled }}
+{{- if not .Values.postgresql.backup.hostPath }}
+  {{- fail "postgresql.backup.hostPath must be set when postgresql.backup.enabled=true" }}
+{{- end }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "news-dashboard.fullname" . }}-postgres-backup
+  labels:
+    app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-postgres-backup
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  schedule: {{ .Values.postgresql.backup.schedule | default "0 2 * * *" | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: postgres-backup
+              image: {{ .Values.postgresql.image | quote }}
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: PGHOST
+                  value: {{ printf "%s-postgres" (include "news-dashboard.fullname" .) | quote }}
+                - name: PGPORT
+                  value: {{ .Values.postgresql.port | quote }}
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "news-dashboard.fullname" . }}-postgres
+                      key: POSTGRES_DB
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "news-dashboard.fullname" . }}-postgres
+                      key: POSTGRES_USER
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "news-dashboard.fullname" . }}-postgres
+                      key: POSTGRES_PASSWORD
+                - name: BACKUP_DIR
+                  value: /backups
+                - name: RETENTION_DAYS
+                  value: {{ .Values.postgresql.backup.retentionDays | default 7 | quote }}
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+                  DUMP_FILE="${BACKUP_DIR}/${PGDATABASE}_${TIMESTAMP}.dump"
+                  echo "Starting backup: ${DUMP_FILE}"
+                  pg_dump -Fc -f "${DUMP_FILE}"
+                  echo "Backup complete. Pruning dumps older than ${RETENTION_DAYS} days."
+                  find "${BACKUP_DIR}" -maxdepth 1 -name "${PGDATABASE}_*.dump" -mtime "+${RETENTION_DAYS}" -delete
+                  echo "Done."
+              resources:
+                requests:
+                  cpu: {{ .Values.postgresql.backup.resources.requests.cpu | default "50m" | quote }}
+                  memory: {{ .Values.postgresql.backup.resources.requests.memory | default "64Mi" | quote }}
+                limits:
+                  cpu: {{ .Values.postgresql.backup.resources.limits.cpu | default "200m" | quote }}
+                  memory: {{ .Values.postgresql.backup.resources.limits.memory | default "128Mi" | quote }}
+              volumeMounts:
+                - name: postgres-backups
+                  mountPath: /backups
+          volumes:
+            - name: postgres-backups
+              hostPath:
+                path: {{ .Values.postgresql.backup.hostPath | quote }}
+                type: DirectoryOrCreate
+{{- end }}

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -111,6 +111,23 @@ postgresql:
     storageClassName: ""
     # Local single-node durable storage. This survives pod restarts/upgrades.
     hostPath: /home/ioachim-minipc/news-dashboard-postgres-data
+  backup:
+    # Set to true to enable scheduled PostgreSQL logical backups.
+    enabled: false
+    # Cron schedule for the backup job. Default: daily at 02:00.
+    schedule: "0 2 * * *"
+    # Number of days to retain backup files. Dumps older than this are pruned.
+    retentionDays: 7
+    # Host path for backup storage. Must differ from the live data hostPath.
+    # Example: /home/ioachim-minipc/news-dashboard-postgres-backups
+    hostPath: ""
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
 
 ingress:
   enabled: false

--- a/scripts/test_helm_postgres_backup.py
+++ b/scripts/test_helm_postgres_backup.py
@@ -1,0 +1,129 @@
+# ruff: noqa: S101
+"""Chart render tests for the postgresql.backup CronJob."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHART = ROOT / "helm" / "news-dashboard"
+
+
+def _helm_template(extra_sets: list[str]) -> str:
+    cmd = [
+        "helm",
+        "template",
+        "test-release",
+        str(CHART),
+        "--set",
+        "app.auth.sessionSecret=dummy-secret-for-test",
+        *extra_sets,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603
+    return result.stdout
+
+
+def test_backup_disabled_by_default() -> None:
+    rendered = _helm_template([])
+    assert "postgres-backup" not in rendered
+
+
+def test_backup_disabled_explicitly() -> None:
+    rendered = _helm_template(["--set", "postgresql.backup.enabled=false"])
+    assert "postgres-backup" not in rendered
+
+
+def test_backup_enabled_renders_cronjob() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "postgresql.backup.enabled=true",
+            "--set",
+            "postgresql.backup.hostPath=/mnt/backups",
+        ]
+    )
+    assert "kind: CronJob" in rendered
+    assert "postgres-backup" in rendered
+
+
+def test_backup_uses_postgres_secret() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "postgresql.backup.enabled=true",
+            "--set",
+            "postgresql.backup.hostPath=/mnt/backups",
+        ]
+    )
+    assert "POSTGRES_DB" in rendered
+    assert "POSTGRES_USER" in rendered
+    assert "POSTGRES_PASSWORD" in rendered
+    assert "PGPASSWORD" in rendered
+
+
+def test_backup_mounts_separate_volume() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "postgresql.backup.enabled=true",
+            "--set",
+            "postgresql.backup.hostPath=/mnt/backups",
+        ]
+    )
+    assert "/mnt/backups" in rendered
+    assert "postgres-backups" in rendered
+    # Backup path must not overlap with live data directory
+    assert "news-dashboard-postgres-data" not in rendered.split("postgres-backup")[1]
+
+
+def test_backup_default_schedule() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "postgresql.backup.enabled=true",
+            "--set",
+            "postgresql.backup.hostPath=/mnt/backups",
+        ]
+    )
+    assert "0 2 * * *" in rendered
+
+
+def test_backup_custom_schedule() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "postgresql.backup.enabled=true",
+            "--set",
+            "postgresql.backup.hostPath=/mnt/backups",
+            "--set",
+            "postgresql.backup.schedule=30 3 * * 0",
+        ]
+    )
+    assert "30 3 * * 0" in rendered
+
+
+def test_backup_retention_days_in_command() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "postgresql.backup.enabled=true",
+            "--set",
+            "postgresql.backup.hostPath=/mnt/backups",
+            "--set",
+            "postgresql.backup.retentionDays=14",
+        ]
+    )
+    assert "14" in rendered
+
+
+def test_backup_pg_dump_custom_format() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "postgresql.backup.enabled=true",
+            "--set",
+            "postgresql.backup.hostPath=/mnt/backups",
+        ]
+    )
+    assert "pg_dump -Fc" in rendered


### PR DESCRIPTION
## Summary

Closes #473.

- Adds `postgresql.backup` values block (`enabled`, `schedule`, `retentionDays`, `hostPath`, `resources`) — **disabled by default**, so no existing chart render changes.
- Renders a `batch/v1` CronJob (`postgres-backup`) when enabled, using `postgres:16-alpine` and reading credentials from the existing postgres Secret.
- Writes timestamped compressed dumps (`pg_dump -Fc`) to a configurable `hostPath` directory that is **separate** from the live data directory.
- Prunes dumps older than `retentionDays` using `find -mtime`.
- Adds `docs/POSTGRES_BACKUP.md` covering enable/disable, manual trigger, restore workflow, and dump verification.
- Adds 9 chart-render regression tests in `scripts/test_helm_postgres_backup.py` (disabled-by-default, enabled state, secret wiring, volume separation, schedule, retention, dump format).

## Test results

```
scripts/test_helm_postgres_backup.py::test_backup_disabled_by_default PASSED
scripts/test_helm_postgres_backup.py::test_backup_disabled_explicitly PASSED
scripts/test_helm_postgres_backup.py::test_backup_enabled_renders_cronjob PASSED
scripts/test_helm_postgres_backup.py::test_backup_uses_postgres_secret PASSED
scripts/test_helm_postgres_backup.py::test_backup_mounts_separate_volume PASSED
scripts/test_helm_postgres_backup.py::test_backup_default_schedule PASSED
scripts/test_helm_postgres_backup.py::test_backup_custom_schedule PASSED
scripts/test_helm_postgres_backup.py::test_backup_retention_days_in_command PASSED
scripts/test_helm_postgres_backup.py::test_backup_pg_dump_custom_format PASSED
9 passed in 0.30s
```

All pre-commit hooks (ruff, mypy, ty, pyrefly) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)