### PR TITLE
ci: add nightly Playwright e2e job (#512)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,10 +67,48 @@ jobs:
         with:
           node-version: '26'
           cache: npm
-      - run: npm install
+      - run: npm ci
 
       - name: Run full frontend suite with coverage
         run: npm run test:frontend:coverage --silent
 
       - name: Build (includes tsc)
         run: npm run build
+
+  # ── Playwright e2e suite ──────────────────────────────────────────────────
+  # Nightly/manual only for now; e2e is intentionally not required on every PR.
+  e2e:
+    name: Playwright e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: npm
+      - run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright e2e suite
+        run: npm run test:e2e --silent
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: test-results/
+          if-no-files-found: ignore


### PR DESCRIPTION
Closes #512

## Summary
- add a dedicated Playwright e2e job to the nightly/manual workflow
- use `npm ci` for frontend installs in nightly lanes
- install Chromium in CI and upload Playwright reports/test results on failure
- document in workflow comments that e2e remains nightly/manual, not every PR

## Tests
- `ruby -e "require 'psych'; Psych.load_file('.github/workflows/nightly.yml'); puts 'nightly.yml parsed'"`\n- `npm ci`\n- `npx playwright install chromium`\n- `npm run test:e2e --silent` (fails on current suite: 471 passed, 1 skipped, 40 failed; failures include existing a11y expectations, command palette shortcuts/actions, Scheduler tab expectations, RD mobile brand visibility, duplicate favicon links, and backend proxy ECONNREFUSED noise)\n\nGenerated by codex automation.