### PR TITLE
feat: distinct co-host podcast voices (onyx/nova) + gpt-4o-mini-tts

### DIFF
--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 _DEFAULT_DATA_DIR = Path("/data")
 _VOICE = "alloy"
 _MODEL = "tts-1"
+# Podcast audio uses the newer, more natural and steerable model and a pair of
+# clearly distinct voices so the two co-hosts are easy to tell apart.
+_PODCAST_MODEL = "gpt-4o-mini-tts"
+_ALEX_VOICE = "onyx"
+_TAYLOR_VOICE = "nova"
 _MAX_CHARS = 4096
 
 
@@ -149,7 +154,7 @@ def generate_podcast_audio(
 
     combined_bytes = bytearray()
     for idx, entry in enumerate(script):
-        voice = entry.get("voice", "alloy")
+        voice = entry.get("voice", _ALEX_VOICE)
         text = entry.get("text", "")
         if not text.strip():
             continue
@@ -165,7 +170,7 @@ def generate_podcast_audio(
         chunk_path = path.parent / f"podcast-{briefing_id}-chunk-{idx}.mp3"
         try:
             with client.audio.speech.with_streaming_response.create(
-                model=_MODEL, voice=voice, input=text
+                model=_PODCAST_MODEL, voice=voice, input=text
             ) as response:
                 response.stream_to_file(chunk_path)
 
@@ -188,7 +193,7 @@ _PODCAST_SYSTEM_PROMPT = (
     "Produce a JSON object with a single key 'script' containing a list of dialogue turns. "
     "Each turn MUST be an object with these exact keys:\n"
     "  speaker — either 'Alex' or 'Taylor'\n"
-    "  voice   — 'alloy' for Alex, 'shimmer' for Taylor\n"
+    "  voice   — 'onyx' for Alex, 'nova' for Taylor\n"
     "  text    — the spoken text for this turn\n"
     "Ensure they talk about all the main topics in the sections. "
     "Return valid JSON only, no markdown wrapper."
@@ -251,12 +256,12 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
         txt = str(item.get("text") or "")
 
         if speaker.lower() == "alex":
-            voice = "alloy"
+            voice = _ALEX_VOICE
         elif speaker.lower() == "taylor":
-            voice = "shimmer"
+            voice = _TAYLOR_VOICE
         else:
             speaker = "Alex" if idx % 2 == 0 else "Taylor"
-            voice = "alloy" if idx % 2 == 0 else "shimmer"
+            voice = _ALEX_VOICE if idx % 2 == 0 else _TAYLOR_VOICE
 
         if txt.strip():
             valid_script.append(
@@ -271,7 +276,7 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
         valid_script.append(
             {
                 "speaker": "Alex",
-                "voice": "alloy",
+                "voice": _ALEX_VOICE,
                 "text": f"Welcome to the daily podcast. Today we are discussing: {summary}",
             }
         )

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -302,10 +302,10 @@ def test_generate_podcast_script() -> None:
         )
     assert len(script) == 2
     assert script[0]["speaker"] == "Alex"
-    assert script[0]["voice"] == "alloy"
+    assert script[0]["voice"] == "onyx"
     assert script[0]["text"] == "Hello!"
     assert script[1]["speaker"] == "Taylor"
-    assert script[1]["voice"] == "shimmer"
+    assert script[1]["voice"] == "nova"
     assert script[1]["text"] == "Hi Alex!"
 
 
@@ -335,8 +335,8 @@ def test_generate_podcast_audio(tmp_path: Path) -> None:
     mock_client.audio.speech.with_streaming_response.create.return_value = mock_response
 
     script = [
-        {"speaker": "Alex", "voice": "alloy", "text": "Chunk 1 text"},
-        {"speaker": "Taylor", "voice": "shimmer", "text": "Chunk 2 text"},
+        {"speaker": "Alex", "voice": "onyx", "text": "Chunk 1 text"},
+        {"speaker": "Taylor", "voice": "nova", "text": "Chunk 2 text"},
     ]
 
     with (
@@ -351,3 +351,24 @@ def test_generate_podcast_audio(tmp_path: Path) -> None:
     for idx in range(2):
         chunk_file = tmp_path / "audio" / f"podcast-123-chunk-{idx}.mp3"
         assert not chunk_file.exists()
+
+    create = mock_client.audio.speech.with_streaming_response.create
+    assert create.call_count == 2
+    models = {call.kwargs["model"] for call in create.call_args_list}
+    voices = [call.kwargs["voice"] for call in create.call_args_list]
+    assert models == {"gpt-4o-mini-tts"}
+    assert voices == ["onyx", "nova"]
+
+
+def test_generate_podcast_script_fallback_uses_alex_onyx() -> None:
+    """When the LLM returns an empty script, the fallback turn is Alex/onyx."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content='{"script": []}'))]
+    with (
+        patch.dict("os.environ", {"FREE_LLM_API_KEY": "sk-free-llm"}),
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
+    ):
+        script = generate_podcast_script({"title": "T", "summary": "Summary text", "sections": []})
+    assert len(script) == 1
+    assert script[0]["speaker"] == "Alex"
+    assert script[0]["voice"] == "onyx"


### PR DESCRIPTION
Closes #558

## Summary
The co-host podcast briefing already rendered two voices, but `alloy` (Alex) and `shimmer` (Taylor) are both soft and neutral, so the hosts were hard to tell apart. This switches to a clearly contrasting pair and upgrades the podcast TTS model.

- Alex → `onyx` (deep, warm), Taylor → `nova` (bright) — applied via the speaker→voice override and the fallback turn, plus the script-writer system prompt.
- Podcast audio now uses `gpt-4o-mini-tts` (newer, more natural, steerable). Article TTS (`generate_audio`) is unchanged on `tts-1`.

## Tests
- `test_generate_podcast_script` asserts Alex→onyx / Taylor→nova.
- `test_generate_podcast_script_fallback_uses_alex_onyx` covers the empty-script fallback.
- `test_generate_podcast_audio` asserts the TTS call uses `gpt-4o-mini-tts` with voices `[onyx, nova]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)