### PR TITLE
feat: enhance Codecov integration with flags and codecov.yml (#682)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,12 +316,23 @@ jobs:
           name: frontend-coverage
           path: ./coverage-frontend
 
-      - name: Upload to Codecov
+      - name: Upload Backend to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage-backend/*.xml,./coverage-frontend/lcov.info
-          name: codecov-umbrella
+          files: ./coverage-backend/*.xml
+          flags: backend
+          name: codecov-backend
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: Upload Frontend to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-frontend/lcov.info
+          flags: frontend
+          name: codecov-frontend
           fail_ci_if_error: false
           verbose: true
 

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -77,8 +77,8 @@ def test_vite_config_coverage_reporter() -> None:
     assert "lcov" in content, "lcov reporter is missing from vite.config.ts coverage settings"
 
 
-def test_codecov_upload_specifies_token() -> None:
-    """All codecov-action steps in ci.yml must specify a token."""
+def test_codecov_upload_specifies_token_and_flags() -> None:
+    """All codecov-action steps in ci.yml must specify a token and flags."""
     ci = _load_ci()
     jobs = ci.get("jobs", {})
     found_codecov = False
@@ -92,5 +92,9 @@ def test_codecov_upload_specifies_token() -> None:
                 assert "token" in with_data, (
                     f"Job `{job_name}` has step `{step.get('name')}` using "
                     f"codecov-action but missing a token"
+                )
+                assert "flags" in with_data, (
+                    f"Job `{job_name}` has step `{step.get('name')}` using "
+                    f"codecov-action but missing the flags parameter"
                 )
     assert found_codecov, "No codecov/codecov-action steps found in ci.yml"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,36 @@
+# Codecov configuration
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+flag_management:
+  individual_flags:
+    - name: backend
+      paths:
+        - backend/
+      carryforward: true
+      statuses:
+        - type: project
+          target: auto
+          threshold: 1%
+    - name: frontend
+      paths:
+        - frontend/
+      carryforward: true
+      statuses:
+        - type: project
+          target: auto
+          threshold: 1%


### PR DESCRIPTION
Closes #682

Enhance Codecov integration:
- Create `codecov.yml` defining individual flags for `backend` and `frontend` and custom PR comments
- Split Codecov upload steps in CI to upload backend/frontend coverage separately using flags
- Update tests to verify that codecov-action steps specify both a token and the flags parameter.