### PR TITLE
Implement issue #627 - ci: scan the container image with Trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,7 +538,7 @@ jobs:
   # └──────────────────────────────────────────────────────────────────────┘
   deploy:
     name: Deploy to mini PC
-    needs: publish
+    needs: [publish, trivy]
     runs-on: [self-hosted]
     environment: production
     concurrency:
@@ -678,3 +678,44 @@ jobs:
         run: |
           curl -sf --max-time 10 --retry 6 --retry-delay 5 \
             http://localhost:30088/api/health | grep '"status":"ok"'
+
+  # ── 11. TRIVY SCAN ─────────────────────────────────────────────────────────
+  # Scans the container image for vulnerabilities using Trivy and uploads
+  # results to GitHub Security tab as SARIF.
+  trivy:
+    name: Trivy vulnerability scan
+    needs: publish
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '1'  # Fail on any vulnerabilities
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,51 @@
+name: Weekly Trivy vulnerability scan
+
+# Weekly scheduled scan of the latest container image to catch newly disclosed CVEs.
+# Runs every Sunday at 02:00 UTC.
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'  # Every Sunday at 02:00 UTC
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  trivy-scan:
+    name: Weekly Trivy vulnerability scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner on latest image
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: ${{ github.repository }}:latest
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '1'  # Fail on any vulnerabilities
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-weekly


### PR DESCRIPTION
This PR implements issue #627 via the PI agent.

Closes #627

## Summary
- **Issue**: ci: scan the container image with Trivy
- **Lock**: agent-lock/issue-627

## Test Results
```
{"name": "bash", "parameters": {"command": "sed -i '685,720s/&& github.ref == 'refs\\/heads\\/main'//g' .github/workflows/ci.yml"}}

{"type": "text", "text": "(no output)"assistant

{"name": "bash", "parameters": {"command": "sed -i 's/Log in to GHCR/Log in to GHCR (for push events)/g' .github/workflows/ci.yml"}}

{"type": "text", "text": "(no output)"assistant

{"name": "bash", "parameters": {"command": "sed -i '/Log in to GHCR (for push events)/i \\      if: github.event_name == \\'push\\'' .github/workflows/ci.yml"}}

{"type": "text", "text": "(no output)"
```