### PR TITLE
fix: align AI credential guidance with free LLM config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ optional OpenAI features for embeddings, Ask AI, and briefings.
 - Node.js and npm compatible with `package-lock.json`
 - PostgreSQL 16+
 - Docker and Docker Compose for the container flow
-- OpenAI API key for AI features
+- API key for AI features (`FREE_LLM_API_KEY` or `OPENAI_API_KEY`)
 
 ## Configuration
 
@@ -43,8 +43,9 @@ Runtime storage is PostgreSQL only. Set `DATABASE_URL` or the split
 | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | PostgreSQL connection parts used when `DATABASE_URL` is unset. |
 | `SESSION_SECRET` | Signed session key. Generate with `python -c "import secrets; print(secrets.token_hex(32))"`. |
 | `BOOTSTRAP_ADMIN_USERNAME`, `BOOTSTRAP_ADMIN_PASSWORD` | First local admin account. Used only when no users exist. |
-| `OPENAI_API_KEY` | Enables embeddings, Ask AI, and briefings. |
-| `OPENAI_BRIEFING_BASE_URL`, `OPENAI_BRIEFING_API_KEY` | Point briefing generation at an OpenAI-compatible endpoint (e.g. a self-hosted gateway). Optional; falls back to `OPENAI_BASE_URL` / `OPENAI_API_KEY`. Pair with `OPENAI_BRIEFING_MODEL` (use `auto` for a routing gateway). |
+| `FREE_LLM_API_KEY`, `FREE_LLM_BASE_URL` | Primary API key and base URL for chat, embeddings, Ask AI, and briefings. Use these to point at a self-hosted OpenAI-compatible gateway. Falls back to `OPENAI_API_KEY` / `OPENAI_BASE_URL` when not set. |
+| `OPENAI_API_KEY`, `OPENAI_BASE_URL` | OpenAI credentials. Required for TTS/audio (not replaceable by the free LLM gateway). Also used as fallback for all other AI features when `FREE_LLM_API_KEY` is absent. |
+| `OPENAI_BRIEFING_MODEL` | Model name for briefing generation (e.g. `auto` for a routing gateway, or a specific model ID). Defaults to `gpt-4o-mini`. |
 | `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` | Traces every OpenAI call (embeddings, Ask AI, briefings, insights, TTS, body fetch) in [Langfuse](https://langfuse.com), each tagged with a descriptive name (`ask-ai`, `briefing-generation`, …). Tracing activates only when both keys are set; otherwise the app uses a plain OpenAI client with no tracing. `LANGFUSE_BASE_URL` is accepted as an alias for `LANGFUSE_HOST`. |
 | `KEYCLOAK_AUTH_ENABLED`, `KEYCLOAK_SERVER_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET` | Enables Keycloak. See [docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md). |
 | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` | VAPID public and private keys for Web Push notifications. Generate using `npx web-push generate-vapid-keys`. |

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -506,7 +506,7 @@ def generate_briefing(  # noqa: PLR0913
     when no eligible articles are found.
 
     Raises:
-        BriefingAINotConfiguredError: OPENAI_API_KEY is not set.
+        BriefingAINotConfiguredError: FREE_LLM_API_KEY (or OPENAI_API_KEY) is not set.
         BriefingGenerationError: AI returned an invalid or unparseable response
             on every attempt.
     """

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -104,7 +104,7 @@ def _run_briefing() -> None:
         else:
             logger.info("Scheduled briefing complete: id=%s", result.get("id"))
     except BriefingAINotConfiguredError:
-        logger.warning("Scheduled briefing skipped: OPENAI_API_KEY not configured.")
+        logger.warning("Briefing skipped: no AI key set (FREE_LLM_API_KEY / OPENAI_API_KEY).")
     except BriefingGenerationError:
         logger.exception("Scheduled briefing failed (generation error)")
     except Exception:

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -200,7 +200,7 @@ def test_get_share_returns_none_for_unauthorized(db: str) -> None:
 
 def test_generate_share_context_no_api_key(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_BRIEFING_API_KEY", raising=False)
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
 
     alice = _make_user(db, "alice")
     bob = _make_user(db, "bob")

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -106,7 +106,7 @@ After ≥ 100 saved/read articles exist:
 - Embed title + summary via the configured OpenAI-compatible embeddings provider.
 - Store embeddings in PostgreSQL-managed article data structures; runtime storage remains PostgreSQL only.
 - Enables semantic search and similarity grouping without adding a second runtime database.
-- Configure with feature-specific variables such as `OPENAI_EMBEDDINGS_API_KEY`, `OPENAI_EMBEDDINGS_BASE_URL`, and `OPENAI_EMBEDDING_MODEL`; see `README.md` and `backend/news_dashboard/embeddings.py`.
+- Configure with `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL` (or the `OPENAI_API_KEY` / `OPENAI_BASE_URL` fallback); see `README.md` and `backend/news_dashboard/embeddings.py`.
 
 ### Ask Clau endpoint (v1.3)
 
@@ -129,7 +129,7 @@ Privacy/security:
 - Endpoint requires the app authentication boundary, either local password sessions or optional Keycloak SSO.
 - No article content is sent to external APIs unless the relevant AI feature is configured with an API key.
 - OpenAI API key stored as an environment secret, never in source.
-- Briefing generation can use `OPENAI_BRIEFING_API_KEY`, `OPENAI_BRIEFING_BASE_URL`, and `OPENAI_BRIEFING_MODEL`; see `README.md` and `backend/news_dashboard/briefings.py`.
+- Briefing generation uses `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL` (or the `OPENAI_API_KEY` fallback) and `OPENAI_BRIEFING_MODEL`; see `README.md` and `backend/news_dashboard/briefings.py`.
 
 ### Privacy/security boundaries
 

--- a/frontend/src/pages/AskPage.tsx
+++ b/frontend/src/pages/AskPage.tsx
@@ -50,7 +50,7 @@ interface AskError {
 
 function parseError(err: unknown): AskError {
   const msg = err instanceof Error ? err.message : String(err);
-  if (/OPENAI_API_KEY|credentials|API key/i.test(msg)) {
+  if (/FREE_LLM_API_KEY|OPENAI_API_KEY|credentials|API key/i.test(msg)) {
     return { kind: 'no_key', message: msg };
   }
   return { kind: 'generation_failed', message: msg };
@@ -60,7 +60,7 @@ function ErrorBanner({ error }: { error: AskError }) {
   const copy: Record<ErrorKind, { title: string; body: string }> = {
     no_key: {
       title: 'Ask AI is not configured',
-      body: 'An OpenAI API key is required. Set OPENAI_API_KEY in the app environment and restart.',
+      body: 'An AI API key is required. Set FREE_LLM_API_KEY (or OPENAI_API_KEY) in the app environment and restart.',
     },
     not_enough: {
       title: 'Not enough articles yet',

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -82,7 +82,7 @@ export function BriefPage() {
             </div>
             <div className="text-xs text-muted-foreground mt-1">
               {generateError.kind === 'no_ai'
-                ? 'OPENAI_API_KEY is not set. Configure it in the app environment to enable briefings.'
+                ? 'FREE_LLM_API_KEY (or OPENAI_API_KEY) is not set. Configure it in the app environment to enable briefings.'
                 : 'The AI returned an unexpected response. Try again or review the raw feed.'}
             </div>
           </div>


### PR DESCRIPTION
Closes #479

## Summary

- **README**: Replaced stale `OPENAI_API_KEY`-only row and removed `OPENAI_BRIEFING_API_KEY`/`OPENAI_BRIEFING_BASE_URL` rows with accurate entries for `FREE_LLM_API_KEY`/`FREE_LLM_BASE_URL` (primary), `OPENAI_API_KEY`/`OPENAI_BASE_URL` (TTS/fallback), and `OPENAI_BRIEFING_MODEL`
- **docs/PRODUCT_SPEC.md**: Removed references to `OPENAI_EMBEDDINGS_API_KEY`/`OPENAI_EMBEDDINGS_BASE_URL` and `OPENAI_BRIEFING_API_KEY`/`OPENAI_BRIEFING_BASE_URL` that the runtime no longer reads
- **AskPage.tsx**: Updated no-key error message to mention `FREE_LLM_API_KEY or OPENAI_API_KEY`; added `FREE_LLM_API_KEY` to the error-pattern regex
- **BriefPage.tsx**: Updated no-AI message to mention `FREE_LLM_API_KEY`
- **scheduler.py**: Fixed briefing-skip log to say "no AI key set (FREE_LLM_API_KEY / OPENAI_API_KEY)" instead of "OPENAI_API_KEY not configured"
- **briefings.py**: Updated docstring to reflect that either key is accepted
- **test_article_shares.py**: Replaced stale `OPENAI_BRIEFING_API_KEY` monkeypatch with `FREE_LLM_API_KEY`

## Test plan

- [x] `make lint` — all checks pass
- [x] `pytest backend/tests/test_briefings_api.py backend/tests/test_article_shares.py` — 43 passed
- [x] `rg "OPENAI_BRIEFING_BASE_URL|OPENAI_BRIEFING_API_KEY|OPENAI_EMBEDDINGS" README.md docs backend frontend` — no results
- [x] All pre-commit hooks pass (ruff, mypy, ty, pyrefly, eslint, prettier, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)