### PR TITLE
fix: keep runner setup pointing to Caddyfile

### DIFF
--- a/docs/RUNNER_SETUP.md
+++ b/docs/RUNNER_SETUP.md
@@ -9,3 +9,6 @@ That guide reflects the current workflow configuration:
 
 - Runner label: `self-hosted` (see `.github/workflows/ci.yml` deploy job `runs-on: [self-hosted]`)
 - Required secret: `GHCR_TOKEN` (not `GHCR_READ_TOKEN`)
+
+Production HTTPS routing is documented against the single source-of-truth
+Caddy config at `deploy/Caddyfile`.


### PR DESCRIPTION
Closes #586

## Summary

- Restore the `deploy/Caddyfile` source-of-truth pointer in the moved runner setup bookmark stub.
- Keep the retired `deploy/news.lihor.ro.caddyfile` path out of the docs.

## Tests

- `source .env && pytest scripts/test_caddy_source_of_truth.py -q`
- `source .env && make check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
