### PR TITLE
feat: add installed-app shortcuts for core news flows (#502)

### DIFF
--- a/android/app/src/main/res/xml/shortcuts.xml
+++ b/android/app/src/main/res/xml/shortcuts.xml
@@ -13,4 +13,49 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<shortcuts xmlns:android='http://schemas.android.com/apk/res/android' />
+<shortcuts xmlns:android='http://schemas.android.com/apk/res/android'>
+  <shortcut
+    android:shortcutId="shortcut-today"
+    android:enabled="true"
+    android:icon="@mipmap/ic_launcher"
+    android:shortcutShortLabel="Today"
+    android:shortcutLongLabel="Today">
+    <intent
+      android:action="android.intent.action.VIEW"
+      android:data="https://news.lihor.ro/today" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+  <shortcut
+    android:shortcutId="shortcut-brief"
+    android:enabled="true"
+    android:icon="@mipmap/ic_launcher"
+    android:shortcutShortLabel="Brief"
+    android:shortcutLongLabel="Brief">
+    <intent
+      android:action="android.intent.action.VIEW"
+      android:data="https://news.lihor.ro/" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+  <shortcut
+    android:shortcutId="shortcut-search"
+    android:enabled="true"
+    android:icon="@mipmap/ic_launcher"
+    android:shortcutShortLabel="Search"
+    android:shortcutLongLabel="Search">
+    <intent
+      android:action="android.intent.action.VIEW"
+      android:data="https://news.lihor.ro/search" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+  <shortcut
+    android:shortcutId="shortcut-shared"
+    android:enabled="true"
+    android:icon="@mipmap/ic_launcher"
+    android:shortcutShortLabel="Shared"
+    android:shortcutLongLabel="Shared">
+    <intent
+      android:action="android.intent.action.VIEW"
+      android:data="https://news.lihor.ro/shared" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+</shortcuts>

--- a/android/twa-manifest.json
+++ b/android/twa-manifest.json
@@ -23,7 +23,52 @@
   },
   "appVersionName": "1.21.0",
   "appVersionCode": 1021000,
-  "shortcuts": [],
+  "shortcuts": [
+    {
+      "name": "Today",
+      "short_name": "Today",
+      "url": "/today",
+      "icons": [
+        {
+          "src": "https://news.lihor.ro/icons/icon-192.png",
+          "sizes": "192x192"
+        }
+      ]
+    },
+    {
+      "name": "Brief",
+      "short_name": "Brief",
+      "url": "/",
+      "icons": [
+        {
+          "src": "https://news.lihor.ro/icons/icon-192.png",
+          "sizes": "192x192"
+        }
+      ]
+    },
+    {
+      "name": "Search",
+      "short_name": "Search",
+      "url": "/search",
+      "icons": [
+        {
+          "src": "https://news.lihor.ro/icons/icon-192.png",
+          "sizes": "192x192"
+        }
+      ]
+    },
+    {
+      "name": "Shared",
+      "short_name": "Shared",
+      "url": "/shared",
+      "icons": [
+        {
+          "src": "https://news.lihor.ro/icons/icon-192.png",
+          "sizes": "192x192"
+        }
+      ]
+    }
+  ],
   "generatorApp": "bubblewrap-cli",
   "webManifestUrl": "https://news.lihor.ro/manifest.webmanifest",
   "fallbackType": "customtabs",

--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -105,6 +105,76 @@ test.describe('PWA — manifest file', () => {
   });
 });
 
