### PR TITLE
test: add axe-core accessibility smoke checks for core routes (#475)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: install ci-install lint format typecheck \
-        test test-smoke test-backend test-frontend test-e2e test-nightly test-full \
+        test test-smoke test-backend test-frontend test-e2e test-a11y test-nightly test-full \
         helm-validate check build
 
 ## install: install backend (editable + dev tools) and update local frontend dependencies
@@ -56,6 +56,10 @@ test-frontend:
 ## test-e2e: Playwright end-to-end tests
 test-e2e:
 	npm run test:e2e --silent
+
+## test-a11y: accessibility smoke tests (axe-core serious/critical violations)
+test-a11y:
+	npm run test:a11y --silent
 
 ## test-nightly: full suite with coverage — same as what the nightly CI runs
 test-nightly:

--- a/e2e/a11y-helper.ts
+++ b/e2e/a11y-helper.ts
@@ -1,0 +1,66 @@
+/**
+ * Accessibility smoke-test helper.
+ *
+ * Injects axe-core via CDN (tests mock only /api/** routes so the CDN
+ * request passes through) and runs an audit limited to serious/critical
+ * violations so tests stay focused on high-signal issues.
+ */
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+const AXE_CDN = 'https://cdn.jsdelivr.net/npm/axe-core@4.10.3/axe.min.js';
+
+export interface A11yCheckOptions {
+  /**
+   * axe rule IDs to exclude. Use sparingly; add a comment explaining why
+   * each exclusion is safe.
+   */
+  exclude?: string[];
+}
+
+/**
+ * Inject axe-core and assert no serious/critical violations on the current
+ * page. Throws an Playwright assertion error listing every violation found.
+ */
+export async function checkA11y(page: Page, options: A11yCheckOptions = {}): Promise<void> {
+  await page.addScriptTag({ url: AXE_CDN });
+
+  const violations = await page.evaluate(
+    async ({ excludeRules }: { excludeRules: string[] }) => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const axe = (window as any).axe as {
+        run: (context: Document, opts: unknown) => Promise<{ violations: AxeViolation[] }>;
+      };
+      /* eslint-enable @typescript-eslint/no-explicit-any */
+
+      interface AxeViolation {
+        id: string;
+        impact: string;
+        description: string;
+        nodes: { html: string }[];
+      }
+
+      const result = await axe.run(document, {
+        runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'best-practice'] },
+        rules: Object.fromEntries(excludeRules.map((id) => [id, { enabled: false }])),
+        resultTypes: ['violations'],
+      });
+
+      return result.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+    },
+    { excludeRules: options.exclude ?? [] }
+  );
+
+  if (violations.length > 0) {
+    const lines = violations.map((v) => {
+      const nodeSnippets = v.nodes
+        .slice(0, 3)
+        .map((n) => `    • ${n.html}`)
+        .join('\n');
+      return `[${v.impact}] ${v.id}: ${v.description}\n${nodeSnippets}`;
+    });
+    expect
+      .soft(violations, `Accessibility violations found:\n\n${lines.join('\n\n')}`)
+      .toHaveLength(0);
+  }
+}

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Accessibility smoke tests — desktop and mobile.
+ *
+ * Uses axe-core (bundled at e2e/axe.min.js) to check for serious/critical
+ * WCAG 2 A/AA violations across the core routes. Intentional exclusions are
+ * named inline with a comment explaining why they are safe.
+ *
+ * CI integration: pair with issue #433 to wire `npm run test:a11y` into the
+ * nightly smart-CI lane.
+ */
+import { test } from '@playwright/test';
+import { mockApi } from './fixtures';
+import { checkA11y } from './a11y-helper';
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+// ── Desktop routes ────────────────────────────────────────────────────────────
+
+test.describe('a11y — desktop routes', () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test('Brief / — no serious/critical violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+
+  test('Today /today — no serious/critical violations', async ({ page }) => {
+    await page.goto('/today');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+
+  test('Search /search — no serious/critical violations', async ({ page }) => {
+    await page.goto('/search');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+
+  test('Ask AI /ask — no serious/critical violations', async ({ page }) => {
+    await page.goto('/ask');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+
+  test('Feeds /feeds — no serious/critical violations', async ({ page }) => {
+    await page.goto('/feeds');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+
+  test('Settings /settings — no serious/critical violations', async ({ page }) => {
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+
+  test('Article reader /articles/1 — no serious/critical violations', async ({ page }) => {
+    await page.goto('/articles/1');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+});
+
+// ── Dialog / overlay state ────────────────────────────────────────────────────
+
+test.describe('a11y — command palette dialog', () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test('command palette open — no serious/critical violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.keyboard.press('Control+k');
+    await page.getByPlaceholder(/jump to a view/i).waitFor({ state: 'visible' });
+    await checkA11y(page);
+  });
+});
+
+// ── Mobile viewport ───────────────────────────────────────────────────────────
+
+test.describe('a11y — mobile viewport', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('Brief / on mobile — no serious/critical violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+
+  test('Today /today on mobile — no serious/critical violations', async ({ page }) => {
+    await page.goto('/today');
+    await page.waitForLoadState('networkidle');
+    await checkA11y(page);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:frontend": "vitest run",
     "test:frontend:smoke": "vitest run frontend/src/__tests__/appRouter.test.tsx frontend/src/__tests__/routing.test.tsx frontend/src/__tests__/navigation.test.ts frontend/src/__tests__/auth.test.tsx",
     "test:frontend:coverage": "vitest run --coverage",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:a11y": "playwright test e2e/a11y.spec.ts"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.13",


### PR DESCRIPTION
## Summary

- Adds `e2e/a11y-helper.ts` — injects axe-core via CDN (`cdn.jsdelivr.net`) into each Playwright page and asserts zero serious/critical WCAG 2 A/AA violations. Only `/api/**` routes are mocked so CDN requests pass through unmodified.
- Adds `e2e/a11y.spec.ts` — smoke tests covering:
  - 7 desktop routes: Brief (`/`), Today (`/today`), Search (`/search`), Ask AI (`/ask`), Feeds (`/feeds`), Settings (`/settings`), Article reader (`/articles/1`)
  - Command palette dialog overlay (opened with Ctrl+K)
  - 2 mobile viewport routes (390×844): Brief and Today
- Adds `npm run test:a11y` script to `package.json`
- Adds `make test-a11y` target to `Makefile`
- No new npm dependencies — no lockfile change needed
- CI wiring is left for issue #433 (smart-CI lanes)

## Test plan

- [ ] `make test-a11y` runs the new suite against the dev server
- [ ] Serious/critical axe violations cause test failure with a clear violation report
- [ ] Existing Playwright specs (`make test-e2e`) continue to pass unchanged
- [ ] `npm run lint --silent` passes
- [ ] `npm run typecheck --silent` passes

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)