### PR TITLE
revert: use canonical FREE_LLM_* names for briefing gateway config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,8 +416,8 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          FREE_LLM_API_KEY: ${{ secrets.OPENAI_BRIEFING_API_KEY }}
-          FREE_LLM_BASE_URL: ${{ vars.OPENAI_BRIEFING_BASE_URL }}
+          FREE_LLM_API_KEY: ${{ secrets.FREE_LLM_API_KEY }}
+          FREE_LLM_BASE_URL: ${{ vars.FREE_LLM_BASE_URL }}
           OPENAI_BRIEFING_MODEL: ${{ vars.OPENAI_BRIEFING_MODEL }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}


### PR DESCRIPTION
Revert the OPENAI_BRIEFING_* bridge (#553). Standardise on two config sets only — OpenAI (OPENAI_API_KEY/OPENAI_BASE_URL) and the freellmapi gateway (FREE_LLM_API_KEY/FREE_LLM_BASE_URL) — which is exactly what the backend reads via free_llm_config(). The deploy now sources the gateway from secrets.FREE_LLM_API_KEY / vars.FREE_LLM_BASE_URL; those repo settings must exist before this deploys or briefings fall back to default OpenAI again. OPENAI_BRIEFING_MODEL stays as the model selector.