### PR TITLE
ci: use lockfile installs in PR metrics

### DIFF
--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           node-version: '26'
           cache: npm
-      - run: npm install
+      - run: npm ci
 
       # Backend: pytest with JSON coverage; time the run with the bash SECONDS
       # builtin. `|| true` so a measurement on the base ref never fails the PR.


### PR DESCRIPTION
Replace npm install with npm ci in the PR metrics workflow to ensure deterministic installation of frontend dependencies matching the required checks.

This change aligns the PR metrics workflow with the CI workflows that already use npm ci.