### PR TITLE
Implement issue #531 - fix: avoid false up-to-date Android TWA checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ android/*.p12
 # Electron desktop build outputs
 desktop/node_modules/
 desktop/dist/
+pi-output.log

--- a/PI-ATTEMPT-531.txt
+++ b/PI-ATTEMPT-531.txt
@@ -1,0 +1,1 @@
+PI agent did not modify any files for issue #531

--- a/frontend/src/__tests__/settingsPlatforms.test.tsx
+++ b/frontend/src/__tests__/settingsPlatforms.test.tsx
@@ -173,9 +173,7 @@ describe('SettingsPage on TWA', () => {
   it('shows "App version: Unknown" for TWA', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
-      )
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
     );
     renderSettings();
     fireEvent.click(screen.getByText('Check for updates'));

--- a/frontend/src/__tests__/settingsPlatforms.test.tsx
+++ b/frontend/src/__tests__/settingsPlatforms.test.tsx
@@ -110,6 +110,10 @@ describe('SettingsPage on TWA', () => {
     sessionStorage.setItem('nd_platform', 'twa');
   });
 
+  afterEach(() => {
+    sessionStorage.removeItem('nd_platform');
+  });
+
   it('checks for updates and offers an APK download', async () => {
     vi.stubGlobal(
       'fetch',
@@ -134,5 +138,47 @@ describe('SettingsPage on TWA', () => {
     fireEvent.click(screen.getByText('Check for updates'));
     const apk = await screen.findByText('Download APK');
     expect(apk.getAttribute('href')).toBe('https://gh/app.apk');
+  });
+
+  it('offers APK download even when server version matches the latest Android release', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        if (url.includes('/api/version')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ version: '2.0.0' }) });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                tag_name: 'android-v2.0.0',
+                html_url: 'https://gh/release',
+                assets: [{ name: 'app.apk', browser_download_url: 'https://gh/app.apk' }],
+              },
+            ]),
+        });
+      })
+    );
+    renderSettings();
+    fireEvent.click(screen.getByText('Check for updates'));
+    const apk = await screen.findByText('Download APK');
+    expect(apk.getAttribute('href')).toBe('https://gh/app.apk');
+    // Should NOT show "up to date" message
+    expect(screen.queryByText(/latest version/i)).toBeNull();
+    // Should show "App version: Unknown" instead of a version number
+    expect(screen.getByText('Unknown')).toBeTruthy();
+  });
+
+  it('shows "App version: Unknown" for TWA', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      )
+    );
+    renderSettings();
+    fireEvent.click(screen.getByText('Check for updates'));
+    await waitFor(() => expect(screen.getByText('Unknown')).toBeTruthy());
   });
 });

--- a/frontend/src/__tests__/useUpdateCheck.test.tsx
+++ b/frontend/src/__tests__/useUpdateCheck.test.tsx
@@ -103,8 +103,9 @@ describe('useUpdateCheck — TWA flow', () => {
     expect(result.current.info?.currentVersion).toBeNull();
     expect(result.current.info?.installedVersionKnown).toBe(false);
     // The API should NOT have called /api/version for TWA
-    expect(vi.mocked(fetch).mock.calls.filter(([url]) => (url as string).includes('/api/version')))
-      .toHaveLength(0);
+    expect(
+      vi.mocked(fetch).mock.calls.filter(([url]) => (url as string).includes('/api/version'))
+    ).toHaveLength(0);
   });
 
   it('reports no update when no matching Android release exists', async () => {

--- a/frontend/src/__tests__/useUpdateCheck.test.tsx
+++ b/frontend/src/__tests__/useUpdateCheck.test.tsx
@@ -157,7 +157,7 @@ describe('useUpdateCheck — TWA flow', () => {
       await result.current.check();
     });
     const calls = vi.mocked(fetch).mock.calls as [string][];
-    const versionCalls = calls.filter(([url]) => (url as string).includes('/api/version'));
+    const versionCalls = calls.filter(([url]) => url.includes('/api/version'));
     expect(versionCalls).toHaveLength(0);
   });
 });

--- a/frontend/src/__tests__/useUpdateCheck.test.tsx
+++ b/frontend/src/__tests__/useUpdateCheck.test.tsx
@@ -71,6 +71,97 @@ describe('useUpdateCheck — web/GitHub flow', () => {
   });
 });
 
