### PR TITLE
feat: record scheduled job outcomes beyond ingest (#497)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -464,6 +464,19 @@ POSTGRES_MULTIUSER_SCHEMA = [
     " ON user_nudge_dismissals(user_id, cooldown_until)",
     "ALTER TABLE user_quizzes ADD COLUMN IF NOT EXISTS submitted_answers JSONB",
     "ALTER TABLE user_quizzes ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ",
+    """
+    CREATE TABLE IF NOT EXISTS scheduled_job_runs (
+      id           SERIAL PRIMARY KEY,
+      job_name     TEXT NOT NULL,
+      started_at   TIMESTAMPTZ NOT NULL,
+      finished_at  TIMESTAMPTZ,
+      duration_ms  INTEGER,
+      status       TEXT NOT NULL,
+      message      TEXT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_scheduled_job_runs_job_started"
+    " ON scheduled_job_runs(job_name, started_at DESC)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1469,6 +1469,13 @@ def ingest_run_sources(run_id: int) -> dict[str, Any]:
     return {"items": run_sources}
 
 
+@api.get("/api/scheduler/job-runs", dependencies=_admin_dep)
+def list_scheduled_job_runs() -> dict[str, Any]:
+    from news_dashboard.scheduled_job_history import list_latest_job_runs
+
+    return {"items": list_latest_job_runs()}
+
+
 @api.get("/api/health/details", dependencies=_admin_dep)
 def health_details() -> dict[str, Any]:
     init_db()

--- a/backend/news_dashboard/scheduled_job_history.py
+++ b/backend/news_dashboard/scheduled_job_history.py
@@ -1,0 +1,54 @@
+"""Persistence layer for non-ingest scheduled-job run outcomes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from news_dashboard.db import connect, init_db, row_to_dict
+
+
+def save_job_run(
+    *,
+    job_name: str,
+    started_at: datetime,
+    finished_at: datetime,
+    status: str,
+    message: str | None = None,
+) -> None:
+    duration_ms = max(0, int((finished_at - started_at).total_seconds() * 1000))
+    init_db()
+    with connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO scheduled_job_runs
+              (job_name, started_at, finished_at, duration_ms, status, message)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (job_name, started_at, finished_at, duration_ms, status, message),
+        )
+
+
+def list_latest_job_runs() -> list[dict[str, Any]]:
+    """Return the most recent run for each distinct job_name."""
+    init_db()
+    with connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT ON (job_name)
+              id, job_name, started_at, finished_at, duration_ms, status, message
+            FROM scheduled_job_runs
+            ORDER BY job_name, started_at DESC
+            """,
+        ).fetchall()
+    result = []
+    for row in rows:
+        d = row_to_dict(row)
+        started = d.get("started_at")
+        finished = d.get("finished_at")
+        if isinstance(started, datetime):
+            d["started_at"] = started.astimezone(timezone.utc).isoformat()
+        if isinstance(finished, datetime):
+            d["finished_at"] = finished.astimezone(timezone.utc).isoformat()
+        result.append(d)
+    return result

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
@@ -64,33 +65,35 @@ def _run_recommendation_recalc() -> None:
         logger.exception("Recommendation recalculation failed")
 
 
-def _run_daily_recommendation_recalc() -> None:
+def _run_daily_recommendation_recalc() -> tuple[str, str | None]:
     from news_dashboard.recommendation_jobs import recalculate_all_recommendations
 
     logger.info("Daily recommendation recalculation starting…")
     try:
         summary = recalculate_all_recommendations()
-        logger.info("Daily recommendation recalculation: %s", summary.as_dict())
-    except Exception:
+        msg = str(summary.as_dict())
+        logger.info("Daily recommendation recalculation: %s", msg)
+        return "success", msg
+    except Exception as exc:
         logger.exception("Daily recommendation recalculation failed")
+        return "failure", str(exc)[:500]
 
 
-def _run_analytics_retention() -> None:
+def _run_analytics_retention() -> tuple[str, str | None]:
     from news_dashboard.analytics import DEFAULT_EVENT_RETENTION_DAYS, prune_old_events
 
     retention_days = int(os.getenv("ANALYTICS_RETENTION_DAYS", str(DEFAULT_EVENT_RETENTION_DAYS)))
     try:
         deleted = prune_old_events(retention_days=retention_days)
-        logger.info(
-            "Analytics retention pruned %d events older than %d days",
-            deleted,
-            retention_days,
-        )
-    except Exception:
+        msg = f"pruned {deleted} events older than {retention_days} days"
+        logger.info("Analytics retention: %s", msg)
+        return "success", msg
+    except Exception as exc:
         logger.exception("Analytics retention failed")
+        return "failure", str(exc)[:500]
 
 
-def _run_briefing() -> None:
+def _run_briefing() -> tuple[str, str | None]:
     from news_dashboard.briefings import (
         BriefingAINotConfiguredError,
         BriefingGenerationError,
@@ -102,27 +105,66 @@ def _run_briefing() -> None:
         result = generate_briefing()
         if result.get("status") == "no_candidates":
             logger.info("Scheduled briefing skipped: no candidate articles found.")
-        else:
-            logger.info("Scheduled briefing complete: id=%s", result.get("id"))
+            return "skipped", "no candidate articles found"
+        logger.info("Scheduled briefing complete: id=%s", result.get("id"))
+        return "success", f"id={result.get('id')}"
     except BriefingAINotConfiguredError:
         logger.warning("Briefing skipped: no AI key set (FREE_LLM_API_KEY / OPENAI_API_KEY).")
-    except BriefingGenerationError:
+        return "skipped", "no AI key configured"
+    except BriefingGenerationError as exc:
         logger.exception("Scheduled briefing failed (generation error)")
-    except Exception:
+        return "failure", str(exc)[:500]
+    except Exception as exc:
         logger.exception("Scheduled briefing failed (unexpected error)")
+        return "failure", str(exc)[:500]
 
 
-def _run_per_user_briefings() -> None:
-    """Generate briefings for users whose local scheduled time matches the current instant."""
-    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-
+def _generate_briefing_for_user(user_id: int) -> bool:
+    """Generate and push a briefing for one user. Returns True on success."""
     from news_dashboard.briefings import (
         BriefingAINotConfiguredError,
         BriefingGenerationError,
         generate_briefing,
     )
-    from news_dashboard.db import connect, row_to_dict
     from news_dashboard.push import generate_push_hook, send_push_for_user
+
+    logger.info("Per-user briefing: generating for user_id=%s", user_id)
+    try:
+        result = generate_briefing(user_id=user_id)
+        if result.get("status") == "no_candidates":
+            logger.info("Per-user briefing: skipped for user_id=%s (no candidates)", user_id)
+        else:
+            logger.info(
+                "Per-user briefing: complete for user_id=%s id=%s", user_id, result.get("id")
+            )
+            try:
+                briefing_id = result.get("id")
+                target_url = f"/briefs/{briefing_id}" if briefing_id is not None else None
+                send_push_for_user(user_id, generate_push_hook(result), "", target_url=target_url)
+            except Exception:
+                logger.exception(
+                    "Per-user briefing: push notification failed for user_id=%s", user_id
+                )
+        return True
+    except BriefingAINotConfiguredError:
+        logger.warning("Per-user briefing: skipped for user_id=%s (AI not configured)", user_id)
+        return True
+    except BriefingGenerationError:
+        logger.exception("Per-user briefing: generation error for user_id=%s", user_id)
+        return False
+    except Exception:
+        logger.exception("Per-user briefing: unexpected error for user_id=%s", user_id)
+        return False
+
+
+def _run_per_user_briefings() -> tuple[str, str | None] | None:
+    """Generate briefings for users whose local scheduled time matches the current instant.
+
+    Returns None when no users are scheduled this minute so the run is not recorded.
+    """
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    from news_dashboard.db import connect, row_to_dict
 
     now = datetime.now(timezone.utc)
 
@@ -133,9 +175,9 @@ def _run_per_user_briefings() -> None:
                 " WHERE briefing_push_enabled = TRUE OR briefing_time IS NOT NULL",
             ).fetchall()
         user_rows = [row_to_dict(r) for r in rows]
-    except Exception:
+    except Exception as exc:
         logger.exception("Per-user briefing: failed to query users")
-        return
+        return "failure", str(exc)[:500]
 
     user_ids: list[int] = []
     for row in user_rows:
@@ -145,43 +187,23 @@ def _run_per_user_briefings() -> None:
             tz = ZoneInfo(tz_name)
         except (ZoneInfoNotFoundError, KeyError):
             tz = ZoneInfo("UTC")
-        local_hm = now.astimezone(tz).strftime("%H:%M")
-        if local_hm == briefing_time:
+        if now.astimezone(tz).strftime("%H:%M") == briefing_time:
             user_ids.append(int(row["id"]))
 
-    for user_id in user_ids:
-        logger.info("Per-user briefing: generating for user_id=%s", user_id)
-        try:
-            result = generate_briefing(user_id=user_id)
-            if result.get("status") == "no_candidates":
-                logger.info("Per-user briefing: skipped for user_id=%s (no candidates)", user_id)
-            else:
-                logger.info(
-                    "Per-user briefing: complete for user_id=%s id=%s", user_id, result.get("id")
-                )
-                try:
-                    briefing_id = result.get("id")
-                    target_url = f"/briefs/{briefing_id}" if briefing_id is not None else None
-                    push_title = generate_push_hook(result)
-                    send_push_for_user(
-                        user_id,
-                        push_title,
-                        "",
-                        target_url=target_url,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Per-user briefing: push notification failed for user_id=%s", user_id
-                    )
-        except BriefingAINotConfiguredError:
-            logger.warning("Per-user briefing: skipped for user_id=%s (AI not configured)", user_id)
-        except BriefingGenerationError:
-            logger.exception("Per-user briefing: generation error for user_id=%s", user_id)
-        except Exception:
-            logger.exception("Per-user briefing: unexpected error for user_id=%s", user_id)
+    if not user_ids:
+        return None  # nothing scheduled this minute — skip recording
+
+    results = [_generate_briefing_for_user(uid) for uid in user_ids]
+    succeeded = sum(1 for ok in results if ok)
+    failed = len(results) - succeeded
+    total = len(user_ids)
+    noun = "user" if total == 1 else "users"
+    msg = f"{total} {noun} targeted, {succeeded} succeeded, {failed} failed"
+    status = "failure" if failed == total else "success"
+    return status, msg
 
 
-def _run_digest() -> None:
+def _run_digest() -> tuple[str, str | None]:
     from news_dashboard.digest import send_digest
 
     logger.info("Sending daily digest…")
@@ -189,10 +211,64 @@ def _run_digest() -> None:
         sent = send_digest()
         if sent:
             logger.info("Daily digest sent.")
-        else:
-            logger.info("Daily digest skipped (no new articles or DIGEST_TO not set).")
-    except Exception:
+            return "success", None
+        logger.info("Daily digest skipped (no new articles or DIGEST_TO not set).")
+        return "skipped", "no new articles or DIGEST_TO not set"
+    except Exception as exc:
         logger.exception("Daily digest failed")
+        return "failure", str(exc)[:500]
+
+
+def _run_and_record(
+    job_name: str,
+    fn: Callable[[], tuple[str, str | None] | None],
+) -> None:
+    """Call fn(), then persist the outcome to scheduled_job_runs.
+
+    If fn returns None the run is not recorded (used by per_user_briefings
+    when no users are scheduled for this minute).
+    """
+    from news_dashboard.scheduled_job_history import save_job_run
+
+    started_at = datetime.now(timezone.utc)
+    try:
+        result = fn()
+    except Exception as exc:
+        result = ("failure", str(exc)[:500])
+    if result is None:
+        return
+    status, message = result
+    finished_at = datetime.now(timezone.utc)
+    try:
+        save_job_run(
+            job_name=job_name,
+            started_at=started_at,
+            finished_at=finished_at,
+            status=status,
+            message=message,
+        )
+    except Exception:
+        logger.exception("Failed to record outcome for scheduled job %r", job_name)
+
+
+def _job_digest() -> None:
+    _run_and_record("digest", _run_digest)
+
+
+def _job_daily_recommendations() -> None:
+    _run_and_record("recommendations", _run_daily_recommendation_recalc)
+
+
+def _job_analytics_retention() -> None:
+    _run_and_record("analytics_retention", _run_analytics_retention)
+
+
+def _job_briefing() -> None:
+    _run_and_record("briefing", _run_briefing)
+
+
+def _job_per_user_briefings() -> None:
+    _run_and_record("per_user_briefings", _run_per_user_briefings)
 
 
 def _parse_cron_hm(cron: str, default_minute: str, default_hour: str) -> tuple[str, str]:
@@ -252,7 +328,7 @@ def start_scheduler() -> None:
 
     cron_minute, cron_hour = _parse_cron_hm(digest_cron, "0", "8")
     scheduler.add_job(
-        _run_digest,
+        _job_digest,
         trigger="cron",
         hour=cron_hour,
         minute=cron_minute,
@@ -266,7 +342,7 @@ def start_scheduler() -> None:
     b_minute, b_hour = _parse_cron_hm(briefing_cron, "0", "9")
     if legacy_global_briefing_enabled:
         scheduler.add_job(
-            _run_briefing,
+            _job_briefing,
             trigger="cron",
             hour=b_hour,
             minute=b_minute,
@@ -281,7 +357,7 @@ def start_scheduler() -> None:
 
     r_minute, r_hour = _parse_cron_hm(recommendations_cron, "30", "7")
     scheduler.add_job(
-        _run_daily_recommendation_recalc,
+        _job_daily_recommendations,
         trigger="cron",
         hour=r_hour,
         minute=r_minute,
@@ -290,7 +366,7 @@ def start_scheduler() -> None:
     )
 
     scheduler.add_job(
-        _run_analytics_retention,
+        _job_analytics_retention,
         trigger="cron",
         hour="3",
         minute="0",
@@ -299,7 +375,7 @@ def start_scheduler() -> None:
     )
 
     scheduler.add_job(
-        _run_per_user_briefings,
+        _job_per_user_briefings,
         trigger="interval",
         minutes=1,
         id="per_user_briefings",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -138,7 +138,7 @@ def pg_clean(pg_url: str) -> str:
             "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
             " user_interest_profiles, user_settings, user_push_subscriptions,"
             " article_shares, user_events, briefing_articles, briefings,"
-            " ingest_run_sources, ingest_runs, articles, sources, users"
+            " ingest_run_sources, ingest_runs, scheduled_job_runs, articles, sources, users"
             " RESTART IDENTITY CASCADE"
         )
     return pg_url

--- a/backend/tests/test_scheduled_job_history.py
+++ b/backend/tests/test_scheduled_job_history.py
@@ -1,0 +1,235 @@
+"""Tests for scheduled_job_history module and the /api/scheduler/job-runs endpoint."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+from news_dashboard.scheduled_job_history import list_latest_job_runs, save_job_run
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ── save_job_run ──────────────────────────────────────────────────────────────
+
+
+def test_save_job_run_success(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    started = datetime(2026, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
+    finished = datetime(2026, 6, 1, 8, 0, 2, tzinfo=timezone.utc)
+    save_job_run(
+        job_name="digest",
+        started_at=started,
+        finished_at=finished,
+        status="success",
+        message=None,
+    )
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT job_name, status, duration_ms, message FROM scheduled_job_runs"
+        ).fetchone()
+    assert row is not None
+    assert row["job_name"] == "digest"
+    assert row["status"] == "success"
+    assert row["duration_ms"] == 2000
+    assert row["message"] is None
+
+
+def test_save_job_run_failure_records_message(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    started = datetime(2026, 6, 1, 9, 0, 0, tzinfo=timezone.utc)
+    finished = datetime(2026, 6, 1, 9, 0, 5, tzinfo=timezone.utc)
+    save_job_run(
+        job_name="recommendations",
+        started_at=started,
+        finished_at=finished,
+        status="failure",
+        message="connection refused",
+    )
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT status, message FROM scheduled_job_runs WHERE job_name = 'recommendations'"
+        ).fetchone()
+    assert row is not None
+    assert row["status"] == "failure"
+    assert row["message"] == "connection refused"
+
+
+def test_save_job_run_skipped(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    started = datetime(2026, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
+    finished = datetime(2026, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
+    save_job_run(
+        job_name="digest",
+        started_at=started,
+        finished_at=finished,
+        status="skipped",
+        message="no DIGEST_TO configured",
+    )
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT status FROM scheduled_job_runs").fetchone()
+    assert row is not None
+    assert row["status"] == "skipped"
+
+
+# ── list_latest_job_runs ──────────────────────────────────────────────────────
+
+
+def test_list_latest_job_runs_returns_one_per_job(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    t1 = datetime(2026, 6, 1, 7, 0, 0, tzinfo=timezone.utc)
+    t2 = datetime(2026, 6, 1, 7, 0, 1, tzinfo=timezone.utc)
+    t3 = datetime(2026, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
+    t4 = datetime(2026, 6, 1, 8, 0, 1, tzinfo=timezone.utc)
+
+    save_job_run(job_name="digest", started_at=t1, finished_at=t2, status="success")
+    # second digest run — this should be the one returned
+    save_job_run(job_name="digest", started_at=t3, finished_at=t4, status="failure", message="oops")
+    save_job_run(job_name="recommendations", started_at=t1, finished_at=t2, status="success")
+
+    rows = list_latest_job_runs()
+    by_job = {r["job_name"]: r for r in rows}
+
+    assert "digest" in by_job
+    assert by_job["digest"]["status"] == "failure"
+    assert by_job["digest"]["message"] == "oops"
+    assert "recommendations" in by_job
+    assert len(rows) == 2
+
+
+def test_list_latest_job_runs_empty(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    assert list_latest_job_runs() == []
+
+
+# ── /api/scheduler/job-runs endpoint ─────────────────────────────────────────
+
+
+def test_api_job_runs_returns_items(client: TestClient, pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    started = datetime(2026, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
+    finished = datetime(2026, 6, 1, 8, 0, 3, tzinfo=timezone.utc)
+    save_job_run(job_name="digest", started_at=started, finished_at=finished, status="success")
+
+    resp = client.get("/api/scheduler/job-runs")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "items" in body
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["job_name"] == "digest"
+    assert item["status"] == "success"
+    assert item["duration_ms"] == 3000
+
+
+def test_api_job_runs_empty(client: TestClient, pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    resp = client.get("/api/scheduler/job-runs")
+    assert resp.status_code == 200
+    assert resp.json() == {"items": []}
+
+
+# ── _run_and_record wrapper ───────────────────────────────────────────────────
+
+
+def test_run_and_record_persists_success(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    from news_dashboard.scheduler import _run_and_record
+
+    _run_and_record("digest", lambda: ("success", "all good"))
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT status, message FROM scheduled_job_runs").fetchone()
+    assert row is not None
+    assert row["status"] == "success"
+    assert row["message"] == "all good"
+
+
+def test_run_and_record_persists_failure(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    from news_dashboard.scheduler import _run_and_record
+
+    def failing_fn() -> tuple[str, str | None]:
+        msg = "something broke"
+        raise RuntimeError(msg)
+
+    _run_and_record("recommendations", failing_fn)
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT status FROM scheduled_job_runs").fetchone()
+    assert row is not None
+    assert row["status"] == "failure"
+
+
+def test_run_and_record_skips_none_result(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+
+    from news_dashboard.scheduler import _run_and_record
+
+    _run_and_record("per_user_briefings", lambda: None)
+
+    with connect(database_url=pg_clean) as conn:
+        count = conn.execute("SELECT COUNT(*) AS n FROM scheduled_job_runs").fetchone()
+    assert count is not None
+    assert int(count["n"]) == 0
+
+
+# ── _run_digest wrapper ───────────────────────────────────────────────────────
+
+
+def test_run_digest_returns_success() -> None:
+    with patch("news_dashboard.digest.send_digest", return_value=True):
+        from news_dashboard.scheduler import _run_digest
+
+        status, msg = _run_digest()
+    assert status == "success"
+    assert msg is None
+
+
+def test_run_digest_returns_skipped_when_nothing_sent() -> None:
+    with patch("news_dashboard.digest.send_digest", return_value=False):
+        from news_dashboard.scheduler import _run_digest
+
+        status, msg = _run_digest()
+    assert status == "skipped"
+    assert msg is not None
+
+
+def test_run_digest_returns_failure_on_exception() -> None:
+    with patch("news_dashboard.digest.send_digest", side_effect=RuntimeError("smtp down")):
+        from news_dashboard.scheduler import _run_digest
+
+        status, msg = _run_digest()
+    assert status == "failure"
+    assert msg is not None
+    assert "smtp down" in (msg or "")

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -214,8 +214,8 @@ def test_start_scheduler_registers_analytics_retention_job(
     assert retention_call.kwargs["minute"] == "0"
 
 
-def test_start_scheduler_briefing_fn_is_run_briefing(monkeypatch: pytest.MonkeyPatch) -> None:
-    from news_dashboard.scheduler import _run_briefing as expected_fn
+def test_start_scheduler_briefing_fn_is_job_briefing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.scheduler import _job_briefing as expected_fn
 
     mock_sched = _start_with_env(monkeypatch, legacy_briefing=True)
     briefing_call = next(

--- a/frontend/src/__tests__/schedulerPage.test.tsx
+++ b/frontend/src/__tests__/schedulerPage.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const apiMock = vi.hoisted(() => ({
+  fetchSchedulerStatus: vi.fn(),
+  fetchLatestJobRuns: vi.fn(),
+  setSchedulerInterval: vi.fn(),
+  pauseScheduler: vi.fn(),
+  resumeScheduler: vi.fn(),
+  ingestNow: vi.fn(),
+}));
+vi.mock('../api', () => apiMock);
+
+import { SchedulerPage } from '../pages/SchedulerPage';
+
+const defaultStatus = {
+  interval_minutes: 30,
+  paused: false,
+  next_run_at: null,
+  interval_ingest_enabled: true,
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  );
+  apiMock.fetchSchedulerStatus.mockResolvedValue(defaultStatus);
+  apiMock.fetchLatestJobRuns.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('SchedulerPage — job outcomes section', () => {
+  it('hides the job outcomes section when there are no runs', async () => {
+    apiMock.fetchLatestJobRuns.mockResolvedValue([]);
+    render(<SchedulerPage />);
+    await waitFor(() => expect(screen.queryByText('Last Job Outcomes')).toBeNull());
+  });
+
+  it('shows a successful job run with correct label and badge', async () => {
+    apiMock.fetchLatestJobRuns.mockResolvedValue([
+      {
+        id: 1,
+        job_name: 'digest',
+        started_at: '2026-06-01T08:00:00Z',
+        finished_at: '2026-06-01T08:00:02Z',
+        duration_ms: 2000,
+        status: 'success',
+        message: null,
+      },
+    ]);
+    render(<SchedulerPage />);
+    await waitFor(() => expect(screen.getByText('Last Job Outcomes')).toBeTruthy());
+    expect(screen.getByText('Daily digest')).toBeTruthy();
+    expect(screen.getByText('success')).toBeTruthy();
+    expect(screen.getByText('2000ms')).toBeTruthy();
+  });
+
+  it('shows a failed job run with message', async () => {
+    apiMock.fetchLatestJobRuns.mockResolvedValue([
+      {
+        id: 2,
+        job_name: 'recommendations',
+        started_at: '2026-06-01T07:30:00Z',
+        finished_at: '2026-06-01T07:30:05Z',
+        duration_ms: 5000,
+        status: 'failure',
+        message: 'connection refused',
+      },
+    ]);
+    render(<SchedulerPage />);
+    await waitFor(() => expect(screen.getByText('failure')).toBeTruthy());
+    expect(screen.getByText('Recommendations')).toBeTruthy();
+    expect(screen.getByText('connection refused')).toBeTruthy();
+  });
+
+  it('shows a skipped job run', async () => {
+    apiMock.fetchLatestJobRuns.mockResolvedValue([
+      {
+        id: 3,
+        job_name: 'digest',
+        started_at: '2026-06-01T08:00:00Z',
+        finished_at: '2026-06-01T08:00:00Z',
+        duration_ms: 10,
+        status: 'skipped',
+        message: 'no DIGEST_TO configured',
+      },
+    ]);
+    render(<SchedulerPage />);
+    await waitFor(() => expect(screen.getByText('skipped')).toBeTruthy());
+    expect(screen.getByText('no DIGEST_TO configured')).toBeTruthy();
+  });
+
+  it('renders multiple job outcomes', async () => {
+    apiMock.fetchLatestJobRuns.mockResolvedValue([
+      {
+        id: 1,
+        job_name: 'digest',
+        started_at: '2026-06-01T08:00:00Z',
+        finished_at: '2026-06-01T08:00:02Z',
+        duration_ms: 2000,
+        status: 'success',
+        message: null,
+      },
+      {
+        id: 2,
+        job_name: 'analytics_retention',
+        started_at: '2026-06-01T03:00:00Z',
+        finished_at: '2026-06-01T03:00:01Z',
+        duration_ms: 800,
+        status: 'success',
+        message: 'pruned 42 events older than 90 days',
+      },
+    ]);
+    render(<SchedulerPage />);
+    await waitFor(() => expect(screen.getByText('Daily digest')).toBeTruthy());
+    expect(screen.getByText('Analytics retention')).toBeTruthy();
+    expect(screen.getByText('pruned 42 events older than 90 days')).toBeTruthy();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -279,6 +279,21 @@ export async function resumeScheduler(): Promise<{ paused: boolean; next_run_at:
   return requestJson('/api/scheduler/resume', { method: 'POST' });
 }
 
+export interface ScheduledJobRun {
+  id: number;
+  job_name: string;
+  started_at: string;
+  finished_at: string | null;
+  duration_ms: number | null;
+  status: 'success' | 'skipped' | 'failure';
+  message: string | null;
+}
+
+export async function fetchLatestJobRuns(): Promise<ScheduledJobRun[]> {
+  const data = await requestJson<{ items: ScheduledJobRun[] }>('/api/scheduler/job-runs');
+  return data.items;
+}
+
 function statsParams(from: string, to: string): string {
   return new URLSearchParams({ from, to }).toString();
 }

--- a/frontend/src/pages/SchedulerPage.tsx
+++ b/frontend/src/pages/SchedulerPage.tsx
@@ -6,13 +6,23 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   fetchSchedulerStatus,
+  fetchLatestJobRuns,
   setSchedulerInterval,
   pauseScheduler,
   resumeScheduler,
   ingestNow,
   type SchedulerStatus,
+  type ScheduledJobRun,
 } from '../api';
 import { relativeCountdown } from '../lib/format';
+
+const JOB_LABELS: Record<string, string> = {
+  digest: 'Daily digest',
+  recommendations: 'Recommendations',
+  analytics_retention: 'Analytics retention',
+  per_user_briefings: 'Per-user briefings',
+  briefing: 'Global briefing',
+};
 
 const INTERVAL_PRESETS = [
   { label: '15m', value: 15 },
@@ -29,6 +39,7 @@ export function SchedulerPage() {
   const [actionPending, setActionPending] = useState(false);
   const [ingesting, setIngesting] = useState(false);
   const [countdown, setCountdown] = useState<string>('—');
+  const [jobRuns, setJobRuns] = useState<ScheduledJobRun[]>([]);
 
   async function loadStatus() {
     try {
@@ -41,8 +52,18 @@ export function SchedulerPage() {
     }
   }
 
+  async function loadJobRuns() {
+    try {
+      const runs = await fetchLatestJobRuns();
+      setJobRuns(runs);
+    } catch {
+      // non-critical — silently ignore if not available
+    }
+  }
+
   useEffect(() => {
     void loadStatus();
+    void loadJobRuns();
   }, []);
 
   useEffect(() => {
@@ -255,6 +276,51 @@ export function SchedulerPage() {
           </Button>
         </div>
       </div>
+
+      {jobRuns.length > 0 && (
+        <div className="rounded-lg border border-border p-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+            Last Job Outcomes
+          </h3>
+          <div className="space-y-2">
+            {jobRuns.map((run) => (
+              <div key={run.job_name} className="flex items-start gap-3 text-sm">
+                <Badge
+                  variant={
+                    run.status === 'success'
+                      ? 'default'
+                      : run.status === 'skipped'
+                        ? 'secondary'
+                        : 'destructive'
+                  }
+                  className="shrink-0 mt-0.5"
+                >
+                  {run.status}
+                </Badge>
+                <div className="min-w-0">
+                  <span className="font-medium">{JOB_LABELS[run.job_name] ?? run.job_name}</span>
+                  {run.started_at && (
+                    <span className="ml-2 text-muted-foreground">
+                      {new Date(run.started_at).toLocaleString([], {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                  )}
+                  {run.duration_ms != null && (
+                    <span className="ml-2 text-muted-foreground">{run.duration_ms}ms</span>
+                  )}
+                  {run.message && (
+                    <p className="text-muted-foreground truncate mt-0.5">{run.message}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #497

## Summary

- Adds a `scheduled_job_runs` table (DB migration) to persist lightweight outcome records for non-ingest scheduled jobs
- New `scheduled_job_history.py` module with `save_job_run()` and `list_latest_job_runs()`
- Refactors `_run_digest`, `_run_daily_recommendation_recalc`, `_run_analytics_retention`, `_run_briefing`, and `_run_per_user_briefings` to return `(status, message)` tuples
- New `_run_and_record()` wrapper records success/skipped/failure outcomes; per-user briefings only record when ≥1 user is targeted (keeps volume bounded)
- New admin-only `GET /api/scheduler/job-runs` endpoint returns latest outcome per job
- `SchedulerPage` shows a "Last Job Outcomes" section when data is available

## Test plan

- [x] `test_scheduled_job_history.py` — schema creation, success/failure/skipped recording, API endpoint, `_run_and_record` wrapper, `_run_digest` return values
- [x] `schedulerPage.test.tsx` — renders outcomes section with success/failure/skipped badges and multiple jobs
- [x] Existing `test_scheduler.py` updated and all 1108 tests pass
- [x] `make lint`, `make typecheck`, `make test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)