### PR TITLE
docs: add MIT LICENSE and declare license in metadata (#606)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 lihor-hub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -221,4 +221,4 @@ keys. Use environment variables or deployment secrets.
 
 ## License
 
-This repository does not include an open-source license.
+This project is licensed under the [MIT License](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 name = "news-dashboard"
 version = "1.21.0"
 description = "Self-hosted news inbox: curated feeds, triage, search, and AI briefings"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "lihor-hub" }]
 requires-python = ">=3.14"
 dependencies = [
   "fastapi>=0.115.0",


### PR DESCRIPTION
## Summary

- Adds `LICENSE` file at repo root with standard MIT text, copyright `Copyright (c) 2026 lihor-hub`
- Updates `README.md` License section to link to `LICENSE` and state MIT
- Adds `license = "MIT"`, `license-files = ["LICENSE"]`, and `authors` to `pyproject.toml` (PEP 639)

Closes #606

## Test plan

- [x] `python3 -c "import tomllib,pathlib; tomllib.loads(pathlib.Path('pyproject.toml').read_text())"` parses without error
- [x] All pre-commit hooks pass
- [ ] GitHub should auto-detect MIT license once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)