### PR TITLE
feat: add share-scoped article reader (#550)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -888,6 +888,32 @@ def get_share_endpoint(
     return share
 
 
+@api.get("/api/shares/{share_id}/article")
+def get_shared_article_endpoint(
+    share_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import get_shared_article
+
+    article = get_shared_article(share_id, current_user["id"])
+    if article is None:
+        raise HTTPException(status_code=404, detail="article not found")
+    return article
+
+
+@api.post("/api/shares/{share_id}/article/body")
+def fetch_shared_article_body_endpoint(
+    share_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import fetch_shared_article_body
+
+    article = fetch_shared_article_body(share_id, current_user["id"])
+    if article is None:
+        raise HTTPException(status_code=404, detail="article not found")
+    return article
+
+
 @api.get("/api/shares/{share_id}/annotations")
 def list_share_annotations(
     share_id: int,

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -14,6 +14,7 @@ import os
 from typing import Any
 
 from news_dashboard.article_visibility import get_visible_article_row
+from news_dashboard.body_fetch import fetch_and_cache_body
 from news_dashboard.db import connect, row_to_dict
 
 logger = logging.getLogger(__name__)
@@ -120,6 +121,34 @@ def get_share(share_id: int, user_id: int) -> dict[str, Any] | None:
     share["annotations"] = list_annotations(share_id)
     share["messages"] = list_messages(share_id)
     return share
+
+
+def get_shared_article(share_id: int, user_id: int) -> dict[str, Any] | None:
+    """Return a share's article when user_id is the sender or recipient."""
+    with connect() as conn:
+        row = conn.execute(
+            """
+            SELECT a.*
+            FROM article_shares s
+            JOIN articles a ON a.id = s.article_id
+            WHERE s.id = %s AND (s.to_user_id = %s OR s.from_user_id = %s)
+            """,
+            (share_id, user_id, user_id),
+        ).fetchone()
+    if row is None:
+        return None
+    article = row_to_dict(row)
+    article.pop("embedding", None)
+    article.pop("fts_vector", None)
+    return article
+
+
+def fetch_shared_article_body(share_id: int, user_id: int) -> dict[str, Any] | None:
+    """Fetch/cache article body through a visible share, not corpus visibility."""
+    share = get_share(share_id, user_id)
+    if share is None:
+        return None
+    return fetch_and_cache_body(int(share["article_id"]), user_id=None)
 
 
 def mark_share_read(share_id: int, user_id: int) -> bool:

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -7,14 +7,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from news_dashboard.auth import create_user
+from news_dashboard.body_fetch import get_article
 from news_dashboard.db import connect
 from news_dashboard.ingest import sync_sources
 from news_dashboard.shares import (
     ShareError,
     add_annotation,
     add_message,
+    fetch_shared_article_body,
     generate_share_context,
     get_share,
+    get_shared_article,
     list_annotations,
     list_messages,
     list_received_shares,
@@ -151,6 +154,54 @@ def test_cannot_share_other_users_private_source_article(db: str) -> None:
     assert row["count"] == 0
     share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
     assert share["article_id"] == article_id
+
+
+def test_shared_article_grants_share_scoped_private_source_access(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    charlie = _make_user(db, "charlie")
+    article_id = _insert_private_article(db, owner_user_id=alice)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    assert get_article(article_id, user_id=bob) is None
+
+    recipient_article = get_shared_article(share_id, bob)
+    assert recipient_article is not None
+    assert recipient_article["id"] == article_id
+    assert recipient_article["title"] == "Private Share Article"
+
+    sender_article = get_shared_article(share_id, alice)
+    assert sender_article is not None
+    assert sender_article["id"] == article_id
+
+    assert get_shared_article(share_id, charlie) is None
+
+
+def test_shared_article_body_fetch_is_anchored_to_visible_share(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    charlie = _make_user(db, "charlie")
+    article_id = _insert_private_article(db, owner_user_id=alice)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    with connect(db) as conn:
+        conn.execute(
+            """
+            UPDATE articles
+            SET body = 'Cached private body', body_status = 'ok'
+            WHERE id = %s
+            """,
+            (article_id,),
+        )
+
+    article = fetch_shared_article_body(share_id, bob)
+    assert article is not None
+    assert article["id"] == article_id
+    assert article["body"] == "Cached private body"
+
+    assert fetch_shared_article_body(share_id, charlie) is None
 
 
 # ── Annotation tests ──────────────────────────────────────────────────────────

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -120,6 +120,10 @@ export const routes: RouteObject[] = [
     element: <RequireAuth>{withSuspense(ArticlePage)}</RequireAuth>,
   },
   {
+    path: '/shared/:shareId/article',
+    element: <RequireAuth>{withSuspense(ArticlePage)}</RequireAuth>,
+  },
+  {
     path: '/',
     element: (
       <RequireAuth>

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -150,6 +150,20 @@ describe('article list endpoints', () => {
     expect(calls[0].url).toBe('/api/articles/7/body');
   });
 
+  it('fetchSharedArticle hits the share-scoped article path', async () => {
+    const { calls } = stubFetch(() => jsonOk({ id: 7 }));
+    const a = await api.fetchSharedArticle(42);
+    expect(a).toEqual({ id: 7 });
+    expect(calls[0].url).toBe('/api/shares/42/article');
+  });
+
+  it('fetchSharedArticleBody POSTs to the share-scoped body path', async () => {
+    const { calls } = stubFetch(() => jsonOk({ id: 7 }));
+    await api.fetchSharedArticleBody(42);
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].url).toBe('/api/shares/42/article/body');
+  });
+
   it('fetchArticleInsights unwraps bullets', async () => {
     stubFetch(() => jsonOk({ bullets: ['a', 'b'] }));
     expect(await api.fetchArticleInsights(1)).toEqual(['a', 'b']);

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -68,6 +68,22 @@ function renderReader(id = '42', cachedArticle?: Article) {
   );
 }
 
+function renderSharedReader(shareId = '42') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/shared/${shareId}/article`]}>
+        <Routes>
+          <Route path="/shared/:shareId/article" element={<ArticlePage />} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
 // ─── Rendering ────────────────────────────────────────────────────────────────
 
 describe('ArticlePage — rendering', () => {
@@ -81,6 +97,30 @@ describe('ArticlePage — rendering', () => {
   it('shows article title after load', async () => {
     renderReader();
     await waitFor(() => expect(screen.getByText('Test Article Title')).toBeTruthy());
+  });
+
+  it('uses share-scoped article endpoints for shared reader routes', async () => {
+    const fetchArticleSpy = vi.spyOn(api, 'fetchArticle');
+    const fetchArticleBodySpy = vi.spyOn(api, 'fetchArticleBody');
+    const fetchSharedArticleSpy = vi
+      .spyOn(api, 'fetchSharedArticle')
+      .mockResolvedValue(makeArticle({ id: 99, title: 'Shared private article' }));
+    const fetchSharedArticleBodySpy = vi.spyOn(api, 'fetchSharedArticleBody').mockResolvedValue(
+      makeArticle({
+        id: 99,
+        title: 'Shared private article',
+        body_status: 'ok',
+        body: 'Shared body',
+      })
+    );
+
+    renderSharedReader('123');
+
+    await waitFor(() => expect(screen.getByText('Shared private article')).toBeTruthy());
+    expect(fetchSharedArticleSpy).toHaveBeenCalledWith('123');
+    expect(fetchSharedArticleBodySpy).toHaveBeenCalledWith('123');
+    expect(fetchArticleSpy).not.toHaveBeenCalled();
+    expect(fetchArticleBodySpy).not.toHaveBeenCalled();
   });
 
   it('shows source and reason', async () => {

--- a/frontend/src/__tests__/shared.test.tsx
+++ b/frontend/src/__tests__/shared.test.tsx
@@ -117,7 +117,7 @@ describe('SharedDetailPage', () => {
     expect(screen.getByText('This matters because TypeScript ships faster now.')).toBeTruthy();
 
     const readLink = screen.getByRole('link', { name: 'Read article' });
-    expect(readLink.getAttribute('href')).toBe('/a/99');
+    expect(readLink.getAttribute('href')).toBe('/shared/42/article');
 
     const origLink = screen.getByRole('link', { name: /Original/ });
     expect(origLink.getAttribute('href')).toBe('https://example.com/ts');

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -115,6 +115,14 @@ export async function fetchArticleBody(id: number | string): Promise<Article> {
   return requestJson<Article>(`/api/articles/${id}/body`, { method: 'POST' });
 }
 
+export async function fetchSharedArticle(shareId: number | string): Promise<Article> {
+  return requestJson<Article>(`/api/shares/${shareId}/article`);
+}
+
+export async function fetchSharedArticleBody(shareId: number | string): Promise<Article> {
+  return requestJson<Article>(`/api/shares/${shareId}/article/body`, { method: 'POST' });
+}
+
 export async function fetchArticleAudioUrl(id: number | string): Promise<string> {
   const response = await fetch(`/api/articles/${id}/audio`, {
     method: 'POST',

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -28,6 +28,8 @@ import {
   fetchArticleAudioUrl,
   fetchArticleInsights,
   fetchArticlePerspectives,
+  fetchSharedArticle,
+  fetchSharedArticleBody,
 } from '@/api';
 import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflowApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
@@ -178,14 +180,19 @@ function ActionBtn({
 }
 
 export function ArticlePage() {
-  const { id } = useParams<{ id: string }>();
+  const { id, shareId } = useParams<{ id?: string; shareId?: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const articleKey = shareId ? `share:${shareId}` : id;
+  const articleQueryKey = useMemo(
+    () => (shareId ? ['sharedArticle', shareId] : ['article', id]),
+    [id, shareId]
+  );
 
   const { data: rawArticle, isLoading } = useQuery({
-    queryKey: ['article', id],
-    queryFn: () => fetchArticle(id!),
-    enabled: !!id,
+    queryKey: articleQueryKey,
+    queryFn: () => (shareId ? fetchSharedArticle(shareId) : fetchArticle(id!)),
+    enabled: !!articleKey,
     staleTime: 30_000,
   });
 
@@ -194,26 +201,26 @@ export function ArticlePage() {
 
   useEffect(() => {
     setShowOriginal(false);
-  }, [id]);
+  }, [articleKey]);
 
   // Trigger body fetch in parallel with metadata — fire at mount so we don't
   // wait for the GET /api/articles/:id round-trip before starting the slow scrape.
   const bodyMutation = useMutation({
-    mutationFn: () => fetchArticleBody(id!),
+    mutationFn: () => (shareId ? fetchSharedArticleBody(shareId) : fetchArticleBody(id!)),
     onSuccess: (updated) => {
-      queryClient.setQueryData(['article', id], updated);
+      queryClient.setQueryData(articleQueryKey, updated);
     },
   });
 
   useEffect(() => {
-    if (!id) return;
+    if (!articleKey) return;
     // Skip if the React Query cache already has a fully-fetched body for this article.
-    const cached = queryClient.getQueryData<{ body_status?: string }>(['article', id]);
+    const cached = queryClient.getQueryData<{ body_status?: string }>(articleQueryKey);
     if (cached?.body_status === 'ok') return;
     bodyMutation.mutate();
-    // Run once per article id; bodyMutation is intentionally omitted from deps.
+    // Run once per article id/share id; bodyMutation is intentionally omitted from deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [articleKey]);
 
   // Per-article dwell telemetry: record an open when the reader mounts (or the
   // user pages to a different article via prev/next, which swaps the id in
@@ -221,24 +228,24 @@ export function ArticlePage() {
   // This feeds the "Most-read articles" analytics panel via article_close
   // events; without it that panel stays empty.
   useEffect(() => {
-    if (!id) return;
-    const articleId = Number(id);
+    if (!rawArticle) return;
+    const articleId = Number(rawArticle.id);
     if (!Number.isFinite(articleId)) return;
     trackArticleOpen(articleId);
     return () => trackArticleClose(articleId);
-  }, [id]);
+  }, [rawArticle]);
 
   const insightsMutation = useMutation({
-    mutationFn: () => fetchArticleInsights(id!),
+    mutationFn: () => fetchArticleInsights(String(article!.id)),
   });
 
   const perspectivesMutation = useMutation({
-    mutationFn: () => fetchArticlePerspectives(id!),
+    mutationFn: () => fetchArticlePerspectives(String(article!.id)),
   });
 
   // Prev/next navigation from sessionStorage list
   const readerList = getReaderList();
-  const idx = readerList ? readerList.ids.indexOf(String(id)) : -1;
+  const idx = readerList && id ? readerList.ids.indexOf(String(id)) : -1;
   const prevId = idx > 0 ? readerList!.ids[idx - 1] : null;
   const nextId =
     idx >= 0 && idx < (readerList?.ids.length ?? 0) - 1 ? readerList!.ids[idx + 1] : null;

--- a/frontend/src/pages/SharedDetailPage.tsx
+++ b/frontend/src/pages/SharedDetailPage.tsx
@@ -105,7 +105,10 @@ export function SharedDetailPage() {
         <p className="mt-0.5 text-xs text-muted-foreground">{share.article_source_name}</p>
 
         <div className="mt-3 flex items-center gap-4 text-xs">
-          <Link to={`/a/${share.article_id}`} className="text-accent-foreground hover:underline">
+          <Link
+            to={`/shared/${share.id}/article`}
+            className="text-accent-foreground hover:underline"
+          >
             Read article
           </Link>
           <a


### PR DESCRIPTION
Closes #550

## Summary
- Add share-scoped backend article and body endpoints guarded by sender/recipient share visibility.
- Route the shared workspace `Read article` link to `/shared/:shareId/article`.
- Teach the article reader to use share-scoped fetch/body APIs on shared reader routes while preserving normal `/api/articles/{id}` visibility rules.

## Tests
- `python -m pytest backend/tests/test_article_shares.py -q`
- `npm run test:frontend -- --run frontend/src/__tests__/shared.test.tsx frontend/src/__tests__/articleReader.test.tsx frontend/src/__tests__/api.test.ts` (passes; suite prints existing localhost:3000 ECONNREFUSED noise)
- `make lint`
- `make typecheck`
- `make test` (passes; frontend suite prints existing localhost:3000 ECONNREFUSED noise)
- `npm run build`
