### PR TITLE
fix: source briefing gateway config from OPENAI_BRIEFING_* names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,8 +416,8 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          FREE_LLM_API_KEY: ${{ secrets.FREE_LLM_API_KEY }}
-          FREE_LLM_BASE_URL: ${{ vars.FREE_LLM_BASE_URL }}
+          FREE_LLM_API_KEY: ${{ secrets.OPENAI_BRIEFING_API_KEY }}
+          FREE_LLM_BASE_URL: ${{ vars.OPENAI_BRIEFING_BASE_URL }}
           OPENAI_BRIEFING_MODEL: ${{ vars.OPENAI_BRIEFING_MODEL }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}


### PR DESCRIPTION
Closes #552

## Problem

Briefing generation fails with `404 model_not_found` for model `auto`. The model `auto` only exists on the self-hosted gateway, but requests were going to the default OpenAI endpoint.

## Root cause

Config naming drift. The backend reads the briefing gateway from `FREE_LLM_BASE_URL` / `FREE_LLM_API_KEY`, but the Deploy (Helm) step in `ci.yml` sourced those from `secrets.FREE_LLM_API_KEY` / `vars.FREE_LLM_BASE_URL` — names that don't exist in the repo config. The values live under the older `OPENAI_BRIEFING_API_KEY` / `OPENAI_BRIEFING_BASE_URL` (`https://llm.lihor.ro/v1`). With no gateway URL in the pod, briefing requests hit default OpenAI with `OPENAI_BRIEFING_MODEL=auto`.

## Change

Bridge the existing `OPENAI_BRIEFING_*` GitHub secret/var to the `FREE_LLM_*` env the backend reads. No new secrets needed.

This is a deploy-config change; it takes effect on the next deploy to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)