### PR TITLE
security: use origin parsing for Electron navigation guards (#516)

### DIFF
--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -141,7 +141,12 @@ def _generate_briefing_for_user(user_id: int, *, push_enabled: bool = True) -> b
                 try:
                     briefing_id = result.get("id")
                     target_url = f"/briefs/{briefing_id}" if briefing_id is not None else None
-                    send_push_for_user(user_id, generate_push_hook(result), "", target_url=target_url)
+                    send_push_for_user(
+                        user_id,
+                        generate_push_hook(result),
+                        "",
+                        target_url=target_url,
+                    )
                 except Exception:
                     logger.exception(
                         "Per-user briefing: push notification failed for user_id=%s", user_id

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "scripts": {
     "start": "electron .",
+    "test": "node src/url-helper.test.js",
     "build": "electron-builder",
     "build:mac": "electron-builder --mac",
     "build:linux": "electron-builder --linux",

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -4,6 +4,7 @@ const { app, BrowserWindow, Menu, shell, ipcMain } = require('electron');
 const { autoUpdater } = require('electron-updater');
 const path = require('path');
 const fs = require('fs');
+const { isAppUrl } = require('./url-helper');
 
 const APP_URL = 'https://news.lihor.ro';
 const isDev = !app.isPackaged;
@@ -69,14 +70,14 @@ function createWindow() {
 
   // Open target=_blank and external links in the system browser.
   win.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith(APP_URL)) return { action: 'allow' };
+    if (isAppUrl(url)) return { action: 'allow' };
     shell.openExternal(url);
     return { action: 'deny' };
   });
 
   // Prevent in-window navigation away from the site.
   win.webContents.on('will-navigate', (event, url) => {
-    if (!url.startsWith(APP_URL)) {
+    if (!isAppUrl(url)) {
       event.preventDefault();
       shell.openExternal(url);
     }

--- a/desktop/src/url-helper.js
+++ b/desktop/src/url-helper.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const APP_ORIGIN = new URL('https://news.lihor.ro').origin;
+
+/**
+ * Returns true if the given URL belongs to the exact app origin.
+ * Malformed URLs are treated as external (returns false).
+ */
+function isAppUrl(url) {
+  try {
+    return new URL(url).origin === APP_ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { isAppUrl, APP_ORIGIN };

--- a/desktop/src/url-helper.test.js
+++ b/desktop/src/url-helper.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('assert');
+const { isAppUrl } = require('./url-helper');
+
+const cases = [
+  // Same-origin app routes — allowed
+  ['https://news.lihor.ro', true],
+  ['https://news.lihor.ro/', true],
+  ['https://news.lihor.ro/a/1', true],
+  ['https://news.lihor.ro/settings', true],
+
+  // Lookalike host — denied
+  ['https://news.lihor.ro.evil.example/', false],
+  ['https://news.lihor.roevil.example/', false],
+
+  // Different scheme — denied
+  ['http://news.lihor.ro/', false],
+  ['ftp://news.lihor.ro/', false],
+
+  // Subdomain — denied
+  ['https://sub.news.lihor.ro/', false],
+
+  // Username trick — denied
+  ['https://news.lihor.ro@evil.example/', false],
+
+  // Unrelated origins — denied
+  ['https://evil.example/', false],
+  ['https://evil.example/?next=https://news.lihor.ro', false],
+
+  // Malformed / empty — denied
+  ['not-a-url', false],
+  ['', false],
+  ['javascript:alert(1)', false],
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const [url, expected] of cases) {
+  const result = isAppUrl(url);
+  if (result === expected) {
+    passed++;
+  } else {
+    console.error(`FAIL isAppUrl(${JSON.stringify(url)}) => ${result}, expected ${expected}`);
+    failed++;
+  }
+}
+
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- Extracts `isAppUrl(url)` helper in `desktop/src/url-helper.js` that compares `new URL(url).origin` against the configured app origin (`https://news.lihor.ro`), treating malformed URLs as external
- Replaces `url.startsWith(APP_URL)` prefix checks in both `setWindowOpenHandler` and `will-navigate` with `isAppUrl(url)`, blocking lookalike hosts like `https://news.lihor.ro.evil.example/`
- Adds `desktop/src/url-helper.test.js` with 15 Node.js `assert`-based test cases covering same-origin routes, lookalike hosts, different schemes, subdomains, username tricks, and malformed URLs
- Adds `npm test` script to `desktop/package.json`

## Test results

```
15 passed, 0 failed
```

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)