### PR TITLE
feat: schedule daily briefs in user timezone (#480)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -374,6 +374,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_time TEXT DEFAULT '09:00'",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_push_enabled"
     " BOOLEAN NOT NULL DEFAULT FALSE",
+    "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_timezone TEXT NOT NULL DEFAULT 'UTC'",
     """
     CREATE TABLE IF NOT EXISTS user_push_subscriptions (
       id          SERIAL PRIMARY KEY,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1701,11 +1701,13 @@ def briefings_chat(
 # ── Notification settings & push subscriptions ───────────────────────────────
 
 _BRIEFING_TIME_RE = __import__("re").compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+_NOTIFICATION_COLS = "briefing_time, briefing_push_enabled, briefing_timezone"
 
 
 class NotificationSettingsUpdate(BaseModel):
     briefing_time: str | None = None
     push_enabled: bool | None = None
+    briefing_timezone: str | None = None
 
 
 class PushSubscribeRequest(BaseModel):
@@ -1780,13 +1782,14 @@ def get_notification_settings(
     uid = current_user["id"]
     with connect() as conn:
         row = conn.execute(
-            "SELECT briefing_time, briefing_push_enabled FROM users WHERE id = %s",
+            f"SELECT {_NOTIFICATION_COLS} FROM users WHERE id = %s",
             (uid,),
         ).fetchone()
     if row is None:
         raise HTTPException(status_code=404, detail="user not found")
     return {
         "briefing_time": row["briefing_time"] or "09:00",
+        "briefing_timezone": row["briefing_timezone"] or "UTC",
         "push_enabled": bool(row["briefing_push_enabled"]),
         "vapid_public_key": get_vapid_public_key(),
     }
@@ -1805,6 +1808,14 @@ def update_notification_settings(
         updates["briefing_time"] = payload.briefing_time
     if payload.push_enabled is not None:
         updates["briefing_push_enabled"] = payload.push_enabled
+    if payload.briefing_timezone is not None:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        try:
+            ZoneInfo(payload.briefing_timezone)
+        except (ZoneInfoNotFoundError, KeyError):
+            raise HTTPException(status_code=422, detail="unknown timezone") from None
+        updates["briefing_timezone"] = payload.briefing_timezone
     if updates:
         set_clauses = ", ".join(f"{k} = %s" for k in updates)
         with connect() as conn:
@@ -1814,13 +1825,14 @@ def update_notification_settings(
             )
     with connect() as conn:
         row = conn.execute(
-            "SELECT briefing_time, briefing_push_enabled FROM users WHERE id = %s",
+            f"SELECT {_NOTIFICATION_COLS} FROM users WHERE id = %s",
             (uid,),
         ).fetchone()
     if row is None:
         raise HTTPException(status_code=404, detail="user not found")
     return {
         "briefing_time": row["briefing_time"] or "09:00",
+        "briefing_timezone": row["briefing_timezone"] or "UTC",
         "push_enabled": bool(row["briefing_push_enabled"]),
     }
 

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -112,7 +112,9 @@ def _run_briefing() -> None:
 
 
 def _run_per_user_briefings() -> None:
-    """Generate briefings for users whose scheduled time matches the current UTC HH:MM."""
+    """Generate briefings for users whose local scheduled time matches the current instant."""
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
     from news_dashboard.briefings import (
         BriefingAINotConfiguredError,
         BriefingGenerationError,
@@ -122,18 +124,29 @@ def _run_per_user_briefings() -> None:
     from news_dashboard.push import generate_push_hook, send_push_for_user
 
     now = datetime.now(timezone.utc)
-    current_hm = now.strftime("%H:%M")
 
     try:
         with connect() as conn:
             rows = conn.execute(
-                "SELECT id FROM users WHERE briefing_time = %s",
-                (current_hm,),
+                "SELECT id, briefing_time, briefing_timezone FROM users"
+                " WHERE briefing_push_enabled = TRUE OR briefing_time IS NOT NULL",
             ).fetchall()
-        user_ids = [int(row_to_dict(r)["id"]) for r in rows]
+        user_rows = [row_to_dict(r) for r in rows]
     except Exception:
-        logger.exception("Per-user briefing: failed to query users for time %s", current_hm)
+        logger.exception("Per-user briefing: failed to query users")
         return
+
+    user_ids: list[int] = []
+    for row in user_rows:
+        tz_name: str = row.get("briefing_timezone") or "UTC"
+        briefing_time: str = row.get("briefing_time") or "09:00"
+        try:
+            tz = ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, KeyError):
+            tz = ZoneInfo("UTC")
+        local_hm = now.astimezone(tz).strftime("%H:%M")
+        if local_hm == briefing_time:
+            user_ids.append(int(row["id"]))
 
     for user_id in user_ids:
         logger.info("Per-user briefing: generating for user_id=%s", user_id)

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -346,7 +346,11 @@ def test_get_notification_settings_returns_defaults(
 ) -> None:
     monkeypatch.setenv("VAPID_PUBLIC_KEY", "BExampleKey==")
 
-    fake_row: dict[str, Any] = {"briefing_time": "09:00", "briefing_push_enabled": False}
+    fake_row: dict[str, Any] = {
+        "briefing_time": "09:00",
+        "briefing_push_enabled": False,
+        "briefing_timezone": "UTC",
+    }
 
     with patch("news_dashboard.main.connect") as mock_connect:
         ctx = mock_connect.return_value.__enter__.return_value
@@ -357,12 +361,39 @@ def test_get_notification_settings_returns_defaults(
     assert resp.status_code == 200
     data = resp.json()
     assert data["briefing_time"] == "09:00"
+    assert data["briefing_timezone"] == "UTC"
     assert data["push_enabled"] is False
     assert data["vapid_public_key"] == "BExampleKey=="
 
 
+def test_get_notification_settings_utc_fallback(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Users without a timezone value fall back to UTC."""
+    monkeypatch.setenv("VAPID_PUBLIC_KEY", "BExampleKey==")
+
+    fake_row: dict[str, Any] = {
+        "briefing_time": "09:00",
+        "briefing_push_enabled": False,
+        "briefing_timezone": None,
+    }
+
+    with patch("news_dashboard.main.connect") as mock_connect:
+        ctx = mock_connect.return_value.__enter__.return_value
+        ctx.execute.return_value.fetchone.return_value = fake_row
+
+        resp = client.get("/api/settings/notifications")
+
+    assert resp.status_code == 200
+    assert resp.json()["briefing_timezone"] == "UTC"
+
+
 def test_put_notification_settings_valid_time(client: TestClient) -> None:
-    fake_row: dict[str, Any] = {"briefing_time": "08:30", "briefing_push_enabled": True}
+    fake_row: dict[str, Any] = {
+        "briefing_time": "08:30",
+        "briefing_push_enabled": True,
+        "briefing_timezone": "UTC",
+    }
 
     with patch("news_dashboard.main.connect") as mock_connect:
         ctx = mock_connect.return_value.__enter__.return_value
@@ -377,6 +408,31 @@ def test_put_notification_settings_valid_time(client: TestClient) -> None:
     data = resp.json()
     assert data["briefing_time"] == "08:30"
     assert data["push_enabled"] is True
+
+
+def test_put_notification_settings_valid_timezone(client: TestClient) -> None:
+    fake_row: dict[str, Any] = {
+        "briefing_time": "09:00",
+        "briefing_push_enabled": False,
+        "briefing_timezone": "Europe/Bucharest",
+    }
+
+    with patch("news_dashboard.main.connect") as mock_connect:
+        ctx = mock_connect.return_value.__enter__.return_value
+        ctx.execute.return_value.fetchone.return_value = fake_row
+
+        resp = client.put(
+            "/api/settings/notifications",
+            json={"briefing_timezone": "Europe/Bucharest"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["briefing_timezone"] == "Europe/Bucharest"
+
+
+def test_put_notification_settings_invalid_timezone(client: TestClient) -> None:
+    resp = client.put("/api/settings/notifications", json={"briefing_timezone": "Mars/Olympus"})
+    assert resp.status_code == 422
 
 
 def test_put_notification_settings_invalid_time(client: TestClient) -> None:

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -739,3 +740,142 @@ def test_scheduler_status_reports_external_ingest_authority(
         "interval_ingest_enabled": False,
         "ingest_authority": "external",
     }
+
+
+# ── _run_per_user_briefings — timezone-aware matching ─────────────────────────
+
+# connect/row_to_dict/generate_briefing/push helpers are lazily imported inside
+# _run_per_user_briefings, so they must be patched at their source modules.
+_CONNECT_PATH = "news_dashboard.db.connect"
+_ROW_TO_DICT_PATH = "news_dashboard.db.row_to_dict"
+_PER_USER_GEN_PATH = "news_dashboard.briefings.generate_briefing"
+_SEND_PUSH_PATH = "news_dashboard.push.send_push_for_user"
+_GEN_PUSH_HOOK_PATH = "news_dashboard.push.generate_push_hook"
+
+
+def _mock_conn_for_rows(user_rows: list[dict[str, Any]]) -> MagicMock:
+    mock_conn = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.execute.return_value.fetchall.return_value = user_rows
+    return mock_conn
+
+
+def test_per_user_briefings_utc_match() -> None:
+    """A user with UTC timezone triggers when UTC wall clock matches briefing_time."""
+    from datetime import datetime, timezone
+
+    from news_dashboard.scheduler import _run_per_user_briefings
+
+    now = datetime(2026, 6, 29, 9, 0, 0, tzinfo=timezone.utc)
+    user_rows = [{"id": 1, "briefing_time": "09:00", "briefing_timezone": "UTC"}]
+    mock_conn = _mock_conn_for_rows(user_rows)
+    mock_generate = MagicMock(return_value={"id": 1, "status": "complete"})
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch(_CONNECT_PATH, return_value=mock_conn),
+        patch(_PER_USER_GEN_PATH, mock_generate),
+        patch(_SEND_PUSH_PATH),
+        patch(_GEN_PUSH_HOOK_PATH, return_value="Brief ready"),
+    ):
+        mock_dt.now.return_value = now
+        _run_per_user_briefings()
+
+    mock_generate.assert_called_once_with(user_id=1)
+
+
+def test_per_user_briefings_utc_no_match() -> None:
+    """A UTC user is NOT triggered when the current UTC minute differs."""
+    from datetime import datetime, timezone
+
+    from news_dashboard.scheduler import _run_per_user_briefings
+
+    now = datetime(2026, 6, 29, 10, 0, 0, tzinfo=timezone.utc)
+    user_rows = [{"id": 1, "briefing_time": "09:00", "briefing_timezone": "UTC"}]
+    mock_conn = _mock_conn_for_rows(user_rows)
+    mock_generate = MagicMock()
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch(_CONNECT_PATH, return_value=mock_conn),
+        patch(_PER_USER_GEN_PATH, mock_generate),
+    ):
+        mock_dt.now.return_value = now
+        _run_per_user_briefings()
+
+    mock_generate.assert_not_called()
+
+
+def test_per_user_briefings_europe_bucharest_summer() -> None:
+    """Europe/Bucharest is UTC+3 in summer (EEST). 09:00 local = 06:00 UTC."""
+    from datetime import datetime, timezone
+
+    from news_dashboard.scheduler import _run_per_user_briefings
+
+    # 2026-06-29 06:00 UTC = 09:00 Europe/Bucharest (EEST, UTC+3)
+    now = datetime(2026, 6, 29, 6, 0, 0, tzinfo=timezone.utc)
+    user_rows = [{"id": 42, "briefing_time": "09:00", "briefing_timezone": "Europe/Bucharest"}]
+    mock_conn = _mock_conn_for_rows(user_rows)
+    mock_generate = MagicMock(return_value={"id": 1, "status": "complete"})
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch(_CONNECT_PATH, return_value=mock_conn),
+        patch(_PER_USER_GEN_PATH, mock_generate),
+        patch(_SEND_PUSH_PATH),
+        patch(_GEN_PUSH_HOOK_PATH, return_value="Brief ready"),
+    ):
+        mock_dt.now.return_value = now
+        _run_per_user_briefings()
+
+    mock_generate.assert_called_once_with(user_id=42)
+
+
+def test_per_user_briefings_europe_bucharest_winter() -> None:
+    """Europe/Bucharest is UTC+2 in winter (EET). 09:00 local = 07:00 UTC."""
+    from datetime import datetime, timezone
+
+    from news_dashboard.scheduler import _run_per_user_briefings
+
+    # 2026-01-15 07:00 UTC = 09:00 Europe/Bucharest (EET, UTC+2)
+    now = datetime(2026, 1, 15, 7, 0, 0, tzinfo=timezone.utc)
+    user_rows = [{"id": 42, "briefing_time": "09:00", "briefing_timezone": "Europe/Bucharest"}]
+    mock_conn = _mock_conn_for_rows(user_rows)
+    mock_generate = MagicMock(return_value={"id": 1, "status": "complete"})
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch(_CONNECT_PATH, return_value=mock_conn),
+        patch(_PER_USER_GEN_PATH, mock_generate),
+        patch(_SEND_PUSH_PATH),
+        patch(_GEN_PUSH_HOOK_PATH, return_value="Brief ready"),
+    ):
+        mock_dt.now.return_value = now
+        _run_per_user_briefings()
+
+    mock_generate.assert_called_once_with(user_id=42)
+
+
+def test_per_user_briefings_null_timezone_falls_back_to_utc() -> None:
+    """A user with NULL briefing_timezone is treated as UTC."""
+    from datetime import datetime, timezone
+
+    from news_dashboard.scheduler import _run_per_user_briefings
+
+    now = datetime(2026, 6, 29, 9, 0, 0, tzinfo=timezone.utc)
+    user_rows = [{"id": 5, "briefing_time": "09:00", "briefing_timezone": None}]
+    mock_conn = _mock_conn_for_rows(user_rows)
+    mock_generate = MagicMock(return_value={"id": 1, "status": "complete"})
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch(_CONNECT_PATH, return_value=mock_conn),
+        patch(_PER_USER_GEN_PATH, mock_generate),
+        patch(_SEND_PUSH_PATH),
+        patch(_GEN_PUSH_HOOK_PATH, return_value="Brief ready"),
+    ):
+        mock_dt.now.return_value = now
+        _run_per_user_briefings()
+
+    mock_generate.assert_called_once_with(user_id=5)

