### PR TITLE
fix: surface live ingest log stream failures (#591)

### DIFF
--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -397,6 +397,7 @@ describe('FeedsLogsPage', () => {
   type Handler = (e: unknown) => void;
 
   const holder: { current: FakeEventSource } = { current: null as never };
+  const instances: FakeEventSource[] = [];
 
   class FakeEventSource {
     handlers: Record<string, Handler> = {};
@@ -408,10 +409,12 @@ describe('FeedsLogsPage', () => {
     };
     constructor() {
       holder.current = this;
+      instances.push(this);
     }
   }
 
   beforeEach(() => {
+    instances.length = 0;
     vi.stubGlobal('EventSource', FakeEventSource);
   });
 
@@ -431,6 +434,33 @@ describe('FeedsLogsPage', () => {
     await waitFor(() => expect(screen.getByText('Waiting for ingest output…')).toBeTruthy());
 
     holder.current.onerror?.(null);
-    await waitFor(() => expect(screen.getByText('Connecting…')).toBeTruthy());
+    await waitFor(() => expect(screen.getByText('Disconnected')).toBeTruthy());
+  });
+
+  it('shows an actionable stream failure and retries with a fresh connection', async () => {
+    render(<FeedsLogsPage />);
+
+    const firstStream = holder.current;
+    holder.current.onerror?.(null);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Live ingest stream is unavailable or requires admin access/i)
+      ).toBeTruthy()
+    );
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(firstStream.close).toHaveBeenCalledTimes(1);
+    expect(instances).toHaveLength(2);
+    expect(holder.current).not.toBe(firstStream);
+    expect(screen.getByText('Connecting…')).toBeTruthy();
+
+    holder.current.onopen?.(null);
+    await waitFor(() => expect(screen.getByText('Live')).toBeTruthy());
+
+    holder.current.handlers.line?.({ data: 'retry worked' });
+    await waitFor(() => expect(screen.getByText(/retry worked/)).toBeTruthy());
   });
 });

--- a/frontend/src/pages/FeedsLogsPage.tsx
+++ b/frontend/src/pages/FeedsLogsPage.tsx
@@ -1,22 +1,26 @@
 import { useState, useEffect, useRef } from 'react';
 
+type StreamStatus = 'connecting' | 'live' | 'error';
+
 export function FeedsLogsPage() {
   const [lines, setLines] = useState<string[]>([]);
-  const [connected, setConnected] = useState(false);
+  const [status, setStatus] = useState<StreamStatus>('connecting');
+  const [retryKey, setRetryKey] = useState(0);
   const terminalRef = useRef<HTMLPreElement | null>(null);
 
   useEffect(() => {
+    setStatus('connecting');
     const events = new EventSource('/api/ingest/stream');
 
-    events.onopen = () => setConnected(true);
-    events.onerror = () => setConnected(false);
+    events.onopen = () => setStatus('live');
+    events.onerror = () => setStatus('error');
     events.addEventListener('reset', () => setLines([]));
     events.addEventListener('line', (event) => {
       setLines((prev) => [...prev, String((event as MessageEvent<string>).data)]);
     });
 
     return () => events.close();
-  }, []);
+  }, [retryKey]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
@@ -25,6 +29,10 @@ export function FeedsLogsPage() {
     }
   }, [lines]);
 
+  const isLive = status === 'live';
+  const statusLabel =
+    status === 'live' ? 'Live' : status === 'error' ? 'Disconnected' : 'Connecting…';
+
   return (
     <div className="p-4 md:p-5">
       <div className="flex items-center justify-between mb-4">
@@ -32,20 +40,35 @@ export function FeedsLogsPage() {
         <span
           className={[
             'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium',
-            connected
+            isLive
               ? 'border-green-500/30 bg-green-500/10 text-green-600 dark:text-green-400'
-              : 'border-border bg-muted text-muted-foreground',
+              : status === 'error'
+                ? 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400'
+                : 'border-border bg-muted text-muted-foreground',
           ].join(' ')}
         >
           <span
             className={[
               'h-1.5 w-1.5 rounded-full',
-              connected ? 'bg-green-500' : 'bg-muted-foreground',
+              isLive ? 'bg-green-500' : status === 'error' ? 'bg-red-500' : 'bg-muted-foreground',
             ].join(' ')}
           />
-          {connected ? 'Live' : 'Connecting…'}
+          {statusLabel}
         </span>
       </div>
+
+      {status === 'error' ? (
+        <div className="mb-4 flex flex-col gap-3 rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-300 sm:flex-row sm:items-center sm:justify-between">
+          <p>Live ingest stream is unavailable or requires admin access.</p>
+          <button
+            type="button"
+            className="inline-flex h-9 items-center justify-center rounded-md border border-red-500/40 px-3 text-sm font-medium text-red-700 transition-colors hover:bg-red-500/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 dark:text-red-300"
+            onClick={() => setRetryKey((current) => current + 1)}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
 
       <div className="rounded-lg border border-border overflow-hidden">
         <pre


### PR DESCRIPTION
Closes #591

## Summary
- Adds explicit connecting/live/error state for the live ingest log stream.
- Shows a clear disconnected message when the stream fails or requires admin access.
- Adds a Retry control that closes the previous EventSource and opens a fresh connection while preserving existing reset and line handling.

## Tests
- npm run test:frontend -- frontend/src/__tests__/feedsPages.test.tsx
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:frontend
- npm run build

Generated with Codex.