+const KNOWN_ROUTES = [
+  '/',
+  '/today',
+  '/search',
+  '/shared',
+  '/later',
+  '/starred',
+  '/briefs',
+  '/feeds',
+  '/settings',
+  '/archive',
+];
+
+test.describe('PWA — shortcuts', () => {
+  test('manifest exposes a shortcuts array', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    const manifest = await response.json();
+    expect(Array.isArray(manifest.shortcuts)).toBe(true);
+    expect((manifest.shortcuts as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  test('each shortcut has name, url, and icons', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    const manifest = await response.json();
+    const shortcuts: Array<{ name: string; url: string; icons?: unknown[] }> =
+      manifest.shortcuts ?? [];
+    for (const shortcut of shortcuts) {
+      expect(typeof shortcut.name).toBe('string');
+      expect(shortcut.name.length).toBeGreaterThan(0);
+      expect(typeof shortcut.url).toBe('string');
+      expect(shortcut.url.length).toBeGreaterThan(0);
+      expect(Array.isArray(shortcut.icons)).toBe(true);
+      expect((shortcut.icons ?? []).length).toBeGreaterThan(0);
+    }
+  });
+
+  test('each shortcut url targets a known app route', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    const manifest = await response.json();
+    const shortcuts: Array<{ url: string }> = manifest.shortcuts ?? [];
+    for (const shortcut of shortcuts) {
+      const url = shortcut.url.split('?')[0].split('#')[0];
+      expect(KNOWN_ROUTES).toContain(url);
+    }
+  });
+
+  test('manifest includes Today, Brief, Search, and Shared shortcuts', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    const manifest = await response.json();
+    const shortcuts: Array<{ name: string; url: string }> = manifest.shortcuts ?? [];
+    const names = shortcuts.map((s) => s.name);
+    expect(names).toContain('Today');
+    expect(names).toContain('Brief');
+    expect(names).toContain('Search');
+    expect(names).toContain('Shared');
+  });
+
+  test('shortcut icon references use existing packaged icons', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    const manifest = await response.json();
+    const shortcuts: Array<{ icons?: Array<{ src: string }> }> = manifest.shortcuts ?? [];
+    for (const shortcut of shortcuts) {
+      for (const icon of shortcut.icons ?? []) {
+        const iconResponse = await page.request.get(icon.src);
+        expect(iconResponse.status()).toBe(200);
+      }
+    }
+  });
+});
+
 test.describe('PWA — icon files', () => {
   test('GET /favicon.svg returns 200', async ({ page }) => {
     const response = await page.request.get('/favicon.svg');

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -44,5 +44,63 @@
       "type": "image/svg+xml",
       "purpose": "monochrome"
     }
+  ],
+  "shortcuts": [
+    {
+      "name": "Today",
+      "short_name": "Today",
+      "description": "Open today's reading queue",
+      "url": "/today",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png",
+          "purpose": "any"
+        }
+      ]
+    },
+    {
+      "name": "Brief",
+      "short_name": "Brief",
+      "description": "Open the latest brief",
+      "url": "/",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png",
+          "purpose": "any"
+        }
+      ]
+    },
+    {
+      "name": "Search",
+      "short_name": "Search",
+      "description": "Search articles",
+      "url": "/search",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png",
+          "purpose": "any"
+        }
+      ]
+    },
+    {
+      "name": "Shared",
+      "short_name": "Shared",
+      "description": "View shared articles",
+      "url": "/shared",
+      "icons": [
+        {
+          "src": "/icons/icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png",
+          "purpose": "any"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a `shortcuts` array to `public/manifest.webmanifest` with Today (`/today`), Brief (`/`), Search (`/search`), and Shared (`/shared`) entries, each reusing the existing `icon-192.png`
- Updates `android/twa-manifest.json` with matching shortcuts so Bubblewrap config stays in sync
- Populates `android/app/src/main/res/xml/shortcuts.xml` with the four corresponding Android static shortcuts using `@mipmap/ic_launcher` and `ACTION_VIEW` intents pointing at `https://news.lihor.ro/<route>`
- Extends `e2e/pwa.spec.ts` with a new "PWA — shortcuts" describe block that asserts: shortcuts array is non-empty, each entry has `name`/`url`/`icons`, each URL targets a known app route, the four named shortcuts are present, and shortcut icons resolve to HTTP 200

## Test plan

- [x] `npm run lint` — passed
- [x] `npm run format:check` — passed
- [x] `npm run typecheck` — passed
- [x] pre-commit hooks — passed (eslint, prettier, tsc)
- [ ] `npm run test:e2e -- e2e/pwa.spec.ts` — new shortcut tests will run in CI
- [ ] `npm run build` — verify manifest is bundled in production

Closes #502