### PR TITLE
feat: add load more to filtered Search results (#496)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -1281,6 +1281,7 @@ def _attach_also_from(conn: Any, articles: list[dict[str, Any]]) -> None:
 def search_articles(  # noqa: PLR0912, PLR0913
     q: str = "",
     limit: int = 50,
+    offset: int = 0,
     db_path: Path | str | None = None,
     states: list[str] | None = None,
     categories: list[str] | None = None,
@@ -1299,6 +1300,7 @@ def search_articles(  # noqa: PLR0912, PLR0913
             user_id=user_id,
             q=q,
             limit=limit,
+            offset=offset,
             db_path=db_path,
             states=states,
             categories=categories,
@@ -1366,15 +1368,143 @@ def search_articles(  # noqa: PLR0912, PLR0913
             " importance_score DESC, discovered_at DESC, id DESC"
         )
     else:
-        order_by = "importance_score DESC, discovered_at DESC"
+        order_by = "importance_score DESC, discovered_at DESC, id DESC"
 
-    params.append(limit)
+    params.extend([limit, offset])
 
-    sql = f"SELECT {_article_list_select()} FROM articles {where} ORDER BY {order_by} LIMIT %s"
+    sql = f"""
+        SELECT {_article_list_select()}
+        FROM articles
+        {where}
+        ORDER BY {order_by}
+        LIMIT %s OFFSET %s
+    """
 
     with connect(db_path) as conn:
         rows = conn.execute(sql, params).fetchall()
         return [_article_dict(row) for row in rows]
+
+
+def search_articles_page(  # noqa: PLR0913
+    q: str = "",
+    limit: int = 50,
+    offset: int = 0,
+    db_path: Path | str | None = None,
+    states: list[str] | None = None,
+    categories: list[str] | None = None,
+    sources: list[str] | None = None,
+    starred_only: bool = False,
+    include_archived: bool = False,
+    date_range: str = "all",
+    user_id: int | None = None,
+) -> dict[str, Any]:
+    items = search_articles(
+        q=q,
+        limit=limit,
+        offset=offset,
+        db_path=db_path,
+        states=states,
+        categories=categories,
+        sources=sources,
+        starred_only=starred_only,
+        include_archived=include_archived,
+        date_range=date_range,
+        user_id=user_id,
+    )
+    total = count_search_articles(
+        q=q,
+        db_path=db_path,
+        states=states,
+        categories=categories,
+        sources=sources,
+        starred_only=starred_only,
+        include_archived=include_archived,
+        date_range=date_range,
+        user_id=user_id,
+    )
+    return {
+        "items": items,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "has_more": offset + len(items) < total,
+    }
+
+
+def count_search_articles(  # noqa: PLR0913
+    q: str = "",
+    db_path: Path | str | None = None,
+    states: list[str] | None = None,
+    categories: list[str] | None = None,
+    sources: list[str] | None = None,
+    starred_only: bool = False,
+    include_archived: bool = False,
+    date_range: str = "all",
+    user_id: int | None = None,
+) -> int:
+    init_db(db_path)
+    tsquery = _search_tsquery(q)
+    now_ts = now_iso()
+
+    if user_id is not None:
+        return _count_search_articles_for_user(
+            user_id=user_id,
+            q=q,
+            db_path=db_path,
+            states=states,
+            categories=categories,
+            sources=sources,
+            starred_only=starred_only,
+            include_archived=include_archived,
+            date_range=date_range,
+            now_ts=now_ts,
+        )
+
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if tsquery:
+        clauses.append("search_vector @@ to_tsquery('english', %s)")
+        params.append(tsquery)
+
+    if not include_archived:
+        clauses.append("state != 'archived'")
+
+    if states:
+        state_placeholders = placeholders(states)
+        clauses.append(f"state IN ({state_placeholders})")
+        params.extend(states)
+        if include_archived is False and "archived" in states:
+            clauses.remove("state != 'archived'")
+
+    if categories:
+        category_placeholders = placeholders(categories)
+        clauses.append(f"category IN ({category_placeholders})")
+        params.extend(categories)
+
+    if sources:
+        source_placeholders = placeholders(sources)
+        clauses.append(f"source_slug IN ({source_placeholders})")
+        params.extend(sources)
+
+    if starred_only:
+        clauses.append("starred IS TRUE")
+
+    if date_range == "today":
+        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '1 day'")
+        params.append(now_ts)
+    elif date_range == "week":
+        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '7 days'")
+        params.append(now_ts)
+    elif date_range == "month":
+        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
+        params.append(now_ts)
+
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+
+    with connect(db_path) as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS total FROM articles {where}", params).fetchone()
+    return int(row["total"] if row is not None else 0)
 
 
 def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
@@ -1382,6 +1512,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     user_id: int,
     q: str,
     limit: int,
+    offset: int,
     db_path: Path | str | None,
     states: list[str] | None,
     categories: list[str] | None,
@@ -1450,11 +1581,19 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
         )
         rank_params: list[Any] = [tsquery]
     else:
-        user_order_by = "a.importance_score DESC, a.discovered_at DESC"
+        user_order_by = "a.importance_score DESC, a.discovered_at DESC, a.id DESC"
         rank_params = []
 
-    # Param order: us_src JOIN, uas JOIN, WHERE params, owner check, rank (if any), limit
-    all_params: list[Any] = [user_id, user_id, *where_params, user_id, *rank_params, limit]
+    # Param order: us_src JOIN, uas JOIN, WHERE params, owner check, rank, limit, offset
+    all_params: list[Any] = [
+        user_id,
+        user_id,
+        *where_params,
+        user_id,
+        *rank_params,
+        limit,
+        offset,
+    ]
 
     sql = f"""
         SELECT {_article_list_select("a")},
@@ -1471,7 +1610,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
         LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
         LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = %s
         {where}
-        ORDER BY {user_order_by} LIMIT %s
+        ORDER BY {user_order_by} LIMIT %s OFFSET %s
     """
     with connect(db_path) as conn:
         rows = conn.execute(sql, all_params).fetchall()
@@ -1488,6 +1627,80 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
             d["restored_at"] = d.pop("_uas_restored_at", None)
             result.append(d)
         return result
+
+
+def _count_search_articles_for_user(  # noqa: PLR0913
+    *,
+    user_id: int,
+    q: str,
+    db_path: Path | str | None,
+    states: list[str] | None,
+    categories: list[str] | None,
+    sources: list[str] | None,
+    starred_only: bool,
+    include_archived: bool,
+    date_range: str,
+    now_ts: str,
+) -> int:
+    tsquery = _search_tsquery(q)
+    clauses: list[str] = []
+    where_params: list[Any] = []
+
+    if tsquery:
+        clauses.append("a.search_vector @@ to_tsquery('english', %s)")
+        where_params.append(tsquery)
+
+    if not include_archived:
+        clauses.append("COALESCE(uas.state, 'today') != 'archived'")
+
+    if states:
+        state_placeholders = placeholders(states)
+        clauses.append(f"COALESCE(uas.state, 'today') IN ({state_placeholders})")
+        where_params.extend(states)
+        if include_archived is False and "archived" in states:
+            clauses.remove("COALESCE(uas.state, 'today') != 'archived'")
+
+    if categories:
+        category_placeholders = placeholders(categories)
+        clauses.append(f"a.category IN ({category_placeholders})")
+        where_params.extend(categories)
+
+    if sources:
+        source_placeholders = placeholders(sources)
+        clauses.append(f"a.source_slug IN ({source_placeholders})")
+        where_params.extend(sources)
+
+    if starred_only:
+        clauses.append("COALESCE(uas.starred, false) = true")
+
+    if date_range == "today":
+        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '1 day'")
+        where_params.append(now_ts)
+    elif date_range == "week":
+        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '7 days'")
+        where_params.append(now_ts)
+    elif date_range == "month":
+        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
+        where_params.append(now_ts)
+
+    src_filter = (
+        "(src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true)) OR src.owner_user_id = %s"
+    )
+    clauses.append(f"({src_filter})")
+    where = f"WHERE {' AND '.join(clauses)}"
+    all_params: list[Any] = [user_id, user_id, *where_params, user_id]
+
+    sql = f"""
+        SELECT COUNT(*) AS total
+        FROM articles a
+        LEFT JOIN sources src ON src.slug = a.source_slug
+        LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
+        LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = %s
+        {where}
+    """
+    with connect(db_path) as conn:
+        row = conn.execute(sql, all_params).fetchone()
+    return int(row["total"] if row is not None else 0)
 
 
 def set_article_status(

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -67,7 +67,7 @@ from news_dashboard.ingest import (
     get_user_summary,
     ingest_all,
     list_articles,
-    search_articles,
+    search_articles_page,
     send_article_later,
     set_article_starred,
     set_article_status,
@@ -546,6 +546,7 @@ def search(  # noqa: PLR0913
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
     q: Annotated[str, Query(description="Space-separated search terms")] = "",
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
     states: Annotated[list[str] | None, Query()] = None,
     categories: Annotated[list[str] | None, Query()] = None,
     sources: Annotated[list[str] | None, Query()] = None,
@@ -553,19 +554,18 @@ def search(  # noqa: PLR0913
     include_archived: Annotated[bool, Query()] = False,
     date_range: Annotated[str, Query()] = "all",
 ) -> dict[str, Any]:
-    return {
-        "items": search_articles(
-            q=q.strip(),
-            limit=limit,
-            states=states,
-            categories=categories,
-            sources=sources,
-            starred_only=starred_only,
-            include_archived=include_archived,
-            date_range=date_range,
-            user_id=current_user["id"],
-        )
-    }
+    return search_articles_page(
+        q=q.strip(),
+        limit=limit,
+        offset=offset,
+        states=states,
+        categories=categories,
+        sources=sources,
+        starred_only=starred_only,
+        include_archived=include_archived,
+        date_range=date_range,
+        user_id=current_user["id"],
+    )
 
 
 @api.get("/api/articles/topic-map")

--- a/backend/tests/test_search_filters.py
+++ b/backend/tests/test_search_filters.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from news_dashboard.db import connect, init_db
-from news_dashboard.ingest import list_articles, search_articles, sync_sources
+from news_dashboard.ingest import list_articles, search_articles, search_articles_page, sync_sources
 from news_dashboard.main import app
 
 
@@ -349,6 +349,63 @@ def test_search_endpoint_returns_matching_articles(client: TestClient, api_db: P
     titles = [it["title"] for it in items]
     assert "Pytest Tips" in titles
     assert "Rust Intro" not in titles
+
+
+def test_search_page_reports_total_and_second_page(db: Path) -> None:
+    for index in range(5):
+        _insert_with_score(
+            db,
+            title=f"Page Article {index}",
+            importance_score=50,
+            url_suffix=f"-page-{index}",
+        )
+
+    first_page = search_articles_page("", limit=2, offset=0, db_path=db)
+    second_page = search_articles_page("", limit=2, offset=2, db_path=db)
+
+    assert first_page["total"] == 5
+    assert first_page["has_more"] is True
+    assert first_page["limit"] == 2
+    assert first_page["offset"] == 0
+    assert len(first_page["items"]) == 2
+    assert second_page["total"] == 5
+    assert second_page["has_more"] is True
+    assert [item["id"] for item in second_page["items"]] != [
+        item["id"] for item in first_page["items"]
+    ]
+
+
+def test_search_empty_query_uses_id_tiebreaker_for_stable_pages(db: Path) -> None:
+    older_id = _insert_with_score(
+        db,
+        title="Older Tie",
+        importance_score=50,
+        url_suffix="-older-tie",
+    )
+    newer_id = _insert_with_score(
+        db,
+        title="Newer Tie",
+        importance_score=50,
+        url_suffix="-newer-tie",
+    )
+
+    results = search_articles("", limit=2, db_path=db)
+
+    assert [item["id"] for item in results[:2]] == [newer_id, older_id]
+
+
+def test_search_endpoint_returns_page_contract(client: TestClient, api_db: Path) -> None:
+    for index in range(3):
+        _insert(api_db, title=f"Endpoint Page {index}", url_suffix=f"-endpoint-{index}")
+
+    resp = client.get("/api/search?limit=2&offset=1")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) >= {"items", "total", "limit", "offset", "has_more"}
+    assert data["total"] == 3
+    assert data["limit"] == 2
+    assert data["offset"] == 1
 
 
 # ─── Text relevance ordering ──────────────────────────────────────────────────

--- a/frontend/src/__tests__/search.test.tsx
+++ b/frontend/src/__tests__/search.test.tsx
@@ -10,6 +10,7 @@ import * as api from '../api';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 import type { Source } from '../types';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import type { SearchArticlePage } from '../api/workflowApi';
 
 vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
@@ -48,6 +49,20 @@ function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle 
     bodyStatus: 'missing',
     state: 'today',
     starred: false,
+    ...overrides,
+  };
+}
+
+function makePage(
+  items: WorkflowArticle[],
+  overrides: Partial<Omit<SearchArticlePage, 'items'>> = {}
+): SearchArticlePage {
+  return {
+    items,
+    total: items.length,
+    limit: 100,
+    offset: 0,
+    hasMore: false,
     ...overrides,
   };
 }
@@ -98,7 +113,7 @@ describe('SearchPage — rendering', () => {
 
 describe('SearchPage — search flow', () => {
   it('calls searchArticlesFiltered when user types a query', async () => {
-    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
     renderSearch();
 
     const input = screen.getByPlaceholderText(/Search titles/);
@@ -113,10 +128,12 @@ describe('SearchPage — search flow', () => {
   });
 
   it('displays results when API returns articles', async () => {
-    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([
-      makeArticle({ id: '1', title: 'Python Tips Article' }),
-      makeArticle({ id: '2', title: 'Async Patterns' }),
-    ]);
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(
+      makePage([
+        makeArticle({ id: '1', title: 'Python Tips Article' }),
+        makeArticle({ id: '2', title: 'Async Patterns' }),
+      ])
+    );
 
     renderSearch('?q=python');
 
@@ -127,25 +144,62 @@ describe('SearchPage — search flow', () => {
   });
 
   it('shows result count', async () => {
-    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([
-      makeArticle({ id: '1' }),
-      makeArticle({ id: '2', url: 'https://example.com/2' }),
-    ]);
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(
+      makePage([makeArticle({ id: '1' }), makeArticle({ id: '2', url: 'https://example.com/2' })])
+    );
 
     renderSearch('?q=python');
 
     await waitFor(() => {
-      expect(screen.getByText('2 results')).toBeTruthy();
+      expect(screen.getByText('2 of 2 results')).toBeTruthy();
     });
   });
 
   it('shows "No results" when API returns empty array', async () => {
-    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
     renderSearch('?q=nonexistent');
 
     await waitFor(() => {
       expect(screen.getByText('No results')).toBeTruthy();
     });
+  });
+
+  it('loads more results with the active filters', async () => {
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered');
+    spy
+      .mockResolvedValueOnce(
+        makePage([makeArticle({ id: '1', title: 'First Page' })], {
+          total: 2,
+          limit: 1,
+          offset: 0,
+          hasMore: true,
+        })
+      )
+      .mockResolvedValueOnce(
+        makePage([makeArticle({ id: '2', title: 'Second Page' })], {
+          total: 2,
+          limit: 1,
+          offset: 1,
+          hasMore: false,
+        })
+      );
+
+    renderSearch('?q=python&categories=python');
+
+    await waitFor(() => {
+      expect(screen.getByText('First Page')).toBeTruthy();
+      expect(screen.getByText('1 of 2 results')).toBeTruthy();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Second Page')).toBeTruthy();
+      expect(screen.getByText('2 of 2 results')).toBeTruthy();
+    });
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ q: 'python', categories: ['python'], offset: 1 })
+    );
   });
 });
 
@@ -153,7 +207,7 @@ describe('SearchPage — search flow', () => {
 
 describe('SearchPage — filter chips', () => {
   it('Starred chip toggles starred_only in API call', async () => {
-    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
     renderSearch('?q=test');
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
@@ -168,7 +222,7 @@ describe('SearchPage — filter chips', () => {
   });
 
   it('Include archived chip toggles includeArchived in API call', async () => {
-    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
     renderSearch('?q=test');
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
@@ -187,9 +241,9 @@ describe('SearchPage — filter chips', () => {
 
 describe('SearchPage — reader navigation', () => {
   it('navigates to reader when article row is clicked', async () => {
-    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([
-      makeArticle({ id: '42', title: 'Clickable Article' }),
-    ]);
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(
+      makePage([makeArticle({ id: '42', title: 'Clickable Article' })])
+    );
 
     renderSearch('?q=python');
 
@@ -246,7 +300,7 @@ describe('SearchPage — source filter', () => {
   });
 
   it('passes selected sources to searchArticlesFiltered', async () => {
-    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue([]);
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
     vi.spyOn(api, 'fetchSources').mockResolvedValue([
       makeSource({ slug: 'hn', name: 'Hacker News' }),
     ]);

--- a/frontend/src/__tests__/workflowApi.test.ts
+++ b/frontend/src/__tests__/workflowApi.test.ts
@@ -175,10 +175,13 @@ describe('snapshot', () => {
 
 describe('searchArticlesFiltered', () => {
   it('builds query params from all filters', async () => {
-    const { calls } = stubFetch(() => jsonOk({ items: [legacy()] }));
-    const items = await searchArticlesFiltered({
+    const { calls } = stubFetch(() =>
+      jsonOk({ items: [legacy()], total: 3, limit: 25, offset: 0, has_more: true })
+    );
+    const page = await searchArticlesFiltered({
       q: 'term',
       limit: 25,
+      offset: 50,
       starredOnly: true,
       includeArchived: true,
       dateRange: 'week',
@@ -186,10 +189,14 @@ describe('searchArticlesFiltered', () => {
       categories: ['ai-llm'],
       sources: ['src'],
     });
-    expect(items).toHaveLength(1);
+    expect(page.items).toHaveLength(1);
+    expect(page.total).toBe(3);
+    expect(page.limit).toBe(25);
+    expect(page.hasMore).toBe(true);
     const url = calls[0].url;
     expect(url).toContain('q=term');
     expect(url).toContain('limit=25');
+    expect(url).toContain('offset=50');
     expect(url).toContain('starred_only=true');
     expect(url).toContain('include_archived=true');
     expect(url).toContain('date_range=week');

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -172,12 +172,30 @@ export interface SearchFilters {
   includeArchived?: boolean;
   dateRange?: 'all' | 'today' | 'week' | 'month';
   limit?: number;
+  offset?: number;
 }
 
-export async function searchArticlesFiltered(filters: SearchFilters): Promise<WorkflowArticle[]> {
+export interface SearchArticlePage {
+  items: WorkflowArticle[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+interface SearchArticleApiPage {
+  items: LegacyArticle[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+  has_more?: boolean;
+}
+
+export async function searchArticlesFiltered(filters: SearchFilters): Promise<SearchArticlePage> {
   const params = new URLSearchParams();
   if (filters.q) params.set('q', filters.q);
   if (filters.limit) params.set('limit', String(filters.limit));
+  if (filters.offset) params.set('offset', String(filters.offset));
   if (filters.starredOnly) params.set('starred_only', 'true');
   if (filters.includeArchived) params.set('include_archived', 'true');
   if (filters.dateRange && filters.dateRange !== 'all') params.set('date_range', filters.dateRange);
@@ -185,6 +203,12 @@ export async function searchArticlesFiltered(filters: SearchFilters): Promise<Wo
   filters.categories?.forEach((c) => params.append('categories', c));
   filters.sources?.forEach((s) => params.append('sources', s));
 
-  const data = await requestJson<{ items: LegacyArticle[] }>(`/api/search?${params}`);
-  return data.items.map(adaptArticle);
+  const data = await requestJson<SearchArticleApiPage>(`/api/search?${params}`);
+  return {
+    items: data.items.map(adaptArticle),
+    total: data.total ?? data.items.length,
+    limit: data.limit ?? filters.limit ?? data.items.length,
+    offset: data.offset ?? filters.offset ?? 0,
+    hasMore: Boolean(data.has_more),
+  };
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { Search as SearchIcon } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
 import { EmptyState } from '@/components/EmptyState';
@@ -39,6 +39,8 @@ const DATE_OPTIONS: { value: string; label: string }[] = [
   { value: 'week', label: 'Past week' },
   { value: 'month', label: 'Past month' },
 ];
+
+const SEARCH_PAGE_SIZE = 100;
 
 // ─── URL state helpers ────────────────────────────────────────────────────────
 
@@ -131,9 +133,9 @@ export function SearchPage() {
     staleTime: 5 * 60_000,
   });
 
-  const { data: results = [], isLoading } = useQuery({
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ['search', q, states, categories, sources, starredOnly, includeArchived, dateRange],
-    queryFn: () =>
+    queryFn: ({ pageParam }) =>
       searchArticlesFiltered({
         q,
         states: states.length ? states : undefined,
@@ -142,11 +144,20 @@ export function SearchPage() {
         starredOnly,
         includeArchived,
         dateRange: (dateRange || 'all') as 'all' | 'today' | 'week' | 'month',
-        limit: 100,
+        limit: SEARCH_PAGE_SIZE,
+        offset: pageParam,
       }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.hasMore) return undefined;
+      return lastPage.offset + lastPage.items.length;
+    },
     enabled: !!hasFilters,
     staleTime: 30_000,
   });
+  const pages = data?.pages ?? [];
+  const results = pages.flatMap((page) => page.items);
+  const total = pages[0]?.total ?? 0;
 
   useEffect(() => {
     setReaderList(results.map((a) => a.id));
@@ -246,7 +257,9 @@ export function SearchPage() {
       {/* Result count */}
       {hasFilters && (
         <div className="px-4 md:px-5 py-2 text-[11px] text-muted-foreground border-b border-border">
-          {isLoading ? '…' : `${results.length} ${results.length === 1 ? 'result' : 'results'}`}
+          {isLoading
+            ? '...'
+            : `${results.length} of ${total} ${total === 1 ? 'result' : 'results'}`}
         </div>
       )}
 
@@ -270,6 +283,18 @@ export function SearchPage() {
           {results.map((a, i) => (
             <ArticleRow key={a.id} article={a} focused={i === focused} />
           ))}
+          {hasNextPage && (
+            <div className="px-4 md:px-5 py-3 border-t border-border">
+              <button
+                type="button"
+                onClick={() => void fetchNextPage()}
+                disabled={isFetchingNextPage}
+                className="h-8 px-3 rounded-md border border-border bg-surface text-xs font-medium text-foreground hover:border-border-strong disabled:opacity-60"
+              >
+                {isFetchingNextPage ? 'Loading...' : 'Load more'}
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #496

## Summary
- add offset, total, and has_more pagination metadata to /api/search
- keep Search ordering stable across pages with id DESC tie-breakers
- add frontend load-more flow that preserves active filters and updates loaded-vs-total counts

## Tests
- python -m pytest backend/tests/test_search_filters.py -q
- npm run test:frontend -- search.test.tsx workflowApi.test.ts
- make lint
- make typecheck
- source .env && make test
- npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)