### PR TITLE
Implement issue #539 - ops: fail scheduled-ingest on whole-run failures

### DIFF
--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
+
 import typer
 
 from news_dashboard.ingest import ingest_all, list_articles, sync_sources
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(help="News dashboard maintenance CLI")
 
@@ -29,7 +33,11 @@ def ingest() -> None:
 def scheduled_ingest() -> None:
     from news_dashboard.scheduler import run_scheduled_ingest
 
-    results = run_scheduled_ingest()
+    try:
+        results = run_scheduled_ingest(raise_on_failure=True)
+    except Exception as e:
+        logger.exception("Scheduled ingest failed")
+        raise typer.Exit(code=1) from e
     for source, count in results.items():
         typer.echo(f"{source}: {count}")
     typer.echo(f"inserted: {sum(value for value in results.values() if value > 0)}")

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -30,7 +30,7 @@ def _env_flag_enabled(name: str, *, default: bool) -> bool:
     return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
-def run_scheduled_ingest() -> dict[str, int]:
+def run_scheduled_ingest(raise_on_failure: bool = False) -> dict[str, int]:
     from news_dashboard.body_fetch import prefetch_article_bodies
     from news_dashboard.ingest import ingest_all
 
@@ -45,6 +45,8 @@ def run_scheduled_ingest() -> dict[str, int]:
             prefetch_article_bodies()
     except Exception:
         logger.exception("Scheduled ingest failed")
+        if raise_on_failure:
+            raise
     # Repair stale/missing scores out-of-band.  Guarded separately so a
     # recalculation or scoring failure never fails the ingest run itself.
     _run_recommendation_recalc()
@@ -52,7 +54,7 @@ def run_scheduled_ingest() -> dict[str, int]:
 
 
 def _run_ingest() -> None:
-    run_scheduled_ingest()
+    run_scheduled_ingest(raise_on_failure=False)
 
 
 def _run_recommendation_recalc() -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -43,9 +43,19 @@ def test_scheduled_ingest_uses_scheduler_runner() -> None:
     ) as run:
         result = runner.invoke(app, ["scheduled-ingest"])
     assert result.exit_code == 0
-    run.assert_called_once_with()
+    run.assert_called_once_with(raise_on_failure=True)
     assert "a: 2" in result.stdout
     assert "inserted: 2" in result.stdout
+
+
+def test_scheduled_ingest_exits_nonzero_when_scheduler_runner_fails() -> None:
+    with patch(
+        "news_dashboard.scheduler.run_scheduled_ingest",
+        side_effect=RuntimeError("boom"),
+    ) as run:
+        result = runner.invoke(app, ["scheduled-ingest"])
+    assert result.exit_code == 1
+    run.assert_called_once_with(raise_on_failure=True)
 
 
 def test_articles_lists_rows() -> None:


### PR DESCRIPTION
This PR implements issue #539 via the PI agent.

Closes #539

## Summary
- **Issue**: ops: fail scheduled-ingest on whole-run failures
- **Lock**: agent-lock/issue-539

## Test Results
```
Let's see the rest of the function:














</function>
</tool_call>
```