### PR TITLE
fix: make Docker Compose quick start login-ready (#478)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ docker compose up --build
 
 Open [http://localhost:8080](http://localhost:8080).
 
+Log in with the default local-development credentials:
+
+| Field | Default value |
+| --- | --- |
+| Username | `admin` |
+| Password | `change-me` |
+
+> **These are local-development defaults only.** Before deploying anywhere
+> outside your own machine, set `SESSION_SECRET`, `BOOTSTRAP_ADMIN_USERNAME`,
+> and `BOOTSTRAP_ADMIN_PASSWORD` to strong, unique values via environment
+> variables or a `.env` file — never use these defaults in production.
+
 Run ingestion in the app container:
 
 ```bash

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -1,0 +1,66 @@
+"""Verify that docker-compose.yml supplies auth env vars for local dev (issue #478).
+
+A fresh ``docker compose up --build`` must be login-ready: the app service must
+have SESSION_SECRET, BOOTSTRAP_ADMIN_USERNAME, and BOOTSTRAP_ADMIN_PASSWORD
+either as explicit values or as ${VAR:-default} expressions with a non-empty
+default, so a first-time user can log in without extra setup.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+_REQUIRED_AUTH_VARS = {
+    "SESSION_SECRET",
+    "BOOTSTRAP_ADMIN_USERNAME",
+    "BOOTSTRAP_ADMIN_PASSWORD",
+}
+
+_COMPOSE_OVERRIDE_PATTERN = re.compile(r"^\$\{[A-Z_]+:-(.+)\}$")
+
+
+def _resolve_default(value: object) -> str:
+    """Return the effective default for a compose env value.
+
+    - A plain string with no substitution is returned as-is.
+    - A ``${VAR:-default}`` expression returns the default part.
+    - Anything else (None, empty string) returns an empty string.
+    """
+    if not isinstance(value, str):
+        return ""
+    m = _COMPOSE_OVERRIDE_PATTERN.match(value.strip())
+    if m:
+        return m.group(1)
+    return value
+
+
+def test_compose_file_exists() -> None:
+    assert COMPOSE_FILE.exists(), f"docker-compose.yml not found at {COMPOSE_FILE}"
+
+
+def test_compose_app_service_has_auth_env_vars() -> None:
+    """The news-dashboard service must declare all three auth env vars with defaults."""
+    compose = yaml.safe_load(COMPOSE_FILE.read_text())
+    services = compose.get("services", {})
+    assert "news-dashboard" in services, "news-dashboard service missing from compose"
+
+    env = services["news-dashboard"].get("environment", {})
+    if isinstance(env, list):
+        env = dict(item.split("=", 1) if "=" in item else (item, "") for item in env)
+
+    missing: list[str] = []
+    empty: list[str] = []
+    for var in sorted(_REQUIRED_AUTH_VARS):
+        if var not in env:
+            missing.append(var)
+        elif not _resolve_default(env[var]):
+            empty.append(var)
+
+    assert not missing, f"Auth env vars not declared in compose: {missing}"
+    assert not empty, f"Auth env vars have no default value in compose: {empty}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       POSTGRES_DB: news_dashboard
       POSTGRES_USER: news_dashboard
       POSTGRES_PASSWORD: news-dashboard-local-password
+      # Local-development-only auth defaults. Override all three for any non-local deployment.
+      SESSION_SECRET: ${SESSION_SECRET:-dev-only-secret-change-before-deploying-00000000000}
+      BOOTSTRAP_ADMIN_USERNAME: ${BOOTSTRAP_ADMIN_USERNAME:-admin}
+      BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD:-change-me}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       FREE_LLM_API_KEY: ${FREE_LLM_API_KEY:-}
       FREE_LLM_BASE_URL: ${FREE_LLM_BASE_URL:-}


### PR DESCRIPTION
Closes #478

## Summary

- Added `SESSION_SECRET`, `BOOTSTRAP_ADMIN_USERNAME`, and `BOOTSTRAP_ADMIN_PASSWORD` to `docker-compose.yml` with local-dev-only defaults (`admin` / `change-me`) using `${VAR:-default}` syntax so any override via environment variable or `.env` file still works
- Updated the README Quick Start section with the default local credentials and a warning that these values must be changed before deploying outside local Compose
- Added `backend/tests/test_compose_auth_env.py` to guard that all three auth env vars remain present with non-empty defaults in the Compose file

## Test results

```
69 passed in 10.84s (auth tests + new compose contract test)
```

All pre-commit gates pass (ruff, mypy, ty, pyrefly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)