### PR TITLE
fix: prevent Briefing Chat 404s on cited article bodies (#547)

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -57,6 +57,10 @@ class BriefingGenerationError(RuntimeError):
     """Raised when the AI returns a structurally invalid or unparseable briefing."""
 
 
+class BriefingNotFoundError(KeyError):
+    """Raised when a requested briefing does not exist for the current user."""
+
+
 # ── Type alias for the injectable AI function ─────────────────────────────────
 
 AiFn = Callable[[list[dict[str, Any]], str], dict[str, Any]]
@@ -760,7 +764,7 @@ def chat_with_briefing(
     briefing = get_briefing(briefing_id, database_url=database_url, user_id=user_id)
     if briefing is None:
         msg = f"briefing {briefing_id} not found"
-        raise KeyError(msg)
+        raise BriefingNotFoundError(msg)
 
     briefing_context = f"Title: {briefing.get('title', '')}\nSummary: {briefing.get('summary', '')}"
 
@@ -770,7 +774,7 @@ def chat_with_briefing(
         with connect(database_url=database_url) as conn:
             for a in articles:
                 row = conn.execute("SELECT body FROM articles WHERE id = %s", (a["id"],)).fetchone()
-                body = (row[0] or "") if row else ""
+                body = (row_to_dict(row).get("body") or "") if row else ""
                 article_parts.append(
                     f"[{a['id']}] {a['title']} ({a.get('source_name', '')})\n{body[:3000]}"
                 )

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -59,6 +59,7 @@ from news_dashboard.body_fetch import fetch_and_cache_body, get_article, prefetc
 from news_dashboard.briefings import (
     BriefingAINotConfiguredError,
     BriefingGenerationError,
+    BriefingNotFoundError,
     chat_with_briefing,
     generate_briefing,
     get_briefing,
@@ -1760,7 +1761,7 @@ def briefings_chat(
             [{"role": m.role, "content": m.content} for m in body.history],
             user_id=current_user["id"],
         )
-    except KeyError as exc:
+    except BriefingNotFoundError as exc:
         raise HTTPException(status_code=404, detail="briefing not found") from exc
     except BriefingAINotConfiguredError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -22,7 +22,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 import news_dashboard.main as main_mod
-from news_dashboard.briefings import BriefingAINotConfiguredError, BriefingGenerationError
+from news_dashboard.briefings import (
+    BriefingAINotConfiguredError,
+    BriefingGenerationError,
+    BriefingNotFoundError,
+)
 from news_dashboard.db import POSTGRES_SCHEMA
 from news_dashboard.main import app
 
@@ -416,12 +420,24 @@ def test_chat_passes_history_to_backend(client: TestClient, monkeypatch: Any) ->
 def test_chat_returns_404_when_briefing_missing(client: TestClient, monkeypatch: Any) -> None:
     def _raise(*_: Any, **__: Any) -> str:
         msg = "briefing 99 not found"
-        raise KeyError(msg)
+        raise BriefingNotFoundError(msg)
 
     monkeypatch.setattr(main_mod, "chat_with_briefing", _raise)
     resp = client.post("/api/briefings/99/chat", json={"message": "hello", "history": []})
     assert resp.status_code == 404
     assert resp.json()["detail"] == "briefing not found"
+
+
+def test_chat_does_not_convert_unexpected_key_errors_to_404(
+    client: TestClient, monkeypatch: Any
+) -> None:
+    def _raise(*_: Any, **__: Any) -> str:
+        raise KeyError(0)
+
+    monkeypatch.setattr(main_mod, "chat_with_briefing", _raise)
+
+    with pytest.raises(KeyError, match="0"):
+        client.post("/api/briefings/1/chat", json={"message": "hello", "history": []})
 
 
 def test_chat_returns_503_when_ai_not_configured(client: TestClient, monkeypatch: Any) -> None:
@@ -462,7 +478,7 @@ def test_chat_constructs_prompt_with_article_bodies(monkeypatch: Any) -> None:
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
-        mock_conn.execute.return_value.fetchone.return_value = (article_body,)
+        mock_conn.execute.return_value.fetchone.return_value = {"body": article_body}
         mock_connect.return_value = mock_conn
 
         from news_dashboard.briefings import chat_with_briefing


### PR DESCRIPTION
Closes #547

## Summary
- Add a dedicated `BriefingNotFoundError` for missing briefing chat targets.
- Read cited article bodies from mapping-style PostgreSQL rows instead of tuple indexes.
- Keep unexpected `KeyError` failures from being converted into false 404 responses.

## Tests
- `pytest backend/tests/test_briefings_api.py::test_chat_constructs_prompt_with_article_bodies -q`
- `make lint`
- `make typecheck`
- `source .env && pytest backend/tests/test_briefings_api.py -q` attempted locally, but the PostgreSQL service on localhost:55432 is unavailable in this environment (connection refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)