+describe('useUpdateCheck — TWA flow', () => {
+  beforeEach(() => {
+    // Simulate TWA platform via sessionStorage
+    sessionStorage.setItem('nd_platform', 'twa');
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem('nd_platform');
+  });
+
+  it('reports update available when an APK asset exists (regardless of server version)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/releases': [
+          {
+            tag_name: 'android-v2.0.0',
+            html_url: 'https://gh/r/android',
+            assets: [{ name: 'app.apk', browser_download_url: 'https://gh/app.apk' }],
+          },
+        ],
+      })
+    );
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.check();
+    });
+    expect(result.current.info?.updateAvailable).toBe(true);
+    expect(result.current.info?.apkUrl).toBe('https://gh/app.apk');
+    expect(result.current.info?.currentVersion).toBeNull();
+    expect(result.current.info?.installedVersionKnown).toBe(false);
+    // The API should NOT have called /api/version for TWA
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => (url as string).includes('/api/version')))
+      .toHaveLength(0);
+  });
+
+  it('reports no update when no matching Android release exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/releases': [{ tag_name: 'desktop-v9.9.9', html_url: 'https://gh/r/d', assets: [] }],
+      })
+    );
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.check();
+    });
+    expect(result.current.info?.updateAvailable).toBe(false);
+    expect(result.current.info?.apkUrl).toBeNull();
+    expect(result.current.info?.currentVersion).toBeNull();
+    expect(result.current.info?.installedVersionKnown).toBe(false);
+  });
+
+  it('reports no update when Android release has no APK asset', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/releases': [
+          {
+            tag_name: 'android-v3.0.0',
+            html_url: 'https://gh/r/android',
+            assets: [],
+          },
+        ],
+      })
+    );
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.check();
+    });
+    expect(result.current.info?.updateAvailable).toBe(false);
+    expect(result.current.info?.apkUrl).toBeNull();
+    expect(result.current.info?.currentVersion).toBeNull();
+    expect(result.current.info?.installedVersionKnown).toBe(false);
+  });
+
+  it('never fetches /api/version for TWA', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    );
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.check();
+    });
+    const calls = vi.mocked(fetch).mock.calls as [string][];
+    const versionCalls = calls.filter(([url]) => (url as string).includes('/api/version'));
+    expect(versionCalls).toHaveLength(0);
+  });
+});
+
 describe('useUpdateCheck — Electron IPC flow', () => {
   type Cb<T> = (arg: T) => void;
   let listeners: Record<string, Cb<unknown>>;

--- a/frontend/src/hooks/useUpdateCheck.ts
+++ b/frontend/src/hooks/useUpdateCheck.ts
@@ -82,7 +82,7 @@ export function useUpdateCheck() {
       if (!release) {
         setInfo({
           currentVersion: isTwa ? null : serverVersion,
-          latestVersion: isTwa ? '0.0.0' : (serverVersion as string),
+          latestVersion: isTwa ? '0.0.0' : serverVersion!,
           updateAvailable: false,
           releaseUrl: `https://github.com/${GH_REPO}/releases`,
           apkUrl: null,
@@ -99,7 +99,7 @@ export function useUpdateCheck() {
       // Android release with an APK asset as an available update.
       const updateAvailable = isTwa
         ? apkAsset !== null
-        : compareVersions(latestVersion, serverVersion as string) > 0;
+        : compareVersions(latestVersion, serverVersion!) > 0;
 
       setInfo({
         currentVersion: isTwa ? null : serverVersion,

--- a/frontend/src/hooks/useUpdateCheck.ts
+++ b/frontend/src/hooks/useUpdateCheck.ts
@@ -19,13 +19,15 @@ export interface GithubRelease {
 }
 
 export interface UpdateInfo {
-  currentVersion: string;
+  currentVersion: string | null;
   latestVersion: string;
   updateAvailable: boolean;
   releaseUrl: string;
   /** Direct APK download URL — only populated for the twa platform. */
   apkUrl: string | null;
   platform: AppPlatform;
+  /** Whether the currentVersion represents a known installed version (as opposed to TWA unknown). */
+  installedVersionKnown: boolean;
 }
 
 /** Fetch all releases and return the latest one matching the prefix. */
@@ -64,42 +66,49 @@ export function useUpdateCheck() {
   const [downloadPercent, setDownloadPercent] = useState(0);
   const [electronLatestVersion, setElectronLatestVersion] = useState<string | null>(null);
 
-  /** Check for updates (GitHub API + /api/version). */
+  /** Check for updates (GitHub API + optionally /api/version). */
   const check = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const prefix = TAG_PREFIX[platform];
-      const [currentVersion, release] = await Promise.all([
-        fetchCurrentVersion(),
-        fetchLatestRelease(prefix),
-      ]);
+      const isTwa = platform === 'twa';
+
+      // For TWA, skip /api/version: it returns the deployed server version,
+      // not the installed APK version on the device.
+      const release = await fetchLatestRelease(prefix);
+      const serverVersion: string | null = isTwa ? null : await fetchCurrentVersion();
 
       if (!release) {
         setInfo({
-          currentVersion,
-          latestVersion: currentVersion,
+          currentVersion: isTwa ? null : serverVersion,
+          latestVersion: isTwa ? '0.0.0' : (serverVersion as string),
           updateAvailable: false,
           releaseUrl: `https://github.com/${GH_REPO}/releases`,
           apkUrl: null,
           platform,
+          installedVersionKnown: !isTwa,
         });
         return;
       }
 
       const latestVersion = tagToVersion(release.tag_name);
-      const updateAvailable = compareVersions(latestVersion, currentVersion) > 0;
+      const apkAsset = release.assets.find((a) => a.name.endsWith('.apk')) ?? null;
 
-      const apkAsset =
-        platform === 'twa' ? (release.assets.find((a) => a.name.endsWith('.apk')) ?? null) : null;
+      // For TWA, since we cannot determine the installed APK version, treat any
+      // Android release with an APK asset as an available update.
+      const updateAvailable = isTwa
+        ? apkAsset !== null
+        : compareVersions(latestVersion, serverVersion as string) > 0;
 
       setInfo({
-        currentVersion,
+        currentVersion: isTwa ? null : serverVersion,
         latestVersion,
         updateAvailable,
         releaseUrl: release.html_url,
         apkUrl: apkAsset?.browser_download_url ?? null,
         platform,
+        installedVersionKnown: !isTwa,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Update check failed');

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -185,8 +185,8 @@ function UpdatesSection() {
               {info.apkUrl ? (
                 <>
                   <p className="text-xs text-muted-foreground">
-                    Version <span className="font-mono">{info.latestVersion}</span> is available
-                    for download.
+                    Version <span className="font-mono">{info.latestVersion}</span> is available for
+                    download.
                   </p>
                   <div className="space-y-1.5">
                     <a
@@ -197,8 +197,7 @@ function UpdatesSection() {
                       Download APK
                     </a>
                     <p className="text-[11px] text-subtle">
-                      Android will prompt you to confirm the install — tap Install when it
-                      appears.
+                      Android will prompt you to confirm the install — tap Install when it appears.
                     </p>
                   </div>
                 </>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -154,8 +154,10 @@ function UpdatesSection() {
         <div className="rounded-lg border border-border bg-card p-4 space-y-3">
           {info && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">Current version</span>
-              <span className="tabular-nums font-mono text-xs">{info.currentVersion}</span>
+              <span className="text-muted-foreground">App version</span>
+              <span className="tabular-nums font-mono text-xs">
+                {info.installedVersionKnown ? info.currentVersion : 'Unknown'}
+              </span>
             </div>
           )}
 
@@ -178,30 +180,28 @@ function UpdatesSection() {
 
           {error && <p className="text-xs text-destructive">{error}</p>}
 
-          {info && !info.updateAvailable && !loading && (
-            <p className="text-xs text-green-600 dark:text-green-400">
-              You're on the latest version ({info.latestVersion}).
-            </p>
-          )}
-
-          {info?.updateAvailable && (
+          {info && !loading && (
             <div className="space-y-2">
-              <p className="text-xs text-muted-foreground">
-                Version <span className="font-mono">{info.latestVersion}</span> is available.
-              </p>
               {info.apkUrl ? (
-                <div className="space-y-1.5">
-                  <a
-                    href={info.apkUrl}
-                    className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors w-fit"
-                  >
-                    <Download className="size-3" />
-                    Download APK
-                  </a>
-                  <p className="text-[11px] text-subtle">
-                    Android will prompt you to confirm the install — tap Install when it appears.
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    Version <span className="font-mono">{info.latestVersion}</span> is available
+                    for download.
                   </p>
-                </div>
+                  <div className="space-y-1.5">
+                    <a
+                      href={info.apkUrl}
+                      className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors w-fit"
+                    >
+                      <Download className="size-3" />
+                      Download APK
+                    </a>
+                    <p className="text-[11px] text-subtle">
+                      Android will prompt you to confirm the install — tap Install when it
+                      appears.
+                    </p>
+                  </div>
+                </>
               ) : (
                 <a
                   href={info.releaseUrl}
@@ -210,7 +210,7 @@ function UpdatesSection() {
                   className="flex items-center gap-1.5 text-xs text-primary hover:underline"
                 >
                   <ExternalLink className="size-3" />
-                  View release
+                  View Android releases
                 </a>
               )}
             </div>


### PR DESCRIPTION
This PR implements issue #531 via the PI agent.

Closes #531

## Summary
- **Issue**: fix: avoid false up-to-date Android TWA checks
- **Lock**: agent-lock/issue-531

## Test Results
```
DONE

The implementation is complete. Here's a summary of what was changed:

### Problem
The Android TWA update check compared `/api/version` (the deployed server/web version) against the latest Android release tag, causing a false "up to date" message when the server version matched the latest Android release — even if the installed APK was older.

### Changes

**`frontend/src/hooks/useUpdateCheck.ts`**
- For TWA platform: skip `fetchCurrentVersion()` entirely (it returns server version, not APK version)
- Set `currentVersion` to `null` and `installedVersionKnown` to `false` for TWA
- For TWA: treat any Android release with an APK asset as an available update (since we can't verify the installed APK version)
- Added `installedVersionKnown` field to `UpdateInfo` interface

**`frontend/src/pages/SettingsPage.tsx`**
- Show "App version: Unknown" for TWA instead of the misleading server version
- Always show APK download link when `apkUrl` exists, regardless of version comparison
- Removed the "You're on the latest version" message from the TWA section entirely

**`frontend/src/__tests__/useUpdateCheck.test.tsx`**
- Added 4 TWA-specific tests covering: APK available regardless of server version, no matching release, release without APK, and verifying `/api/version` is never called for TWA

**`frontend/src/__tests__/settingsPlatforms.test.tsx`**
- Added regression test proving APK download is offered even when server version matches latest Android release
- Added test confirming "App version: Unknown" is shown for TWA
```