--- a/frontend/src/__tests__/dailyBriefSettings.test.tsx
+++ b/frontend/src/__tests__/dailyBriefSettings.test.tsx
@@ -39,6 +39,7 @@ function renderSettings() {
 
 const defaultSettings = {
   briefing_time: '09:00',
+  briefing_timezone: 'UTC',
   push_enabled: false,
   vapid_public_key: null as string | null,
 };
@@ -69,21 +70,21 @@ describe('DailyBriefSection', () => {
 
   it('shows the time loaded from settings', async () => {
     renderSettings();
-    const input = await screen.findByLabelText('Generation time (UTC)');
+    const input = await screen.findByLabelText('Generation time');
     expect(input).toHaveValue('09:00');
   });
 
   it('shows a custom time from settings', async () => {
     mockFetchSettings.mockResolvedValue({ ...defaultSettings, briefing_time: '07:30' });
     renderSettings();
-    const input = await screen.findByLabelText('Generation time (UTC)');
+    const input = await screen.findByLabelText('Generation time');
     expect(input).toHaveValue('07:30');
   });
 
   it('calls updateNotificationSettings on time input blur', async () => {
     const user = userEvent.setup();
     renderSettings();
-    const input = await screen.findByLabelText('Generation time (UTC)');
+    const input = await screen.findByLabelText('Generation time');
     await user.clear(input);
     await user.type(input, '08:00');
     await user.tab();
@@ -188,5 +189,43 @@ describe('DailyBriefSection', () => {
     expect(
       screen.getByText('Push notifications require server configuration (VAPID keys).')
     ).toBeInTheDocument();
+  });
+});
+
+describe('DailyBriefSection — timezone', () => {
+  it('shows timezone loaded from settings', async () => {
+    mockFetchSettings.mockResolvedValue({
+      ...defaultSettings,
+      briefing_timezone: 'Europe/Bucharest',
+    });
+    renderSettings();
+    const input = await screen.findByLabelText('Timezone');
+    expect(input).toHaveValue('Europe/Bucharest');
+  });
+
+  it('falls back to browser timezone when server returns UTC', async () => {
+    mockFetchSettings.mockResolvedValue({ ...defaultSettings, briefing_timezone: 'UTC' });
+    renderSettings();
+    const input = await screen.findByLabelText('Timezone');
+    expect(input).toHaveValue('UTC');
+  });
+
+  it('calls updateNotificationSettings with briefing_timezone on blur', async () => {
+    const user = userEvent.setup();
+    mockFetchSettings.mockResolvedValue({ ...defaultSettings, briefing_timezone: 'UTC' });
+    renderSettings();
+    const input = await screen.findByLabelText('Timezone');
+    await user.clear(input);
+    await user.type(input, 'America/New_York');
+    await user.tab();
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({ briefing_timezone: 'America/New_York' });
+    });
+  });
+
+  it('shows local-time wording without UTC suffix in label', async () => {
+    renderSettings();
+    await waitFor(() => expect(screen.getByLabelText('Generation time')).toBeInTheDocument());
+    expect(screen.queryByLabelText('Generation time (UTC)')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -359,6 +359,9 @@ type PushState = 'idle' | 'requesting' | 'subscribed' | 'denied' | 'unavailable'
 
 function DailyBriefSection() {
   const [briefingTime, setBriefingTime] = useState('09:00');
+  const [briefingTimezone, setBriefingTimezone] = useState(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
   const [pushEnabled, setPushEnabled] = useState(false);
   const [vapidKey, setVapidKey] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -372,6 +375,9 @@ function DailyBriefSection() {
         const s = await fetchNotificationSettings();
         if (!cancelled) {
           setBriefingTime(s.briefing_time);
+          setBriefingTimezone(
+            s.briefing_timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+          );
           setPushEnabled(s.push_enabled);
           setVapidKey(s.vapid_public_key);
           if (s.push_enabled) setPushState('subscribed');
@@ -397,6 +403,15 @@ function DailyBriefSection() {
       // non-critical — time preference will resync on next load
     } finally {
       setTimeSaving(false);
+    }
+  };
+
+  const handleTimezoneBlur = async (tz: string) => {
+    if (!tz) return;
+    try {
+      await updateNotificationSettings({ briefing_timezone: tz });
+    } catch {
+      // non-critical
     }
   };
 
@@ -478,7 +493,7 @@ function DailyBriefSection() {
       <div className="rounded-lg border border-border bg-card p-4 space-y-4">
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-foreground" htmlFor="briefing-time">
-            Generation time (UTC)
+            Generation time
           </label>
           <div className="flex items-center gap-2">
             <input
@@ -492,7 +507,25 @@ function DailyBriefSection() {
             {timeSaving && <RefreshCw className="size-3 animate-spin text-muted-foreground" />}
           </div>
           <p className="text-[11px] text-muted-foreground">
-            Your brief will be generated automatically at this time each day.
+            Your brief will be generated automatically at this local time each day.
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-foreground" htmlFor="briefing-timezone">
+            Timezone
+          </label>
+          <input
+            id="briefing-timezone"
+            type="text"
+            value={briefingTimezone}
+            onChange={(e) => setBriefingTimezone(e.target.value)}
+            onBlur={(e) => void handleTimezoneBlur(e.target.value)}
+            placeholder="e.g. Europe/Bucharest"
+            className="w-full rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <p className="text-[11px] text-muted-foreground">
+            IANA timezone name (e.g. America/New_York). DST is applied automatically.
           </p>
         </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -289,12 +289,14 @@ export type BriefingCreateResponse = Briefing | { status: 'no_candidates' };
 
 export interface NotificationSettings {
   briefing_time: string;
+  briefing_timezone: string;
   push_enabled: boolean;
   vapid_public_key: string | null;
 }
 
 export interface NotificationSettingsUpdate {
   briefing_time?: string;
+  briefing_timezone?: string;
   push_enabled?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Adds `briefing_timezone TEXT NOT NULL DEFAULT 'UTC'` column to the `users` table via a new migration
- The `GET/PUT /api/settings/notifications` endpoints now return and accept `briefing_timezone` (validated using `zoneinfo.ZoneInfo`, 422 on unknown zone)
- `_run_per_user_briefings()` in the scheduler now queries all users and matches each user's `briefing_time` against their local wall-clock time (DST-aware), instead of comparing UTC HH:MM globally
- Settings page no longer labels the time field as UTC; a new Timezone input lets users enter any IANA name (defaults to browser timezone on first use)
- Existing users with no timezone saved continue to fire at their stored UTC `briefing_time` unchanged (UTC fallback)

Closes #480

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` (mypy strict + ty + pyrefly) — clean
- [x] `pytest backend/tests/test_push_notifications.py backend/tests/test_scheduler.py` — 89 passed
  - New: GET returns `briefing_timezone`, UTC fallback test, valid/invalid timezone PUT tests
  - New: scheduler UTC match/no-match, Europe/Bucharest summer (EEST UTC+3) and winter (EET UTC+2) tests, NULL timezone fallback
- [x] `npm run test:frontend -- --run frontend/src/__tests__/dailyBriefSettings.test.tsx` — 15 passed
  - New: timezone loaded from settings, persist on blur, label no longer shows "(UTC)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)