### PR TITLE
fix: keep article dedupe within source-visibility boundaries (#506)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -323,16 +323,35 @@ def _fetch_article_snippet(url: str) -> str:
     return ""
 
 
-def _find_canonical(conn: Any, canonical_url: str, title: str) -> int | None:
-    """Return the id of an existing canonical article matching by URL or fuzzy title, or None."""
+def _find_canonical(
+    conn: Any, canonical_url: str, title: str, owner_user_id: int | None = None
+) -> int | None:
+    """Return the id of an existing canonical article matching by URL or fuzzy title, or None.
+
+    Source-visibility rules for canonical selection:
+    - A global source (owner_user_id=None) may only canonicalize against other global canonicals.
+    - A private source (owner_user_id!=None) may canonicalize against global canonicals or
+      canonicals owned by the same user, but not private canonicals from a different owner.
+    """
+    if owner_user_id is None:
+        # Global source: only match global canonical articles
+        visibility_clause = "AND s.owner_user_id IS NULL"
+        visibility_params: tuple[int, ...] = ()
+    else:
+        # Private source: match global or same-owner private canonical articles
+        visibility_clause = "AND (s.owner_user_id IS NULL OR s.owner_user_id = %s)"
+        visibility_params = (owner_user_id,)
+
     # Exact URL match (canonical_url already stripped of tracking params)
     row = conn.execute(
-        """
-        SELECT id FROM articles
-        WHERE canonical_url=%s AND (canonical_id IS NULL OR canonical_id=id)
+        f"""
+        SELECT a.id FROM articles a
+        JOIN sources s ON s.slug = a.source_slug
+        WHERE a.canonical_url = %s AND (a.canonical_id IS NULL OR a.canonical_id = a.id)
+        {visibility_clause}
         LIMIT 1
         """,
-        (canonical_url,),
+        (canonical_url, *visibility_params),
     ).fetchone()
     if row:
         return int(row["id"] if isinstance(row, dict) else row[0])
@@ -340,12 +359,14 @@ def _find_canonical(conn: Any, canonical_url: str, title: str) -> int | None:
     # Fuzzy title match against recent articles (last 7 days) that are canonical
     cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
     rows = conn.execute(
-        """SELECT id, title FROM articles
-           WHERE canonical_id IS NULL
-             AND discovered_at >= %s
-           ORDER BY discovered_at DESC
+        f"""SELECT a.id, a.title FROM articles a
+           JOIN sources s ON s.slug = a.source_slug
+           WHERE a.canonical_id IS NULL
+             AND a.discovered_at >= %s
+             {visibility_clause}
+           ORDER BY a.discovered_at DESC
            LIMIT 200""",
-        (cutoff,),
+        (cutoff, *visibility_params),
     ).fetchall()
     for r in rows:
         existing_title = str(r["title"] if isinstance(r, dict) else r[1])
@@ -597,7 +618,7 @@ def _ingest_source(
                 )
 
                 # Deduplication: check if this article is a duplicate of an existing canonical
-                canonical_id = _find_canonical(conn, url, translated_title)
+                canonical_id = _find_canonical(conn, url, translated_title, source.owner_user_id)
                 if canonical_id is not None:
                     # Insert as archived duplicate pointing to canonical
                     conn.execute(
@@ -786,7 +807,7 @@ def ingest_all(db_path: Path | str | None = None) -> IngestResult:
         sources_to_ingest: list[SourceDefinition] = [s for s in DEFAULT_SOURCES if s.enabled]
         with connect(db_path) as conn:
             private_rows = conn.execute(
-                "SELECT slug, name, url, category, kind, priority, lang"
+                "SELECT slug, name, url, category, kind, priority, lang, owner_user_id"
                 " FROM sources WHERE owner_user_id IS NOT NULL AND enabled IS TRUE"
             ).fetchall()
         for row in private_rows:
@@ -800,6 +821,7 @@ def ingest_all(db_path: Path | str | None = None) -> IngestResult:
                     kind=r["kind"],
                     priority=int(r["priority"] or 0),
                     lang=r.get("lang") or "en",
+                    owner_user_id=int(r["owner_user_id"]),
                 )
             )
 
