### PR TITLE
security: scope cached article AI artifacts to visible articles (#500)

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -310,13 +310,31 @@ def get_article(
 ) -> dict[str, Any] | None:
     """Fetch a single article by ID, stripping internal columns.
 
-    When user_id is given the per-user state from user_article_state is merged
-    in so that state/starred/timestamps reflect the calling user, not the
-    global articles table defaults.
+    When user_id is given the article must be visible to that user
+    (global source not disabled, or private source owned by the user).
+    Returns None for invisible articles as well as non-existent ones.
+    Per-user state from user_article_state is merged in for the returned dict.
     """
     init_db(db_path)
     with connect(db_path) as conn:
-        row = conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
+        if user_id is not None:
+            row = conn.execute(
+                """
+                SELECT a.*
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us_src
+                  ON us_src.source_slug = a.source_slug AND us_src.user_id = %s
+                WHERE a.id = %s
+                  AND (
+                    (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+                    OR src.owner_user_id = %s
+                  )
+                """,
+                (user_id, article_id, user_id),
+            ).fetchone()
+        else:
+            row = conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
         if row is None:
             return None
         return _article_from_row(row, conn, article_id, user_id)

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -117,13 +117,35 @@ def get_or_generate_insights(
 ) -> list[str]:
     """Return cached insights or generate + cache them.
 
+    When user_id is provided the article must be visible to that user
+    (global source not disabled, or private source owned by the user).
+    Returns [] for invisible or non-existent articles.
+
     Raises InsightsNotConfiguredError when OPENAI_API_KEY is absent and
     no cached insights exist.
     """
     init_db(database_url=database_url)
 
     with connect(database_url=database_url) as conn:
-        row = conn.execute("SELECT insights FROM articles WHERE id = %s", (article_id,)).fetchone()
+        if user_id is not None:
+            row = conn.execute(
+                """
+                SELECT a.insights
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us_src
+                  ON us_src.source_slug = a.source_slug AND us_src.user_id = %s
+                WHERE a.id = %s AND (
+                  (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+                  OR src.owner_user_id = %s
+                )
+                """,
+                (user_id, article_id, user_id),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT insights FROM articles WHERE id = %s", (article_id,)
+            ).fetchone()
 
     if row is None:
         return []

--- a/backend/news_dashboard/perspectives.py
+++ b/backend/news_dashboard/perspectives.py
@@ -108,23 +108,51 @@ def _parse_analysis(response_text: str) -> dict[str, list[str]]:
 
 
 def _fetch_related_articles(
-    article_id: int, *, database_url: str | None = None
+    article_id: int,
+    *,
+    user_id: int | None = None,
+    database_url: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Return up to _MAX_RELATED articles that share the same source/category."""
+    """Return up to _MAX_RELATED articles sharing the same category.
+
+    When user_id is provided, only articles visible to that user are included.
+    """
     with connect(database_url=database_url) as conn:
-        rows = conn.execute(
-            """
-            SELECT a.title, a.body, a.summary
-            FROM articles a
-            JOIN articles pivot ON pivot.id = %s
-            WHERE a.id <> %s
-              AND a.category = pivot.category
-              AND (a.body IS NOT NULL OR a.summary IS NOT NULL)
-            ORDER BY a.discovered_at DESC
-            LIMIT %s
-            """,
-            (article_id, article_id, _MAX_RELATED),
-        ).fetchall()
+        if user_id is not None:
+            rows = conn.execute(
+                """
+                SELECT a.title, a.body, a.summary
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us_src
+                  ON us_src.source_slug = a.source_slug AND us_src.user_id = %s
+                JOIN articles pivot ON pivot.id = %s
+                WHERE a.id <> %s
+                  AND a.category = pivot.category
+                  AND (a.body IS NOT NULL OR a.summary IS NOT NULL)
+                  AND (
+                    (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+                    OR src.owner_user_id = %s
+                  )
+                ORDER BY a.discovered_at DESC
+                LIMIT %s
+                """,
+                (user_id, article_id, article_id, user_id, _MAX_RELATED),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT a.title, a.body, a.summary
+                FROM articles a
+                JOIN articles pivot ON pivot.id = %s
+                WHERE a.id <> %s
+                  AND a.category = pivot.category
+                  AND (a.body IS NOT NULL OR a.summary IS NOT NULL)
+                ORDER BY a.discovered_at DESC
+                LIMIT %s
+                """,
+                (article_id, article_id, _MAX_RELATED),
+            ).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -172,16 +200,32 @@ def get_or_generate_perspectives(
 ) -> dict[str, list[str]] | None:
     """Return cached perspective analysis or generate and cache it.
 
-    Returns None if the article does not exist.
+    Returns None if the article does not exist or is not visible to user_id.
     Raises PerspectivesNotConfiguredError when OPENAI_API_KEY is absent and
     no cached analysis exists.
     """
     init_db(database_url=database_url)
 
     with connect(database_url=database_url) as conn:
-        row = conn.execute(
-            "SELECT perspective_analysis FROM articles WHERE id = %s", (article_id,)
-        ).fetchone()
+        if user_id is not None:
+            row = conn.execute(
+                """
+                SELECT a.perspective_analysis
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us_src
+                  ON us_src.source_slug = a.source_slug AND us_src.user_id = %s
+                WHERE a.id = %s AND (
+                  (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+                  OR src.owner_user_id = %s
+                )
+                """,
+                (user_id, article_id, user_id),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT perspective_analysis FROM articles WHERE id = %s", (article_id,)
+            ).fetchone()
 
     if row is None:
         return None
@@ -200,7 +244,7 @@ def get_or_generate_perspectives(
     if not str(article.get("body") or "").strip():
         return {"verified_facts": [], "omissions": [], "alternative_perspectives": []}
 
-    related = _fetch_related_articles(article_id, database_url=database_url)
+    related = _fetch_related_articles(article_id, user_id=user_id, database_url=database_url)
     analysis = generate_perspectives(article, related, user_id=user_id)
 
     with connect(database_url=database_url) as conn:

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -86,6 +86,55 @@ def _seed_article(pg_url: str, *, insights: str | None = None) -> int:
     return int(row["id"])
 
 
+def _seed_user(pg_url: str, username: str) -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, 'x') RETURNING id",
+            (username,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_private_article(
+    pg_url: str,
+    *,
+    owner_user_id: int,
+    url_slug: str = "priv-a",
+    insights: str | None = None,
+) -> int:
+    slug = f"private-src-{url_slug}"
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES (%s, 'Private', %s, 'tech', 'rss_feed', %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, f"https://{slug}.example", owner_user_id),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, summary, insights
+            )
+            VALUES (
+              %s, %s, 'Private Article', %s, 'Private', 'tech', 'rss_feed', 'Summary.', %s
+            )
+            RETURNING id
+            """,
+            (
+                f"https://{slug}.example/a",
+                f"https://{slug}.example/a",
+                slug,
+                insights,
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
 # ── _parse_bullets ────────────────────────────────────────────────────────────
 
 
@@ -383,6 +432,71 @@ def test_get_or_generate_insights_returns_empty_when_body_is_empty_string(pg_cle
 
     assert result == []
     mock_client.chat.completions.create.assert_not_called()
+
+
+def test_get_or_generate_insights_cached_blocked_for_unauthorized_user(pg_clean: str) -> None:
+    """Cached insights for a private article must not be returned to another user."""
+    owner_id = _seed_user(pg_clean, "owner-ins-1")
+    other_id = _seed_user(pg_clean, "other-ins-1")
+    cached = json.dumps(["Secret insight"])
+    article_id = _seed_private_article(
+        pg_clean, owner_user_id=owner_id, url_slug="auth1", insights=cached
+    )
+
+    mock_client = MagicMock()
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        result = get_or_generate_insights(article_id, user_id=other_id, database_url=pg_clean)
+
+    assert result == []
+    mock_client.chat.completions.create.assert_not_called()
+
+
+def test_get_or_generate_insights_cached_returned_for_owner(pg_clean: str) -> None:
+    """Owner can still retrieve cached insights for their private article."""
+    owner_id = _seed_user(pg_clean, "owner-ins-2")
+    cached = ["Owner insight"]
+    article_id = _seed_private_article(
+        pg_clean,
+        owner_user_id=owner_id,
+        url_slug="auth2",
+        insights=json.dumps(cached),
+    )
+
+    result = get_or_generate_insights(article_id, user_id=owner_id, database_url=pg_clean)
+
+    assert result == cached
+
+
+def test_get_or_generate_insights_endpoint_returns_404_for_unauthorized_cached(
+    pg_clean: str,
+) -> None:
+    """GET /api/articles/{id}/insights returns 404 when user cannot access the article."""
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    owner_id = _seed_user(pg_clean, "owner-ins-3")
+    other_id = _seed_user(pg_clean, "other-ins-3")
+    article_id = _seed_private_article(
+        pg_clean,
+        owner_user_id=owner_id,
+        url_slug="auth3",
+        insights=json.dumps(["Cached"]),
+    )
+
+    other_user = {"id": other_id, "is_admin": False, "username": "other-ins-3"}
+    app.dependency_overrides[require_auth] = lambda: other_user
+    try:
+        client = TestClient(app)
+        resp = client.get(f"/api/articles/{article_id}/insights")
+    finally:
+        del app.dependency_overrides[require_auth]
+
+    assert resp.status_code == 404
 
 
 # ── clustering unit tests (no DB, no AI) ─────────────────────────────────────

--- a/backend/tests/test_perspectives.py
+++ b/backend/tests/test_perspectives.py
@@ -17,6 +17,7 @@ from news_dashboard.perspectives import (
     DEFAULT_PERSPECTIVES_MODEL,
     PerspectivesNotConfiguredError,
     _build_text,
+    _fetch_related_articles,
     _parse_analysis,
     _perspectives_ai_config,
     generate_perspectives,
@@ -73,6 +74,58 @@ def _seed_article(pg_url: str, *, perspective_analysis: str | None = None) -> in
             RETURNING id
             """,
             (perspective_analysis,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_user(pg_url: str, username: str) -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, 'x') RETURNING id",
+            (username,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_private_article(
+    pg_url: str,
+    *,
+    owner_user_id: int,
+    url_slug: str = "priv-p",
+    category: str = "tech",
+    perspective_analysis: str | None = None,
+) -> int:
+    slug = f"private-src-{url_slug}"
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES (%s, 'Private', %s, %s, 'rss_feed', %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, f"https://{slug}.example", category, owner_user_id),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, summary, body, perspective_analysis
+            )
+            VALUES (
+              %s, %s, 'Private Article', %s, 'Private', %s,
+              'rss_feed', 'Summary.', 'Body text here.', %s
+            )
+            RETURNING id
+            """,
+            (
+                f"https://{slug}.example/a",
+                f"https://{slug}.example/a",
+                slug,
+                category,
+                perspective_analysis,
+            ),
         ).fetchone()
     assert row is not None
     return int(row["id"])
@@ -309,3 +362,82 @@ def test_get_or_generate_second_call_uses_cache(pg_clean: str) -> None:
 
     assert r1 == r2
     assert len(call_count) == 1, "AI called more than once — cache not working"
+
+
+# ── visibility / authorization tests ─────────────────────────────────────────
+
+
+def test_get_or_generate_returns_none_for_unauthorized_user_cached(pg_clean: str) -> None:
+    """Cached perspectives for a private article must not be returned to another user."""
+    owner_id = _seed_user(pg_clean, "owner-p-1")
+    other_id = _seed_user(pg_clean, "other-p-1")
+    article_id = _seed_private_article(
+        pg_clean,
+        owner_user_id=owner_id,
+        url_slug="vis1",
+        perspective_analysis=json.dumps(_VALID_ANALYSIS),
+    )
+
+    result = get_or_generate_perspectives(article_id, user_id=other_id, database_url=pg_clean)
+
+    assert result is None
+
+
+def test_get_or_generate_returns_cached_for_owner(pg_clean: str) -> None:
+    """Owner can still retrieve cached perspectives for their private article."""
+    owner_id = _seed_user(pg_clean, "owner-p-2")
+    article_id = _seed_private_article(
+        pg_clean,
+        owner_user_id=owner_id,
+        url_slug="vis2",
+        perspective_analysis=json.dumps(_VALID_ANALYSIS),
+    )
+
+    result = get_or_generate_perspectives(article_id, user_id=owner_id, database_url=pg_clean)
+
+    assert result is not None
+    assert result["verified_facts"] == ["Fact one"]
+
+
+def test_fetch_related_articles_excludes_invisible_sources(pg_clean: str) -> None:
+    """Related articles from sources invisible to the user must be excluded."""
+    owner_id = _seed_user(pg_clean, "owner-p-3")
+    other_id = _seed_user(pg_clean, "other-p-3")
+
+    pivot_id = _seed_private_article(
+        pg_clean, owner_user_id=owner_id, url_slug="pivot", category="tech"
+    )
+    _seed_private_article(pg_clean, owner_user_id=owner_id, url_slug="related1", category="tech")
+
+    related_as_owner = _fetch_related_articles(pivot_id, user_id=owner_id, database_url=pg_clean)
+    related_as_other = _fetch_related_articles(pivot_id, user_id=other_id, database_url=pg_clean)
+
+    assert len(related_as_owner) == 1
+    assert len(related_as_other) == 0
+
+
+def test_perspectives_endpoint_returns_404_for_unauthorized_cached(pg_clean: str) -> None:
+    """GET /api/articles/{id}/perspectives returns 404 when user cannot access the article."""
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    owner_id = _seed_user(pg_clean, "owner-p-4")
+    other_id = _seed_user(pg_clean, "other-p-4")
+    article_id = _seed_private_article(
+        pg_clean,
+        owner_user_id=owner_id,
+        url_slug="vis4",
+        perspective_analysis=json.dumps(_VALID_ANALYSIS),
+    )
+
+    other_user = {"id": other_id, "is_admin": False, "username": "other-p-4"}
+    app.dependency_overrides[require_auth] = lambda: other_user
+    try:
+        client = TestClient(app)
+        resp = client.get(f"/api/articles/{article_id}/perspectives")
+    finally:
+        del app.dependency_overrides[require_auth]
+
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `get_or_generate_insights` and `get_or_generate_perspectives` returned cached AI content before checking whether the requesting user can see the article — any authenticated user could read AI-derived bullets/analysis for articles outside their subscriptions or private-source ownership
- `get_article` (in `body_fetch.py`) now enforces the user-visibility contract when `user_id` is provided: global source not disabled OR private source owned by the user
- `_fetch_related_articles` now accepts `user_id` and scopes related articles to the same visibility contract, preventing cross-user context leakage in perspective generation

## Test plan

- [x] `test_get_or_generate_insights_cached_blocked_for_unauthorized_user` — cached insights invisible to other user → `[]`
- [x] `test_get_or_generate_insights_cached_returned_for_owner` — owner still gets cached insights
- [x] `test_get_or_generate_insights_endpoint_returns_404_for_unauthorized_cached` — route-level 404 for invisible cached insights
- [x] `test_get_or_generate_returns_none_for_unauthorized_user_cached` — cached perspectives invisible to other user → `None`
- [x] `test_get_or_generate_returns_cached_for_owner` — owner still gets cached perspectives
- [x] `test_fetch_related_articles_excludes_invisible_sources` — related articles scoped to user-visible sources
- [x] `test_perspectives_endpoint_returns_404_for_unauthorized_cached` — route-level 404 for invisible cached perspectives
- [x] Full backend suite: 602 tests pass

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)