### PR TITLE
fix: scope recommendation recalculation candidates to visible articles (#507)

### DIFF
--- a/backend/news_dashboard/recommendation_jobs.py
+++ b/backend/news_dashboard/recommendation_jobs.py
@@ -101,11 +101,18 @@ def find_recalculation_candidates(
             )
             OR EXISTS (
                 SELECT 1 FROM articles a
+                LEFT JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us_src
+                  ON us_src.user_id = u.id AND us_src.source_slug = a.source_slug
                 LEFT JOIN user_article_state uas
                   ON uas.article_id = a.id AND uas.user_id = u.id
                 LEFT JOIN user_article_recommendations uar
                   ON uar.user_id = u.id AND uar.article_id = a.id
                 WHERE {_CANDIDATE_PREDICATE}
+                  AND (
+                    (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+                    OR src.owner_user_id = u.id
+                  )
                   AND uar.user_id IS NULL
             )
             ORDER BY u.id
@@ -251,11 +258,18 @@ def recommendation_health(
                 SELECT COUNT(*) AS missing_scores
                 FROM users u
                 JOIN articles a ON TRUE
+                LEFT JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us_src
+                  ON us_src.user_id = u.id AND us_src.source_slug = a.source_slug
                 LEFT JOIN user_article_state uas
                   ON uas.article_id = a.id AND uas.user_id = u.id
                 LEFT JOIN user_article_recommendations uar
                   ON uar.user_id = u.id AND uar.article_id = a.id
                 WHERE {_CANDIDATE_PREDICATE}
+                  AND (
+                    (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+                    OR src.owner_user_id = u.id
+                  )
                   AND uar.user_id IS NULL
                 """,
             ).fetchone()

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -556,7 +556,11 @@ def _load_user_history_vectors(conn: Any, user_id: int) -> list[list[float]]:
 
 
 def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]]:
-    """Read today/later-eligible articles with their cold-start base score."""
+    """Read today/later-eligible articles with their cold-start base score.
+
+    Scoped to the user's visible corpus: global sources the user has not
+    disabled, and private sources owned by this user.
+    """
     from news_dashboard.ingest import _COLD_START_RECOMMENDATION_SCORE_SQL
 
     rows = conn.execute(
@@ -568,14 +572,20 @@ def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]
           {_COLD_START_RECOMMENDATION_SCORE_SQL} AS base_score
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
+        LEFT JOIN user_sources us_src
+          ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
         LEFT JOIN user_article_state uas
           ON uas.article_id = a.id AND uas.user_id = %s
         WHERE (a.canonical_id IS NULL OR COALESCE(uas.state, 'today') != 'archived')
           AND COALESCE(uas.state, 'today') IN ('today', 'later')
+          AND (
+            (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+            OR src.owner_user_id = %s
+          )
         ORDER BY a.discovered_at DESC, a.id DESC
         LIMIT %s
         """,
-        (user_id, limit),
+        (user_id, user_id, user_id, limit),
     ).fetchall()
     return [row_to_dict(row) for row in rows]
 

--- a/backend/tests/test_recommendation_recalc.py
+++ b/backend/tests/test_recommendation_recalc.py
@@ -49,6 +49,38 @@ def _insert_source(db_path: str, slug: str, *, category: str = "tech", priority:
         )
 
 
+def _insert_private_source(
+    db_path: str, slug: str, owner_user_id: int, *, category: str = "tech"
+) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+            VALUES (%s, %s, %s, %s, 'rss_feed', 50, TRUE, %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (
+                slug,
+                slug.title(),
+                f"https://example.com/{slug}.xml",
+                category,
+                owner_user_id,
+            ),
+        )
+
+
+def _disable_source(db_path: str, user_id: int, source_slug: str) -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_sources(user_id, source_slug, enabled)
+            VALUES (%s, %s, FALSE)
+            ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = FALSE
+            """,
+            (user_id, source_slug),
+        )
+
+
 def _insert_article(db_path: str, slug: str, suffix: str, *, category: str = "tech") -> int:
     with connect(db_path) as conn:
         row = conn.execute(
@@ -287,3 +319,84 @@ def test_recalculate_all_refreshes_non_stale_current_scores(
     row = _rec_row(db_path, user_id, article)
     assert row is not None
     assert row["recommendation_score"] != pytest.approx(1.0)
+
+
+# ── Source visibility scoping ─────────────────────────────────────────────────
+
+
+def test_hidden_private_source_not_scored_for_other_user(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """Articles from another user's private source must not appear in candidates."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    owner = _make_user(db_path, "owner")
+    other = _make_user(db_path, "other")
+    _insert_private_source(db_path, "private-src", owner)
+    hidden_article = _insert_article(db_path, "private-src", "hidden")
+
+    # 'other' has no scores → would normally appear as a missing candidate
+    # but private-src is owned by 'owner', so 'other' should not see it.
+    candidates = find_recalculation_candidates(db_path=db_path)
+    # 'other' must not need recalculation for a hidden private article
+    assert other not in candidates
+
+    # Scoring for 'other' must not write a row for the hidden article
+    from news_dashboard.recommendations import recompute_user_recommendations
+
+    recompute_user_recommendations(other, db_path=db_path)
+    assert _rec_row(db_path, other, hidden_article) is None
+
+
+def test_disabled_global_source_not_scored_for_user(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """Articles from a global source disabled by a user must not be candidates."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    _insert_source(db_path, "global-src")
+    disabled_article = _insert_article(db_path, "global-src", "disabled")
+    _disable_source(db_path, user_id, "global-src")
+
+    candidates = find_recalculation_candidates(db_path=db_path)
+    assert user_id not in candidates
+
+    from news_dashboard.recommendations import recompute_user_recommendations
+
+    recompute_user_recommendations(user_id, db_path=db_path)
+    assert _rec_row(db_path, user_id, disabled_article) is None
+
+
+def test_own_private_source_is_scored(tmp_path: Path, monkeypatch: Any, pg_clean: str) -> None:
+    """Articles from a user's own private source must still be scored for that user."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    owner = _make_user(db_path, "owner")
+    _insert_private_source(db_path, "my-private", owner)
+    own_article = _insert_article(db_path, "my-private", "own")
+
+    candidates = find_recalculation_candidates(db_path=db_path)
+    assert owner in candidates
+
+    from news_dashboard.recommendations import recompute_user_recommendations
+
+    recompute_user_recommendations(owner, db_path=db_path)
+    assert _rec_row(db_path, owner, own_article) is not None
+
+
+def test_health_missing_scores_excludes_invisible_articles(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """recommendation_health must not count hidden private articles as missing scores."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    owner = _make_user(db_path, "owner")
+    other = _make_user(db_path, "other")
+    _insert_private_source(db_path, "private-src", owner)
+    _insert_article(db_path, "private-src", "hidden")
+    # Add a global source disabled by 'other' — must not inflate missing_scores for 'other'.
+    _insert_source(db_path, "global-src")
+    _insert_article(db_path, "global-src", "visible")
+    _disable_source(db_path, other, "global-src")
+
+    health = recommendation_health(db_path=db_path)
+    # owner needs scores for own-private + global = 2; other sees neither → 0.
+    # Total missing must be exactly 2, not 3.
+    assert health["missing_scores"] == 2


### PR DESCRIPTION
## Summary

Closes #507

- Applied source-visibility predicate (same as Today feed) to `_load_candidates` in `recommendations.py` — global sources user hasn't disabled + private sources owned by the user
- Applied same predicate to the missing-score subquery in `find_recalculation_candidates` in `recommendation_jobs.py` — so other users' private-source articles no longer trigger a recalculation candidate flag
- Applied same predicate to `recommendation_health` missing scores count — hidden articles no longer inflate the diagnostic count

## Test plan

- [x] `test_hidden_private_source_not_scored_for_other_user` — verifies another user's private article is not scored and not a recalculation trigger
- [x] `test_disabled_global_source_not_scored_for_user` — verifies user-disabled global source articles are excluded from candidates
- [x] `test_own_private_source_is_scored` — verifies owner's own private articles still get scored
- [x] `test_health_missing_scores_excludes_invisible_articles` — verifies health counts only visible user/article pairs
- [x] All 30 existing recommendation tests pass
- [x] `make lint`, `make typecheck` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)