### PR TITLE
fix: make digest read tokens user-scoped (#501)

### DIFF
--- a/backend/news_dashboard/digest.py
+++ b/backend/news_dashboard/digest.py
@@ -14,7 +14,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
 
-from news_dashboard.db import connect, init_db, row_to_dict
+from news_dashboard.db import init_db
 
 logger = logging.getLogger(__name__)
 
@@ -28,15 +28,26 @@ _TOKEN_SECRET = os.getenv("TOKEN_SECRET", "news-dashboard-default-secret-change-
 # ---------------------------------------------------------------------------
 
 
-def _make_token(article_id: int) -> str:
-    """Return a short HMAC token for the given article id."""
-    msg = f"read:{article_id}".encode()
+def _token_signature(user_id: int, article_id: int) -> str:
+    msg = f"read:{user_id}:{article_id}".encode()
     return hmac.new(_TOKEN_SECRET.encode(), msg, hashlib.sha256).hexdigest()[:32]
 
 
-def verify_read_token(article_id: int, token: str) -> bool:
-    expected = _make_token(article_id)
-    return hmac.compare_digest(expected, token)
+def _make_token(user_id: int, article_id: int) -> str:
+    """Return a signed token binding the article to the digest recipient."""
+    return f"{user_id}.{_token_signature(user_id, article_id)}"
+
+
+def verify_read_token(article_id: int, token: str) -> int | None:
+    try:
+        user_id_text, signature = token.split(".", 1)
+        user_id = int(user_id_text)
+    except ValueError:
+        return None
+    expected = _token_signature(user_id, article_id)
+    if not hmac.compare_digest(expected, signature):
+        return None
+    return user_id
 
 
 # ---------------------------------------------------------------------------
@@ -44,19 +55,19 @@ def verify_read_token(article_id: int, token: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _get_top_new_articles(limit: int = 10) -> list[dict[str, Any]]:
+def _get_top_new_articles(user_id: int, limit: int = 10) -> list[dict[str, Any]]:
+    from news_dashboard.ingest import list_articles
+
     init_db()
-    with connect() as conn:
-        rows = conn.execute(
-            """
-            SELECT * FROM articles
-            WHERE status = 'new'
-            ORDER BY importance_score DESC, discovered_at DESC
-            LIMIT %s
-            """,
-            (limit,),
-        ).fetchall()
-    return [row_to_dict(r) for r in rows]
+    articles = list_articles(state="today", user_id=user_id, limit=max(limit * 5, limit))
+    return sorted(
+        articles,
+        key=lambda article: (
+            article.get("importance_score") or 0,
+            article.get("discovered_at") or "",
+        ),
+        reverse=True,
+    )[:limit]
 
 
 # ---------------------------------------------------------------------------
@@ -68,11 +79,11 @@ def _base_url() -> str:
     return os.getenv("APP_BASE_URL", "http://localhost:8000")
 
 
-def _render_html(articles: list[dict[str, Any]]) -> str:
+def _render_html(articles: list[dict[str, Any]], *, user_id: int) -> str:
     base = _base_url()
     rows = ""
     for a in articles:
-        token = _make_token(a["id"])
+        token = _make_token(user_id, a["id"])
         mark_read_url = f"{base}/api/articles/{a['id']}/read?token={token}"
         title = html.escape(a.get("title") or "Untitled")
         url = html.escape(a.get("url") or "#", quote=True)
@@ -105,11 +116,11 @@ def _render_html(articles: list[dict[str, Any]]) -> str:
     """
 
 
-def _render_text(articles: list[dict[str, Any]]) -> str:
+def _render_text(articles: list[dict[str, Any]], *, user_id: int) -> str:
     base = _base_url()
     lines = [f"News Digest — {datetime.now(timezone.utc).strftime('%A, %B %d %Y')}", ""]
     for i, a in enumerate(articles, 1):
-        token = _make_token(a["id"])
+        token = _make_token(user_id, a["id"])
         mark_read_url = f"{base}/api/articles/{a['id']}/read?token={token}"
         title = a.get("title") or "Untitled"
         url = a.get("url") or ""
@@ -180,8 +191,17 @@ def send_digest() -> bool:
     if not digest_to:
         logger.info("DIGEST_TO not set — skipping digest.")
         return False
+    digest_user_id_raw = os.getenv("DIGEST_USER_ID", "")
+    if not digest_user_id_raw:
+        logger.info("DIGEST_USER_ID not set — skipping digest.")
+        return False
+    try:
+        digest_user_id = int(digest_user_id_raw)
+    except ValueError:
+        logger.warning("DIGEST_USER_ID is not a valid integer — skipping digest.")
+        return False
 
-    articles = _get_top_new_articles(limit=10)
+    articles = _get_top_new_articles(digest_user_id, limit=10)
     if not articles:
         logger.info("No new articles — skipping digest.")
         return False
@@ -190,8 +210,8 @@ def send_digest() -> bool:
     subject = (
         f"News Digest {date_str} — {len(articles)} new article{'s' if len(articles) != 1 else ''}"
     )
-    html_body = _render_html(articles)
-    text_body = _render_text(articles)
+    html_body = _render_html(articles, user_id=digest_user_id)
+    text_body = _render_text(articles, user_id=digest_user_id)
 
     _send_email(subject, html_body, text_body)
     return True

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -70,7 +70,6 @@ from news_dashboard.ingest import (
     search_articles_page,
     send_article_later,
     set_article_starred,
-    set_article_status,
     sync_sources,
     transition_article_state,
 )
@@ -398,10 +397,11 @@ def logout(response: Response) -> dict[str, str]:
 def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict[str, Any]:
     from news_dashboard.digest import verify_read_token
 
-    if not verify_read_token(article_id, token):
+    user_id = verify_read_token(article_id, token)
+    if user_id is None:
         raise HTTPException(status_code=403, detail="invalid or expired token")
     try:
-        article = set_article_status(article_id, "read")
+        article = transition_article_state(article_id, "done", user_id=user_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not article:

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from news_dashboard import digest
+from news_dashboard.auth import create_user
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -42,38 +43,44 @@ _ARTICLES: list[dict[str, Any]] = [
 
 
 def test_token_roundtrip_verifies() -> None:
-    token = digest._make_token(42)
-    assert digest.verify_read_token(42, token) is True
+    token = digest._make_token(7, 42)
+    assert digest.verify_read_token(42, token) == 7
 
 
 def test_token_is_rejected_for_wrong_article() -> None:
-    token = digest._make_token(42)
-    assert digest.verify_read_token(43, token) is False
+    token = digest._make_token(7, 42)
+    assert digest.verify_read_token(43, token) is None
 
 
 def test_token_rejects_garbage() -> None:
-    assert digest.verify_read_token(42, "deadbeef") is False
+    assert digest.verify_read_token(42, "deadbeef") is None
+
+
+def test_token_is_rejected_for_wrong_user_signature() -> None:
+    token = digest._make_token(7, 42)
+    replayed = token.replace("7.", "8.", 1)
+    assert digest.verify_read_token(42, replayed) is None
 
 
 # ── HTML / text rendering ─────────────────────────────────────────────────────
 
 
 def test_render_html_includes_titles_and_mark_read_links() -> None:
-    html = digest._render_html(_ARTICLES)
+    html = digest._render_html(_ARTICLES, user_id=7)
     assert "First Headline" in html
     # Missing title falls back to "Untitled".
     assert "Untitled" in html
     # Each article gets a signed mark-read link.
-    assert f"/api/articles/1/read?token={digest._make_token(1)}" in html
+    assert f"/api/articles/1/read?token={digest._make_token(7, 1)}" in html
 
 
 def test_render_html_pluralises_count() -> None:
-    assert "1\n        new article today" in digest._render_html(_ARTICLES[:1])
-    assert "article" in digest._render_html(_ARTICLES)
+    assert "1\n        new article today" in digest._render_html(_ARTICLES[:1], user_id=7)
+    assert "article" in digest._render_html(_ARTICLES, user_id=7)
 
 
 def test_render_text_lists_articles_in_order() -> None:
-    text = digest._render_text(_ARTICLES)
+    text = digest._render_text(_ARTICLES, user_id=7)
     assert "1. First Headline" in text
     assert "2. Untitled" in text
     assert "Source: Example News | Score: 90" in text
@@ -138,7 +145,11 @@ def test_send_digest_returns_false_without_recipient(pg_clean: str) -> None:
 @pytest.mark.postgres
 def test_send_digest_returns_false_when_no_new_articles(pg_clean: str) -> None:
     with (
-        patch.dict("os.environ", {"DIGEST_TO": "me@example.com"}, clear=False),
+        patch.dict(
+            "os.environ",
+            {"DIGEST_TO": "me@example.com", "DIGEST_USER_ID": "1"},
+            clear=False,
+        ),
         patch.object(digest, "_send_email") as send,
     ):
         assert digest.send_digest() is False
@@ -147,6 +158,7 @@ def test_send_digest_returns_false_when_no_new_articles(pg_clean: str) -> None:
 
 @pytest.mark.postgres
 def test_send_digest_sends_when_new_articles_exist(pg_clean: str) -> None:
+    user = create_user("digest-user", "pw", email="me@example.com", db_path=pg_clean)
     with psycopg.connect(pg_clean) as conn:
         conn.execute(
             "INSERT INTO sources(slug, name, url, category, kind) VALUES (%s, %s, %s, %s, %s)",
@@ -176,13 +188,55 @@ def test_send_digest_sends_when_new_articles_exist(pg_clean: str) -> None:
         conn.commit()
 
     with (
-        patch.dict("os.environ", {"DIGEST_TO": "me@example.com"}, clear=False),
+        patch.dict(
+            "os.environ",
+            {"DIGEST_TO": "me@example.com", "DIGEST_USER_ID": str(user["id"])},
+            clear=False,
+        ),
         patch.object(digest, "_send_email") as send,
     ):
         assert digest.send_digest() is True
         send.assert_called_once()
         subject = send.call_args.args[0]
         assert "News Digest" in subject
+
+
+@pytest.mark.postgres
+def test_get_top_new_articles_uses_recipient_source_visibility(pg_clean: str) -> None:
+    user = create_user("digest-user", "pw", email="me@example.com", db_path=pg_clean)
+    with psycopg.connect(pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind) VALUES (%s, %s, %s, %s, %s)",
+            ("visible", "Visible", "https://example.com/visible", "engineering", "rss"),
+        )
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind) VALUES (%s, %s, %s, %s, %s)",
+            ("hidden", "Hidden", "https://example.com/hidden", "engineering", "rss"),
+        )
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) VALUES (%s, %s, FALSE)",
+            (user["id"], "hidden"),
+        )
+        for slug in ("visible", "hidden"):
+            conn.execute(
+                """
+                INSERT INTO articles(
+                    url, canonical_url, title, source_slug, source_name,
+                    category, kind, state, importance_score
+                ) VALUES (%s, %s, %s, %s, %s, 'engineering', 'rss', 'today', 90)
+                """,
+                (
+                    f"https://example.com/{slug}/a",
+                    f"https://example.com/{slug}/a",
+                    slug,
+                    slug,
+                    slug.title(),
+                ),
+            )
+        conn.commit()
+
+    articles = digest._get_top_new_articles(int(user["id"]))
+    assert {article["source_slug"] for article in articles} == {"visible"}
 
 
 # ── HTML escaping ─────────────────────────────────────────────────────────────
@@ -199,7 +253,7 @@ def test_render_html_escapes_script_in_title() -> None:
             "importance_score": 50,
         }
     ]
-    html = digest._render_html(articles)
+    html = digest._render_html(articles, user_id=7)
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
 
@@ -215,7 +269,7 @@ def test_render_html_escapes_quotes_in_url() -> None:
             "importance_score": 0,
         }
     ]
-    html = digest._render_html(articles)
+    html = digest._render_html(articles, user_id=7)
     assert '"evil"' not in html
 
 
@@ -230,7 +284,7 @@ def test_render_html_escapes_summary_and_source() -> None:
             "importance_score": 0,
         }
     ]
-    html = digest._render_html(articles)
+    html = digest._render_html(articles, user_id=7)
     assert "<b>" not in html
     assert "<em>" not in html
     assert "&lt;b&gt;" in html
@@ -251,6 +305,8 @@ def _fresh_client() -> TestClient:
 def test_mark_read_via_token_succeeds_without_session(pg_clean: str) -> None:
     import psycopg
 
+    user_a = create_user("alice", "pw", db_path=pg_clean)
+    user_b = create_user("bob", "pw", db_path=pg_clean)
     with psycopg.connect(pg_clean) as conn:
         conn.execute(
             "INSERT INTO sources(slug, name, url, category, kind) VALUES (%s, %s, %s, %s, %s)",
@@ -260,8 +316,8 @@ def test_mark_read_via_token_succeeds_without_session(pg_clean: str) -> None:
             """
             INSERT INTO articles(
                 url, canonical_url, title, source_slug, source_name,
-                category, kind, status, importance_score, summary, reason, tags
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'new', 70, 'Sum', '', '')
+                category, kind, status, state, importance_score, summary, reason, tags
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'new', 'today', 70, 'Sum', '', '')
             """,
             (
                 "https://example.com/a",
@@ -278,11 +334,23 @@ def test_mark_read_via_token_succeeds_without_session(pg_clean: str) -> None:
         article_id: int = row[0]
         conn.commit()
 
-    token = digest._make_token(article_id)
+    token = digest._make_token(int(user_a["id"]), article_id)
     client = _fresh_client()
     resp = client.get(f"/api/articles/{article_id}/read", params={"token": token}, cookies={})
     assert resp.status_code == 200
     assert resp.json()["status"] == "marked_read"
+    with psycopg.connect(pg_clean) as conn:
+        states = conn.execute(
+            "SELECT user_id, state FROM user_article_state WHERE article_id = %s ORDER BY user_id",
+            (article_id,),
+        ).fetchall()
+        article_state = conn.execute(
+            "SELECT status, state FROM articles WHERE id = %s",
+            (article_id,),
+        ).fetchone()
+    assert [(row[0], row[1]) for row in states] == [(user_a["id"], "done")]
+    assert article_state == ("new", "today")
+    assert user_b["id"] not in {row[0] for row in states}
 
 
 @pytest.mark.postgres
@@ -294,7 +362,7 @@ def test_mark_read_via_token_rejects_bad_token(pg_clean: str) -> None:
 
 @pytest.mark.postgres
 def test_mark_read_via_token_rejects_wrong_article_token(pg_clean: str) -> None:
-    token = digest._make_token(1)
+    token = digest._make_token(7, 1)
     client = _fresh_client()
     resp = client.get("/api/articles/2/read", params={"token": token}, cookies={})
     assert resp.status_code == 403


### PR DESCRIPTION
Closes #501

## Summary
- bind digest mark-read tokens to both user id and article id
- select digest articles from the configured recipient user's visible today feed
- make the public mark-read route update only that user's `user_article_state` as `done`
- add regressions for token replay, source visibility, sessionless marking, and unchanged legacy article status

## Tests
- `pytest backend/tests/test_digest.py`
- `make lint`
- `make typecheck`
- `source .env && make test`

Generated with Codex