### PR TITLE
Implement issue #530 - fix: make private source deletion safe after ingest

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -428,6 +428,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_quizzes_user ON user_quizzes(user_id, created_at DESC)",
     "ALTER TABLE article_shares ADD COLUMN IF NOT EXISTS context_summary TEXT",
+    "ALTER TABLE sources ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ",
     """
     CREATE TABLE IF NOT EXISTS share_annotations (
       id              BIGSERIAL PRIMARY KEY,

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -815,6 +815,7 @@ def ingest_all(db_path: Path | str | None = None) -> IngestResult:
             private_rows = conn.execute(
                 "SELECT slug, name, url, category, kind, priority, lang, owner_user_id"
                 " FROM sources WHERE owner_user_id IS NOT NULL AND enabled IS TRUE"
+                " AND deleted_at IS NULL"
             ).fetchall()
         for row in private_rows:
             r = row_to_dict(row)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1309,7 +1309,8 @@ def delete_source(
         if src.get("deleted_at") is not None:
             raise HTTPException(status_code=404, detail="source not found")
         conn.execute(
-            "UPDATE sources SET deleted_at = NOW(), enabled = FALSE WHERE slug = %s AND owner_user_id = %s",
+            "UPDATE sources SET deleted_at = NOW(), enabled = FALSE "
+            "WHERE slug = %s AND owner_user_id = %s",
             (slug, uid),
         )
     return {"status": "deleted"}

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1243,7 +1243,8 @@ def sources(
                    ELSE (s.enabled IS TRUE) END AS user_enabled
             FROM sources s
             LEFT JOIN user_sources us ON us.source_slug = s.slug AND us.user_id = %s
-            WHERE s.owner_user_id IS NULL OR s.owner_user_id = %s
+            WHERE (s.owner_user_id IS NULL OR s.owner_user_id = %s)
+              AND s.deleted_at IS NULL
             ORDER BY s.category, s.priority DESC, s.name
             """,
             (uid, uid),
