### PR TITLE
fix: update runtime GitHub repo owner

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -15,7 +15,7 @@ window always loads the live deployed site, so it stays up-to-date automatically
 
 ## Download
 
-Go to the [Releases page](https://github.com/ioachim-hub/news-dashboard/releases)
+Go to the [Releases page](https://github.com/lihor-hub/news-dashboard/releases)
 and download the latest `News Dashboard-*.dmg` (macOS) or `News Dashboard-*.AppImage`
 (Linux).
 

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -17,7 +17,7 @@ files:
 # need these manifest files generated locally so they can be uploaded.
 publish:
   provider: github
-  owner: ioachim-hub
+  owner: lihor-hub
   repo: news-dashboard
   releaseType: release
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,7 +3,7 @@
   "version": "1.21.0",
   "description": "News Dashboard desktop app — wraps https://news.lihor.ro in a native window",
   "main": "src/main.js",
-  "author": "ioachim-hub",
+  "author": "lihor-hub",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/frontend/src/__tests__/useUpdateCheck.test.tsx
+++ b/frontend/src/__tests__/useUpdateCheck.test.tsx
@@ -39,6 +39,9 @@ describe('useUpdateCheck — web/GitHub flow', () => {
     expect(result.current.info?.latestVersion).toBe('2.0.0');
     expect(result.current.info?.releaseUrl).toBe('https://gh/r/2');
     expect(result.current.loading).toBe(false);
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe(
+      'https://api.github.com/repos/lihor-hub/news-dashboard/releases?per_page=30'
+    );
   });
 
   it('reports no update when there is no matching release', async () => {

--- a/frontend/src/hooks/useUpdateCheck.ts
+++ b/frontend/src/hooks/useUpdateCheck.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { compareVersions, tagToVersion } from '../lib/version';
 import { detectPlatform, type AppPlatform } from '../lib/platform';
 
-const GH_REPO = 'ioachim-hub/news-dashboard';
+const GH_REPO = 'lihor-hub/news-dashboard';
 const GH_RELEASES = `https://api.github.com/repos/${GH_REPO}/releases`;
 
 /** Tag prefix per platform. */

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -265,7 +265,7 @@ function UpdatesSection() {
               The web app is always current — the live site updates automatically on each release.
             </p>
             <a
-              href={`https://github.com/${info.releaseUrl.split('github.com/')[1]?.split('/releases')[0] ?? 'ioachim-hub/news-dashboard'}/releases`}
+              href={`https://github.com/${info.releaseUrl.split('github.com/')[1]?.split('/releases')[0] ?? 'lihor-hub/news-dashboard'}/releases`}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-1.5 text-xs text-primary hover:underline w-fit"


### PR DESCRIPTION
Closes #608.

## Summary
- update frontend update-check and release-history fallback links to `lihor-hub/news-dashboard`
- update desktop publish owner, package author, and README release link
- assert the update-check hook requests the new GitHub Releases API URL

## Verification
- `git grep -n ioachim-hub -- frontend desktop` returns no matches
- `npm run test:frontend --silent` (53 files, 620 tests)
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run build --silent`

Note: `make typecheck` / `make lint` could not be run literally on this Windows environment because `make` is not installed; the equivalent frontend commands above passed.