### PR TITLE
feat: add load-more pagination to article queues (#490)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -518,16 +518,20 @@ def articles(
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
     offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict[str, Any]:
+    items = list_articles(
+        status=status,
+        state=state,
+        starred=starred,
+        category=category,
+        limit=limit + 1,
+        offset=offset,
+        user_id=current_user["id"],
+    )
     return {
-        "items": list_articles(
-            status=status,
-            state=state,
-            starred=starred,
-            category=category,
-            limit=limit,
-            offset=offset,
-            user_id=current_user["id"],
-        )
+        "items": items[:limit],
+        "limit": limit,
+        "offset": offset,
+        "has_more": len(items) > limit,
     }
 
 

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -366,6 +366,49 @@ def test_api_articles_uses_user_state(pg_clean: str, monkeypatch: pytest.MonkeyP
         app.dependency_overrides.pop(require_auth, None)
 
 
+def test_api_articles_exposes_pagination_metadata(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /api/articles tells clients when another queue page is available."""
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    uid = _make_user(pg_clean, "pagination-user")
+    for index in range(3):
+        _insert_article(pg_clean, url_suffix=f"page-{index}")
+
+    fake_user = {"id": uid, "username": "pagination-user", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            first = client.get("/api/articles", params={"state": "today", "limit": 2})
+            assert first.status_code == 200
+            first_payload = first.json()
+            assert len(first_payload["items"]) == 2
+            assert first_payload["limit"] == 2
+            assert first_payload["offset"] == 0
+            assert first_payload["has_more"] is True
+
+            second = client.get(
+                "/api/articles",
+                params={"state": "today", "limit": 2, "offset": 2},
+            )
+            assert second.status_code == 200
+            second_payload = second.json()
+            assert len(second_payload["items"]) == 1
+            assert second_payload["limit"] == 2
+            assert second_payload["offset"] == 2
+            assert second_payload["has_more"] is False
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
 def test_api_state_transition_writes_uas(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """PATCH /api/articles/{id}/state writes to user_article_state."""
     monkeypatch.setenv("DATABASE_URL", str(pg_clean))

--- a/frontend/src/__tests__/articleListView.test.tsx
+++ b/frontend/src/__tests__/articleListView.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
 import { ArticleListView } from '../components/article/ArticleListView';
 import type { WorkflowArticle } from '../lib/workflowTypes';
+import type { TriageArticlePage } from '../api/workflowApi';
 import { Inbox } from 'lucide-react';
 
 vi.mock('../hooks/useTriageMutations', () => ({
@@ -34,7 +35,22 @@ function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle 
   };
 }
 
-function renderArticleList(queryFn: () => Promise<WorkflowArticle[]>) {
+function page(
+  items: WorkflowArticle[],
+  overrides: Partial<Omit<TriageArticlePage, 'items'>> = {}
+): TriageArticlePage {
+  return {
+    items,
+    limit: 100,
+    offset: 0,
+    hasMore: false,
+    ...overrides,
+  };
+}
+
+function renderArticleList(
+  queryFn: (params: { limit: number; offset: number }) => Promise<TriageArticlePage>
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -67,7 +83,7 @@ function renderArticleList(queryFn: () => Promise<WorkflowArticle[]>) {
 
 describe('ArticleListView', () => {
   it('renders a configured heading, category filter, count, and article links', async () => {
-    renderArticleList(() => Promise.resolve([makeArticle()]));
+    renderArticleList(() => Promise.resolve(page([makeArticle()])));
 
     await waitFor(() => expect(screen.getByText('Readable article')).toBeTruthy());
 
@@ -80,7 +96,7 @@ describe('ArticleListView', () => {
   });
 
   it('marks article rows for deferred off-screen rendering', async () => {
-    renderArticleList(() => Promise.resolve([makeArticle()]));
+    renderArticleList(() => Promise.resolve(page([makeArticle()])));
 
     await waitFor(() => expect(screen.getByText('Readable article')).toBeTruthy());
 
@@ -89,15 +105,41 @@ describe('ArticleListView', () => {
   });
 
   it('renders the configured empty state after a successful empty response', async () => {
-    renderArticleList(() => Promise.resolve([]));
+    renderArticleList(() => Promise.resolve(page([])));
 
     await waitFor(() => expect(screen.getByText('Queue clear')).toBeTruthy());
+  });
+
+  it('loads and appends another page when more articles are available', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        page([makeArticle({ id: '1', title: 'First page' })], { hasMore: true })
+      )
+      .mockResolvedValueOnce(
+        page([makeArticle({ id: '2', title: 'Second page' })], {
+          offset: 1,
+          hasMore: false,
+        })
+      );
+
+    renderArticleList(queryFn);
+
+    await waitFor(() => expect(screen.getByText('First page')).toBeTruthy());
+    expect(screen.getByText('1 unhandled')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => expect(screen.getByText('Second page')).toBeTruthy());
+    expect(queryFn).toHaveBeenNthCalledWith(1, { limit: 100, offset: 0 });
+    expect(queryFn).toHaveBeenNthCalledWith(2, { limit: 100, offset: 1 });
+    expect(screen.getByText('2 unhandled')).toBeTruthy();
   });
 });
 
 describe('ArticleListView — list-view triage actions do not navigate', () => {
   it('swipe-right (done) calls setState but stays on the list page', async () => {
-    renderArticleList(() => Promise.resolve([makeArticle()]));
+    renderArticleList(() => Promise.resolve(page([makeArticle()])));
     await waitFor(() => screen.getByText('Readable article'));
 
     // The SwipeableRow inner div (touch target) wraps the article Link.

--- a/frontend/src/__tests__/triagePages.test.tsx
+++ b/frontend/src/__tests__/triagePages.test.tsx
@@ -9,10 +9,11 @@ import { InboxPage } from '../pages/InboxPage';
 import { LaterPage } from '../pages/LaterPage';
 import { StarredPage } from '../pages/StarredPage';
 import { ArchivePage } from '../pages/ArchivePage';
+import type { TriageArticlePage } from '../api/workflowApi';
 
 // Pin the data layer: each page only differs in title/sort/config wiring, so we
 // stub fetchTriageArticles and assert the page renders its heading + rows.
-const fetchTriageArticles = vi.fn<(...args: unknown[]) => Promise<WorkflowArticle[]>>();
+const fetchTriageArticles = vi.fn<(...args: unknown[]) => Promise<TriageArticlePage>>();
 vi.mock('@/api/workflowApi', () => ({
   fetchTriageArticles: (...args: unknown[]) => fetchTriageArticles(...args),
 }));
@@ -42,6 +43,10 @@ function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle 
   };
 }
 
+function page(items: WorkflowArticle[]): TriageArticlePage {
+  return { items, limit: 100, offset: 0, hasMore: false };
+}
+
 function renderPage(ui: React.ReactElement, route = '/') {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -57,42 +62,64 @@ function renderPage(ui: React.ReactElement, route = '/') {
 
 describe('triage wrapper pages', () => {
   it('InboxPage renders the Today heading and forwards the category filter', async () => {
-    fetchTriageArticles.mockResolvedValueOnce([makeArticle()]);
+    fetchTriageArticles.mockResolvedValueOnce(page([makeArticle()]));
     renderPage(<InboxPage />, '/today?category=ai-llm');
     expect(await screen.findByRole('heading', { name: 'Today' })).toBeTruthy();
-    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('today', 'ai-llm'));
+    await waitFor(() =>
+      expect(fetchTriageArticles).toHaveBeenCalledWith('today', 'ai-llm', {
+        limit: 100,
+        offset: 0,
+      })
+    );
   });
 
   it('LaterPage renders snoozed articles sorted by return date', async () => {
-    fetchTriageArticles.mockResolvedValueOnce([
-      makeArticle({ id: '1', title: 'Returns later', later_until: '2026-07-01T00:00:00Z' }),
-      makeArticle({ id: '2', title: 'Returns sooner', later_until: '2026-06-25T00:00:00Z' }),
-    ]);
+    fetchTriageArticles.mockResolvedValueOnce(
+      page([
+        makeArticle({ id: '1', title: 'Returns later', later_until: '2026-07-01T00:00:00Z' }),
+        makeArticle({ id: '2', title: 'Returns sooner', later_until: '2026-06-25T00:00:00Z' }),
+      ])
+    );
     renderPage(<LaterPage />, '/later');
     expect(await screen.findByRole('heading', { name: 'Later' })).toBeTruthy();
-    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('later'));
+    await waitFor(() =>
+      expect(fetchTriageArticles).toHaveBeenCalledWith('later', undefined, {
+        limit: 100,
+        offset: 0,
+      })
+    );
   });
 
   it('StarredPage renders the Starred heading', async () => {
-    fetchTriageArticles.mockResolvedValueOnce([
-      makeArticle({ starred: true, starred_at: '2026-06-20T00:00:00Z' }),
-    ]);
+    fetchTriageArticles.mockResolvedValueOnce(
+      page([makeArticle({ starred: true, starred_at: '2026-06-20T00:00:00Z' })])
+    );
     renderPage(<StarredPage />, '/starred');
     expect(await screen.findByRole('heading', { name: 'Starred' })).toBeTruthy();
-    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('starred', undefined));
+    await waitFor(() =>
+      expect(fetchTriageArticles).toHaveBeenCalledWith('starred', undefined, {
+        limit: 100,
+        offset: 0,
+      })
+    );
   });
 
   it('ArchivePage renders the Archive heading', async () => {
-    fetchTriageArticles.mockResolvedValueOnce([
-      makeArticle({ archived_at: '2026-06-19T00:00:00Z' }),
-    ]);
+    fetchTriageArticles.mockResolvedValueOnce(
+      page([makeArticle({ archived_at: '2026-06-19T00:00:00Z' })])
+    );
     renderPage(<ArchivePage />, '/archive');
     expect(await screen.findByRole('heading', { name: 'Archive' })).toBeTruthy();
-    await waitFor(() => expect(fetchTriageArticles).toHaveBeenCalledWith('archived', undefined));
+    await waitFor(() =>
+      expect(fetchTriageArticles).toHaveBeenCalledWith('archived', undefined, {
+        limit: 100,
+        offset: 0,
+      })
+    );
   });
 
   it('ArchivePage shows the empty state when there are no rows', async () => {
-    fetchTriageArticles.mockResolvedValueOnce([]);
+    fetchTriageArticles.mockResolvedValueOnce(page([]));
     renderPage(<ArchivePage />, '/archive');
     expect(await screen.findByText('Archive empty')).toBeTruthy();
   });

--- a/frontend/src/__tests__/workflowApi.test.ts
+++ b/frontend/src/__tests__/workflowApi.test.ts
@@ -106,9 +106,12 @@ describe('adaptArticle', () => {
 
 describe('fetchTriageArticles', () => {
   it('queries starred=true for the starred view', async () => {
-    const { calls } = stubFetch(() => jsonOk({ items: [legacy()] }));
-    const items = await fetchTriageArticles('starred');
-    expect(items).toHaveLength(1);
+    const { calls } = stubFetch(() =>
+      jsonOk({ items: [legacy()], limit: 100, offset: 0, has_more: false })
+    );
+    const page = await fetchTriageArticles('starred');
+    expect(page.items).toHaveLength(1);
+    expect(page.hasMore).toBe(false);
     expect(calls[0].url).toContain('starred=true');
   });
 
@@ -117,6 +120,18 @@ describe('fetchTriageArticles', () => {
     await fetchTriageArticles('today', 'ai-llm');
     expect(calls[0].url).toContain('state=today');
     expect(calls[0].url).toContain('category=ai-llm');
+  });
+
+  it('forwards pagination params and normalizes page metadata', async () => {
+    const { calls } = stubFetch(() =>
+      jsonOk({ items: [legacy()], limit: 50, offset: 100, has_more: true })
+    );
+    const page = await fetchTriageArticles('today', undefined, { limit: 50, offset: 100 });
+    expect(calls[0].url).toContain('limit=50');
+    expect(calls[0].url).toContain('offset=100');
+    expect(page.limit).toBe(50);
+    expect(page.offset).toBe(100);
+    expect(page.hasMore).toBe(true);
   });
 });
 

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -88,10 +88,25 @@ export function adaptArticle(a: LegacyArticle): WorkflowArticle {
 
 type TriageView = 'today' | 'later' | 'starred' | 'archived';
 
+export interface TriageArticlePage {
+  items: WorkflowArticle[];
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+interface TriageArticleApiPage {
+  items: LegacyArticle[];
+  limit?: number;
+  offset?: number;
+  has_more?: boolean;
+}
+
 export async function fetchTriageArticles(
   view: TriageView,
-  category?: string
-): Promise<WorkflowArticle[]> {
+  category?: string,
+  options: { limit?: number; offset?: number } = {}
+): Promise<TriageArticlePage> {
   const params = new URLSearchParams();
   if (view === 'starred') {
     params.set('starred', 'true');
@@ -99,9 +114,16 @@ export async function fetchTriageArticles(
     params.set('state', view);
   }
   if (category) params.set('category', category);
+  if (options.limit) params.set('limit', String(options.limit));
+  if (options.offset) params.set('offset', String(options.offset));
   const suffix = params.size ? `?${params}` : '';
-  const data = await requestJson<{ items: LegacyArticle[] }>(`/api/articles${suffix}`);
-  return data.items.map(adaptArticle);
+  const data = await requestJson<TriageArticleApiPage>(`/api/articles${suffix}`);
+  return {
+    items: data.items.map(adaptArticle),
+    limit: data.limit ?? options.limit ?? data.items.length,
+    offset: data.offset ?? options.offset ?? 0,
+    hasMore: Boolean(data.has_more),
+  };
 }
 
 // ─── Mutations ──────────────────────────────────────────────────────────────

--- a/frontend/src/components/article/ArticleListView.tsx
+++ b/frontend/src/components/article/ArticleListView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery, type QueryKey } from '@tanstack/react-query';
+import { useInfiniteQuery, type QueryKey } from '@tanstack/react-query';
 import type { LucideIcon } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
 import { CategoryFilter } from '@/components/CategoryFilter';
@@ -10,12 +10,20 @@ import { useArticleListNav } from '@/hooks/useArticleListNav';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { setReaderList } from '@/lib/readerList';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
+import type { TriageArticlePage } from '@/api/workflowApi';
+
+const ARTICLE_PAGE_SIZE = 100;
 
 interface ArticleListViewProps {
   title: string;
-  description: (state: { count: number; isLoading: boolean }) => React.ReactNode;
+  description: (state: {
+    count: number;
+    loadedCount: number;
+    hasMore: boolean;
+    isLoading: boolean;
+  }) => React.ReactNode;
   queryKey: QueryKey;
-  queryFn: () => Promise<WorkflowArticle[]>;
+  queryFn: (params: { limit: number; offset: number }) => Promise<TriageArticlePage>;
   empty: {
     icon: LucideIcon;
     title: string;
@@ -39,10 +47,15 @@ export function ArticleListView({
   banner,
 }: ArticleListViewProps) {
   const navigate = useNavigate();
-  const { data: articles = [], isLoading } = useQuery({
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
     queryKey,
-    queryFn,
+    queryFn: ({ pageParam }) => queryFn({ limit: ARTICLE_PAGE_SIZE, offset: pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.offset + lastPage.items.length : undefined,
   });
+  const articles = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data?.pages]);
+  const hasMore = Boolean(hasNextPage);
 
   const list = useMemo(
     () => (sortArticles ? sortArticles(articles) : articles),
@@ -67,7 +80,12 @@ export function ArticleListView({
       <div className="px-4 md:px-5 pt-4 pb-3">
         <h2 className="text-[22px] font-semibold tracking-tight">{title}</h2>
         <p className="text-xs text-muted-foreground mt-0.5">
-          {description({ count: list.length, isLoading })}
+          {description({
+            count: list.length,
+            loadedCount: list.length,
+            hasMore,
+            isLoading,
+          })}
         </p>
       </div>
       {showCategoryFilter && <CategoryFilter />}
@@ -77,14 +95,28 @@ export function ArticleListView({
       ) : list.length === 0 ? (
         <EmptyState icon={empty.icon} title={empty.title} subtitle={empty.subtitle} />
       ) : (
-        list.map((article, index) => (
-          <ArticleRow
-            key={article.id}
-            article={article}
-            focused={index === focused}
-            showLaterUntil={showLaterUntil}
-          />
-        ))
+        <>
+          {list.map((article, index) => (
+            <ArticleRow
+              key={article.id}
+              article={article}
+              focused={index === focused}
+              showLaterUntil={showLaterUntil}
+            />
+          ))}
+          {hasMore && (
+            <div className="px-4 py-4 md:px-5">
+              <button
+                type="button"
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => void fetchNextPage()}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? 'Loading...' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/ArchivePage.tsx
+++ b/frontend/src/pages/ArchivePage.tsx
@@ -18,9 +18,11 @@ export function ArchivePage() {
   return (
     <ArticleListView
       title="Archive"
-      description={() => 'Hidden from daily surfaces · still searchable'}
+      description={({ loadedCount, hasMore }) =>
+        `${loadedCount}${hasMore ? '+' : ''} archived · still searchable`
+      }
       queryKey={[ARTICLES_KEY, 'archived', category]}
-      queryFn={() => fetchTriageArticles('archived', category)}
+      queryFn={(params) => fetchTriageArticles('archived', category, params)}
       empty={{ icon: ArchiveIcon, title: 'Archive empty' }}
       showCategoryFilter
       sortArticles={sortByArchivedDate}

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -12,11 +12,11 @@ export function InboxPage() {
   return (
     <ArticleListView
       title="Today"
-      description={({ count, isLoading }) =>
-        `${isLoading ? '…' : `${count} unhandled`} · scan, decide, move on`
+      description={({ loadedCount, hasMore, isLoading }) =>
+        `${isLoading ? '...' : `${loadedCount}${hasMore ? '+' : ''} unhandled`} · scan, decide, move on`
       }
       queryKey={[ARTICLES_KEY, 'today', category]}
-      queryFn={() => fetchTriageArticles('today', category)}
+      queryFn={(params) => fetchTriageArticles('today', category, params)}
       empty={{ icon: Inbox, title: 'Queue clear', subtitle: 'Nothing left to triage today.' }}
       showCategoryFilter
       banner={<FeedNudgeBanner />}

--- a/frontend/src/pages/LaterPage.tsx
+++ b/frontend/src/pages/LaterPage.tsx
@@ -14,9 +14,11 @@ export function LaterPage() {
   return (
     <ArticleListView
       title="Later"
-      description={({ count }) => `${count} snoozed · returns to Today automatically`}
+      description={({ loadedCount, hasMore }) =>
+        `${loadedCount}${hasMore ? '+' : ''} snoozed · returns to Today automatically`
+      }
       queryKey={[ARTICLES_KEY, 'later']}
-      queryFn={() => fetchTriageArticles('later')}
+      queryFn={(params) => fetchTriageArticles('later', undefined, params)}
       empty={{
         icon: Clock,
         title: 'Nothing snoozed',

--- a/frontend/src/pages/StarredPage.tsx
+++ b/frontend/src/pages/StarredPage.tsx
@@ -18,11 +18,11 @@ export function StarredPage() {
   return (
     <ArticleListView
       title="Starred"
-      description={({ count, isLoading }) =>
-        `${isLoading ? '…' : `${count} reference articles`} · always available to Ask AI`
+      description={({ loadedCount, hasMore, isLoading }) =>
+        `${isLoading ? '...' : `${loadedCount}${hasMore ? '+' : ''} reference articles`} · always available to Ask AI`
       }
       queryKey={[ARTICLES_KEY, 'starred', category]}
-      queryFn={() => fetchTriageArticles('starred', category)}
+      queryFn={(params) => fetchTriageArticles('starred', category, params)}
       empty={{
         icon: Star,
         title: 'No stars yet',


### PR DESCRIPTION
Closes #490

## Summary
- Add `/api/articles` pagination metadata (`limit`, `offset`, `has_more`) while preserving the existing `items` payload.
- Switch Today, Later, Starred, and Archive queues to paged fetching with a bottom Load more button.
- Show partial queue counts with a `+` suffix when more rows are available.

## Tests
- `source .env && pytest backend/tests/test_per_user_article_state.py::test_api_articles_exposes_pagination_metadata`
- `npm run test:frontend -- --run frontend/src/__tests__/workflowApi.test.ts frontend/src/__tests__/articleListView.test.tsx frontend/src/__tests__/triagePages.test.tsx`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `make lint`
- `make typecheck`
- `source .env && make test`
- `npm run build`

Note: Vitest logs localhost:3000 ECONNREFUSED probes in this environment, but the test commands exit successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)