### PR TITLE
chore: reposition repo as public OSS (description, topics, version) (#607)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # News Dashboard
 
-News Dashboard is a private personal news reader that collects curated technical news, supports triage, and generates AI briefings over the user's news corpus.
+News Dashboard is a self-hosted, open-source technical news reader that collects curated news from RSS/Atom feeds and other sources, supports triage, and generates AI briefings over the user's news corpus.
 
 ## Language
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # News Dashboard Architecture
 
-This project is a private personal news dashboard for `news.lihor.ro`. It collects curated technical news feeds, stores articles, lets the owner triage them as `new`, `read`, `saved`, `skipped`, or `archived`, tracks source health, and can send a daily digest email.
+This project is a self-hosted, open-source news dashboard. It collects curated technical news feeds, stores articles, lets the owner triage them as `new`, `read`, `saved`, `skipped`, or `archived`, tracks source health, and can send a daily digest email.
 
 The system is not a large microservice platform. It is best understood as a modular monolith with a small number of runtime units:
 

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-A private personal news dashboard for Ioachim. It combines:
+A self-hosted, open-source news dashboard. It combines:
 
 1. **News inbox** — Clau/cron collects useful sources automatically via RSS, GitHub release feeds, trending feeds, and scraped pages.
 2. **Reading tracker** — records what was read, saved, skipped, and archived with timestamps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "news-dashboard"
-version = "0.1.0"
-description = "Private news inbox, reading tracker, summaries, and source dashboard"
+version = "1.21.0"
+description = "Self-hosted news inbox: curated feeds, triage, search, and AI briefings"
 requires-python = ">=3.14"
 dependencies = [
   "fastapi>=0.115.0",
@@ -145,6 +145,9 @@ ban-relative-imports = "all"
   "PT009",   # plain assert is preferred over self.assertEqual here
 ]
 "scripts/test_agent_skill_sync.py" = [
+  "S101",    # asserts are the point of tests
+]
+"scripts/test_repo_metadata.py" = [
   "S101",    # asserts are the point of tests
 ]
 

--- a/scripts/test_repo_metadata.py
+++ b/scripts/test_repo_metadata.py
@@ -1,0 +1,48 @@
+"""Guard tests for repo-level metadata consistency.
+
+Run: python3 -m unittest scripts/test_repo_metadata.py
+"""
+
+import re
+import unittest
+from pathlib import Path
+from typing import ClassVar
+
+ROOT = Path(__file__).parent.parent
+
+
+class TestVersionConsistency(unittest.TestCase):
+    def test_pyproject_version_matches_version_file(self) -> None:
+        version_file = (ROOT / "VERSION").read_text().strip()
+        pyproject = (ROOT / "pyproject.toml").read_text()
+        m = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+        assert m is not None, "version field not found in pyproject.toml"
+        assert m.group(1) == version_file, (
+            f"pyproject.toml version ({m.group(1)}) does not match VERSION ({version_file})"
+        )
+
+
+class TestNoPrivatePersonalPhrases(unittest.TestCase):
+    _FORBIDDEN: ClassVar[list[str]] = ["private personal", "for Ioachim"]
+    _EXTENSIONS: ClassVar[set[str]] = {".py", ".md", ".toml", ".ts", ".tsx", ".txt", ".rst"}
+
+    def test_no_forbidden_phrases_in_tracked_files(self) -> None:
+        this_file = Path(__file__).resolve()
+        violations: list[str] = []
+        for ext in self._EXTENSIONS:
+            for path in ROOT.rglob(f"*{ext}"):
+                if path.resolve() == this_file:
+                    continue
+                if any(part.startswith(".") for part in path.parts):
+                    continue
+                text = path.read_text(errors="replace")
+                violations.extend(
+                    f"{path.relative_to(ROOT)}: contains '{phrase}'"
+                    for phrase in self._FORBIDDEN
+                    if phrase.lower() in text.lower()
+                )
+        assert not violations, "Forbidden phrases found:\n" + "\n".join(violations)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #607

- Removed "private personal" and personal-owner framing from `CONTEXT.md`, `docs/ARCHITECTURE.md`, and `docs/PRODUCT_SPEC.md`; replaced with self-hosted / open-source voice matching the existing README.
- Bumped `pyproject.toml` `version` from stale `0.1.0` to `1.21.0` (matching root `VERSION` file).
- Updated `pyproject.toml` `description` to drop "Private".
- Added `scripts/test_repo_metadata.py` with two guard tests:
  1. `test_pyproject_version_matches_version_file` — asserts `pyproject.toml` version matches `VERSION`.
  2. `test_no_forbidden_phrases_in_tracked_files` — asserts no tracked file contains "private personal" or "for Ioachim".
- Added `S101` ignore for the new test file in `pyproject.toml` ruff per-file-ignores.

## Maintainer one-time step (not blocking this PR)

After merge, a repo admin should run:

```sh
gh repo edit lihor-hub/news-dashboard \
  --description "Self-hosted technical news inbox: curated feeds, triage, search, AI briefings" \
  --add-topic news-reader \
  --add-topic rss \
  --add-topic fastapi \
  --add-topic react \
  --add-topic self-hosted \
  --add-topic typescript \
  --add-topic postgresql
```

## Test plan

- [x] `python3 -m unittest scripts/test_repo_metadata.py -v` — both tests pass
- [x] `grep -ri "private personal\|for Ioachim"` over tracked files — returns nothing
- [x] All pre-commit hooks pass (ruff, mypy, ty, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)