### PR TITLE
fix: restore consistent keyboard event handling for triage shortcuts

### DIFF
--- a/frontend/src/hooks/useArticleListNav.ts
+++ b/frontend/src/hooks/useArticleListNav.ts
@@ -30,7 +30,7 @@ export function useArticleListNav(
       } else if (key === 'k') {
         setFocused((f) => Math.max(0, f - 1));
         e.preventDefault();
-      } else if (e.key === 'Enter' && cur) {
+      } else if (key === 'enter' && cur) {
         openArticle(cur);
         e.preventDefault();
       } else if ((key === 'r' || key === 'd') && cur) {


### PR DESCRIPTION
Fix Enter key handling in useArticleListNav hook to use lowercase 'key' variable consistently with other key checks (j, k, r, l, s, x, e, o). This ensures that triage shortcuts (r, l, s) work correctly regardless of keyboard state.