### PR TITLE
fix: unsubscribe current push endpoint (#549)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1775,6 +1775,10 @@ class PushSubscribeRequest(BaseModel):
     auth: str
 
 
+class PushUnsubscribeRequest(BaseModel):
+    endpoint: str | None = None
+
+
 class RecommendationPreferencesUpdate(BaseModel):
     category_weights: dict[str, float] | None = None
     novelty_weight: float | None = None
@@ -1920,10 +1924,14 @@ def push_subscribe(
 @api.delete("/api/notifications/subscribe")
 def push_unsubscribe(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    payload: PushUnsubscribeRequest | None = None,
 ) -> dict[str, Any]:
     from news_dashboard.push import delete_push_subscriptions
 
-    delete_push_subscriptions(current_user["id"])
+    if payload and payload.endpoint is not None:
+        delete_push_subscriptions(current_user["id"], endpoint=payload.endpoint)
+    else:
+        delete_push_subscriptions(current_user["id"])
     return {"unsubscribed": True}
 
 

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -454,6 +454,20 @@ def test_push_subscribe_endpoint(client: TestClient) -> None:
 
 def test_push_unsubscribe_endpoint(client: TestClient) -> None:
     with patch("news_dashboard.push.delete_push_subscriptions") as mock_del:
+        resp = client.request(
+            "DELETE",
+            "/api/notifications/subscribe",
+            json={"endpoint": "https://ep.example.com"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"unsubscribed": True}
+    mock_del.assert_called_once_with(1, endpoint="https://ep.example.com")
+
+
+def test_push_unsubscribe_without_endpoint_preserves_all_endpoint_cleanup(
+    client: TestClient,
+) -> None:
+    with patch("news_dashboard.push.delete_push_subscriptions") as mock_del:
         resp = client.delete("/api/notifications/subscribe")
     assert resp.status_code == 200
     assert resp.json() == {"unsubscribed": True}

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -436,4 +436,22 @@ describe('subscriptions & recommendations', () => {
     expect((await api.recalculateMyRecommendations()).scored).toBe(12);
     expect(calls[0].init?.method).toBe('POST');
   });
+
+  it('unsubscribePush sends the current endpoint when provided', async () => {
+    const { calls } = stubFetch(() => jsonOk({ unsubscribed: true }));
+    await api.unsubscribePush('https://push.example.com/current');
+    expect(calls[0].url).toBe('/api/notifications/subscribe');
+    expect(calls[0].init?.method).toBe('DELETE');
+    expect(calls[0].init?.body).toBe(
+      JSON.stringify({ endpoint: 'https://push.example.com/current' })
+    );
+  });
+
+  it('unsubscribePush keeps all-endpoint cleanup available without an endpoint', async () => {
+    const { calls } = stubFetch(() => jsonOk({ unsubscribed: true }));
+    await api.unsubscribePush();
+    expect(calls[0].url).toBe('/api/notifications/subscribe');
+    expect(calls[0].init?.method).toBe('DELETE');
+    expect(calls[0].init?.body).toBeUndefined();
+  });
 });

--- a/frontend/src/__tests__/dailyBriefSettings.test.tsx
+++ b/frontend/src/__tests__/dailyBriefSettings.test.tsx
@@ -117,6 +117,19 @@ describe('DailyBriefSection', () => {
 
   it('calls unsubscribePush and updateNotificationSettings on Disable click', async () => {
     const user = userEvent.setup();
+    const localUnsubscribe = vi.fn().mockResolvedValue(true);
+    const getSubscription = vi.fn().mockResolvedValue({
+      endpoint: 'https://push.example.com/current',
+      unsubscribe: localUnsubscribe,
+    });
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        ready: Promise.resolve({
+          pushManager: { getSubscription },
+        }),
+      },
+    });
+    vi.stubGlobal('PushManager', {});
     mockFetchSettings.mockResolvedValue({
       ...defaultSettings,
       push_enabled: true,
@@ -125,7 +138,39 @@ describe('DailyBriefSection', () => {
     renderSettings();
     const disableBtn = await screen.findByRole('button', { name: /disable/i });
     await user.click(disableBtn);
-    await waitFor(() => expect(mockUnsubscribePush).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockUnsubscribePush).toHaveBeenCalledWith('https://push.example.com/current')
+    );
+    expect(getSubscription).toHaveBeenCalled();
+    expect(localUnsubscribe).toHaveBeenCalled();
+    await waitFor(() => expect(mockUpdateSettings).toHaveBeenCalledWith({ push_enabled: false }));
+  });
+
+  it('keeps Electron disable working without a browser PushManager subscription', async () => {
+    const user = userEvent.setup();
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      platform: 'electron',
+      appVersion: '1.0.0',
+      checkForUpdate: vi.fn(),
+      downloadUpdate: vi.fn(),
+      quitAndInstall: vi.fn(),
+      onUpdateAvailable: vi.fn(),
+      onUpdateNotAvailable: vi.fn(),
+      onUpdateDownloaded: vi.fn(),
+      onUpdateError: vi.fn(),
+      onDownloadProgress: vi.fn(),
+      removeUpdateListeners: vi.fn(),
+      showNotification: vi.fn(),
+    };
+    mockFetchSettings.mockResolvedValue({
+      ...defaultSettings,
+      push_enabled: true,
+      vapid_public_key: null,
+    });
+    renderSettings();
+    const disableBtn = await screen.findByRole('button', { name: /disable/i });
+    await user.click(disableBtn);
+    await waitFor(() => expect(mockUnsubscribePush).toHaveBeenCalledWith(undefined));
     await waitFor(() => expect(mockUpdateSettings).toHaveBeenCalledWith({ push_enabled: false }));
   });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -528,8 +528,11 @@ export async function subscribePush(
   });
 }
 
-export async function unsubscribePush(): Promise<{ unsubscribed: boolean }> {
-  return requestJson('/api/notifications/subscribe', { method: 'DELETE' });
+export async function unsubscribePush(endpoint?: string): Promise<{ unsubscribed: boolean }> {
+  return requestJson('/api/notifications/subscribe', {
+    method: 'DELETE',
+    body: endpoint ? JSON.stringify({ endpoint }) : undefined,
+  });
 }
 
 // ─── In-platform sharing ──────────────────────────────────────────────────────

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -463,8 +463,14 @@ function DailyBriefSection() {
   };
 
   const disablePush = async () => {
+    let subscription: PushSubscription | null = null;
     try {
-      await unsubscribePush();
+      if (!window.electronAPI && 'serviceWorker' in navigator && 'PushManager' in window) {
+        const reg = await navigator.serviceWorker.ready;
+        subscription = await reg.pushManager.getSubscription();
+      }
+      await unsubscribePush(subscription?.endpoint);
+      await subscription?.unsubscribe();
     } catch {
       // best-effort
     }


### PR DESCRIPTION
Closes #549

## Summary
- accept an optional push endpoint on the unsubscribe API and preserve no-endpoint all-device cleanup
- send the current browser PushSubscription endpoint when disabling push notifications
- unsubscribe the local PushManager subscription after the server-side endpoint delete succeeds, while keeping Electron disable working without PushManager

## Tests
- `python -m pytest backend/tests/test_push_notifications.py -q -k 'push_unsubscribe or delete_push_subscription'`\n- `npm run test:frontend -- frontend/src/__tests__/dailyBriefSettings.test.tsx frontend/src/__tests__/api.test.ts`\n- `make lint`\n- `make typecheck`\n- `set -a; . ./.env; set +a; make test`\n- `npm run test:frontend && npm run build`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)