### PR TITLE
security: require admin for GET /api/ingest/stream and GET /api/scheduler/status (#510)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -509,7 +509,7 @@ def ingest(background_tasks: BackgroundTasks) -> dict[str, Any]:
     }
 
 
-@api.get("/api/ingest/stream")
+@api.get("/api/ingest/stream", dependencies=[Depends(require_admin)])
 def ingest_stream() -> StreamingResponse:
     return StreamingResponse(stream_ingest_events(), media_type="text/event-stream")
 
@@ -1414,7 +1414,10 @@ def set_source_enabled(
     return {**row_to_dict(row), "subscribed": payload.enabled}
 
 
-@api.get("/api/scheduler/status")
+_admin_dep = [Depends(require_admin)]
+
+
+@api.get("/api/scheduler/status", dependencies=_admin_dep)
 def scheduler_status() -> dict[str, Any]:
     interval_enabled = is_ingest_interval_enabled()
     next_run = get_next_ingest_at()
@@ -1426,9 +1429,6 @@ def scheduler_status() -> dict[str, Any]:
         "interval_ingest_enabled": interval_enabled,
         "ingest_authority": "in_process" if interval_enabled else "external",
     }
-
-
-_admin_dep = [Depends(require_admin)]
 
 
 @api.post("/api/scheduler/interval", dependencies=_admin_dep)

--- a/backend/tests/test_operational_read_auth.py
+++ b/backend/tests/test_operational_read_auth.py
@@ -1,0 +1,97 @@
+"""Tests that GET /api/ingest/stream and GET /api/scheduler/status are admin-only."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import app
+
+_ADMIN_USER = {"id": 1, "username": "adminuser", "email": None, "is_admin": True}
+_REGULAR_USER = {"id": 2, "username": "regularuser", "email": None, "is_admin": False}
+
+
+@pytest.fixture
+def client() -> Generator[TestClient]:
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def _deny_admin() -> None:
+    raise HTTPException(status_code=403, detail="Admin access required")
+
+
+# ── /api/ingest/stream ────────────────────────────────────────────────────────
+
+
+def test_ingest_stream_requires_admin(client: TestClient) -> None:
+    from news_dashboard.auth import require_admin, require_auth
+
+    app.dependency_overrides[require_auth] = lambda: _REGULAR_USER
+    app.dependency_overrides[require_admin] = _deny_admin
+    try:
+        resp = client.get("/api/ingest/stream")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_ingest_stream_succeeds_for_admin(client: TestClient) -> None:
+    from news_dashboard.auth import require_admin, require_auth
+
+    app.dependency_overrides[require_auth] = lambda: _ADMIN_USER
+    app.dependency_overrides[require_admin] = lambda: _ADMIN_USER
+
+    def _fake_stream() -> Generator[bytes]:
+        yield b"data: {}\n\n"
+
+    try:
+        with patch("news_dashboard.main.stream_ingest_events", return_value=_fake_stream()):
+            resp = client.get("/api/ingest/stream")
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+# ── /api/scheduler/status ─────────────────────────────────────────────────────
+
+
+def test_scheduler_status_requires_admin(client: TestClient) -> None:
+    from news_dashboard.auth import require_admin, require_auth
+
+    app.dependency_overrides[require_auth] = lambda: _REGULAR_USER
+    app.dependency_overrides[require_admin] = _deny_admin
+    try:
+        resp = client.get("/api/scheduler/status")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_scheduler_status_succeeds_for_admin(client: TestClient) -> None:
+    from news_dashboard.auth import require_admin, require_auth
+
+    app.dependency_overrides[require_auth] = lambda: _ADMIN_USER
+    app.dependency_overrides[require_admin] = lambda: _ADMIN_USER
+    try:
+        with (
+            patch("news_dashboard.main.is_ingest_interval_enabled", return_value=True),
+            patch("news_dashboard.main.get_next_ingest_at", return_value=None),
+            patch("news_dashboard.main.is_paused", return_value=False),
+            patch("news_dashboard.main.get_interval_minutes", return_value=60),
+        ):
+            resp = client.get("/api/scheduler/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "interval_minutes" in body
+        assert "paused" in body
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)


### PR DESCRIPTION
## Summary

Closes #510

- Added `Depends(require_admin)` to `GET /api/ingest/stream` — previously open to any authenticated user
- Added `dependencies=_admin_dep` to `GET /api/scheduler/status` — previously open to any authenticated user
- Moved `_admin_dep` definition before `scheduler_status` so it can be reused there
- Added `backend/tests/test_operational_read_auth.py` with 4 tests covering admin and non-admin access for both endpoints

## Test plan

- [x] `test_ingest_stream_requires_admin` — non-admin gets 403
- [x] `test_ingest_stream_succeeds_for_admin` — admin gets 200
- [x] `test_scheduler_status_requires_admin` — non-admin gets 403
- [x] `test_scheduler_status_succeeds_for_admin` — admin gets 200
- [x] All pre-commit hooks pass (ruff, mypy, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)