### PR TITLE
security: harden Helm pod security contexts

### DIFF
--- a/helm/news-dashboard/templates/cronjob.yaml
+++ b/helm/news-dashboard/templates/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
         spec:
           restartPolicy: OnFailure
           securityContext:
-            fsGroup: 1000
+{{ toYaml .Values.ingestCronJob.podSecurityContext | indent 12 }}
           {{- if .Values.image.pullSecretName }}
           imagePullSecrets:
             - name: {{ .Values.image.pullSecretName | quote }}
@@ -36,9 +36,7 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               securityContext:
-                runAsNonRoot: true
-                runAsUser: 1000
-                runAsGroup: 1000
+{{ toYaml .Values.ingestCronJob.containerSecurityContext | indent 16 }}
               command: ["news-dashboard", "scheduled-ingest"]
               {{- with .Values.ingestCronJob.resources }}
               resources:
@@ -93,4 +91,10 @@ spec:
   {{- end }}
 {{- end }}
 {{ include "news-dashboard.aiEnv" . | indent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}
 {{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       securityContext:
-        fsGroup: 1000
+{{ toYaml .Values.app.podSecurityContext | indent 8 }}
       {{- if .Values.image.pullSecretName }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecretName | quote }}
@@ -28,9 +28,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+{{ toYaml .Values.app.containerSecurityContext | indent 12 }}
           env:
             - name: INGEST_INTERVAL_SCHEDULER_ENABLED
               value: {{ ternary "false" "true" .Values.ingestCronJob.enabled | quote }}
@@ -152,3 +150,9 @@ spec:
             periodSeconds: 20
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/helm/news-dashboard/templates/postgres-backup-cronjob.yaml
+++ b/helm/news-dashboard/templates/postgres-backup-cronjob.yaml
@@ -20,10 +20,14 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          securityContext:
+{{ toYaml .Values.postgresql.podSecurityContext | indent 12 }}
           containers:
             - name: postgres-backup
               image: {{ .Values.postgresql.image | quote }}
               imagePullPolicy: IfNotPresent
+              securityContext:
+{{ toYaml .Values.postgresql.containerSecurityContext | indent 16 }}
               env:
                 - name: PGHOST
                   value: {{ printf "%s-postgres" (include "news-dashboard.fullname" .) | quote }}

--- a/helm/news-dashboard/templates/postgres-statefulset.yaml
+++ b/helm/news-dashboard/templates/postgres-statefulset.yaml
@@ -34,11 +34,13 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       securityContext:
-        fsGroup: 999
+{{ toYaml .Values.postgresql.podSecurityContext | indent 8 }}
       containers:
         - name: postgres
           image: {{ .Values.postgresql.image | quote }}
           imagePullPolicy: IfNotPresent
+          securityContext:
+{{ toYaml .Values.postgresql.containerSecurityContext | indent 12 }}
           ports:
             - name: postgres
               containerPort: {{ .Values.postgresql.port }}

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -22,6 +22,18 @@ service:
   nodePort: ""
 
 app:
+  podSecurityContext:
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   postgresExternal:
     # Set host when postgresql.enabled is false to use an external PostgreSQL.
     host: ""
@@ -85,6 +97,18 @@ app:
 
 ingestCronJob:
   enabled: true
+  podSecurityContext:
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   schedule: "17 */6 * * *"
   # Keep private single-node ingestion serialized; skip new runs while one is active.
   concurrencyPolicy: Forbid
@@ -111,6 +135,14 @@ ingestCronJob:
 postgresql:
   enabled: true
   image: postgres:16-alpine
+  podSecurityContext:
+    fsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
   database: news_dashboard
   username: news_dashboard
   # Internal cluster password. Override in real environments.


### PR DESCRIPTION
## Summary

Closes #519

- Add `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]` to app Deployment and ingest CronJob containers
- Add `readOnlyRootFilesystem: true` to app and ingest containers with a `/tmp` emptyDir volume for temporary file access
- Add `seccompProfile: { type: RuntimeDefault }` at the pod level for app, ingest, and PostgreSQL
- Apply conservative hardening to PostgreSQL (`allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]`, no `readOnlyRootFilesystem` to preserve data directory writes)
- Apply same conservative context to the postgres-backup CronJob
- All security context values live under `app.podSecurityContext`, `app.containerSecurityContext`, `ingestCronJob.podSecurityContext`, `ingestCronJob.containerSecurityContext`, `postgresql.podSecurityContext`, and `postgresql.containerSecurityContext` in `values.yaml` — fully overridable per environment

## Test plan

- [x] `make helm-validate` passes all three render scenarios (default, production-like NodePort, external PostgreSQL)
- [x] Rendered manifests show `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault` on all containers
- [x] App and ingest containers show `readOnlyRootFilesystem: true` with `/tmp` emptyDir mount
- [x] PostgreSQL StatefulSet does NOT set `readOnlyRootFilesystem` (preserves data directory writes)
- [x] NodePort + hostPath mini-PC deployment path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)