### PR TITLE
fix: make a11y smoke audit real reader (#569)

### DIFF
--- a/e2e/a11y-helper.ts
+++ b/e2e/a11y-helper.ts
@@ -1,14 +1,12 @@
 /**
  * Accessibility smoke-test helper.
  *
- * Injects axe-core via CDN (tests mock only /api/** routes so the CDN
- * request passes through) and runs an audit limited to serious/critical
- * violations so tests stay focused on high-signal issues.
+ * Injects the repo-pinned axe-core package and runs an audit limited to
+ * serious/critical violations so tests stay focused on high-signal issues.
  */
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
-
-const AXE_CDN = 'https://cdn.jsdelivr.net/npm/axe-core@4.10.3/axe.min.js';
+import { source as axeSource } from 'axe-core';
 
 export interface A11yCheckOptions {
   /**
@@ -23,7 +21,7 @@ export interface A11yCheckOptions {
  * page. Throws an Playwright assertion error listing every violation found.
  */
 export async function checkA11y(page: Page, options: A11yCheckOptions = {}): Promise<void> {
-  await page.addScriptTag({ url: AXE_CDN });
+  await page.addScriptTag({ content: axeSource });
 
   const violations = await page.evaluate(
     async ({ excludeRules }: { excludeRules: string[] }) => {

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -8,8 +8,8 @@
  * CI: wired as a required gate in ci.yml (test-a11y job). Runs on every PR
  * and push; failures block merging.
  */
-import { test } from '@playwright/test';
-import { mockApi } from './fixtures';
+import { expect, test } from '@playwright/test';
+import { mockApi, SAMPLE_ARTICLE } from './fixtures';
 import { checkA11y } from './a11y-helper';
 
 test.beforeEach(async ({ page }) => {
@@ -57,9 +57,10 @@ test.describe('a11y — desktop routes', () => {
     await checkA11y(page);
   });
 
-  test('Article reader /articles/1 — no serious/critical violations', async ({ page }) => {
-    await page.goto('/articles/1');
+  test('Article reader /a/1 — no serious/critical violations', async ({ page }) => {
+    await page.goto('/a/1');
     await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { name: SAMPLE_ARTICLE.title })).toBeVisible();
     await checkA11y(page);
   });
 });

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const GROUP_CLS =
-  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-subtle';
+  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-foreground';
 
 const ITEM_CLS =
   'flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer data-[selected=true]:bg-surface-2';

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
         "@vitest/coverage-v8": "^4.1.8",
+        "axe-core": "4.10.3",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -6535,6 +6536,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.8",
+    "axe-core": "4.10.3",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",


### PR DESCRIPTION
Closes #569

## Summary
- Change the article-reader a11y smoke test to visit `/a/1` and assert the mocked article heading before running axe.
- Load axe from the repo-pinned `axe-core@4.10.3` dev dependency instead of jsDelivr.
- Raise command palette group heading contrast so the now-reliable a11y scan passes on desktop and mobile.

## Tests
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm run format:check --silent`
- `npm run test:frontend --silent`
- `npm run build --silent`
- `npm run test:a11y --silent`
- `npm run test:e2e --silent -- e2e/article-pages.spec.ts`
