### PR TITLE
fix: render source switches from per-user subscription state (#571)

### DIFF
--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -249,6 +249,44 @@ describe('SourcesPage', () => {
     expect(screen.queryByRole('button', { name: /delete global news/i })).toBeNull();
   });
 
+  it('renders global source switch as off when subscribed=false even if enabled=1', async () => {
+    apiMock.fetchSources.mockResolvedValue([
+      source({
+        slug: 'global',
+        name: 'Global News',
+        owner_user_id: null,
+        enabled: 1,
+        subscribed: false,
+      }),
+    ]);
+    withProviders(<SourcesPage />);
+    await screen.findAllByText('Global News');
+    const switches = screen.getAllByRole('switch');
+    // Both desktop and mobile switches should be off
+    switches.forEach((sw) => {
+      expect(sw).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  it('optimistically sets subscribed=false for global source toggle off', async () => {
+    apiMock.fetchSources.mockResolvedValue([
+      source({
+        slug: 'global',
+        name: 'Global News',
+        owner_user_id: null,
+        enabled: 1,
+        subscribed: true,
+      }),
+    ]);
+    apiMock.updateSourceEnabled.mockResolvedValue(
+      source({ slug: 'global', owner_user_id: null, enabled: 0, subscribed: false })
+    );
+    withProviders(<SourcesPage />);
+    const switches = await screen.findAllByRole('switch');
+    fireEvent.click(switches[0]);
+    await waitFor(() => expect(apiMock.updateSourceEnabled).toHaveBeenCalledWith('global', false));
+  });
+
   it('calls deleteSource when delete button is clicked', async () => {
     apiMock.fetchSources.mockResolvedValue([
       source({ slug: 'mine', name: 'My Blog', owner_user_id: regularUser.id }),

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -29,6 +29,10 @@ import { useAuth } from '@/contexts/auth';
 
 type HealthState = 'ok' | 'stale' | 'error';
 
+function isSourceOn(s: Source): boolean {
+  return s.owner_user_id == null ? (s.subscribed ?? !!s.enabled) : !!s.enabled;
+}
+
 function computeHealth(s: Source): HealthState {
   if (s.last_error) return 'error';
   const ref = s.last_success_at ?? s.last_checked_at;
@@ -219,7 +223,13 @@ export function SourcesPage() {
       await qc.cancelQueries({ queryKey: [SOURCES_KEY] });
       const prev = qc.getQueryData<Source[]>([SOURCES_KEY]);
       qc.setQueryData<Source[]>([SOURCES_KEY], (old = []) =>
-        old.map((s) => (s.slug === slug ? { ...s, enabled: enabled ? 1 : 0 } : s))
+        old.map((s) => {
+          if (s.slug !== slug) return s;
+          const isGlobal = s.owner_user_id == null;
+          return isGlobal
+            ? { ...s, subscribed: enabled, enabled: enabled ? 1 : 0 }
+            : { ...s, enabled: enabled ? 1 : 0 };
+        })
       );
       return { prev };
     },
@@ -400,7 +410,7 @@ export function SourcesPage() {
                   </td>
                   <td className="px-3 py-3 text-right">
                     <Switch
-                      checked={!!s.enabled}
+                      checked={isSourceOn(s)}
                       onCheckedChange={(checked) =>
                         toggleMutation.mutate({ slug: s.slug, enabled: checked })
                       }
@@ -461,7 +471,7 @@ export function SourcesPage() {
                     </Button>
                   )}
                   <Switch
-                    checked={!!s.enabled}
+                    checked={isSourceOn(s)}
                     onCheckedChange={(checked) =>
                       toggleMutation.mutate({ slug: s.slug, enabled: checked })
                     }


### PR DESCRIPTION
## Summary

- Adds `isSourceOn(s)` helper in `SourcesPage.tsx` that returns `subscribed` for global sources (`owner_user_id == null`) and `enabled` for private sources
- Updates both desktop and mobile switch render sites to call `isSourceOn(s)` instead of `!!s.enabled`
- Fixes optimistic update in `toggleMutation.onMutate` to patch `subscribed` (and `enabled`) for global sources, keeping the switch consistent before the refetch lands
- Adds two new Vitest tests: one verifying a global source with `enabled=1, subscribed=false` renders switch off; one verifying the optimistic toggle path

## Test results

```
Test Files  53 passed (53)
Tests  617 passed (617)
```

All pre-commit hooks passed (eslint, prettier, tsc).

Closes #571