### PR TITLE
docs: add Getting Started guide (Android APK + web account + self-host)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ deploy/                   Deployment files
 scripts/                  Maintenance scripts
 ```
 
+## Getting Started
+
+To begin using News Dashboard as a reader, see the
+[Getting Started guide](website/docs/getting-started/index.md) which covers:
+
+- [Install the Android APK](website/docs/getting-started/install-android-apk.md)
+  — native Android app wrapping the PWA
+- [Create a web account](website/docs/getting-started/create-web-account.md)
+  — sign in from any browser
+- [Self-host your own instance](#quick-start)
+  — run News Dashboard on your own infrastructure
+
 ## Documentation
 
 For end-user documentation, see the [User Guide](docs/user-guide/README.md) which covers:

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -18,7 +18,16 @@ core concepts and features so you can get the most out of your reading workflow.
 
 ## Before you start
 
-If you haven't set up News Dashboard yet, follow the instructions in the
-[Quick Start](../../README.md#quick-start) section of the README. For
-self-hosted production deployments, see the
+If you haven't set up News Dashboard yet, start with the
+[Getting Started guide](../../website/docs/getting-started/index.md).
+It covers the three ways to begin:
+
+- [Install the Android APK](../../website/docs/getting-started/install-android-apk.md)
+  — native app for Android phones and tablets
+- [Create a web account](../../website/docs/getting-started/create-web-account.md)
+  — sign in from any browser
+- [Self-host your own instance](../../README.md#quick-start)
+  — run News Dashboard on your own infrastructure
+
+For detailed self-hosting instructions, see the
 [Self-Hosting guide](../SELF_HOSTING.md).

--- a/website/docs/getting-started/create-web-account.md
+++ b/website/docs/getting-started/create-web-account.md
@@ -1,0 +1,97 @@
+# Create a Web Account
+
+News Dashboard supports two authentication methods depending on how the server
+is configured:
+
+- **Local password auth** — username and password stored in the app's database
+- **Keycloak auth** — single sign-on through an external Keycloak provider
+
+The registration flow differs for each. This guide covers both.
+
+## Before you start
+
+You need the URL of a running News Dashboard instance. The public instance is
+at **[news.lihor.ro](https://news.lihor.ro)**. Self-hosters should use their
+own domain.
+
+Open the URL in any modern browser (Chrome, Firefox, Safari, Edge). You will
+see the **Sign in** page.
+
+## Local password auth (default)
+
+When Keycloak is not enabled, the login page shows a **username** and
+**password** form, plus a link to switch to email code login.
+
+### First admin bootstrap
+
+The very first account on a fresh server is created through the **bootstrap
+mechanism**. The server administrator sets the environment variables
+`BOOTSTRAP_ADMIN_USERNAME` and `BOOTSTRAP_ADMIN_PASSWORD` before starting the
+app. On first startup, the app creates an admin user with those credentials.
+
+Ask your server administrator for the bootstrap credentials if you should be
+the first admin.
+
+### Additional users
+
+If you are an admin, you can create additional users through the **Admin
+panel** (visible to admin users only). Go to **Settings → Admin → Users**
+and click **Generate user**. This creates a local user account with a
+generated username and password that you can share with the new user.
+
+### Signing in
+
+1. Enter your **Username** and **Password**.
+2. Click **Sign in**.
+3. On success, you are redirected to your Today Feed (or the page you were
+   trying to reach).
+
+If you do not have an account yet, ask an admin to create one for you.
+
+### Email code login (alternative)
+
+The login page also offers an **email code** option. Click **Use email code
+instead**, enter your email address, and a 6-digit code will be sent to it.
+Enter the code to sign in. This requires the server to have an email sending
+channel configured.
+
+## Keycloak auth
+
+When Keycloak is enabled, the login page shows a **Sign in with Keycloak**
+button and a **Create Account** link.
+
+1. Click **Sign in with Keycloak** to be redirected to the Keycloak login
+   page.
+2. Enter your Keycloak credentials.
+3. After successful authentication, you are redirected back to News Dashboard.
+
+To create a new account through Keycloak:
+
+1. Click the **Create Account** link on the login page.
+2. You are redirected to the Keycloak registration form.
+3. Fill in the required fields and submit.
+4. After registration, you are redirected back to News Dashboard and
+   automatically signed in.
+
+> The **Create Account** link is only available when Keycloak is enabled.
+> For local password auth, account creation is handled by an admin through
+> the Admin panel.
+
+## After signing in
+
+Once you are signed in, you land on your **Today Feed** — the main triage
+view. See the [User Guide](../../docs/user-guide/README.md) to learn how to
+use it.
+
+If this is your first time using News Dashboard, the app will have already
+seeded a set of default news sources. Articles will start appearing after the
+next ingest cycle (or you can trigger an ingest from the **Sources** page).
+
+## Troubleshooting
+
+| Problem | Likely cause | Solution |
+|---------|-------------|----------|
+| "Not authenticated" / redirected to login | Session expired | Sign in again |
+| "Invalid username or password" | Wrong credentials | Check your username and password; contact an admin to reset |
+| No "Create Account" link | Server uses local auth | Ask an admin to create an account for you |
+| Keycloak login fails | Keycloak server unreachable or misconfigured | Contact your server administrator |

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -1,0 +1,31 @@
+# Getting Started
+
+Welcome to **News Dashboard** — your private news platform. There are three ways
+to start using the app, depending on how you want to access it.
+
+| On-ramp | Best for |
+|---------|----------|
+| [Install the Android APK](install-android-apk.md) | Reading on an Android phone or tablet |
+| [Create a web account](create-web-account.md) | Reading in a browser on any device |
+| [Self-host your own instance](../../../README.md#quick-start) | Running News Dashboard on your own infrastructure |
+
+The public instance runs at **[news.lihor.ro](https://news.lihor.ro)**. If you
+are using that instance, follow the APK or web-account guide above.
+
+If you are running your own instance (via Docker, Docker Compose, or Helm),
+see the [Self-Hosting guide](../../docs/SELF_HOSTING.md) for detailed
+deployment instructions after you have completed the quick start in the
+README.
+
+## Next steps
+
+Once you have an account and are signed in, see the
+[User Guide](../../docs/user-guide/README.md) to learn about:
+
+- The [Today Feed and triage workflow](../../docs/user-guide/today-feed-triage.md)
+- Managing your [sources and subscriptions](../../docs/user-guide/sources.md)
+- [Searching articles](../../docs/user-guide/search.md)
+- Daily [briefings and the Current-Day Report](../../docs/user-guide/briefings.md)
+- [Recommendations](../../docs/user-guide/recommendations.md)
+- Your [reading history and Reading DNA](../../docs/user-guide/saved-history.md)
+- [Sharing articles](../../docs/user-guide/sharing.md)

--- a/website/docs/getting-started/install-android-apk.md
+++ b/website/docs/getting-started/install-android-apk.md
@@ -1,0 +1,88 @@
+# Install the Android APK
+
+News Dashboard publishes a native Android APK that wraps the web app using a
+[Trusted Web Activity (TWA)](https://developer.chrome.com/docs/android/trusted-web-activity/).
+It renders the PWA full-screen with no address bar, supports adaptive icons
+and Material You theming, and behaves like a real installed app.
+
+The APK always loads **news.lihor.ro** (or the domain your self-hosted instance
+is configured with). It is **not** a standalone reader — it requires network
+access to the server.
+
+## What you need
+
+- An Android device running Android 6.0+ (API 23+)
+- A network connection to reach the server
+- Permission to install apps from outside the Play Store (see below)
+
+## Where to get the APK
+
+The signed APK is published as part of every
+[GitHub Release](https://github.com/lihor-hub/news-dashboard/releases).
+
+1. Open the [Releases page](https://github.com/lihor-hub/news-dashboard/releases).
+2. Find the latest release (highest version number).
+3. Under **Assets**, download the file named `news-dashboard-<version>.apk`.
+
+> **Note**: The APK is not distributed through Google Play or any app store.
+> You must download it from GitHub and install it manually.
+
+## How to install
+
+### 1. Allow installation from unknown sources
+
+Android blocks apps installed outside the Play Store by default. You need to
+enable **Install from unknown sources** (sometimes called **Install unknown
+apps**) for the app you will use to open the APK file (usually your file
+manager or browser).
+
+Depending on your Android version:
+
+- **Android 8+**: When you open the APK, Android will prompt you to allow
+  installation from that source. Tap **Settings** and enable **Allow from
+  this source**.
+- **Android 6–7**: Go to **Settings → Security → Unknown sources** and
+  enable the toggle.
+
+### 2. Open the APK file
+
+Transfer the downloaded `.apk` file to your device (if you downloaded it
+directly from the device browser, it will be in the Downloads folder).
+
+Open the file. Android will show a confirmation screen with the app name and
+permissions.
+
+Tap **Install**.
+
+### 3. Launch the app
+
+Once installed, tap **Open** to launch News Dashboard. You will see a sign-in
+screen — see [Create a web account](create-web-account.md) if you do not have
+one yet.
+
+## Verifying the installation
+
+The app icon should appear in your app drawer under the name **News Dashboard**.
+Tapping it opens the sign-in page in a full-screen Chrome view with no address
+bar.
+
+## Updates
+
+To update, download the latest APK from the
+[Releases page](https://github.com/lihor-hub/news-dashboard/releases) and
+install it over the existing app. Android will preserve your app data and
+session.
+
+## Troubleshooting
+
+| Problem | Likely cause | Solution |
+|---------|-------------|----------|
+| "App not installed" | APK is corrupted or incompatible | Re-download the APK and check that your Android version is 6.0+ |
+| "Parse error" | Incomplete download | Delete the file and download again |
+| "Blocked by Play Protect" | Google's safety check | Tap **Install anyway** (the APK is signed and safe) |
+| White screen / doesn't load | No network or wrong server URL | Check your connection and ensure news.lihor.ro is reachable |
+
+## Building the APK yourself
+
+Developers and self-hosters can build the APK from source. See the
+[Android build guide](../../android/README.md) for instructions.


### PR DESCRIPTION
Closes #622

## Summary

Three Getting Started pages for end-user onboarding:

| Page | What it covers |
|------|---------------|
| `website/docs/getting-started/index.md` | Landing page linking all three on-ramps |
| `website/docs/getting-started/install-android-apk.md` | Download & sideload the TWA APK from GitHub Releases |
| `website/docs/getting-started/create-web-account.md` | Sign-in flows: local password auth, Keycloak, first-admin bootstrap |

Also updates README and user-guide index to link to the new Getting Started section.

## Acceptance criteria

- [x] Getting Started section has three pages: APK install, web account, and a landing that links all on-ramps
- [x] APK page matches the actual TWA build/distribution reality (no fabricated app-store links)
- [x] Web-account page matches the real registration/login flow (registration URL + first-admin bootstrap) with no invented screens
- [x] Secrets kept out; only env var names referenced

## Verification

- Content accuracy verified against `android/README.md`, `LoginPage.tsx`, `auth.py`, and `main.py`
- Cross-links to existing docs are relative paths that resolve to real files
- No app-store links fabricated (APK is GitHub Releases only)