### PR TITLE
Implement issue #546 - fix: align Stats and analytics routes with admin-only access

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -15,6 +15,8 @@ import { StarredPage } from './pages/StarredPage';
 import { FeedsPage } from './pages/FeedsPage';
 import { SourcesPage } from './pages/SourcesPage';
 import { ArchivePage } from './pages/ArchivePage';
+import { useAuth } from './contexts/auth';
+import { ShieldAlert } from 'lucide-react';
 
 const SearchPage = lazy(() =>
   import('./pages/SearchPage').then((m) => ({ default: m.SearchPage }))
@@ -67,6 +69,22 @@ function withSuspense(Component: React.ComponentType) {
       <Component />
     </Suspense>
   );
+}
+
+function AdminOnlyGuard({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  if (!user?.is_admin) {
+    return (
+      <div className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center gap-3 text-center">
+        <ShieldAlert className="size-8 text-muted-foreground" />
+        <h1 className="text-lg font-semibold text-foreground">Admins only</h1>
+        <p className="text-sm text-muted-foreground">
+          You need an administrator account to access this page.
+        </p>
+      </div>
+    );
+  }
+  return <>{children}</ >;
 }
 
 export function NotFound() {
@@ -130,12 +148,24 @@ export const routes: RouteObject[] = [
       { path: 'briefs', element: withSuspense(BriefingsHistoryPage) },
       { path: 'briefs/:id', element: withSuspense(BriefingDetailPage) },
       { path: 'topic-map', element: withSuspense(TopicMapPage) },
-      { path: 'stats', element: withSuspense(StatsPage) },
+      { path: 'stats', element: (
+        <AdminOnlyGuard>
+          <Suspense fallback={<PageLoader />}>
+            <StatsPage />
+          </Suspense>
+        </AdminOnlyGuard>
+      )},
       { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'settings', element: withSuspense(SettingsPage) },
       { path: 'admin', element: withSuspense(AdminPage) },
-      { path: 'analytics', element: withSuspense(AnalyticsPage) },
+      { path: 'analytics', element: (
+        <AdminOnlyGuard>
+          <Suspense fallback={<PageLoader />}>
+            <AnalyticsPage />
+          </Suspense>
+        </AdminOnlyGuard>
+      )},
 
       /* Legacy route redirects — remove when each migration slice lands */
       { path: 'inbox', element: <Navigate to="/today" replace /> },

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -84,7 +84,7 @@ function AdminOnlyGuard({ children }: { children: React.ReactNode }) {
       </div>
     );
   }
-  return <>{children}</ >;
+  return <>{children}</>;
 }
 
 export function NotFound() {
@@ -148,24 +148,30 @@ export const routes: RouteObject[] = [
       { path: 'briefs', element: withSuspense(BriefingsHistoryPage) },
       { path: 'briefs/:id', element: withSuspense(BriefingDetailPage) },
       { path: 'topic-map', element: withSuspense(TopicMapPage) },
-      { path: 'stats', element: (
-        <AdminOnlyGuard>
-          <Suspense fallback={<PageLoader />}>
-            <StatsPage />
-          </Suspense>
-        </AdminOnlyGuard>
-      )},
+      {
+        path: 'stats',
+        element: (
+          <AdminOnlyGuard>
+            <Suspense fallback={<PageLoader />}>
+              <StatsPage />
+            </Suspense>
+          </AdminOnlyGuard>
+        ),
+      },
       { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'settings', element: withSuspense(SettingsPage) },
       { path: 'admin', element: withSuspense(AdminPage) },
-      { path: 'analytics', element: (
-        <AdminOnlyGuard>
-          <Suspense fallback={<PageLoader />}>
-            <AnalyticsPage />
-          </Suspense>
-        </AdminOnlyGuard>
-      )},
+      {
+        path: 'analytics',
+        element: (
+          <AdminOnlyGuard>
+            <Suspense fallback={<PageLoader />}>
+              <AnalyticsPage />
+            </Suspense>
+          </AdminOnlyGuard>
+        ),
+      },
 
       /* Legacy route redirects — remove when each migration slice lands */
       { path: 'inbox', element: <Navigate to="/today" replace /> },

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -22,7 +22,7 @@ import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { useFocusedArticle } from '@/contexts/focusedArticle';
 import { useAuth } from '@/contexts/auth';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
-import { commandNavigationItems } from '@/lib/navigation';
+import { commandNavigationItemsFor } from '@/lib/navigation';
 import { trackFeature } from '@/lib/analytics';
 
 interface Props {
@@ -244,7 +244,7 @@ export function CommandPalette({ open, onOpenChange, onShortcuts }: Props) {
 
             {/* Navigation */}
             <Command.Group heading="Navigation" className={GROUP_CLS}>
-              {commandNavigationItems.map(({ icon: Icon, label, to }) => (
+              {commandNavigationItemsFor(Boolean(user?.is_admin)).map(({ icon: Icon, label, to }) => (
                 <Command.Item key={to} onSelect={() => go(to)} className={ITEM_CLS}>
                   <Icon className="size-4 text-muted-foreground" />
                   <span className="text-sm">{label}</span>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -244,12 +244,14 @@ export function CommandPalette({ open, onOpenChange, onShortcuts }: Props) {
 
             {/* Navigation */}
             <Command.Group heading="Navigation" className={GROUP_CLS}>
-              {commandNavigationItemsFor(Boolean(user?.is_admin)).map(({ icon: Icon, label, to }) => (
-                <Command.Item key={to} onSelect={() => go(to)} className={ITEM_CLS}>
-                  <Icon className="size-4 text-muted-foreground" />
-                  <span className="text-sm">{label}</span>
-                </Command.Item>
-              ))}
+              {commandNavigationItemsFor(Boolean(user?.is_admin)).map(
+                ({ icon: Icon, label, to }) => (
+                  <Command.Item key={to} onSelect={() => go(to)} className={ITEM_CLS}>
+                    <Icon className="size-4 text-muted-foreground" />
+                    <span className="text-sm">{label}</span>
+                  </Command.Item>
+                )
+              )}
             </Command.Group>
 
             {/* App actions */}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -24,6 +24,7 @@ export interface NavigationItem {
   icon: LucideIcon;
   commandLabel?: string;
   shortcut?: string;
+  adminOnly?: boolean;
 }
 
 export const primaryNavigationItems: NavigationItem[] = [
@@ -40,7 +41,6 @@ export const secondaryNavigationItems: NavigationItem[] = [
   { to: '/briefs', label: 'Briefing History', icon: History, shortcut: 'h' },
   { to: '/topic-map', label: 'Topic Map', icon: Network },
   { to: '/feeds', label: 'Feeds', icon: Radio, shortcut: 'f' },
-  { to: '/stats', label: 'Stats', icon: BarChart3 },
   { to: '/reading-dna', label: 'Reading DNA', icon: SlidersHorizontal },
   { to: '/archive', label: 'Archive', icon: Archive },
   { to: '/settings', label: 'Settings', icon: Settings },
@@ -48,6 +48,7 @@ export const secondaryNavigationItems: NavigationItem[] = [
 
 // Shown in the secondary nav only for admin users.
 export const adminNavigationItems: NavigationItem[] = [
+  { to: '/stats', label: 'Stats', icon: BarChart3 },
   { to: '/analytics', label: 'Analytics', icon: Activity },
   { to: '/admin', label: 'Users', icon: Users },
 ];
@@ -82,6 +83,20 @@ export const commandNavigationItems = [...primaryNavigationItems, ...secondaryNa
     label: item.commandLabel ?? item.label,
   })
 );
+
+export function commandNavigationItemsFor(isAdmin: boolean): NavigationItem[] {
+  const baseItems = [...primaryNavigationItems, ...secondaryNavigationItems];
+  if (isAdmin) {
+    return [...baseItems, ...adminNavigationItems].map((item) => ({
+      ...item,
+      label: item.commandLabel ?? item.label,
+    }));
+  }
+  return baseItems.map((item) => ({
+    ...item,
+    label: item.commandLabel ?? item.label,
+  }));
+}
 
 export const navigationShortcutRows: [string, string][] = [
   ['j / k', 'Move down / up in list'],


### PR DESCRIPTION
This PR implements issue #546 via the PI agent.

Closes #546

## Summary
- **Issue**: fix: align Stats and analytics routes with admin-only access
- **Lock**: agent-lock/issue-546

## Test Results
```
 Good, the AppShell is already using `secondaryNavigationItemsFor` which properly handles admin-only items. Now let me update the command palette. But first, let me also check the shortcut handling for g-key keyboard shortcuts: 
```