### PR TITLE
ops: add Helm resource controls for ingest CronJob and Postgres pods (#485)

### DIFF
--- a/helm/news-dashboard/templates/cronjob.yaml
+++ b/helm/news-dashboard/templates/cronjob.yaml
@@ -40,6 +40,10 @@ spec:
                 runAsUser: 1000
                 runAsGroup: 1000
               command: ["news-dashboard", "scheduled-ingest"]
+              {{- with .Values.ingestCronJob.resources }}
+              resources:
+{{ toYaml . | indent 16 }}
+              {{- end }}
               env:
 {{- if .Values.postgresql.enabled }}
                 - name: POSTGRES_HOST

--- a/helm/news-dashboard/templates/postgres-statefulset.yaml
+++ b/helm/news-dashboard/templates/postgres-statefulset.yaml
@@ -58,6 +58,10 @@ spec:
               command: ["pg_isready", "-U", {{ .Values.postgresql.username | quote }}, "-d", {{ .Values.postgresql.database | quote }}]
             initialDelaySeconds: 30
             periodSeconds: 20
+          {{- with .Values.postgresql.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+          {{- end }}
       volumes:
         - name: postgres-data
 {{- if .Values.postgresql.persistence.hostPath }}

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -96,6 +96,17 @@ ingestCronJob:
   backoffLimit: 1
   # Optional cluster cleanup for finished Jobs. Leave empty to preserve history limits.
   ttlSecondsAfterFinished: ""
+  # Resource requests/limits for the ingest CronJob container.
+  # On a single-node deployment these prevent ingest spikes from crowding the app pod.
+  # Example override: helm upgrade --set ingestCronJob.resources.requests.cpu=100m
+  resources: {}
+  # resources:
+  #   requests:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   limits:
+  #     cpu: 500m
+  #     memory: 512Mi
 
 postgresql:
   enabled: true
@@ -105,6 +116,17 @@ postgresql:
   # Internal cluster password. Override in real environments.
   password: news-dashboard-local-password
   port: 5432
+  # Resource requests/limits for the bundled PostgreSQL StatefulSet container.
+  # On a single-node deployment these prevent Postgres memory spikes from crowding the app pod.
+  # Example override: helm upgrade --set postgresql.resources.requests.memory=256Mi
+  resources: {}
+  # resources:
+  #   requests:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   limits:
+  #     cpu: 500m
+  #     memory: 512Mi
   persistence:
     enabled: true
     size: 2Gi


### PR DESCRIPTION
## Summary

- Adds `ingestCronJob.resources` knob to `values.yaml` with an empty-map default (no-op for current deployments); includes inline comment with example override values
- Adds `postgresql.resources` knob to `values.yaml` with an empty-map default; includes inline comment with example override values
- Renders both new resource blocks in `templates/cronjob.yaml` and `templates/postgres-statefulset.yaml` using the same `{{- with }} ... toYaml | indent` pattern as the existing app Deployment at `deployment.yaml:153`

Closes #485

## Test plan

- [x] `helm template news-dashboard ./helm/news-dashboard --set app.auth.sessionSecret=x` renders without resources blocks for CronJob and Postgres (default empty-map)
- [x] `helm template ... --set ingestCronJob.resources.requests.cpu=100m --set ingestCronJob.resources.requests.memory=256Mi --set postgresql.resources.requests.cpu=100m --set postgresql.resources.requests.memory=256Mi` renders `resources:` blocks in both the ingest CronJob container and the Postgres StatefulSet container
- [x] App Deployment `resources` block remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)