### PR TITLE
security: scope /api/sources/health to user-visible sources (#495)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1270,8 +1270,10 @@ def delete_source(
 
 
 @api.get("/api/sources/health")
-def sources_health() -> dict[str, Any]:
-    return {"items": list_source_health()}
+def sources_health(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": list_source_health(user_id=int(current_user["id"]))}
 
 
 @api.get("/api/sources/cleanup-suggestions")

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -55,11 +55,22 @@ def _as_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
-def list_source_health(db_path: Path | str | None = None) -> list[dict[str, Any]]:
-    init_db(db_path)
-    with connect(db_path) as conn:
+def list_source_health(
+    db_path: Path | str | None = None,
+    *,
+    user_id: int | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
         source_rows = conn.execute(
-            "SELECT * FROM sources ORDER BY category, priority DESC, name"
+            """
+            SELECT * FROM sources
+            WHERE owner_user_id IS NULL
+               OR (%s::integer IS NULL OR owner_user_id = %s)
+            ORDER BY category, priority DESC, name
+            """,
+            (user_id, user_id),
         ).fetchall()
         run_rows = conn.execute(
             """

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -65,6 +65,16 @@ def _add_source(conn: Any, slug: str, name: str) -> None:
     )
 
 
+def _add_private_source(conn: Any, slug: str, name: str, owner_user_id: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+        VALUES (%s, %s, %s, 'tech', 'rss_feed', 10, TRUE, %s)
+        """,
+        (slug, name, f"https://example.com/{slug}.xml", owner_user_id),
+    )
+
+
 def _add_article(
     conn: Any,
     *,
@@ -218,6 +228,52 @@ def test_source_health_counts_leading_errors_and_sorts_first(tmp_path: Path) -> 
     assert python["status"] == "ERROR"
     assert python["last_error"] == "TimeoutError: connection timed out"
     assert items[0]["slug"] == "python-insider"
+
+
+def test_source_health_scoped_to_user_visibility(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    alice_id = _make_user(pg_clean, "alice")
+    bob_id = _make_user(pg_clean, "bob")
+
+    with connect(pg_clean) as conn:
+        _add_private_source(conn, "alice-private", "Alice Private Feed", alice_id)
+        _add_private_source(conn, "bob-private", "Bob Private Feed", bob_id)
+
+    alice_items = list_source_health(user_id=alice_id, database_url=pg_clean)
+    alice_slugs = {item["slug"] for item in alice_items}
+
+    assert "alice-private" in alice_slugs, "alice should see her own private source"
+    assert "bob-private" not in alice_slugs, "alice should not see bob's private source"
+
+    bob_items = list_source_health(user_id=bob_id, database_url=pg_clean)
+    bob_slugs = {item["slug"] for item in bob_items}
+
+    assert "bob-private" in bob_slugs, "bob should see his own private source"
+    assert "alice-private" not in bob_slugs, "bob should not see alice's private source"
+
+
+def test_source_health_api_scoped_to_current_user(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    alice_id = _make_user(pg_clean, "alice")
+    bob_id = _make_user(pg_clean, "bob")
+
+    with connect(pg_clean) as conn:
+        _add_private_source(conn, "alice-private", "Alice Private Feed", alice_id)
+        _add_private_source(conn, "bob-private", "Bob Private Feed", bob_id)
+
+    client = _api_client(alice_id)
+    try:
+        resp = client.get("/api/sources/health")
+        assert resp.status_code == 200
+        slugs = {item["slug"] for item in resp.json()["items"]}
+        assert "alice-private" in slugs, "alice should see her own private source via API"
+        assert "bob-private" not in slugs, "alice should not see bob's private source via API"
+    finally:
+        from news_dashboard.auth import require_admin, require_auth
+        from news_dashboard.main import app
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
 
 
 def test_subscription_cleanup_suggests_high_skip_rate_source(


### PR DESCRIPTION
## Summary

- `list_source_health()` previously queried all sources with no visibility filter, allowing any authenticated user to see private sources owned by other users via `/api/sources/health`
- Added `user_id: int | None` parameter to `list_source_health()` that applies the same visibility contract as `/api/sources`: `WHERE owner_user_id IS NULL OR owner_user_id = %s`
- Updated the `/api/sources/health` endpoint to inject `current_user` and pass their id to the scoped query

## Test plan

- [x] `test_source_health_scoped_to_user_visibility`: creates two users with private sources each, calls `list_source_health(user_id=...)` directly and asserts cross-user isolation
- [x] `test_source_health_api_scoped_to_current_user`: same isolation check via the FastAPI test client through `/api/sources/health`
- [x] All 19 existing source health tests still pass
- [x] `make lint`, `make typecheck` clean

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)