### PR TITLE
fix: retry transient Postgres connection failures during startup

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from hashlib import sha256
@@ -533,6 +534,48 @@ def describe_database(database_url: str | None = None) -> str:
     return url
 
 
+def _open_connection(database_url: str | None) -> Any:
+    """Open a psycopg connection, retrying transient connection failures.
+
+    PostgreSQL may not yet be accepting TCP connections when the app starts
+    (a common race in containerized/Kubernetes deployments where the app pod
+    comes up before the database). Retry ``OperationalError`` — the
+    connection-level failure class — with a fixed backoff before giving up, so
+    startup waits the database out instead of crashing. Non-connection errors
+    are not retried. Tunable via ``DB_CONNECT_MAX_ATTEMPTS`` and
+    ``DB_CONNECT_RETRY_DELAY_SECONDS``.
+    """
+    dsn = active_database_url(database_url)
+    try:
+        max_attempts = max(1, int(os.getenv("DB_CONNECT_MAX_ATTEMPTS", "30")))
+    except ValueError:
+        max_attempts = 30
+    try:
+        delay = max(0.0, float(os.getenv("DB_CONNECT_RETRY_DELAY_SECONDS", "2.0")))
+    except ValueError:
+        delay = 2.0
+    for attempt in range(1, max_attempts + 1):
+        try:
+            # ty mis-resolves psycopg's overloaded connect() and infers the
+            # default tuple row_factory; mypy and pyrefly both accept dict_row.
+            return psycopg.connect(dsn, row_factory=dict_row)  # ty: ignore[invalid-argument-type]
+        except psycopg.OperationalError as exc:
+            if attempt >= max_attempts:
+                raise
+            logger.warning(
+                "PostgreSQL connection attempt %d/%d failed (%s); retrying in %.1fs",
+                attempt,
+                max_attempts,
+                exc,
+                delay,
+            )
+            time.sleep(delay)
+    # Unreachable: range starts at 1 and max_attempts >= 1, so the loop body
+    # always runs and either returns or raises.
+    message = "PostgreSQL connection retry loop exited without connecting"
+    raise RuntimeError(message)  # pragma: no cover
+
+
 @contextmanager
 def connect(
     db_path: Path | str | None = None,
@@ -542,9 +585,7 @@ def connect(
     if isinstance(db_path, str) and db_path.startswith(POSTGRES_PREFIXES):
         database_url = db_path
         db_path = None
-    # ty mis-resolves psycopg's overloaded connect() and infers the default
-    # tuple row_factory; mypy and pyrefly both accept dict_row here.
-    conn = psycopg.connect(active_database_url(database_url), row_factory=dict_row)  # ty: ignore[invalid-argument-type]
+    conn = _open_connection(database_url)
     try:
         if isinstance(db_path, Path):
             schema = _schema_name(db_path)

--- a/backend/tests/test_db_connect_retry.py
+++ b/backend/tests/test_db_connect_retry.py
@@ -1,0 +1,114 @@
+"""Unit tests for connect() transient-connection retry behaviour.
+
+These tests mock psycopg.connect so they run without Docker. The invariant:
+connect() should wait out a not-yet-ready PostgreSQL (connection refused) by
+retrying OperationalErrors with backoff, while non-connection errors and
+exhausted retries still surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import pytest
+
+_CONNECTION_REFUSED = "connection refused"
+_SYNTAX_ERROR = "syntax error"
+
+
+class _FakeConn:
+    def execute(self, *args: Any, **kwargs: Any) -> None:  # noqa: ARG002
+        return None
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def test_connect_retries_transient_operational_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A connection refused is retried until PostgreSQL becomes reachable."""
+    from news_dashboard import db
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+    monkeypatch.setenv("DB_CONNECT_RETRY_DELAY_SECONDS", "0")
+    monkeypatch.setenv("DB_CONNECT_MAX_ATTEMPTS", "5")
+
+    attempts = {"n": 0}
+
+    def fake_connect(dsn: str, row_factory: Any = None) -> _FakeConn:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise psycopg.OperationalError(_CONNECTION_REFUSED)
+        return _FakeConn()
+
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("news_dashboard.db.psycopg.connect", fake_connect)
+    monkeypatch.setattr("news_dashboard.db.time.sleep", fake_sleep)
+
+    with db.connect() as conn:
+        assert isinstance(conn, _FakeConn)
+
+    assert attempts["n"] == 3
+    assert sleeps == [0.0, 0.0]
+
+
+def test_connect_gives_up_after_max_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Once attempts are exhausted the original OperationalError is re-raised."""
+    from news_dashboard import db
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+    monkeypatch.setenv("DB_CONNECT_RETRY_DELAY_SECONDS", "0")
+    monkeypatch.setenv("DB_CONNECT_MAX_ATTEMPTS", "3")
+
+    attempts = {"n": 0}
+
+    def fake_connect(dsn: str, row_factory: Any = None) -> _FakeConn:
+        attempts["n"] += 1
+        raise psycopg.OperationalError(_CONNECTION_REFUSED)
+
+    def fake_sleep(seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("news_dashboard.db.psycopg.connect", fake_connect)
+    monkeypatch.setattr("news_dashboard.db.time.sleep", fake_sleep)
+
+    with pytest.raises(psycopg.OperationalError, match=_CONNECTION_REFUSED), db.connect():
+        pass
+
+    assert attempts["n"] == 3
+
+
+def test_connect_does_not_retry_non_connection_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Programming/other errors must surface immediately without retrying."""
+    from news_dashboard import db
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+    monkeypatch.setenv("DB_CONNECT_RETRY_DELAY_SECONDS", "0")
+    monkeypatch.setenv("DB_CONNECT_MAX_ATTEMPTS", "5")
+
+    attempts = {"n": 0}
+
+    def fake_connect(dsn: str, row_factory: Any = None) -> _FakeConn:
+        attempts["n"] += 1
+        raise psycopg.ProgrammingError(_SYNTAX_ERROR)
+
+    def fake_sleep(seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("news_dashboard.db.psycopg.connect", fake_connect)
+    monkeypatch.setattr("news_dashboard.db.time.sleep", fake_sleep)
+
+    with pytest.raises(psycopg.ProgrammingError, match=_SYNTAX_ERROR), db.connect():
+        pass
+
+    assert attempts["n"] == 1


### PR DESCRIPTION
Closes #666

## Problem

On startup the app (notably `init` → `sync_sources()` → `init_db()`) opened a single `psycopg.connect` with no retry. When PostgreSQL was not yet accepting TCP connections — a common race in Kubernetes where the app pod starts before the DB — the connection was refused and the pod crashed with `SchemaInitializationError`.

## Change

`connect()` now opens connections through a new `_open_connection()` helper that retries **only** `psycopg.OperationalError` (the connection-level failure class) with a fixed backoff before giving up, so startup waits the database out instead of crashing. Tunable via `DB_CONNECT_MAX_ATTEMPTS` (default 30) and `DB_CONNECT_RETRY_DELAY_SECONDS` (default 2.0). Non-connection errors (programming/integrity) still surface immediately.

## Tests

New `backend/tests/test_db_connect_retry.py` (no Docker — mocks `psycopg.connect`):
- retries a transient `OperationalError` then succeeds
- re-raises the original `OperationalError` after exhausting max attempts
- does not retry non-connection errors (`ProgrammingError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)