### PR TITLE
fix: surface manual ingest partial failures in Scheduler toast (#491)

### DIFF
--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -15,10 +15,10 @@ def init() -> None:
 
 @app.command()
 def ingest() -> None:
-    results = ingest_all()
-    for source, count in results.items():
+    ingest_result = ingest_all()
+    for source, count in ingest_result.results.items():
         typer.echo(f"{source}: {count}")
-    typer.echo(f"inserted: {sum(value for value in results.values() if value > 0)}")
+    typer.echo(f"inserted: {sum(value for value in ingest_result.results.values() if value > 0)}")
     # Short-lived process: flush any buffered Langfuse traces before exit.
     from news_dashboard.ai_client import flush
 

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -83,6 +83,17 @@ class SourceIngestOutcome:
     error_message: str | None = None
 
 
+@dataclass(frozen=True)
+class IngestResult:
+    results: dict[str, int]
+    run_id: int
+    total_errors: int
+
+    @property
+    def failed_sources(self) -> list[str]:
+        return [slug for slug, count in self.results.items() if count < 0]
+
+
 TRACKING_PARAMS = {
     "utm_source",
     "utm_medium",
@@ -762,7 +773,7 @@ def _format_source_log(outcome: SourceIngestOutcome) -> str:
     )
 
 
-def ingest_all(db_path: Path | str | None = None) -> dict[str, int]:
+def ingest_all(db_path: Path | str | None = None) -> IngestResult:
     with _INGEST_RUN_LOCK:
         sync_sources(db_path)
         run_started_at = now_iso()
@@ -816,7 +827,7 @@ def ingest_all(db_path: Path | str | None = None) -> dict[str, int]:
             ingest_events.complete_run(
                 f"Summary — {total_new} new {article_word}{error_text} ({duration_seconds:.1f}s)"
             )
-    return results
+    return IngestResult(results=results, run_id=run_id, total_errors=total_errors)
 
 
 _INTERNAL_ARTICLE_COLUMNS = frozenset({"embedding", "fts_vector", "search_vector"})

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -496,11 +496,17 @@ def auth_me(current_user: Annotated[dict[str, Any], Depends(require_auth)]) -> d
 
 @api.post("/api/ingest", dependencies=[Depends(require_admin)])
 def ingest(background_tasks: BackgroundTasks) -> dict[str, Any]:
-    results = ingest_all()
-    inserted = sum(v for v in results.values() if v > 0)
+    ingest_result = ingest_all()
+    inserted = sum(v for v in ingest_result.results.values() if v > 0)
     if inserted > 0:
         background_tasks.add_task(prefetch_article_bodies)
-    return {"results": results, "inserted": inserted}
+    return {
+        "results": ingest_result.results,
+        "inserted": inserted,
+        "run_id": ingest_result.run_id,
+        "total_errors": ingest_result.total_errors,
+        "failed_sources": ingest_result.failed_sources,
+    }
 
 
 @api.get("/api/ingest/stream")

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -36,7 +36,8 @@ def run_scheduled_ingest() -> dict[str, int]:
     logger.info("Scheduled ingest starting…")
     results: dict[str, int] = {}
     try:
-        results = ingest_all()
+        ingest_result = ingest_all()
+        results = ingest_result.results
         total = sum(v for v in results.values() if v > 0)
         logger.info("Scheduled ingest complete: %d new articles", total)
         if total > 0:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -24,7 +24,10 @@ def test_init_syncs_sources() -> None:
 
 
 def test_ingest_prints_per_source_counts_and_total() -> None:
-    with patch("news_dashboard.cli.ingest_all", return_value={"a": 2, "b": 3, "c": -1}):
+    from news_dashboard.ingest import IngestResult
+
+    fake = IngestResult(results={"a": 2, "b": 3, "c": -1}, run_id=1, total_errors=1)
+    with patch("news_dashboard.cli.ingest_all", return_value=fake):
         result = runner.invoke(app, ["ingest"])
     assert result.exit_code == 0
     assert "a: 2" in result.stdout

--- a/backend/tests/test_hf_blog_ingest.py
+++ b/backend/tests/test_hf_blog_ingest.py
@@ -199,7 +199,7 @@ def test_hf_blog_snippet_fetch_failure_still_inserts_article(
 
     result = ingest_all(db_path)
 
-    assert result.get("huggingface-blog", -1) == 1
+    assert result.results.get("huggingface-blog", -1) == 1
 
     with connect(db_path) as conn:
         row = conn.execute("SELECT summary, title FROM articles").fetchone()

--- a/backend/tests/test_ingest_route_auth.py
+++ b/backend/tests/test_ingest_route_auth.py
@@ -48,11 +48,34 @@ def test_ingest_requires_admin(client: TestClient) -> None:
 
 
 def test_ingest_succeeds_for_admin(client: TestClient) -> None:
+    from news_dashboard.ingest import IngestResult
+
+    fake_result = IngestResult(results={"feed1": 3, "feed2": 0}, run_id=1, total_errors=0)
     with (
-        patch("news_dashboard.main.ingest_all", return_value={"feed1": 3, "feed2": 0}),
+        patch("news_dashboard.main.ingest_all", return_value=fake_result),
         patch("news_dashboard.main.prefetch_article_bodies"),
     ):
         resp = client.post("/api/ingest")
     assert resp.status_code == 200
     body = resp.json()
     assert body["inserted"] == 3
+    assert body["run_id"] == 1
+    assert body["total_errors"] == 0
+    assert body["failed_sources"] == []
+
+
+def test_ingest_exposes_partial_failure_metadata(client: TestClient) -> None:
+    from news_dashboard.ingest import IngestResult
+
+    fake_result = IngestResult(results={"good-feed": 2, "bad-feed": -1}, run_id=42, total_errors=1)
+    with (
+        patch("news_dashboard.main.ingest_all", return_value=fake_result),
+        patch("news_dashboard.main.prefetch_article_bodies"),
+    ):
+        resp = client.post("/api/ingest")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["inserted"] == 2
+    assert body["run_id"] == 42
+    assert body["total_errors"] == 1
+    assert body["failed_sources"] == ["bad-feed"]

--- a/backend/tests/test_ingest_runs.py
+++ b/backend/tests/test_ingest_runs.py
@@ -38,7 +38,9 @@ def test_ingest_all_writes_run_rows_and_buffers_terminal_lines(
 
     monkeypatch.setattr(ingest_module, "_parse_feed_url", fake_parse_url)
 
-    assert ingest_all(db_path) == {"test-feed": 1}
+    result = ingest_all(db_path)
+    assert result.results == {"test-feed": 1}
+    assert result.total_errors == 0
 
     with connect(db_path) as conn:
         run = conn.execute("SELECT * FROM ingest_runs").fetchone()
@@ -73,7 +75,10 @@ def test_ingest_all_records_source_errors(tmp_path: Path, monkeypatch: Any) -> N
 
     monkeypatch.setattr(ingest_module, "_parse_feed_url", fake_parse_url)
 
-    assert ingest_all(db_path) == {"bad-feed": -1}
+    result = ingest_all(db_path)
+    assert result.results == {"bad-feed": -1}
+    assert result.total_errors == 1
+    assert result.failed_sources == ["bad-feed"]
 
     with connect(db_path) as conn:
         run = conn.execute("SELECT * FROM ingest_runs").fetchone()

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -229,9 +229,13 @@ def test_start_scheduler_briefing_fn_is_run_briefing(monkeypatch: pytest.MonkeyP
 
 def test_run_ingest_prefetches_when_new_articles() -> None:
     from news_dashboard import scheduler
+    from news_dashboard.ingest import IngestResult
 
     with (
-        patch("news_dashboard.ingest.ingest_all", return_value={"a": 2, "b": -1}) as ingest,
+        patch(
+            "news_dashboard.ingest.ingest_all",
+            return_value=IngestResult(results={"a": 2, "b": -1}, run_id=1, total_errors=1),
+        ) as ingest,
         patch("news_dashboard.body_fetch.prefetch_article_bodies") as prefetch,
         patch.object(scheduler, "_run_recommendation_recalc") as recalc,
     ):
@@ -244,9 +248,13 @@ def test_run_ingest_prefetches_when_new_articles() -> None:
 
 def test_run_scheduled_ingest_returns_results_and_runs_maintenance() -> None:
     from news_dashboard import scheduler
+    from news_dashboard.ingest import IngestResult
 
     with (
-        patch("news_dashboard.ingest.ingest_all", return_value={"a": 2, "b": -1}) as ingest,
+        patch(
+            "news_dashboard.ingest.ingest_all",
+            return_value=IngestResult(results={"a": 2, "b": -1}, run_id=1, total_errors=1),
+        ) as ingest,
         patch("news_dashboard.body_fetch.prefetch_article_bodies") as prefetch,
         patch.object(scheduler, "_run_recommendation_recalc") as recalc,
     ):
@@ -260,9 +268,13 @@ def test_run_scheduled_ingest_returns_results_and_runs_maintenance() -> None:
 
 def test_run_ingest_skips_prefetch_when_no_new_articles() -> None:
     from news_dashboard import scheduler
+    from news_dashboard.ingest import IngestResult
 
     with (
-        patch("news_dashboard.ingest.ingest_all", return_value={"a": 0}),
+        patch(
+            "news_dashboard.ingest.ingest_all",
+            return_value=IngestResult(results={"a": 0}, run_id=1, total_errors=0),
+        ),
         patch("news_dashboard.body_fetch.prefetch_article_bodies") as prefetch,
         patch.object(scheduler, "_run_recommendation_recalc"),
     ):

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -230,9 +230,14 @@ describe('sources, summary, ingest', () => {
   });
 
   it('ingestNow POSTs', async () => {
-    const { calls } = stubFetch(() => jsonOk({ inserted: 2, results: {} }));
+    const { calls } = stubFetch(() =>
+      jsonOk({ inserted: 2, results: {}, run_id: 5, total_errors: 0, failed_sources: [] })
+    );
     const r = await api.ingestNow();
     expect(r.inserted).toBe(2);
+    expect(r.run_id).toBe(5);
+    expect(r.total_errors).toBe(0);
+    expect(r.failed_sources).toEqual([]);
     expect(calls[0].init?.method).toBe('POST');
   });
 

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../api', () => apiMock);
 vi.mock('sonner', () => ({
   toast: Object.assign(vi.fn(), {
     success: vi.fn(),
+    warning: vi.fn(),
     error: vi.fn(),
     loading: vi.fn(() => 'id'),
   }),
@@ -322,10 +323,54 @@ describe('SchedulerPage', () => {
 
   it('triggers an on-demand ingest', async () => {
     apiMock.fetchSchedulerStatus.mockResolvedValue(running);
-    apiMock.ingestNow.mockResolvedValue({ inserted: 2, results: {} });
+    apiMock.ingestNow.mockResolvedValue({
+      inserted: 2,
+      results: {},
+      run_id: 1,
+      total_errors: 0,
+      failed_sources: [],
+    });
     withProviders(<SchedulerPage />);
     fireEvent.click(await screen.findByText('↻ Fetch now'));
     await waitFor(() => expect(apiMock.ingestNow).toHaveBeenCalled());
+  });
+
+  it('shows success toast when all sources succeed', async () => {
+    const { toast } = await import('sonner');
+    apiMock.fetchSchedulerStatus.mockResolvedValue(running);
+    apiMock.ingestNow.mockResolvedValue({
+      inserted: 3,
+      results: { feed: 3 },
+      run_id: 1,
+      total_errors: 0,
+      failed_sources: [],
+    });
+    withProviders(<SchedulerPage />);
+    fireEvent.click(await screen.findByText('↻ Fetch now'));
+    await waitFor(() =>
+      expect(
+        (toast as unknown as { success: ReturnType<typeof vi.fn> }).success
+      ).toHaveBeenCalledWith(expect.stringContaining('3 new articles'), expect.anything())
+    );
+  });
+
+  it('shows warning toast when some sources fail', async () => {
+    const { toast } = await import('sonner');
+    apiMock.fetchSchedulerStatus.mockResolvedValue(running);
+    apiMock.ingestNow.mockResolvedValue({
+      inserted: 2,
+      results: { ok: 2, bad: -1 },
+      run_id: 42,
+      total_errors: 1,
+      failed_sources: ['bad'],
+    });
+    withProviders(<SchedulerPage />);
+    fireEvent.click(await screen.findByText('↻ Fetch now'));
+    await waitFor(() =>
+      expect(
+        (toast as unknown as { warning: ReturnType<typeof vi.fn> }).warning
+      ).toHaveBeenCalledWith(expect.stringContaining('1 source failed'), expect.anything())
+    );
   });
 
   it('saves a valid custom interval and rejects an invalid one', async () => {

--- a/frontend/src/__tests__/palette.test.tsx
+++ b/frontend/src/__tests__/palette.test.tsx
@@ -183,7 +183,13 @@ describe('CommandPalette — article search', () => {
 
 describe('CommandPalette — ingest action', () => {
   it('calls ingestNow when "Refresh feeds now" is selected by admin', async () => {
-    const ingestSpy = vi.spyOn(api, 'ingestNow').mockResolvedValue({ inserted: 3, results: {} });
+    const ingestSpy = vi.spyOn(api, 'ingestNow').mockResolvedValue({
+      inserted: 3,
+      results: {},
+      run_id: 1,
+      total_errors: 0,
+      failed_sources: [],
+    });
     const onOpenChange = vi.fn();
     render(
       <Wrapper user={adminUser}>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -208,7 +208,13 @@ export async function saveRecommendationPreferences(
   });
 }
 
-export async function ingestNow(): Promise<{ inserted: number; results: Record<string, number> }> {
+export async function ingestNow(): Promise<{
+  inserted: number;
+  results: Record<string, number>;
+  run_id: number;
+  total_errors: number;
+  failed_sources: string[];
+}> {
   return requestJson('/api/ingest', { method: 'POST' });
 }
 

--- a/frontend/src/pages/SchedulerPage.tsx
+++ b/frontend/src/pages/SchedulerPage.tsx
@@ -116,9 +116,17 @@ export function SchedulerPage() {
     const id = toast.loading('Running ingest…');
     try {
       const result = await ingestNow();
-      toast.success(`Done — ${result.inserted} new article${result.inserted !== 1 ? 's' : ''}`, {
-        id,
-      });
+      if (result.total_errors > 0) {
+        const errCount = result.total_errors;
+        toast.warning(
+          `Done — ${result.inserted} new article${result.inserted !== 1 ? 's' : ''}, ${errCount} source${errCount !== 1 ? 's' : ''} failed. Check Feeds › Runs for details.`,
+          { id, duration: 8000 }
+        );
+      } else {
+        toast.success(`Done — ${result.inserted} new article${result.inserted !== 1 ? 's' : ''}`, {
+          id,
+        });
+      }
     } catch {
       toast.error('Ingest failed', { id });
     } finally {


### PR DESCRIPTION
## Summary

Closes #491

- Added `IngestResult` dataclass to `ingest.py` with `results`, `run_id`, `total_errors`, and `failed_sources` fields
- `POST /api/ingest` now returns `run_id`, `total_errors`, and `failed_sources` alongside the existing `inserted` and `results` fields
- `SchedulerPage` "Fetch now" shows a **warning toast** (8s duration) with the error count and a prompt to check Feeds › Runs when some sources fail; fully successful runs keep the existing concise success toast
- Updated callers in `cli.py` and `scheduler.py` to use the new return type; `run_scheduled_ingest()` still returns `dict[str, int]`

## Test plan

- [x] Backend: `test_ingest_route_auth.py` — new `test_ingest_exposes_partial_failure_metadata` test verifies `run_id`, `total_errors`, `failed_sources` in API response
- [x] Backend: `test_ingest_runs.py` — assertions updated to compare `.results`, `.total_errors`, `.failed_sources`
- [x] Frontend: `feedsPages.test.tsx` — new tests for success toast and warning toast paths; `toast.warning` added to mock
- [x] Frontend: `api.test.ts` — `ingestNow` test checks all new response fields
- [x] All 73 backend tests pass; all 592 frontend tests pass; mypy, ruff, tsc, eslint, prettier all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)