### PR TITLE
fix: ignore modified article shortcuts (#492)

### DIFF
--- a/frontend/src/__tests__/keyboard.test.ts
+++ b/frontend/src/__tests__/keyboard.test.ts
@@ -38,8 +38,8 @@ function makeMutations(): Mutations {
   };
 }
 
-function fireKey(key: string) {
-  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+function fireKey(key: string, init: KeyboardEventInit = {}) {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, ...init }));
 }
 
 // ─── useArticleListNav — j/k navigation ──────────────────────────────────────
@@ -83,6 +83,14 @@ describe('useArticleListNav — j/k navigation', () => {
   it('k does not go below 0', () => {
     const { result } = renderHook(() => useArticleListNav(articles, vi.fn(), makeMutations()));
     act(() => fireKey('k'));
+    expect(result.current.focused).toBe(0);
+  });
+
+  it('ignores modified navigation keys', () => {
+    const { result } = renderHook(() => useArticleListNav(articles, vi.fn(), makeMutations()));
+    act(() => fireKey('j', { metaKey: true }));
+    act(() => fireKey('j', { ctrlKey: true }));
+    act(() => fireKey('j', { altKey: true }));
     expect(result.current.focused).toBe(0);
   });
 });
@@ -158,6 +166,17 @@ describe('useArticleListNav — action keys', () => {
     renderHook(() => useArticleListNav(articles, openArticle, mutations));
     act(() => fireKey('Enter'));
     expect(openArticle).toHaveBeenCalledWith(article);
+  });
+
+  it('ignores modified action keys', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('s', { altKey: true }));
+    act(() => fireKey('r', { ctrlKey: true }));
+    act(() => fireKey('o', { metaKey: true }));
+    expect(mutations.toggleStar).not.toHaveBeenCalled();
+    expect(mutations.setState).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it('ignores keys when target is an INPUT', () => {

--- a/frontend/src/hooks/useArticleListNav.ts
+++ b/frontend/src/hooks/useArticleListNav.ts
@@ -19,6 +19,7 @@ export function useArticleListNav(
     const handler = (e: KeyboardEvent) => {
       const t = e.target as HTMLElement;
       if (t?.tagName === 'INPUT' || t?.tagName === 'TEXTAREA' || t?.isContentEditable) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       const cur = list[focused];
 

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -355,6 +355,7 @@ export function ArticlePage() {
     const onKey = (e: KeyboardEvent) => {
       const t = e.target as HTMLElement;
       if (t?.tagName === 'INPUT' || t?.tagName === 'TEXTAREA' || t?.isContentEditable) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (e.key === 'Escape') goBack();
       else if (e.key === 'ArrowLeft') goPrev();
       else if (e.key === 'ArrowRight') goNext();


### PR DESCRIPTION
Closes #492

## Summary
- Ignore article list shortcut events when meta, ctrl, or alt modifiers are held.
- Apply the same modifier guard to the reader page single-key shortcuts.
- Add keyboard regression coverage for modified navigation and action keys.

## Tests
- npm run test:frontend -- frontend/src/__tests__/keyboard.test.ts
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:frontend (passes; existing tests emit ECONNREFUSED localhost:3000 noise)
- npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)