### PR TITLE
ci: add Dependency Review on pull requests

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          # Explicitly left permissive for licenses to allow any open-source license compatible with MIT.
+          # If we want to prevent GPL/copyleft code being introduced in the future, we could configure deny-licenses here.


### PR DESCRIPTION
Closes #626

Adds Dependency Review to flag vulnerable dependencies on PRs. GitHub Dependency Graph is enabled as a repository setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)