@@ -1254,23 +1276,40 @@ def _list_articles_for_user(  # noqa: PLR0913
             d["restored_at"] = d.pop("_uas_restored_at", None)
             _apply_recommendation_fields(d)
             articles.append(d)
-        _attach_also_from(conn, articles)
+        _attach_also_from(conn, articles, user_id=user_id)
         return articles
 
 
-def _attach_also_from(conn: Any, articles: list[dict[str, Any]]) -> None:
-    """Attach duplicate source names to canonical articles (in-place)."""
+def _attach_also_from(
+    conn: Any, articles: list[dict[str, Any]], user_id: int | None = None
+) -> None:
+    """Attach duplicate source names to canonical articles (in-place).
+
+    When user_id is provided, only include duplicate sources visible to that user
+    (global sources or sources owned by that user).
+    """
     article_ids = [a["id"] for a in articles]
     if not article_ids:
         return
     article_placeholders = placeholders(article_ids)
-    dup_rows = conn.execute(
-        f"""
-        SELECT canonical_id, source_name FROM articles
-        WHERE canonical_id IN ({article_placeholders}) AND state='archived'
-        """,
-        article_ids,
-    ).fetchall()
+    if user_id is not None:
+        dup_rows = conn.execute(
+            f"""
+            SELECT a.canonical_id, a.source_name FROM articles a
+            JOIN sources s ON s.slug = a.source_slug
+            WHERE a.canonical_id IN ({article_placeholders}) AND a.state = 'archived'
+              AND (s.owner_user_id IS NULL OR s.owner_user_id = %s)
+            """,
+            [*article_ids, user_id],
+        ).fetchall()
+    else:
+        dup_rows = conn.execute(
+            f"""
+            SELECT canonical_id, source_name FROM articles
+            WHERE canonical_id IN ({article_placeholders}) AND state = 'archived'
+            """,
+            article_ids,
+        ).fetchall()
     dupes_by_canonical: dict[int, list[str]] = defaultdict(list)
     for dr in dup_rows:
         d = row_to_dict(dr)

--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -15,6 +15,7 @@ class SourceDefinition:
     lang: str = "en"
     interest_tags: tuple[str, ...] = ()
     description: str | None = None
+    owner_user_id: int | None = None
 
 
 DEFAULT_SOURCES: list[SourceDefinition] = [

--- a/backend/tests/test_ingest_dedupe_boundaries.py
+++ b/backend/tests/test_ingest_dedupe_boundaries.py
@@ -1,0 +1,236 @@
+"""Regression tests for source-visibility-aware article deduplication.
+
+Covers:
+- Global-source-first / private-source-second: private duplicate must NOT
+  displace the global canonical for other users.
+- Private-source-first / global-source-second: global article must NOT be
+  hidden behind a private canonical.
+- Same-owner private duplicate deduplicates against the private canonical.
+- Two-owner private articles do NOT deduplicate against each other.
+- _attach_also_from is user-scoped: private source names are excluded from
+  other users' also_from lists.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from news_dashboard.db import connect
+from news_dashboard.ingest import _attach_also_from, _find_canonical
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _insert_user(pg_url: str, username: str) -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, 'x') RETURNING id",
+            (username,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_source(pg_url: str, slug: str, owner_user_id: int | None = None) -> None:
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES (%s, %s, 'https://example.com', 'tech', 'rss_feed', %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug, owner_user_id),
+        )
+
+
+def _insert_canonical(pg_url: str, url: str, title: str, source_slug: str) -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+                                 category, kind)
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed')
+            RETURNING id
+            """,
+            (url, url, title, source_slug, source_slug),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_duplicate(
+    pg_url: str, url: str, title: str, source_slug: str, canonical_id: int
+) -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+                                 category, kind, canonical_id, state)
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', %s, 'archived')
+            RETURNING id
+            """,
+            (url, url, title, source_slug, source_slug, canonical_id),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+# ── _find_canonical tests ─────────────────────────────────────────────────────
+
+
+def test_global_first_private_second_does_not_hide_global(pg_clean: str) -> None:
+    """A global article inserted first should be the canonical.
+    A later private source must find the global canonical but that
+    canonical remains global — other users can still see it."""
+    _insert_source(pg_clean, "global-src")
+    global_id = _insert_canonical(pg_clean, "https://a.com/story", "Big Story Today", "global-src")
+
+    uid = _insert_user(pg_clean, "alice")
+    _insert_source(pg_clean, "alice-private", owner_user_id=uid)
+
+    with connect(database_url=pg_clean) as conn:
+        # Alice's private source should find the global canonical
+        found = _find_canonical(conn, "https://a.com/story", "Big Story Today", owner_user_id=uid)
+
+    assert found == global_id
+
+
+def test_private_first_global_second_finds_no_private_canonical(pg_clean: str) -> None:
+    """A private article inserted first must NOT become the canonical for a global source.
+    The global source can only canonicalize against other global articles."""
+    uid = _insert_user(pg_clean, "bob")
+    _insert_source(pg_clean, "bob-private", owner_user_id=uid)
+    _insert_canonical(pg_clean, "https://b.com/story", "Breaking News Now", "bob-private")
+
+    _insert_source(pg_clean, "global-src")
+
+    with connect(database_url=pg_clean) as conn:
+        # Global source must NOT canonicalize against the private article
+        found = _find_canonical(
+            conn, "https://b.com/story", "Breaking News Now", owner_user_id=None
+        )
+
+    assert found is None
+
+
+def test_global_dedupes_against_global(pg_clean: str) -> None:
+    """Two global sources with the same URL should deduplicate."""
+    _insert_source(pg_clean, "global-src-1")
+    global_id = _insert_canonical(
+        pg_clean, "https://c.com/story", "Tech Event 2026", "global-src-1"
+    )
+
+    _insert_source(pg_clean, "global-src-2")
+
+    with connect(database_url=pg_clean) as conn:
+        found = _find_canonical(conn, "https://c.com/story", "Tech Event 2026", owner_user_id=None)
+
+    assert found == global_id
+
+
+def test_same_owner_private_deduplicates(pg_clean: str) -> None:
+    """A user's second private source should deduplicate against the same owner's first."""
+    uid = _insert_user(pg_clean, "carol")
+    _insert_source(pg_clean, "carol-private-1", owner_user_id=uid)
+    private_id = _insert_canonical(
+        pg_clean, "https://d.com/story", "Private Scoop", "carol-private-1"
+    )
+
+    _insert_source(pg_clean, "carol-private-2", owner_user_id=uid)
+
+    with connect(database_url=pg_clean) as conn:
+        found = _find_canonical(conn, "https://d.com/story", "Private Scoop", owner_user_id=uid)
+
+    assert found == private_id
+
+
+def test_different_owner_private_does_not_deduplicate(pg_clean: str) -> None:
+    """Private articles from different users must NOT deduplicate against each other."""
+    uid1 = _insert_user(pg_clean, "dave")
+    _insert_source(pg_clean, "dave-private", owner_user_id=uid1)
+    _insert_canonical(pg_clean, "https://e.com/story", "Exclusive Report", "dave-private")
+
+    uid2 = _insert_user(pg_clean, "eve")
+    _insert_source(pg_clean, "eve-private", owner_user_id=uid2)
+
+    with connect(database_url=pg_clean) as conn:
+        # Eve's source must NOT match Dave's private canonical
+        found = _find_canonical(conn, "https://e.com/story", "Exclusive Report", owner_user_id=uid2)
+
+    assert found is None
+
+
+# ── _attach_also_from user-scoping tests ──────────────────────────────────────
+
+
+def test_also_from_excludes_other_users_private_source(pg_clean: str) -> None:
+    """A private duplicate from user A must not appear in also_from for user B."""
+    _insert_source(pg_clean, "global-src")
+    canonical_id = _insert_canonical(pg_clean, "https://f.com/story", "Shared Story", "global-src")
+
+    uid_a = _insert_user(pg_clean, "frank")
+    _insert_source(pg_clean, "frank-private", owner_user_id=uid_a)
+    _insert_duplicate(
+        pg_clean, "https://f.com/story-private", "Shared Story", "frank-private", canonical_id
+    )
+
+    uid_b = _insert_user(pg_clean, "grace")
+
+    article: dict[str, Any] = {"id": canonical_id}
+    with connect(database_url=pg_clean) as conn:
+        _attach_also_from(conn, [article], user_id=uid_b)
+
+    # Grace cannot see Frank's private source
+    assert "frank-private" not in article["also_from"]
+
+
+def test_also_from_includes_own_private_source(pg_clean: str) -> None:
+    """A user's own private duplicate must appear in their own also_from."""
+    _insert_source(pg_clean, "global-src")
+    canonical_id = _insert_canonical(pg_clean, "https://g.com/story", "My Story", "global-src")
+
+    uid = _insert_user(pg_clean, "hank")
+    _insert_source(pg_clean, "hank-private", owner_user_id=uid)
+    _insert_duplicate(pg_clean, "https://g.com/story-dup", "My Story", "hank-private", canonical_id)
+
+    article: dict[str, Any] = {"id": canonical_id}
+    with connect(database_url=pg_clean) as conn:
+        _attach_also_from(conn, [article], user_id=uid)
+
+    assert "hank-private" in article["also_from"]
+
+
+def test_also_from_includes_global_duplicate_for_all_users(pg_clean: str) -> None:
+    """Global source duplicates are visible to all users in also_from."""
+    _insert_source(pg_clean, "global-src-1")
+    canonical_id = _insert_canonical(pg_clean, "https://h.com/story", "World News", "global-src-1")
+
+    _insert_source(pg_clean, "global-src-2")
+    _insert_duplicate(pg_clean, "https://h.com/story2", "World News", "global-src-2", canonical_id)
+
+    uid = _insert_user(pg_clean, "ivan")
+
+    article: dict[str, Any] = {"id": canonical_id}
+    with connect(database_url=pg_clean) as conn:
+        _attach_also_from(conn, [article], user_id=uid)
+
+    assert "global-src-2" in article["also_from"]
+
+
+def test_also_from_no_user_includes_all_sources(pg_clean: str) -> None:
+    """The legacy (no user_id) path includes all duplicate sources for admin use."""
+    _insert_source(pg_clean, "global-src")
+    canonical_id = _insert_canonical(pg_clean, "https://i.com/story", "Admin View", "global-src")
+
+    uid = _insert_user(pg_clean, "judy")
+    _insert_source(pg_clean, "judy-private", owner_user_id=uid)
+    _insert_duplicate(
+        pg_clean, "https://i.com/story-dup", "Admin View", "judy-private", canonical_id
+    )
+
+    article: dict[str, Any] = {"id": canonical_id}
+    with connect(database_url=pg_clean) as conn:
+        _attach_also_from(conn, [article])
+
+    # Admin path sees private source name too
+    assert "judy-private" in article["also_from"]


### PR DESCRIPTION
## Summary

- `_find_canonical` now joins `sources` and enforces visibility boundaries: global sources only canonicalize against other global articles; private sources can canonicalize against global or same-owner private articles, never another owner's private canonical.
- `_attach_also_from` accepts an optional `user_id`; when set, only duplicate source names visible to that user (global or their own private) are included in `also_from`.
- `SourceDefinition` gains an `owner_user_id: int | None` field; `ingest_all` populates it when loading private sources from the DB.
- `_list_articles_for_user` passes `user_id` to `_attach_also_from` so user-scoped article lists don't leak private source names.

## Test plan

- [x] `test_global_first_private_second_does_not_hide_global` — private source can still find a global canonical
- [x] `test_private_first_global_second_finds_no_private_canonical` — global source does NOT match a private canonical
- [x] `test_global_dedupes_against_global` — two global sources still deduplicate
- [x] `test_same_owner_private_deduplicates` — same-owner private sources still deduplicate
- [x] `test_different_owner_private_does_not_deduplicate` — cross-owner private articles don't deduplicate
- [x] `test_also_from_excludes_other_users_private_source` — private source names are hidden from other users
- [x] `test_also_from_includes_own_private_source` — user sees their own private source in also_from
- [x] `test_also_from_includes_global_duplicate_for_all_users` — global duplicates visible to all
- [x] `test_also_from_no_user_includes_all_sources` — legacy admin path still sees everything

All 9 tests pass. `make lint` and `make typecheck` clean.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)