### PR TITLE
fix: surface Reading DNA load failures (#487)

### DIFF
--- a/frontend/src/__tests__/quizCandidates.test.tsx
+++ b/frontend/src/__tests__/quizCandidates.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../api', () => ({
   fetchGoals: vi.fn(),
   fetchLatestQuiz: vi.fn(),
   fetchQuizCandidates: vi.fn(),
+  fetchQuizHistory: vi.fn(),
   fetchReadingDna: vi.fn(),
   fetchRecommendationPreferences: vi.fn(),
   createGoal: vi.fn(),
@@ -37,6 +38,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   mockedApi.fetchGoals.mockResolvedValue([]);
   mockedApi.fetchLatestQuiz.mockResolvedValue(null);
+  mockedApi.fetchQuizHistory.mockResolvedValue([]);
   mockedApi.fetchReadingDna.mockResolvedValue({
     range_days: 30,
     generated_at: '2026-06-27T00:00:00Z',

--- a/frontend/src/__tests__/readingDnaLoadErrors.test.tsx
+++ b/frontend/src/__tests__/readingDnaLoadErrors.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as api from '../api';
+import { HttpError } from '../api';
+import { ReadingDnaPage } from '../pages/ReadingDnaPage';
+import type { ReadingDna } from '../types';
+
+const dna: ReadingDna = {
+  range_days: 30,
+  generated_at: '2026-06-21T10:00:00Z',
+  categories: [],
+  sources: [],
+  monthly_time: [],
+  average_dwell_seconds: 0,
+};
+
+function mockBasics() {
+  vi.spyOn(api, 'fetchReadingDna').mockResolvedValue(dna);
+  vi.spyOn(api, 'fetchRecommendationPreferences').mockResolvedValue({
+    category_weights: {},
+    novelty_weight: 1,
+  });
+  vi.spyOn(api, 'fetchGoals').mockResolvedValue([]);
+  vi.spyOn(api, 'fetchLatestQuiz').mockResolvedValue(null);
+  vi.spyOn(api, 'fetchQuizCandidates').mockResolvedValue([]);
+  vi.spyOn(api, 'fetchQuizHistory').mockResolvedValue([]);
+}
+
+async function renderLearningCenter() {
+  render(<ReadingDnaPage />);
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Learning Center' })).toBeTruthy());
+  await userEvent.click(screen.getByRole('button', { name: 'Learning Center' }));
+}
+
+describe('ReadingDnaPage load error surfaces', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockBasics();
+  });
+
+  describe('fetchLatestQuiz error differentiation', () => {
+    it('shows normal "No quiz yet" path when latest quiz returns 404', async () => {
+      vi.spyOn(api, 'fetchLatestQuiz').mockResolvedValue(null);
+      vi.spyOn(api, 'fetchQuizCandidates').mockResolvedValue([
+        {
+          id: 1,
+          title: 'Some Article',
+          category: 'tech',
+          source_name: null,
+          done_at: '2026-06-21T10:00:00Z',
+          goal_matched: false,
+          matched_keywords: [],
+        },
+      ]);
+
+      await renderLearningCenter();
+
+      expect(
+        await screen.findByText('No quiz yet. Generate one based on your recent reading.')
+      ).toBeTruthy();
+      expect(screen.queryByText('Failed to load quiz.')).toBeNull();
+    });
+
+    it('shows quiz error state when latest quiz request fails with non-404', async () => {
+      vi.spyOn(api, 'fetchLatestQuiz').mockRejectedValue(
+        new HttpError(500, 'Internal Server Error')
+      );
+
+      await renderLearningCenter();
+
+      expect(await screen.findByText('Failed to load quiz.')).toBeTruthy();
+      expect(
+        screen.queryByText('No quiz yet. Generate one based on your recent reading.')
+      ).toBeNull();
+    });
+
+    it('shows quiz error state when latest quiz request is rejected (network failure)', async () => {
+      vi.spyOn(api, 'fetchLatestQuiz').mockRejectedValue(new Error('Network error'));
+
+      await renderLearningCenter();
+
+      expect(await screen.findByText('Failed to load quiz.')).toBeTruthy();
+    });
+  });
+
+  it('shows goals error when goals request fails', async () => {
+    vi.spyOn(api, 'fetchGoals').mockRejectedValue(new Error('Unauthorized'));
+
+    await renderLearningCenter();
+
+    expect(await screen.findByText('Failed to load goals.')).toBeTruthy();
+    expect(screen.queryByText('No goals yet. Add one to boost relevant articles.')).toBeNull();
+  });
+
+  it('shows history error when quiz history request fails', async () => {
+    vi.spyOn(api, 'fetchQuizHistory').mockRejectedValue(new Error('server error'));
+
+    await renderLearningCenter();
+
+    expect(await screen.findByText('Failed to load quiz history.')).toBeTruthy();
+  });
+
+  it('shows candidates error when quiz candidates request fails', async () => {
+    vi.spyOn(api, 'fetchQuizCandidates').mockRejectedValue(new Error('Forbidden'));
+
+    await renderLearningCenter();
+
+    expect(await screen.findByText('Failed to load quiz material.')).toBeTruthy();
+  });
+
+  it('preserves generate button when only candidates fail', async () => {
+    vi.spyOn(api, 'fetchQuizCandidates').mockRejectedValue(new Error('Forbidden'));
+
+    await renderLearningCenter();
+
+    await screen.findByText('Failed to load quiz material.');
+    expect(screen.getByRole('button', { name: 'Generate quiz' })).toBeTruthy();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -63,6 +63,16 @@ async function readErrorMessage(response: Response): Promise<string> {
   return `${response.status} ${response.statusText}`;
 }
 
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
 export async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
     headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
@@ -70,7 +80,7 @@ export async function requestJson<T>(url: string, init?: RequestInit): Promise<T
     ...init,
   });
   if (!response.ok) {
-    throw new Error(await readErrorMessage(response));
+    throw new HttpError(response.status, await readErrorMessage(response));
   }
   return response.json() as Promise<T>;
 }
@@ -543,8 +553,9 @@ export async function fetchQuizCandidates(): Promise<QuizCandidate[]> {
 export async function fetchLatestQuiz(): Promise<Quiz | null> {
   try {
     return await requestJson<Quiz>('/api/quizzes/latest');
-  } catch {
-    return null;
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) return null;
+    throw err;
   }
 }
 

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -230,6 +230,10 @@ function LearningCenter() {
   const [generatingQuiz, setGeneratingQuiz] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [goalsError, setGoalsError] = useState<string | null>(null);
+  const [quizError, setQuizError] = useState<string | null>(null);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [candidatesError, setCandidatesError] = useState<string | null>(null);
   const [newDescription, setNewDescription] = useState('');
   const [newKeywords, setNewKeywords] = useState('');
   const [addingGoal, setAddingGoal] = useState(false);
@@ -239,30 +243,36 @@ function LearningCenter() {
   const refreshQuizHistory = async () => {
     try {
       setQuizHistory(await fetchQuizHistory());
+      setHistoryError(null);
     } catch {
-      setQuizHistory([]);
+      setHistoryError('Failed to load quiz history.');
     }
   };
 
   useEffect(() => {
     fetchGoals()
-      .then(setGoals)
-      .catch(() => setGoals([]))
+      .then((g) => {
+        setGoals(g);
+        setGoalsError(null);
+      })
+      .catch(() => setGoalsError('Failed to load goals.'))
       .finally(() => setLoadingGoals(false));
     fetchLatestQuiz()
       .then((q) => {
         setQuiz(q);
+        setQuizError(null);
         if (q?.completed_result) {
           setResult(q.completed_result);
         }
       })
-      .catch(() => setQuiz(null))
+      .catch(() => setQuizError('Failed to load quiz.'))
       .finally(() => setLoadingQuiz(false));
     fetchQuizCandidates()
-      .then(setCandidates)
-      .catch(() => {
-        // leave candidates null so the default UI renders when the endpoint is unavailable
-      });
+      .then((c) => {
+        setCandidates(c);
+        setCandidatesError(null);
+      })
+      .catch(() => setCandidatesError('Failed to load quiz material.'));
     void refreshQuizHistory();
   }, []);
 
@@ -339,6 +349,8 @@ function LearningCenter() {
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="size-3 animate-spin" /> Loading goals…
             </div>
+          ) : goalsError ? (
+            <p className="text-sm text-destructive">{goalsError}</p>
           ) : goals.length === 0 ? (
             <p className="text-sm text-muted-foreground">
               No goals yet. Add one to boost relevant articles.
@@ -421,6 +433,8 @@ function LearningCenter() {
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="size-3 animate-spin" /> Loading quiz…
           </div>
+        ) : quizError ? (
+          <p className="text-sm text-destructive">{quizError}</p>
         ) : result ? (
           <QuizResultView
             result={result}
@@ -446,30 +460,35 @@ function LearningCenter() {
           </div>
         ) : (
           <div className="space-y-3">
-            {candidates && candidates.length > 0 && (
-              <div className="space-y-1.5">
-                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                  Quiz will draw from
-                </p>
-                <ul className="space-y-1">
-                  {candidates.slice(0, 5).map((c) => (
-                    <li key={c.id} className="flex items-start gap-2 text-xs">
-                      <span className="mt-0.5 shrink-0 text-muted-foreground">·</span>
-                      <span className="min-w-0">
-                        <span className="font-medium">{c.title}</span>
-                        {(c.source_name ?? c.category) && (
-                          <span className="ml-1 text-muted-foreground">
-                            {[c.source_name ?? null, c.category ?? null]
-                              .filter(Boolean)
-                              .join(' · ')}
-                          </span>
-                        )}
-                        {c.goal_matched && <span className="ml-1 text-primary">✓ goal</span>}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+            {candidatesError ? (
+              <p className="text-xs text-destructive">{candidatesError}</p>
+            ) : (
+              candidates &&
+              candidates.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Quiz will draw from
+                  </p>
+                  <ul className="space-y-1">
+                    {candidates.slice(0, 5).map((c) => (
+                      <li key={c.id} className="flex items-start gap-2 text-xs">
+                        <span className="mt-0.5 shrink-0 text-muted-foreground">·</span>
+                        <span className="min-w-0">
+                          <span className="font-medium">{c.title}</span>
+                          {(c.source_name ?? c.category) && (
+                            <span className="ml-1 text-muted-foreground">
+                              {[c.source_name ?? null, c.category ?? null]
+                                .filter(Boolean)
+                                .join(' · ')}
+                            </span>
+                          )}
+                          {c.goal_matched && <span className="ml-1 text-primary">✓ goal</span>}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )
             )}
             <p className="text-sm text-muted-foreground">
               No quiz yet. Generate one based on your recent reading.
@@ -502,7 +521,11 @@ function LearningCenter() {
         )}
       </Panel>
 
-      {quizHistory.length > 0 && <QuizHistoryPanel items={quizHistory} />}
+      {historyError ? (
+        <p className="text-sm text-destructive">{historyError}</p>
+      ) : (
+        quizHistory.length > 0 && <QuizHistoryPanel items={quizHistory} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `HttpError` class to `api.ts` so HTTP status codes are preserved when requests fail; `requestJson` now throws `HttpError` instead of a plain `Error`
- Fixes `fetchLatestQuiz` to return `null` only for the expected 404 (no quiz exists) and rethrow all other failures
- Adds per-panel error state (`goalsError`, `quizError`, `historyError`, `candidatesError`) to `LearningCenter` so auth failures, 500s, and network errors render a visible message instead of a false empty state
- Adds `readingDnaLoadErrors.test.tsx` covering: 404 quiz path, non-404 quiz error, goals error, history error, candidates error, and generate button presence when only candidates fail

## Test plan

- [x] `npm run test:frontend` — all 18 tests in the 4 targeted files pass
- [x] `npm run typecheck` — clean

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)