### PR TITLE
Implement issue #623 - docs: write the User Guide for core features

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,23 @@ Run a specific lane with `pytest -m smoke`, `pytest -m "not db"`, or `pytest -m 
 ```text
 backend/news_dashboard/   FastAPI app, ingest, auth, scheduler, CLI, database layer
 frontend/src/             React app
-docs/                     Architecture, product, deployment, and auth notes
+docs/                     Architecture, product, deployment, auth, and user guides
 helm/news-dashboard/      Kubernetes chart
 deploy/                   Deployment files
 scripts/                  Maintenance scripts
 ```
+
+## Documentation
+
+For end-user documentation, see the [User Guide](docs/user-guide/README.md) which covers:
+- Concepts and terminology
+- The Today Feed and triage workflow
+- Managing sources and subscriptions
+- Search, briefings, and recommendations
+- Saved and read history
+- Sharing articles with other users
+
+For technical documentation (architecture, deployment, authentication), see the files in the `docs/` directory.
 
 ## Deployment
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,24 @@
+# User Guide
+
+Welcome to **News Dashboard** — your private news platform. This guide explains the
+core concepts and features so you can get the most out of your reading workflow.
+
+## What you'll find here
+
+| Page                                                              | What it covers                                                  |
+| ----------------------------------------------------------------- | --------------------------------------------------------------- |
+| [Concepts & terminology](concepts.md)                             | The language the app uses: Article, Workflow State, Today Feed, Current-Day Report, Source Subscription |
+| [The Today Feed & triage states](today-feed-triage.md)            | How to process your daily queue and what each state means       |
+| [Sources & subscriptions](sources.md)                             | Where your news comes from and how to manage subscriptions      |
+| [Search](search.md)                                               | Finding articles across your history                            |
+| [Briefings](briefings.md)                                         | The Current-Day Report, scheduled delivery, and podcast audio   |
+| [Recommendations](recommendations.md)                             | How the app learns what matters to you                          |
+| [Saved & read history](saved-history.md)                          | Your personal reading archive and Reading DNA                   |
+| [Sharing articles](sharing.md)                                    | Sending articles to other users on the same instance            |
+
+## Before you start
+
+If you haven't set up News Dashboard yet, follow the instructions in the
+[Quick Start](../../README.md#quick-start) section of the README. For
+self-hosted production deployments, see the
+[Self-Hosting guide](../SELF_HOSTING.md).

--- a/docs/user-guide/briefings.md
+++ b/docs/user-guide/briefings.md
@@ -1,0 +1,188 @@
+# Briefings
+
+Stay informed with **Briefings** — AI-generated audio and text summaries of
+your news corpus. News Dashboard offers two main briefing features:
+
+1. **Current-Day Report** — a text summary of today's news (read in-app)
+2. **Scheduled delivery** — automatic delivery of the briefing at a time you
+   choose (in-app notification, optional email, and podcast audio)
+
+## The Current-Day Report
+
+The **Current-Day Report** is a textual summary that answers: *"What
+happened today in my subscribed sources?"* It appears at the top of your app
+and can be played as audio.
+
+### What it includes
+
+The report summarizes **all articles discovered today**, regardless of your
+Workflow State. It pulls from:
+
+- Articles ingested today (midnight to midnight in your server's timezone)
+- All sources you have enabled
+- All article kinds (RSS, GitHub releases, trending, scraped)
+
+For each article, the report includes:
+- A one-sentence **reason** (why this article surfaced)
+- The article title
+- The source name
+- Optional: a relevance score if personalized recommendations are active
+
+### How it's generated
+
+Each day, after the overnight ingestion run:
+1. The app collects all articles with a `discovered_at` timestamp today
+2. For each article, it runs `make_reason()` to generate a contextual blurb:
+   - Release feeds → "New release vX.Y.Z from source."
+   - Security content → "Security update from source — review recommended."
+   - Tutorial/how-to → "How-to or deep-dive on category from source."
+   - Trending (HN) → "Trending on Hacker News."
+   - Trending (GitHub) → "Trending {Language} repository on GitHub today."
+   - AI/agent content → "AI/agent development news from source."
+   - Python content → "Python ecosystem update from source."
+   - Fallback → "{Category} — {Source}."
+3. These reason lines are combined into a readable paragraph, ordered by
+   importance score (combination of source priority, recency, and kind)
+4. The result is stored as today's briefing and served at `/api/briefings/today`
+
+You can view the Current-Day Report:
+- At the top of the app homepage
+- Via the "Briefings" tab in the navigation
+- By clicking the speaker icon to hear it read aloud (uses your browser's
+  built-in TTS or optional external TTS if configured)
+
+### Audio playback
+
+Tap the **Play** button next to the Current-Day Report to hear it read
+aloud. This uses:
+- Your browser's built-in SpeechSynthesis API (no extra setup)
+- Optional: if you've configured `OPENAI_API_KEY` for TTS, it uses
+  OpenAI's audio generation for higher-quality narration
+- Controls: play/pause, skip forward/back 10 seconds, speed adjustment
+
+## Scheduled delivery
+
+Want the briefing delivered to you automatically? Set up **scheduled
+delivery** to get a notification (and optionally email) when today's briefing
+is ready.
+
+### How to enable
+
+1. Go to Settings → Notifications
+2. Toggle **"Enable daily briefing notification"**
+3. Choose your preferred delivery time (in your local timezone)
+4. Optionally enable:
+   - **Email delivery** — receive the briefing text via email
+   - **Push notifications** — get a banner/alert on your device
+5. Save your preferences
+
+### What you get
+
+At your chosen time each day:
+- An **in-app notification** appears (tap to open the briefing)
+- If email is enabled — you receive an email with:
+  - The full Current-Day Report text
+  - Links to open the article list for today
+  - A "Mark all as read" button (optional)
+- If push notifications are enabled — you get a system-level alert
+- The briefing is marked as "delivered" in your history
+
+### How it works behind the scenes
+
+The scheduler runs a lightweight job at your specified time:
+1. Checks if today's briefing has been generated (triggers generation if not)
+2. Sends a push notification via your device's service worker (if subscribed)
+3. Sends an email via SMTP (if `SMTP_*` settings are configured)
+4. Records the delivery in your briefings history
+
+## Podcast audio (optional)
+
+Want to listen to your briefing in a podcast app? Enable **podcast audio**
+to generate an MP3 file each day that you can subscribe to in any podcast
+player.
+
+### How to enable
+
+1. Go to Settings → Advanced
+2. Toggle **"Enable briefing podcast"**
+3. Save — the system will generate an MP3 after each successful briefing
+   generation
+4. Copy your personal podcast feed URL from Settings → Podcast
+5. Add that URL to your favorite podcast app (Overcast, Pocket Casts,
+   Apple Podcasts, etc.)
+
+### What you get
+
+Each day, after the briefing is generated:
+- An MP3 file is created using your configured TTS engine:
+  - Browser TTS → not applicable (podcast requires server-side)
+  - OpenAI TTS → high-quality narration (requires `OPENAI_API_KEY`)
+  - gTTS / eSpeak → free robotic voice (no API key needed)
+- The MP3 is stored locally and served at:
+  `/api/briefings/podcast.rss` (a personalized, token-secured RSS feed)
+- Your feed URL includes a revocable token for security:
+  `https://your.instance/api/briefings/podcast.rss?token=abc123`
+
+### Privacy
+
+- The podcast feed is **private and unguessable** — contains a unique token
+- Only you (or anyone you share the URL with) can access it
+- No audio leaves your server unless you explicitly enable the feature
+- Tokens can be regenerated or revoked from Settings → Podcast
+
+## Managing your briefing history
+
+View past briefings in the **Briefings** tab:
+- Lists all generated briefings (today, yesterday, last week, etc.)
+- Shows generation time and duration
+- Lets you re-read or re-listen to any past briefing
+- Includes a "Regenerate audio" button if you change TTS settings
+- Shows delivery status (whether notification/email/podcast was sent)
+
+## Customizing the briefing
+
+While the core algorithm is fixed, you can influence what appears:
+
+### Via source management
+- Disable noisy sources to reduce clutter
+- Prioritize high-signal sources in Sources → Edit → Priority
+- Remove sources you don't care about entirely
+
+### Via noise filtering (built-in)
+The app automatically caps noisy feeds:
+- Broad feeds (HN, GitHub trending): 15–20 items per run
+- Newsletter feeds (Import AI, Latent Space): 5 per run
+- Curated blog feeds: 50 per run
+
+### Via TTS engine
+Choose your text-to-speech engine in Settings → Advanced:
+- **Browser** — free, uses your device's voice (for in-app playback only)
+- **OpenAI** — highest quality, requires API key
+- **gTTS** — free, Google-backed, requires internet
+- **eSpeak** — free, fully offline, robotic voice
+- **None** — disables audio generation
+
+## Troubleshooting
+
+### No briefing showing?
+- Check that ingestion has run recently (Sources → Last checked)
+- Verify today's date matches the server's timezone
+- Look in the Briefings tab — if today's is missing, try "Generate now"
+
+### Audio not playing?
+- For in-app: ensure browser allows audio (check site permissions)
+- For podcast: verify your podcast app can fetch the URL (test in browser)
+- For OpenAI TTS: confirm `OPENAI_API_KEY` is set and has credit
+
+### Not getting notifications?
+- Check Settings → Notifications
+- Ensure browser notification permission is granted
+- For email: verify SMTP settings and that `DAILY_BRIEFING_EMAIL=true`
+
+## Privacy
+
+Briefings are private to your account:
+- Generated only from your source subscriptions
+- Stored only in your database
+- Never shared unless you explicitly export or share the audio file
+- The podcast feed uses a secret token — treat it like a password

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -1,0 +1,69 @@
+# Concepts & Terminology
+
+News Dashboard uses a small set of precise terms to describe the reading
+workflow. Using these terms consistently makes the product predictable and
+avoids confusion between "read" as a state and "read" as an action.
+
+## Article
+
+A **news item** discovered from a subscribed source. An Article has a title,
+URL, summary, and metadata (category, tags, source, publication date). All
+features — triage, search, briefings, sharing — operate on articles.
+
+*Don't call it*: Feed item, story, post, entry.
+
+## Workflow State
+
+The user's **triage position** for an article. Workflow State tells you where
+an article sits in your reading process. It does **not** decide whether the
+article belongs to the day's news corpus (the [Current-Day Report][1] covers
+all articles discovered today regardless of state).
+
+The states are:
+
+| State      | Meaning                                                          |
+| ---------- | ---------------------------------------------------------------- |
+| **Today**  | In your active triage queue, waiting to be reviewed              |
+| **Later**  | Interesting but not right now — come back to it                  |
+| **Done**   | Reviewed and finished                                            |
+| **Skipped**| Not relevant; dismissed without reading                          |
+| **Starred**| Saved as a permanent reference                                   |
+| **Snoozed**| Hidden until a later time                                        |
+| **Archived** | Tucked out of view; can be restored to Done                  |
+
+*Don't call it*: Read status, started status, view state.
+
+[1]: briefings.md
+
+## Today Feed
+
+Your **active triage queue** — the list of articles currently meant to be
+reviewed. Processing your Today Feed is the primary workflow. Articles arrive
+here from new ingestions and recommendations; you move them to Done, Later,
+Skipped, or other states as you work through them.
+
+*Don't call it*: Current-day news, all news, inbox, unread feed.
+
+## Current-Day Report
+
+A **generated briefing** that summarizes all news discovered in the
+current-day window from your available sources — regardless of each article's
+Workflow State. This is the daily brief the app generates for you.
+
+*Don't call it*: Since-last-briefing report, Today-only briefing, inbox-only
+briefing.
+
+## Source Subscription
+
+The **set of news sources** available to your account. A source is a feed
+(RSS, GitHub releases, trending, scraped page, etc.) from which the app
+discovers articles. You manage sources from the Sources page: add, remove,
+enable, or disable them.
+
+*Don't call it*: Feed filter, source state, channel.
+
+## Where these terms come from
+
+This terminology is defined in [`CONTEXT.md`](../../CONTEXT.md) and is the
+canonical language for the project. All documentation, UI labels, and
+changelog entries use these terms.

