### PR TITLE
ci: add lcov reporter to vitest coverage and ignore coverage dir

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ package-lock.json
 helm/news-dashboard/templates
 design/
 frontend/src/components/ui/
+coverage

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -66,3 +66,12 @@ def test_test_jobs_run_on_merge_group() -> None:
             f"(its `if:` is {condition!r}); the merge queue would report a "
             "hollow green for `Test & build`."
         )
+
+
+def test_vite_config_coverage_reporter() -> None:
+    """vite.config.ts must output lcov format for the CI artifact download to succeed."""
+    config_path = REPO_ROOT / "vite.config.ts"
+    assert config_path.exists(), f"vite.config.ts not found at {config_path}"
+    content = config_path.read_text()
+    assert "reporter:" in content, "reporter not found in vite.config.ts"
+    assert "lcov" in content, "lcov reporter is missing from vite.config.ts coverage settings"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default tseslint.config(
       'frontend/dist',
       'node_modules',
       'design/',
+      'coverage',
       'frontend/src/components/ui/**',
       // Stale git worktrees — lint runs on the whole tree so exclude them explicitly
       '.claude/worktrees/**',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
     include: ['frontend/src/**/*.test.{ts,tsx}'],
     coverage: {
       provider: 'v8',
-      reporter: ['text'],
+      reporter: ['text', 'lcov'],
       include: ['frontend/src/**'],
       exclude: ['frontend/src/**/*.test.{ts,tsx}', 'frontend/src/test-setup.ts'],
     },


### PR DESCRIPTION
Closes #671

Adds the lcov reporter to vitest coverage in vite.config.ts to produce the expected coverage/lcov.info artifact, and ignores the coverage directory in eslint and prettier to pass local pre-commit gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)