### PR TITLE
fix: surface schema initialization failures (#548)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 _INIT_DB_LOCK = threading.Lock()
 _INITIALIZED_DATABASES: set[tuple[str, str | None, str]] = set()
 
+
+class SchemaInitializationError(RuntimeError):
+    """Raised when PostgreSQL schema initialization cannot complete."""
+
+
 POSTGRES_SCHEMA = [
     """
     CREATE TABLE IF NOT EXISTS users (
@@ -581,16 +586,19 @@ def init_db(db_path: Path | str | None = None, database_url: str | None = None) 
         if cache_key in _INITIALIZED_DATABASES:
             return
 
-    # Each statement runs in its own transaction so a harmless idempotency
-    # failure does not leave later schema statements in an aborted transaction.
+    # Each statement runs in its own transaction so one failed statement does
+    # not leave later attempts in an aborted transaction.
     applied = 0
     for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
         try:
             with connect(db_path, database_url=database_url) as conn:
                 conn.execute(statement)
                 applied += 1
-        except Exception:  # idempotent best-effort schema statements
-            logger.debug("Schema statement skipped (already applied): %.80s", statement)
+        except Exception as exc:
+            statement_preview = " ".join(statement.split())[:240]
+            logger.exception("Schema initialization failed on statement: %s", statement_preview)
+            message = f"Schema initialization failed on statement: {statement_preview}"
+            raise SchemaInitializationError(message) from exc
     if applied > 0:
         with _INIT_DB_LOCK:
             _INITIALIZED_DATABASES.add(cache_key)

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -1,16 +1,18 @@
 """Unit tests for init_db PostgreSQL transaction-safety behaviour.
 
 These tests mock the connect() context manager so they run without Docker.
-The key invariant: each schema statement must execute in its own transaction
-so that a failing statement does not put psycopg3 into ABORTED state and
-prevent every subsequent statement — and the final commit() — from running.
+The key invariant: schema failures must surface while successful runs remain
+cached on the hot path.
 """
 
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from typing import Any
 from unittest.mock import patch
+
+import pytest
 
 _SIMULATED_FAILURE = "simulated: column already exists"
 
@@ -41,13 +43,11 @@ def test_init_db_postgres_applies_all_statements(tmp_path: Any) -> None:
     assert applied == fake_schema
 
 
-def test_init_db_postgres_continues_after_statement_failure(tmp_path: Any) -> None:
-    """A failing schema statement must not prevent subsequent ones from running.
-
-    Before the fix, all 47 statements shared one psycopg3 transaction: a single
-    failure left the transaction in ABORTED state, causing every later execute()
-    and the final commit() to raise InFailedSqlTransaction.
-    """
+def test_init_db_postgres_failure_surfaces_and_is_not_cached(
+    tmp_path: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failing schema statement must raise and retry on the next init_db()."""
     applied: list[str] = []
 
     @contextmanager
@@ -63,17 +63,24 @@ def test_init_db_postgres_continues_after_statement_failure(tmp_path: Any) -> No
     fake_schema = ["stmt_ok_1", "WILL_FAIL", "stmt_ok_2"]
 
     with (
+        caplog.at_level(logging.ERROR, logger="news_dashboard.db"),
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
     ):
-        from news_dashboard.db import init_db
+        from news_dashboard.db import SchemaInitializationError, init_db
 
-        init_db()  # must not raise
+        token = tmp_path / "partial-schema.db"
+        with pytest.raises(SchemaInitializationError, match="WILL_FAIL"):
+            init_db(token)
 
-    assert "stmt_ok_1" in applied
-    assert "stmt_ok_2" in applied
+        with pytest.raises(SchemaInitializationError, match="WILL_FAIL"):
+            init_db(token)
+
+    assert applied == ["stmt_ok_1", "stmt_ok_1"]
     assert "WILL_FAIL" not in applied
+    assert "stmt_ok_2" not in applied
+    assert "Schema initialization failed on statement: WILL_FAIL" in caplog.text
 
 
 def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> None:


### PR DESCRIPTION
Closes #548

## Summary
- add a SchemaInitializationError for failed PostgreSQL schema statements
- log the failed schema statement preview at error level and stop initialization
- avoid caching partially initialized schema fingerprints so later calls retry
- update init_db tests to cover surfaced failure, retry behavior, and successful hot-path caching

## Tests
- `pytest backend/tests/test_db_init.py -q`
- `make lint`
- `make typecheck`
- `source .env && make test` (fails on existing unrelated `scripts/test_caddy_source_of_truth.py::test_docs_point_to_single_production_caddyfile`, which expects `docs/RUNNER_SETUP.md` to mention `deploy/Caddyfile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)