### PR TITLE
fix: bound AI client requests with timeouts (#486)

### DIFF
--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -30,6 +30,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ScoreDataType = Literal["NUMERIC", "CATEGORICAL", "BOOLEAN"]
+_DEFAULT_AI_REQUEST_TIMEOUT_SECONDS = 30.0
+_DEFAULT_AI_TTS_TIMEOUT_SECONDS = 120.0
+
+
+def _timeout_seconds_from_env(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %.1fs", name, value, default)
+        return default
+    if parsed <= 0:
+        logger.warning("Ignoring non-positive %s=%r; using %.1fs", name, value, default)
+        return default
+    return parsed
+
+
+def request_timeout_seconds() -> float:
+    """Return the configured timeout for chat and embedding OpenAI-compatible calls."""
+    return _timeout_seconds_from_env(
+        "AI_REQUEST_TIMEOUT_SECONDS", _DEFAULT_AI_REQUEST_TIMEOUT_SECONDS
+    )
+
+
+def tts_timeout_seconds() -> float:
+    """Return the configured timeout for OpenAI TTS/audio calls."""
+    return _timeout_seconds_from_env("AI_TTS_TIMEOUT_SECONDS", _DEFAULT_AI_TTS_TIMEOUT_SECONDS)
 
 
 def langfuse_enabled() -> bool:
@@ -144,13 +173,21 @@ def free_llm_config() -> tuple[str, str | None]:
     return api_key, base_url
 
 
-def get_openai_client(*, api_key: str, base_url: str | None = None) -> OpenAI:
+def get_openai_client(
+    *,
+    api_key: str,
+    base_url: str | None = None,
+    timeout_seconds: float | None = None,
+) -> OpenAI:
     """Return an OpenAI client, Langfuse-wrapped when tracing is configured.
 
     The returned object is API-compatible with ``openai.OpenAI`` in both cases,
     so call sites are identical whether or not tracing is active.
     """
-    kwargs: dict[str, Any] = {"api_key": api_key}
+    kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "timeout": request_timeout_seconds() if timeout_seconds is None else timeout_seconds,
+    }
     if base_url is not None:
         kwargs["base_url"] = base_url
 

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -99,9 +99,11 @@ def generate_audio(
 
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    from news_dashboard.ai_client import get_openai_client
+    from news_dashboard.ai_client import get_openai_client, tts_timeout_seconds
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_openai_client(
+        api_key=api_key, base_url=base_url, timeout_seconds=tts_timeout_seconds()
+    )
     logger.info("Generating TTS audio for article %d (%d chars)", article_id, len(text))
     # audio/speech does not accept Langfuse trace kwargs, so TTS calls are
     # intentionally untraced. The wrapped client still routes through the same
@@ -139,9 +141,11 @@ def generate_podcast_audio(
 
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    from news_dashboard.ai_client import get_openai_client
+    from news_dashboard.ai_client import get_openai_client, tts_timeout_seconds
 
-    client = get_openai_client(api_key=api_key, base_url=base_url)
+    client = get_openai_client(
+        api_key=api_key, base_url=base_url, timeout_seconds=tts_timeout_seconds()
+    )
 
     combined_bytes = bytearray()
     for idx, entry in enumerate(script):

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,11 +25,14 @@ _LANGFUSE_VARS = (
     "LANGFUSE_HOST",
     "LANGFUSE_BASE_URL",
 )
+_AI_TIMEOUT_VARS = ("AI_REQUEST_TIMEOUT_SECONDS", "AI_TTS_TIMEOUT_SECONDS")
 
 
 @pytest.fixture
 def _no_langfuse(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in _LANGFUSE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for var in _AI_TIMEOUT_VARS:
         monkeypatch.delenv(var, raising=False)
 
 
@@ -59,6 +63,34 @@ def test_base_url_is_forwarded() -> None:
     assert str(client.base_url).rstrip("/") == "http://gateway:9130/v1"
 
 
+@pytest.mark.usefixtures("_no_langfuse")
+def test_plain_openai_client_uses_configured_request_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    import openai
+
+    monkeypatch.setenv("AI_REQUEST_TIMEOUT_SECONDS", "12.5")
+
+    with patch.object(openai, "OpenAI", return_value=MagicMock()) as constructor:
+        get_openai_client(api_key="test-key")
+
+    assert constructor.call_args.kwargs["timeout"] == 12.5
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_plain_openai_client_accepts_explicit_timeout_override() -> None:
+    from unittest.mock import patch
+
+    import openai
+
+    with patch.object(openai, "OpenAI", return_value=MagicMock()) as constructor:
+        get_openai_client(api_key="test-key", timeout_seconds=90.0)
+
+    assert constructor.call_args.kwargs["timeout"] == 90.0
+
+
 def test_returns_langfuse_client_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     # The wrapped client requires the langfuse SDK; skip when it is not importable
     # in this interpreter (e.g. a system pytest outside the project venv). It is a
@@ -73,6 +105,41 @@ def test_returns_langfuse_client_when_enabled(monkeypatch: pytest.MonkeyPatch) -
     # Langfuse traces by wrapping the OpenAI SDK methods (wrapt), rather than
     # subclassing — a wrapt wrapper exposes the original via __wrapped__.
     assert hasattr(client.chat.completions.create, "__wrapped__")
+
+
+def test_langfuse_client_uses_configured_request_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    wrapped_openai = MagicMock(return_value=MagicMock())
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    monkeypatch.setenv("AI_REQUEST_TIMEOUT_SECONDS", "17")
+
+    with patch(
+        "news_dashboard.ai_client.importlib.import_module",
+        return_value=SimpleNamespace(OpenAI=wrapped_openai),
+    ):
+        get_openai_client(api_key="test-key", base_url="http://gateway:9130/v1")
+
+    assert wrapped_openai.call_args.kwargs == {
+        "api_key": "test-key",
+        "base_url": "http://gateway:9130/v1",
+        "timeout": 17.0,
+    }
+
+
+def test_tts_timeout_uses_separate_default_and_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.ai_client import tts_timeout_seconds
+
+    monkeypatch.delenv("AI_TTS_TIMEOUT_SECONDS", raising=False)
+    assert tts_timeout_seconds() == 120.0
+
+    monkeypatch.setenv("AI_TTS_TIMEOUT_SECONDS", "240")
+    assert tts_timeout_seconds() == 240.0
 
 
 @pytest.mark.usefixtures("_no_langfuse")

--- a/backend/tests/test_ai_credentials.py
+++ b/backend/tests/test_ai_credentials.py
@@ -67,7 +67,7 @@ def test_answer_uses_openai_api_key_and_default_model(
     monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=FakeOpenAI))
 
     assert _answer("system", "user") == "answer text"
-    assert calls[0] == {"api_key": "test-key"}
+    assert calls[0] == {"api_key": "test-key", "timeout": 30.0}
     assert calls[1]["model"] == DEFAULT_ANSWER_MODEL
 
 

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -146,7 +146,7 @@ def test_generate_audio_calls_openai_and_writes_file(tmp_path: Path) -> None:
     assert call_kwargs.kwargs["model"] == "tts-1"
     assert call_kwargs.kwargs["voice"] == "alloy"
     assert "Test Article Title" in call_kwargs.kwargs["input"]
-    mock_factory.assert_called_once_with(api_key="sk-test")
+    mock_factory.assert_called_once_with(api_key="sk-test", timeout=120.0)
 
 
 def test_generate_audio_uses_configured_gateway_base_url(tmp_path: Path) -> None:
@@ -176,7 +176,7 @@ def test_generate_audio_uses_configured_gateway_base_url(tmp_path: Path) -> None
 
     assert path.exists()
     mock_factory.assert_called_once_with(
-        api_key="sk-test", base_url="http://shared-gateway:9130/v1"
+        api_key="sk-test", base_url="http://shared-gateway:9130/v1", timeout=120.0
     )
 
 


### PR DESCRIPTION
Closes #486

## Summary
- add configurable OpenAI-compatible request timeouts via AI_REQUEST_TIMEOUT_SECONDS
- use a separate AI_TTS_TIMEOUT_SECONDS override for TTS/audio clients
- cover plain OpenAI, Langfuse-wrapped clients, fallback behavior expectations, and TTS constructor calls in tests

## Tests
- pytest backend/tests/test_ai_client.py backend/tests/test_tts.py
- pytest backend/tests/test_ai_credentials.py::test_answer_uses_openai_api_key_and_default_model
- make lint
- make typecheck
- source .env && make test

🤖 Generated with [Claude Code](https://claude.com/claude-code)