### PR TITLE
fix: enforce source visibility for article-id operations (#505)

### DIFF
--- a/backend/news_dashboard/article_visibility.py
+++ b/backend/news_dashboard/article_visibility.py
@@ -1,0 +1,40 @@
+"""Article source-visibility helpers.
+
+Runtime SQL is PostgreSQL-specific and uses psycopg ``%s`` parameters.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def visible_article_sql(alias: str = "a") -> str:
+    """Return the source-visibility predicate for an article table alias."""
+    return (
+        f"({alias}_src.owner_user_id IS NULL AND COALESCE({alias}_us.enabled, TRUE)) "
+        f"OR {alias}_src.owner_user_id = %s"
+    )
+
+
+def get_visible_article_row(conn: Any, article_id: int, user_id: int | None) -> Any | None:
+    """Return an article row only when it is visible to ``user_id``.
+
+    Userless callers keep the legacy article-id-only behavior for CLI/background
+    paths. User-scoped callers see global subscribed sources plus their own
+    private sources.
+    """
+    if user_id is None:
+        return conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
+
+    return conn.execute(
+        f"""
+        SELECT a.*
+        FROM articles a
+        JOIN sources a_src ON a_src.slug = a.source_slug
+        LEFT JOIN user_sources a_us
+          ON a_us.source_slug = a.source_slug AND a_us.user_id = %s
+        WHERE a.id = %s
+          AND ({visible_article_sql("a")})
+        """,
+        (user_id, article_id, user_id),
+    ).fetchone()

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -15,6 +15,7 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 
+from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.db import connect, init_db, row_to_dict
 from news_dashboard.scraper import TIMEOUT_SECS, USER_AGENT
 
@@ -317,24 +318,7 @@ def get_article(
     """
     init_db(db_path)
     with connect(db_path) as conn:
-        if user_id is not None:
-            row = conn.execute(
-                """
-                SELECT a.*
-                FROM articles a
-                JOIN sources src ON src.slug = a.source_slug
-                LEFT JOIN user_sources us_src
-                  ON us_src.source_slug = a.source_slug AND us_src.user_id = %s
-                WHERE a.id = %s
-                  AND (
-                    (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
-                    OR src.owner_user_id = %s
-                  )
-                """,
-                (user_id, article_id, user_id),
-            ).fetchone()
-        else:
-            row = conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
+        row = get_visible_article_row(conn, article_id, user_id)
         if row is None:
             return None
         return _article_from_row(row, conn, article_id, user_id)
@@ -390,7 +374,7 @@ def fetch_and_cache_body(
     """
     init_db(db_path)
     with connect(db_path) as conn:
-        row = conn.execute("SELECT * FROM articles WHERE id = %s", (article_id,)).fetchone()
+        row = get_visible_article_row(conn, article_id, user_id)
         if row is None:
             return None
         row_d = row_to_dict(row)

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -17,6 +17,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import feedparser
 
+from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.db import connect, init_db, insert_article_sql, placeholders, row_to_dict
 from news_dashboard.ingest_events import ingest_events
 from news_dashboard.recommendations import COLD_START_MODEL_VERSION
@@ -1747,6 +1748,13 @@ def _get_article_row(conn: Any, article_id: int) -> dict[str, Any] | None:
     return _article_dict(row) if row else None
 
 
+def _get_article_row_for_user(
+    conn: Any, article_id: int, user_id: int | None
+) -> dict[str, Any] | None:
+    row = get_visible_article_row(conn, article_id, user_id)
+    return _article_dict(row) if row else None
+
+
 def transition_article_state(  # noqa: PLR0912
     article_id: int,
     new_state: str,
@@ -1764,7 +1772,7 @@ def transition_article_state(  # noqa: PLR0912
 
     init_db(db_path)
     with connect(db_path) as conn:
-        base = _get_article_row(conn, article_id)
+        base = _get_article_row_for_user(conn, article_id, user_id)
         if base is None:
             return None
 
@@ -1847,7 +1855,7 @@ def set_article_starred(
     """Set the starred flag on an article. Raises ValueError if starring a skipped article."""
     init_db(db_path)
     with connect(db_path) as conn:
-        base = _get_article_row(conn, article_id)
+        base = _get_article_row_for_user(conn, article_id, user_id)
         if base is None:
             return None
 
@@ -1900,7 +1908,7 @@ def send_article_later(
 
     init_db(db_path)
     with connect(db_path) as conn:
-        base = _get_article_row(conn, article_id)
+        base = _get_article_row_for_user(conn, article_id, user_id)
         if base is None:
             return None
 

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -13,6 +13,7 @@ import logging
 import os
 from typing import Any
 
+from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.db import connect, row_to_dict
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,7 @@ def share_article(
 
     clean_note = (note or "").strip() or None
     with connect() as conn:
-        if conn.execute("SELECT 1 FROM articles WHERE id = %s", (article_id,)).fetchone() is None:
+        if get_visible_article_row(conn, article_id, from_user_id) is None:
             msg = f"Article {article_id} not found"
             raise ShareError(msg)
         if conn.execute("SELECT 1 FROM users WHERE id = %s", (to_user_id,)).fetchone() is None:

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -60,6 +60,29 @@ def _insert_article(db_path: str, suffix: str = "1") -> int:
     return int(row["id"])
 
 
+def _insert_private_article(db_path: str, *, owner_user_id: int) -> int:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES ('private-share', 'Private Share', 'https://private.example.com/feed.xml',
+                    'private', 'rss_feed', %s)
+            """,
+            (owner_user_id,),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug,
+              source_name, category, kind, state)
+            VALUES ('https://private.example.com/share', 'https://private.example.com/share',
+                    'Private Share Article', 'private-share', 'Private Share',
+                    'private', 'rss_feed', 'today')
+            RETURNING id
+            """
+        ).fetchone()
+    return int(row["id"])
+
+
 def test_share_and_list(db: str) -> None:
     alice = _make_user(db, "alice")
     bob = _make_user(db, "bob")
@@ -113,6 +136,21 @@ def test_share_unknown_article_raises(db: str) -> None:
     bob = _make_user(db, "bob")
     with pytest.raises(ShareError):
         share_article(article_id=999999, from_user_id=alice, to_user_id=bob)
+
+
+def test_cannot_share_other_users_private_source_article(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_private_article(db, owner_user_id=alice)
+
+    with pytest.raises(ShareError, match="not found"):
+        share_article(article_id=article_id, from_user_id=bob, to_user_id=alice)
+
+    with connect(db) as conn:
+        row = conn.execute("SELECT COUNT(*) AS count FROM article_shares").fetchone()
+    assert row["count"] == 0
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    assert share["article_id"] == article_id
 
 
 # ── Annotation tests ──────────────────────────────────────────────────────────

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -215,6 +215,33 @@ def _seed_user(db_path: Path, username: str = "alice") -> int:
     return int(row["id"] if isinstance(row, dict) else row[0])
 
 
+def _seed_private_article(db_path: Path, *, owner_user_id: int, slug: str = "private") -> int:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES (%s, %s, %s, 'private', 'rss_feed', %s)
+            """,
+            (slug, slug, f"https://{slug}.example.com/feed.xml", owner_user_id),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name, category, kind
+            )
+            VALUES (%s, %s, 'Private Article', %s, %s, 'private', 'rss_feed')
+            RETURNING id
+            """,
+            (
+                f"https://{slug}.example.com/article",
+                f"https://{slug}.example.com/article",
+                slug,
+                slug,
+            ),
+        ).fetchone()
+    return int(row["id"] if isinstance(row, dict) else row[0])
+
+
 def test_get_article_with_no_uas_defaults_to_today(tmp_path: Path) -> None:
     db_path = _db(tmp_path)
     article_id = _seed_article(db_path)
@@ -268,6 +295,17 @@ def test_get_article_with_user_id_does_not_bleed_across_users(tmp_path: Path) ->
     assert result_b["starred"] is False
 
 
+def test_get_article_with_user_id_hides_other_users_private_source(tmp_path: Path) -> None:
+    db_path = _db(tmp_path)
+    sync_sources(db_path)
+    owner_id = _seed_user(db_path, "owner")
+    other_id = _seed_user(db_path, "other")
+    article_id = _seed_private_article(db_path, owner_user_id=owner_id)
+
+    assert get_article(article_id, db_path=db_path, user_id=owner_id) is not None
+    assert get_article(article_id, db_path=db_path, user_id=other_id) is None
+
+
 # ── fetch_and_cache_body with user_id ────────────────────────────────────────
 
 
@@ -292,6 +330,29 @@ def test_fetch_and_cache_body_with_user_id_reflects_state(tmp_path: Path) -> Non
     assert result["body_status"] == "ok"
     assert result["state"] == "done"
     assert result["starred"] is True
+
+
+def test_fetch_and_cache_body_with_user_id_hides_other_users_private_source(
+    tmp_path: Path,
+) -> None:
+    db_path = _db(tmp_path)
+    sync_sources(db_path)
+    owner_id = _seed_user(db_path, "owner")
+    other_id = _seed_user(db_path, "other")
+    article_id = _seed_private_article(db_path, owner_user_id=owner_id)
+
+    with patch("news_dashboard.body_fetch.extract_body") as extract:
+        result = fetch_and_cache_body(article_id, db_path=db_path, user_id=other_id)
+
+    assert result is None
+    extract.assert_not_called()
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT body_status, body FROM articles WHERE id = %s",
+            (article_id,),
+        ).fetchone()
+    assert row["body_status"] == "missing"
+    assert row["body"] is None
 
 
 # ── prefetch_article_bodies ───────────────────────────────────────────────────

--- a/backend/tests/test_per_user_article_state.py
+++ b/backend/tests/test_per_user_article_state.py
@@ -56,6 +56,29 @@ def _make_user(db_path: Path | str, username: str = "alice") -> int:
     return int(user["id"])
 
 
+def _insert_private_article(db_path: Path | str, *, owner_user_id: int) -> int:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES ('owner-private', 'Owner Private', 'https://private.example.com/feed.xml',
+                    'private', 'rss_feed', %s)
+            """,
+            (owner_user_id,),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+                                 category, kind, state)
+            VALUES ('https://private.example.com/art', 'https://private.example.com/art',
+                    'Private Article', 'owner-private', 'Owner Private',
+                    'private', 'rss_feed', 'today')
+            RETURNING id
+            """
+        ).fetchone()
+    return int(row["id"] if isinstance(row, dict) else row[0])
+
+
 # ── implicit today (no UAS row yet) ──────────────────────────────────────────
 
 
@@ -261,6 +284,39 @@ def test_snooze_cannot_snooze_done(tmp_path: Path) -> None:
     transition_article_state(aid, "done", db_path=db, user_id=uid)
     with pytest.raises(ValueError, match="cannot snooze"):
         send_article_later(aid, days=1, db_path=db, user_id=uid)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["state", "star", "later"],
+)
+def test_article_state_operations_hide_other_users_private_source(
+    tmp_path: Path, operation: str
+) -> None:
+    db = _setup_db(tmp_path)
+    owner_id = _make_user(db, "owner")
+    other_id = _make_user(db, "other")
+    aid = _insert_private_article(db, owner_user_id=owner_id)
+
+    if operation == "state":
+        result = transition_article_state(aid, "done", db_path=db, user_id=other_id)
+    elif operation == "star":
+        result = set_article_starred(aid, True, db_path=db, user_id=other_id)
+    else:
+        result = send_article_later(aid, days=1, db_path=db, user_id=other_id)
+
+    assert result is None
+    with connect(db) as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM user_article_state
+            WHERE article_id = %s AND user_id = %s
+            """,
+            (aid, other_id),
+        ).fetchone()
+    assert row["count"] == 0
+    assert transition_article_state(aid, "done", db_path=db, user_id=owner_id) is not None
 
 
 def test_snooze_returns_to_today_after_expiry(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #505

## Summary
- add a shared PostgreSQL article visibility helper for article-id lookups
- enforce source visibility before body fetching, workflow state mutations, starring/later, and article sharing
- add regressions for another user's private source across body fetch, state operations, and sharing

## Tests
- `uv run make lint`
- `uv run make typecheck`
- `set -a; source .env; set +a; uv run pytest backend/tests/test_body_fetch.py backend/tests/test_per_user_article_state.py backend/tests/test_article_shares.py`
- `set -a; source .env; set +a; uv run make test` (backend 1129 passed; frontend 602 passed; Vitest printed localhost:3000 ECONNREFUSED diagnostics but exited 0)

Generated by codex.