@@ -1305,7 +1306,12 @@ def delete_source(
         src = row_to_dict(row)
         if src.get("owner_user_id") != uid:
             raise HTTPException(status_code=403, detail="cannot delete a source you don't own")
-        conn.execute("DELETE FROM sources WHERE slug = %s", (slug,))
+        if src.get("deleted_at") is not None:
+            raise HTTPException(status_code=404, detail="source not found")
+        conn.execute(
+            "UPDATE sources SET deleted_at = NOW(), enabled = FALSE WHERE slug = %s AND owner_user_id = %s",
+            (slug, uid),
+        )
     return {"status": "deleted"}
 
 
@@ -1341,6 +1347,7 @@ def source_cleanup(
             FROM sources
             WHERE slug = ANY(%s)
               AND (owner_user_id IS NULL OR owner_user_id = %s)
+              AND deleted_at IS NULL
             """,
             (requested_slugs, uid),
         ).fetchall()
@@ -1432,6 +1439,8 @@ def set_source_enabled(
         if not row:
             raise HTTPException(status_code=404, detail="source not found")
         src = row_to_dict(row)
+        if src.get("deleted_at") is not None:
+            raise HTTPException(status_code=404, detail="source not found")
         if src.get("owner_user_id") is None:
             # Global source — write to user_sources subscription table
             conn.execute(

--- a/backend/news_dashboard/personalization_nudges.py
+++ b/backend/news_dashboard/personalization_nudges.py
@@ -56,6 +56,7 @@ def generate_nudges(
               LEFT JOIN user_sources us
                 ON us.source_slug = s.slug AND us.user_id = %(uid)s
               WHERE (s.owner_user_id IS NULL OR s.owner_user_id = %(uid)s)
+                AND s.deleted_at IS NULL
                 AND CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, TRUE)
                          ELSE s.enabled IS TRUE END
             ),

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -66,8 +66,9 @@ def list_source_health(
         source_rows = conn.execute(
             """
             SELECT * FROM sources
-            WHERE owner_user_id IS NULL
-               OR (%s::integer IS NULL OR owner_user_id = %s)
+            WHERE (owner_user_id IS NULL
+               OR (%s::integer IS NULL OR owner_user_id = %s))
+              AND deleted_at IS NULL
             ORDER BY category, priority DESC, name
             """,
             (user_id, user_id),
@@ -179,6 +180,7 @@ def generate_subscription_cleanup_suggestions(
               LEFT JOIN user_sources us
                 ON us.source_slug = s.slug AND us.user_id = %s
               WHERE (s.owner_user_id IS NULL OR s.owner_user_id = %s)
+                AND s.deleted_at IS NULL
                 AND CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, TRUE)
                          ELSE s.enabled IS TRUE END
             ),

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -301,6 +301,77 @@ def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.Monkey
         assert resp.json()["status"] == "deleted"
 
 
+def test_api_delete_private_source_with_articles(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deleting a private source that already has articles must not FK-error."""
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    _add_private_source(pg_clean, slug="my-blog", owner_user_id=uid)
+    aid = _insert_article(pg_clean, source_slug="my-blog", url_suffix="keep-this")
+
+    with _api_client(pg_clean, uid) as client:
+        # Delete the source
+        resp = client.delete("/api/sources/my-blog")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        # Source no longer in listing
+        resp2 = client.get("/api/sources")
+        slugs = [i["slug"] for i in resp2.json()["items"]]
+        assert "my-blog" not in slugs
+
+        # Article remains accessible to owner
+        articles = list_articles(state="today", db_path=pg_clean, user_id=uid)
+        assert any(a["id"] == aid for a in articles)
+
+        # Toggling the deleted source returns 404
+        resp3 = client.patch("/api/sources/my-blog/enabled", json={"enabled": True})
+        assert resp3.status_code == 404
+
+        # Deleting again returns 404
+        resp4 = client.delete("/api/sources/my-blog")
+        assert resp4.status_code == 404
+
+
+def test_api_delete_private_source_no_articles_still_soft_deletes(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even an empty private source is soft-deleted, not hard-deleted."""
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        client.post(
+            "/api/sources",
+            json={
+                "url": "https://example.com/empty-feed.xml",
+                "name": "Empty Source",
+                "slug": "empty-src",
+            },
+        )
+        resp = client.delete("/api/sources/empty-src")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        # Verify the row still exists with deleted_at set
+        with connect(pg_clean) as conn:
+            row = conn.execute(
+                "SELECT slug, deleted_at IS NOT NULL as is_deleted FROM sources WHERE slug = %s",
+                ("empty-src",),
+            ).fetchone()
+            assert row is not None
+            assert row["is_deleted"] is True
+
+        # Source not in listing
+        resp2 = client.get("/api/sources")
+        slugs = [i["slug"] for i in resp2.json()["items"]]
+        assert "empty-src" not in slugs
+
+
 def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", str(pg_clean))
     sync_sources(pg_clean)

--- a/pi-output.log
+++ b/pi-output.log
@@ -1,0 +1,29 @@
+All 35 tests pass across the three affected test files.
+
+Here's a summary of what was changed:
+
+## Changes made
+
+### `backend/news_dashboard/db.py`
+- Added `ALTER TABLE sources ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ` to the schema migration list (idempotent, safe for existing deployments)
+
+### `backend/news_dashboard/main.py`
+- **`sources()`** — Added `AND s.deleted_at IS NULL` to the source listing query so retired sources don't appear in the UI
+- **`delete_source()`** — Changed from `DELETE FROM sources WHERE slug = %s` to `UPDATE sources SET deleted_at = NOW(), enabled = FALSE WHERE slug = %s AND owner_user_id = %s`. Added guard to return 404 if the source is already deleted
+- **`set_source_enabled()`** — Added check for `deleted_at`; returns 404 if the source is retired
+- **`source_cleanup()`** — Added `AND deleted_at IS NULL` to the source lookup query
+
+### `backend/news_dashboard/ingest.py`
+- Added `AND deleted_at IS NULL` to the private source selection query so retired sources are excluded from future ingest runs
+
+### `backend/news_dashboard/source_health.py`
+- Added `AND deleted_at IS NULL` to both `list_source_health()` and `generate_subscription_cleanup_suggestions()` queries
+
+### `backend/news_dashboard/personalization_nudges.py`
+- Added `AND s.deleted_at IS NULL` to the `generate_nudges()` source visibility CTE
+
+### `backend/tests/test_source_subscriptions.py`
+- **`test_api_delete_private_source_with_articles`** — Regression test: creates a private source, inserts an article, deletes source, verifies 200 response, source removed from listing, article still readable, toggle returns 404, re-delete returns 404
+- **`test_api_delete_private_source_no_articles_still_soft_deletes`** — Verifies even empty source deletion is a soft-delete (row still exists with `deleted_at` set) and excluded from listing
+
+DONE


### PR DESCRIPTION
This PR implements issue #530 via the PI agent.

Closes #530

## Summary
- **Issue**: fix: make private source deletion safe after ingest
- **Lock**: agent-lock/issue-530

## Test Results
```
All 35 tests pass across the three affected test files.

Here's a summary of what was changed:

## Changes made

### `backend/news_dashboard/db.py`
- Added `ALTER TABLE sources ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ` to the schema migration list (idempotent, safe for existing deployments)

### `backend/news_dashboard/main.py`
- **`sources()`** — Added `AND s.deleted_at IS NULL` to the source listing query so retired sources don't appear in the UI
- **`delete_source()`** — Changed from `DELETE FROM sources WHERE slug = %s` to `UPDATE sources SET deleted_at = NOW(), enabled = FALSE WHERE slug = %s AND owner_user_id = %s`. Added guard to return 404 if the source is already deleted
- **`set_source_enabled()`** — Added check for `deleted_at`; returns 404 if the source is retired
- **`source_cleanup()`** — Added `AND deleted_at IS NULL` to the source lookup query

### `backend/news_dashboard/ingest.py`
- Added `AND deleted_at IS NULL` to the private source selection query so retired sources are excluded from future ingest runs

### `backend/news_dashboard/source_health.py`
- Added `AND deleted_at IS NULL` to both `list_source_health()` and `generate_subscription_cleanup_suggestions()` queries

### `backend/news_dashboard/personalization_nudges.py`
- Added `AND s.deleted_at IS NULL` to the `generate_nudges()` source visibility CTE

### `backend/tests/test_source_subscriptions.py`
- **`test_api_delete_private_source_with_articles`** — Regression test: creates a private source, inserts an article, deletes source, verifies 200 response, source removed from listing, article still readable, toggle returns 404, re-delete returns 404
- **`test_api_delete_private_source_no_articles_still_soft_deletes`** — Verifies even empty source deletion is a soft-delete (row still exists with `deleted_at` set) and excluded from listing

DONE
```