### PR TITLE
fix(ci): drop setup-python 3.14 from self-hosted publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,9 +296,12 @@ jobs:
         with:
           fetch-depth: 0 # tags + history for version computation
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.14'
+      # No actions/setup-python here: this job runs on the self-hosted runner,
+      # which has no prebuilt Python 3.14 in the actions tool-cache for its
+      # OS/arch (setup-python fails with "version '3.14' … was not found").
+      # The changelog step only needs the runner's system python3 to run
+      # scripts/update_changelog.py (pure stdlib), matching release.yml's
+      # self-hosted job, which also runs without setup-python.
 
       # Derive the release version from tags + commits and bake it into the
       # image, so /api/version and /api/changelog match the deployed code.


### PR DESCRIPTION
Closes #663

## What
Remove the leftover `actions/setup-python@v5` (pinned to `python-version: '3.14'`) step from the `publish` (**Build & push image**) job in `.github/workflows/ci.yml`.

## Why
Commit #660 moved `publish` from `ubuntu-latest` to a `self-hosted` runner but kept the `setup-python` step. The self-hosted runner has no prebuilt Python 3.14 in the actions tool-cache for its OS/arch, so the step fails:

> The version '3.14' with architecture 'x64' was not found for this operating system.

Failing run: https://github.com/lihor-hub/news-dashboard/actions/runs/28457929460/job/84343024228

The job only needs the runner's system `python3` to run `scripts/update_changelog.py` (pure stdlib). This mirrors the sibling `release.yml` job, which runs on the same self-hosted runner without `setup-python`. The other `setup-python@v5` steps in `ci.yml` are untouched — they run on `ubuntu-latest`, where 3.14 is available, and already pass.

## Testing
No automated test exists for workflow YAML; verification is CI itself (`yaml.safe_load` parses clean locally, pre-commit `check yaml` passes). The merge-queue CI on `main` will confirm the publish job no longer fails on the Python lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)