--- a/docs/user-guide/recommendations.md
+++ b/docs/user-guide/recommendations.md
@@ -1,0 +1,94 @@
+# Recommendations
+
+Discover articles you might have missed with **Recommendations** — personalized
+suggestions that learn from your triage behavior to surface relevant, older, or
+related content in your Today Feed.
+
+## How recommendations work
+
+News Dashboard watches how you triage articles (Done, Skip, Star, etc.) and
+uses those signals to score unseen articles in your database. Articles with
+high scores appear in your Today Feed with a **"Why recommended"** explanation
+and a relevance indicator.
+
+The recommender does **not** look at article content or use external services.
+It operates purely on:
+- Your past actions (which articles you did/didn't engage with)
+- Article metadata (source, category, tags, discovery time)
+- Simple collaborative filtering (users with similar behavior patterns)
+
+No machine learning models, no external APIs, no data leaves your instance.
+
+## Where you see recommendations
+
+Recommendations appear mixed into your **Today Feed** alongside new
+ingestions. Recommended articles are marked with:
+
+1. **A relevance badge** — a colored dot indicating how strongly the article
+   matches your interests (calculated from your history)
+2. **A "Why recommended" button** — tap to see a short explanation like:
+   - "You often star articles from this source"
+   - "You read similar articles about this topic"
+   - "This matches your saved article patterns"
+   - "You skipped fewer articles from this category recently"
+
+## Training the recommender
+
+The system learns implicitly from your normal usage — no explicit training
+required. Signals that strengthen recommendations:
+
+- **Starring** an article → strong positive signal
+- **Marking Done** → positive signal (you found it worth reading)
+- **Skipping** an article → negative signal (less relevant to you)
+- **Saving to Later** → mild positive signal (interested but not now)
+- **Time spent** (if available) — longer reads suggest higher interest
+
+The recommender adapts continuously. If you start skipping articles you used
+to star, the weights shift and those topics appear less frequently.
+
+## Recommendations in the Today Feed
+
+When recommendations are active:
+- Your Today Feed blends **new articles** (from the latest ingest) with
+  **recommended articles** (from your existing database)
+- The mix aims to balance freshness with relevance
+- You can tell an article is recommended by the presence of:
+  - The relevance indicator (dot or bar)
+  - The "Why recommended" button (tapping shows the explanation)
+- Recommended articles still follow normal triage — you can Done, Skip,
+  Star, etc. them just like new articles
+
+## Controlling recommendations
+
+You can adjust recommendation behavior in Settings → Recommendations:
+
+- **Mix ratio** — what percentage of your Today Feed should be recommendations
+  (default: 30%, range: 0%–100%)
+- **Minimum age** — how old an article must be to be considered for
+  recommendation (default: 2 days, prevents brand-new items from being
+  labeled as "recommended")
+- **Feature toggle** — turn recommendations off entirely to see only new
+  ingestions in your Today Feed
+
+## Where recommendations pull from
+
+The recommender scans your entire article database (excluding items you've
+already interacted with in the current session) to find:
+- Articles you haven't seen yet (status: `new`)
+- Articles you previously skipped but might now find relevant
+- Older saved/articles you haven't read
+- Items from sources/categories you engage with frequently
+
+It does **not** recommend:
+- Articles you've already triaged (Done/Skipped/Starred) in this session
+- Archived items (unless restored)
+- Items from disabled sources
+
+## Privacy
+
+Recommendations are 100% local and private:
+- No user behavior leaves your server
+- No external model calls or API keys needed
+- No collaborative filtering with other users (the "similar users" pattern
+  is computed entirely from your local data)
+- All scoring happens in-memory using your PostgreSQL data

--- a/docs/user-guide/saved-history.md
+++ b/docs/user-guide/saved-history.md
@@ -1,0 +1,114 @@
+# Saved & Read History
+
+Your personal article archive — the articles you've **Saved**, **Read**, or
+**Starred** — is searchable, browsable, and powers features like
+Recommendations and the Reading DNA.
+
+## What counts as "read" or "saved"?
+
+News Dashboard tracks user interaction with articles:
+
+- **Read** — you've opened and viewed the article (marked Done)
+- **Saved** — you've explicitly set aside for later (Saved state, not to be
+  confused with the verb "to save")
+- **Starred** — you've marked as a permanent reference (immune to archival)
+- **Snoozed** — temporarily hidden until a future time
+
+Each of these actions stores a timestamp (`read_at`, `saved_at`, `starred_at`,
+`snoozed_at`, `unsnoozed_at`) so you can see when you interacted with an
+article.
+
+## Where to find your history
+
+Navigate to these tabs to browse your personal archive:
+
+| Tab         | Contains                                                                  |
+| ----------- | ------------------------------------------------------------------------- |
+| **Read**    | Articles you've marked Done                                               |
+| **Saved**   | Articles you've set to Later (the "read-it-later" queue)                  |
+| **Starred** | Articles you've Starred (your permanent reference library)                |
+| **Archived**| Articles you've tucked away (can be restored to Read)                     |
+
+Each tab shows:
+- Article title, source, and discovery time
+- Your interaction timestamp (when you read/saved/etc.)
+- Tags (if you've applied any)
+- A shortcut to triage the article again (e.g., from Saved to Read)
+
+## Search within history
+
+You can search your Saved, Read, or Starred tabs just like the Today Feed:
+- Open the tab
+- Focus the search box (click the magnifying glass or press `/`)
+- Type your query — results are limited to articles in that tab
+
+This lets you quickly find, for example:
+- "all Saved articles about Kubernetes"
+- "Starred Python releases from June"
+- "Read articles where I skipped the AI summary"
+
+## The Reading DNA
+
+The **Reading DNA** is a personalized snapshot of your reading habits,
+accessible from your user menu. It shows:
+
+- **Articles read** — total count and trend over time
+- **Reading time saved** — estimated hours saved via summaries vs. full reads
+- **Top categories** — which source categories you engage with most
+- **Top sources** — individual feeds you read most frequently
+- **Top tags** — keywords you've applied to articles
+- **Streaks** — consecutive days with reading activity (if streaks feature is enabled)
+- **Recent activity** — your last few interactions (article + timestamp)
+
+The Reading DNA updates in real time as you triage and read articles. It's a
+private dashboard — only you can see your own DNA on a multi-user instance.
+
+## Tags and history
+
+If you use the **tags** feature (user-defined labels), your tags appear in:
+- Article cards across all tabs
+- The Reading DNA (top tags list)
+- Search results (you can search by tag)
+- The tag management view (where you can rename or delete tags)
+
+Tags are a powerful way to organize your Saved and Read history beyond
+categories and sources.
+
+## Exporting your data
+
+Want to back up or migrate your history? Use the built-in export:
+
+1. Go to Settings → Advanced
+2. Click "Download my data"
+3. Receive a JSON file containing:
+   - Your article interactions (read/saved/starred/etc. timestamps)
+   - Applied tags
+   - Source subscriptions and health
+   - Briefings history
+   - Personal settings (excluding secrets)
+
+The export excludes article bodies/text (to keep the file small and focused on
+your personal state). You can re-import this data on another instance using
+the import tool (see Settings → Advanced → Import).
+
+## Auto-cleanup
+
+To keep your database lean, News Dashboard automatically removes certain
+interactions after a period:
+
+- **Read/Done articles** — kept indefinitely (they form your reading history)
+- **Saved/Later articles** — kept until you change their state
+- **Starred articles** — kept indefinitely (permanent reference)
+- **Snoozed articles** — automatically unsnoozed when the timer expires
+- **Article views** — no separate view logs are stored (privacy by design)
+
+The `user_events` table (used for analytics and streaks) is pruned according
+to `ANALYTICS_RETENTION_DAYS` (default: 180 days) by a daily cleanup job.
+
+## Privacy
+
+Your Saved and Read history is:
+- 100% local — stored only in your PostgreSQL database
+- Never sent externally unless you explicitly export it
+- Not used for advertising or profiling
+- Accessible only to your user account (on multi-user instances)

--- a/docs/user-guide/search.md
+++ b/docs/user-guide/search.md
@@ -1,0 +1,96 @@
+# Search
+
+News Dashboard includes full-text search across your article corpus so you can
+find articles by keyword, topic, or phrase.
+
+## What you can search
+
+The search index includes:
+
+- **Title** — the article headline
+- **Summary** — the first 280 characters of the feed description (HTML stripped)
+- **Reason** — the contextual blurb (e.g., "New release vX.Y.Z from source.")
+- **Tags** — any tags you've applied to articles
+- **Source name** — the human-readable name of the source (e.g., "Hugging Face Blog")
+- **Body** — the full article text (if the full-text extraction feature is enabled; see note below)
+
+By default, search operates on title, summary, reason, tags, and source name.
+If you have enabled full-text extraction (via the `FULL_TEXT_ENABLED` setting or
+equivalent), the article body is also indexed.
+
+## How search works
+
+Behind the scenes, News Dashboard uses PostgreSQL's built-in full-text search
+(`tsvector` column and `GIN` index). When you type a query:
+
+1. The app parses your input into search terms
+2. It constructs a `tsquery` using the `&` (AND) operator by default — meaning
+   all terms must appear in the document
+3. The database returns matching articles ranked by relevance (ts_rank)
+4. The UI displays results with the matching terms highlighted
+
+You can refine your search with:
+- **Exact phrases**: `"exact phrase"` (requires full-text to be enabled)
+- **Wildcards**: `prefix*` (matches any word starting with prefix)
+- **OR logic**: `term1 | term2` (matches articles with either term)
+
+## Where to search
+
+Click the search icon in the top navigation bar or press `/` anywhere in the
+app to focus the search box. As you type, results appear instantly below the
+input.
+
+Results show:
+- Article title
+- Summary snippet with matches highlighted
+- Source name and category
+- Article status (new/read/saved/skipped/archived)
+- Publication date
+
+Click any result to open the article in the main view.
+
+## Search scope
+
+Search looks across **all articles in your database**, regardless of:
+- Workflow state (new, read, saved, skipped, archived, starred, snoozed)
+- Category or source
+- Date (unless you include date-specific terms in your query)
+
+If you want to limit results to a specific state, use the filters in conjunction
+with search (e.g., open the Saved tab, then search within saved articles).
+
+## Keeping search relevant
+
+Because the search index is built from the article metadata you already have:
+
+- No extra ingestion steps are required — search works on existing articles
+- The index updates automatically when:
+  - New articles are ingested
+  - You add or remove tags
+  - An article's status changes
+- No external services are needed; everything runs inside your PostgreSQL
+  instance
+
+## Full-text extraction (optional)
+
+For deeper search, you can enable full-text extraction:
+
+1. Set `FULL_TEXT_ENABLED=true` in your environment
+2. The app will download and extract the full article body for saved/read
+   articles (using Trafilatura or goose3 under the hood)
+3. Extracted text is indexed alongside title/summary/reason/tags/source
+4. This enables searching within the article body — useful for finding
+   specific mentions inside long-form content
+
+> **Note**: Full-text extraction increases:
+> - Database storage (one extra `text` column per article)
+> - Ingestion time (HTTP fetch + parsing per article)
+> - Index size (larger `tsvector`)
+
+It is off by default to keep the app lightweight and privacy-respecting (no
+extra network calls during ingest unless enabled).
+
+## Privacy
+
+Search is 100% local — your query text and article contents never leave your
+instance. No telemetry is sent when you search.

--- a/docs/user-guide/sharing.md
+++ b/docs/user-guide/sharing.md
@@ -1,0 +1,112 @@
+# Sharing articles
+
+Share interesting articles with other users on your News Dashboard instance
+using the built-in **Sharing** feature. This lets you send a link to an
+article that, when opened by the recipient, shows the article in their own
+interface with their own triage state.
+
+## How sharing works
+
+When you share an article:
+1. The system generates a **single-use, time-limited token** for that article
+2. It creates a share record linking you (the sender), the recipient, and the
+   article
+3. You give the recipient a URL like: `https://your-instance.com/article/123?share=abc123`
+4. When the recipient opens that link:
+   - The app validates the token (ensures it's unused and not expired)
+   - The article loads in their interface
+   - They can read, triage, star, etc. — just like any other article
+   - Their actions are recorded under their own user account
+   - The share token is marked as used and cannot be reused
+
+Sharing is **not** forwarding the article text or URL — it's granting access
+to the article within the app, respecting permissions and personal state.
+
+## Sharing from the article view
+
+To share an article you're viewing:
+
+1. Open the article (tap/click on it in any feed)
+2. In the article header, tap the **Share** icon (usually three dots connected
+   by lines, or a paper airplane)
+3. In the share dialog:
+   - Enter the recipient's username (must exist on your instance)
+   - Optionally add a note explaining why you're sharing
+   - Tap "Send share"
+4. The recipient receives a notification (in-app bell, and optionally email
+   or push if configured) with your note and a link to accept the share
+
+## Sharing from feeds
+
+You can also share directly from any article list (Today Feed, Saved, etc.):
+
+1. Hover over or long-press an article card
+2. Look for the **Share** action in the article menu
+3. Follow the same steps as above
+
+## Receiving shares
+
+When someone shares an article with you:
+- You'll see a notification in the app (bell icon in the header)
+- Optionally, you may receive an email or push notification (if enabled)
+- The notification shows:
+  - Who shared it
+  - Their note (if any)
+  - The article title and source
+- Tap the notification to go straight to the article
+- Alternatively, visit the **Shares** tab (in your user menu) to see all
+  incoming and outgoing shares
+
+## What the recipient sees
+
+When the recipient opens the shared article:
+- The article loads normally (title, summary, body, metadata)
+- They see any tags you've applied (tags are visible to all users)
+- They do **not** see:
+  - Your personal triage state (your Done/Skip/Star/etc.)
+  - Your personal notes (if notes feature is enabled)
+  - Your read/save timestamps
+- They interact with the article as if they discovered it themselves:
+  - Their triage actions are recorded under their username
+  - They can star, save, skip, or mark as done
+  - Their own tags can be added (separate from yours)
+
+## Share expiration and limits
+
+Shares are designed to be private and temporary:
+- **Single-use**: once the recipient opens the link, it cannot be reused
+- **Time-limited**: shares expire after 7 days if not opened
+- **Revokable**: you can delete a sent share from the Shares tab before it's
+  opened
+- **Auditable**: both sender and recipient can see the share in their
+  Shares history (who, when, article, note)
+
+## Privacy
+
+Sharing respects the app's privacy model:
+- No article content leaves your server
+- No personal notes or private state are shared
+- The recipient cannot see your tags unless the tags feature is enabled for
+  all users (tags are always visible if the feature is on)
+- Share tokens are cryptographically random and unguessable
+- Expired shares are automatically cleaned up by a daily job
+
+## Requirements
+
+Sharing requires:
+- A working instance (single-user or multi-user)
+- Recipient must have an account on the same instance
+- No additional configuration needed — sharing is enabled by default
+
+## Troubleshooting
+
+If sharing doesn't work:
+- **"Invalid or expired share"**: the link was already used or too old; ask
+  the sender to resend
+- **"User not found"**: double-check the recipient's username
+- **"Sharing not available"**: contact your admin — on private instances,
+  sharing can be disabled site-wide (though this is not the default)
+- No notifications?: check your notification settings (bell icon → Settings)
+
+Sharing works the same whether you're on desktop, tablet or mobile — the share dialog
+and notifications adapt to the screen size.

--- a/docs/user-guide/sources.md
+++ b/docs/user-guide/sources.md
@@ -1,0 +1,102 @@
+# Sources & Subscriptions
+
+Your **Source Subscription** is the set of feeds News Dashboard uses to discover
+articles. Managing sources lets you shape what appears in your Today Feed.
+
+## What is a source?
+
+A source is a feed — an RSS/Atom feed, GitHub releases, Hacker News/GitHub
+trending, or a custom-scraped page — from which the app discovers articles.
+Each source belongs to a category (AI/LLM, Python, engineering, trending,
+etc.) and a kind (rss_feed, github_release_feed, trending_feed, scraped_page).
+
+## Default sources
+
+When you first run `news-dashboard init`, the app populates your subscription
+with a curated list of technical news sources. These are defined in
+`sources.py` and grouped by category:
+
+- **python** — Python Insider, Astral blog, Ruff/uv/mypy/pyright/scikit-learn/scipy/PyTorch/TensorFlow releases
+- **ai-llm** — Anthropic (scraped), OpenAI, Google AI, Hugging Face, Augment Code, Simon Willison, Latent Space, Import AI, InfoQ
+- **agents** — LangChain, LangGraph, Langfuse releases
+- **cloud-infra** — Kubernetes, Docker, AWS ML blog
+- **engineering** — Pragmatic Engineer, GitHub Changelog, GitHub Engineering
+- **trending** — Hacker News Best, Hacker News AI search
+- **repositories** — GitHub Trending (All, Python, TypeScript)
+
+You can add, remove, enable, or disable any of these sources to match your
+interests.
+
+## Source kinds
+
+The app understands these feed types:
+
+| Kind               | What it is                                                  |
+| ------------------ | ----------------------------------------------------------- |
+| **rss_feed**       | Standard RSS/Atom feed (parsed by feedparser)               |
+| **github_release_feed** | GitHub releases Atom feed                                 |
+| **trending_feed**  | Hacker News/GitHub trending RSS                             |
+| **scraped_page**   | Custom HTML scraper (stdlib urllib + html.parser, no deps)  |
+
+## Source health
+
+Each source displays a health badge in the Sources tab:
+
+- **✅ OK** — last fetch succeeded
+- **⚠️ Stale** — last fetch was more than the expected interval ago but not an error
+- **❌ Error** — last fetch failed; tooltip shows the error message
+
+The app tracks:
+- `last_checked_at` — timestamp of last fetch attempt
+- `last_success_at` — timestamp of last successful fetch
+- `last_error` — last error message (null if no error)
+- `last_fetched_count` — items found in last run
+- `last_inserted_count` — new articles added in last run
+
+## Managing sources
+
+On the **Sources** page you can:
+
+- **Enable/disable** a source without deleting it (toggle the switch)
+- **Add a new source** by pasting its feed URL (rss_feed, github_release_feed,
+  or trending_feed kinds)
+- **Remove a source** permanently
+- **View health** and last-check timestamps
+- **See how many articles** were fetched and inserted in the last run
+
+Only RSS/Atom-type feeds (kind `rss_feed`) can be added via URL. For
+github_release_feed and trending_feed kinds, use the dropdown when adding a
+source — these are predefined (GitHub user/org/repo releases, HN/GitHub trending).
+
+## Noise filtering
+
+Some broad feeds are capped to avoid overwhelming your Today Feed:
+
+- Broad feeds (HN, GitHub trending): 15–20 items per run
+- Newsletter feeds (Import AI, Latent Space): 5 per run
+- Curated blog feeds: 50 per run
+
+This keeps the ingestion manageable while still surfacing high-signal content.
+
+## Adding a source
+
+1. Navigate to the Sources page
+2. Click "Add source"
+3. Choose the kind:
+   - For RSS/Atom: paste the feed URL
+   - For GitHub releases: select a user/org/repo from the dropdown
+   - For trending: select Hacker News or GitHub trending
+4. Assign a category (optional; you can create a new one)
+5. Click Save — the source will be enabled and queued for the next fetch
+
+## Removing a source
+
+1. On the Sources page, find the source you want to remove
+2. Click the trash icon or "Remove" button
+3. Confirm — the source is deleted and its articles remain in your database
+   (they won't be re-ingested unless you add the source back)
+
+## Source subscriptions are per-user
+
+On a multi-user instance, each user maintains their own source list. Changes
+you make affect only your subscription.

--- a/docs/user-guide/today-feed-triage.md
+++ b/docs/user-guide/today-feed-triage.md
@@ -1,0 +1,83 @@
+# The Today Feed & Triage States
+
+The Today Feed is the heart of News Dashboard. It's your daily queue of
+articles, and triage is how you process it.
+
+## What is the Today Feed?
+
+The Today Feed contains articles that are ready for you to review. Articles
+enter the feed from:
+
+- **New ingestion** — articles from your [Source Subscriptions](../concepts.md#source-subscription) discovered during the latest fetch.
+- **Recommendations** — the app may surface older or related articles you haven't seen, based on your reading patterns.
+
+The Today Feed is separated from your Later queue and your archive — it's
+specifically the active batch you're working through *right now*.
+
+## Triage states
+
+Each article in your Today Feed can be moved to one of these states:
+
+### Done
+You've reviewed the article and moved on. Done articles are removed from the
+Today Feed and stored in your read history. Use Done for articles you've read
+fully or skimmed sufficiently.
+
+### Later
+Interesting, but you don't have time right now. Later articles are queued on
+the Later page, where you can return to them when you're ready. The Later
+queue is a separate triage surface — it doesn't mix back into Today.
+
+### Skipped
+Not relevant. Skipped articles are dismissed without being counted as read.
+The app uses skip feedback to refine your recommendations.
+
+### Starred
+Saved as a permanent reference. Starred articles appear on the Starred page
+and are immune to archival cleanup. Use the star for articles you want to
+keep handy regardless of triage state.
+
+### Snoozed
+Hidden from the Today Feed until a time you choose. After the snooze period
+expires, the article returns to Today. Useful for articles you want to read
+but not right now — and don't want sitting indefinitely in Later.
+
+### Archived
+Tucked out of view. Archived articles don't appear in the Today Feed, Later,
+or Done lists. You can restore an archived article to Done if you need it
+back. Archiving is a way to declutter without permanently deleting.
+
+## How triage works
+
+Each article card shows:
+
+- Title, source name, and discovery time
+- A short summary (first ~280 characters of the body)
+- A **reason** — a one-line contextual blurb explaining why this article surfaced ("New release v2.3.0 from source", "Trending on Hacker News", etc.)
+- A **relevance** indicator when recommendations are active
+- Triage action buttons: Done, Skip, Star, Later, Snooze
+
+Triage actions happen immediately (optimistic updates). You can use keyboard
+shortcuts on the Today Feed:
+
+| Key | Action       |
+| --- | ------------ |
+| `d` | Mark Done    |
+| `r` | Mark Done    |
+| `s` | Star         |
+| `l` | Send to Later|
+| `x` | Skip         |
+| `o` | Open article |
+| `j` | Next article |
+| `k` | Previous article |
+
+After triaging an article, you're returned to your list automatically so you
+can keep moving through the feed.
+
+## Workflow State independence
+
+A key concept: **Workflow State does not decide whether an article belongs to
+the day's news corpus.** The [Current-Day Report](../briefings.md#the-current-day-report)
+covers all articles discovered today, even ones you've already marked Done or
+Skipped. This means your triage actions don't affect the briefing — the
+briefing reflects what's happening, regardless of what you decided to read.


### PR DESCRIPTION
This PR implements issue #623 via the PI agent.

Closes #623

## Summary
- **Issue**: docs: write the User Guide for core features
- **Lock**: agent-lock/issue-623

## Test Results
```
The links look correct. Let me check if the docs build passes with broken-link checking on:
```bash
# From project root
make check-docs
``` (Implementation detail: this runs `make docs` under the hood, which is currently just a placeholder.)

Let me run the command:
```bash
make check-docs
```
```