### PR TITLE
fix: restore uppercase Today triage shortcuts

### DIFF
--- a/frontend/src/__tests__/keyboard.test.ts
+++ b/frontend/src/__tests__/keyboard.test.ts
@@ -116,15 +116,33 @@ describe('useArticleListNav — action keys', () => {
     expect(mutations.setState).toHaveBeenCalledWith(article, 'done', 'Done');
   });
 
+  it('R marks article done', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('R', { shiftKey: true }));
+    expect(mutations.setState).toHaveBeenCalledWith(article, 'done', 'Done');
+  });
+
   it('d marks article done', () => {
     renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
     act(() => fireKey('d'));
     expect(mutations.setState).toHaveBeenCalledWith(article, 'done', 'Done');
   });
 
+  it('D marks article done', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('D', { shiftKey: true }));
+    expect(mutations.setState).toHaveBeenCalledWith(article, 'done', 'Done');
+  });
+
   it('l sends to later', () => {
     renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
     act(() => fireKey('l'));
+    expect(mutations.sendLater).toHaveBeenCalledWith(article);
+  });
+
+  it('L sends to later', () => {
+    renderHook(() => useArticleListNav(articles, vi.fn(), mutations));
+    act(() => fireKey('L', { shiftKey: true }));
     expect(mutations.sendLater).toHaveBeenCalledWith(article);
   });
 

--- a/frontend/src/hooks/useArticleListNav.ts
+++ b/frontend/src/hooks/useArticleListNav.ts
@@ -22,27 +22,28 @@ export function useArticleListNav(
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       const cur = list[focused];
+      const key = e.key.toLowerCase();
 
-      if (e.key === 'j') {
+      if (key === 'j') {
         setFocused((f) => Math.min(list.length - 1, f + 1));
         e.preventDefault();
-      } else if (e.key === 'k') {
+      } else if (key === 'k') {
         setFocused((f) => Math.max(0, f - 1));
         e.preventDefault();
       } else if (e.key === 'Enter' && cur) {
         openArticle(cur);
         e.preventDefault();
-      } else if ((e.key === 'r' || e.key === 'd') && cur) {
+      } else if ((key === 'r' || key === 'd') && cur) {
         mutations.setState(cur, 'done', 'Done');
-      } else if (e.key === 'l' && cur) {
+      } else if (key === 'l' && cur) {
         mutations.sendLater(cur);
-      } else if (e.key === 's' && cur) {
+      } else if (key === 's' && cur) {
         mutations.toggleStar(cur);
-      } else if (e.key === 'x' && cur && !cur.starred) {
+      } else if (key === 'x' && cur && !cur.starred) {
         mutations.setState(cur, 'skipped', 'Skipped');
-      } else if (e.key === 'e' && cur) {
+      } else if (key === 'e' && cur) {
         mutations.setState(cur, 'archived', 'Archived');
-      } else if (e.key === 'o' && cur) {
+      } else if (key === 'o' && cur) {
         window.open(cur.url, '_blank', 'noopener,noreferrer');
       }
     };


### PR DESCRIPTION
## Summary
- Normalize Today feed article shortcut keys so uppercase `R`, `L`, and `D` trigger the same triage actions as lowercase keys.
- Add regression tests for uppercase done/later shortcuts.

## Root cause
The list keyboard handler compared `KeyboardEvent.key` directly against lowercase letters, so shifted/uppercase key events were ignored while `Enter` continued to work.

## Validation
- `npm run test:frontend -- frontend/src/__tests__/keyboard.test.ts`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test:frontend`
- `npm run build`
