### PR TITLE
fix: patch infinite-query caches in triage mutations

### DIFF
--- a/frontend/src/__tests__/useTriageMutations.test.tsx
+++ b/frontend/src/__tests__/useTriageMutations.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, type InfiniteData } from '@tanstack/react-query';
 import { createElement } from 'react';
 import { toast } from 'sonner';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 import * as workflowApi from '../api/workflowApi';
+import type { TriageArticlePage } from '../api/workflowApi';
 import { useTriageMutations, ARTICLES_KEY } from '../hooks/useTriageMutations';
 import { trackFeature } from '../lib/analytics';
 
@@ -59,12 +60,25 @@ function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle 
   };
 }
 
+// Article lists are loaded with `useInfiniteQuery`, so the cache holds an
+// `InfiniteData` page envelope — not a flat array. Seed and read it that way.
+type ListCache = InfiniteData<TriageArticlePage>;
+
+function infiniteList(articles: WorkflowArticle[]): ListCache {
+  return { pages: [{ items: articles, limit: 100, offset: 0, hasMore: false }], pageParams: [0] };
+}
+
+function cachedItems(queryClient: QueryClient, queryKey: unknown[]): WorkflowArticle[] {
+  const data = queryClient.getQueryData<ListCache>(queryKey);
+  return data?.pages.flatMap((page) => page.items) ?? [];
+}
+
 function makeWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const article = makeArticle();
-  queryClient.setQueryData([ARTICLES_KEY, { state: 'today' }], [article]);
+  queryClient.setQueryData([ARTICLES_KEY, { state: 'today' }], infiniteList([article]));
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
     createElement(QueryClientProvider, { client: queryClient }, children);
   return { wrapper: Wrapper, queryClient };
@@ -242,13 +256,13 @@ describe('useTriageMutations — undo calls the API to revert server state', () 
     const { wrapper, queryClient } = makeWrapper();
     const { result } = renderHook(() => useTriageMutations(), { wrapper });
     const article = makeArticle({ state: 'today' });
-    queryClient.setQueryData([ARTICLES_KEY, 'today'], [article]);
+    queryClient.setQueryData([ARTICLES_KEY, 'today'], infiniteList([article]));
 
     act(() => {
       result.current.setState(article, 'done', 'Marked as read');
     });
 
-    expect(queryClient.getQueryData([ARTICLES_KEY, 'today'])).toEqual([]);
+    expect(cachedItems(queryClient, [ARTICLES_KEY, 'today'])).toEqual([]);
   });
 });
 
@@ -302,7 +316,7 @@ describe('useTriageMutations — surfaces backend error details in error toast',
     const { wrapper, queryClient } = makeWrapper();
     const { result } = renderHook(() => useTriageMutations(), { wrapper });
     const article = makeArticle({ state: 'today' });
-    queryClient.setQueryData([ARTICLES_KEY, 'today'], [article]);
+    queryClient.setQueryData([ARTICLES_KEY, 'today'], infiniteList([article]));
 
     await act(async () => {
       result.current.setState(article, 'done', 'Marked as read');
@@ -310,8 +324,8 @@ describe('useTriageMutations — surfaces backend error details in error toast',
     });
 
     await waitFor(() => {
-      const cached = queryClient.getQueryData<WorkflowArticle[]>([ARTICLES_KEY, 'today']);
-      expect(cached?.some((a) => a.id === article.id)).toBe(true);
+      const cached = cachedItems(queryClient, [ARTICLES_KEY, 'today']);
+      expect(cached.some((a) => a.id === article.id)).toBe(true);
     });
   });
 
@@ -355,6 +369,62 @@ describe('useTriageMutations — surfaces backend error details in error toast',
         { id: 'triage' }
       );
     });
+  });
+});
+
+// Regression: article feeds load via `useInfiniteQuery`, so the cache is an
+// `InfiniteData` envelope. The optimistic-update helpers must patch through
+// `pages` rather than assuming a flat array — otherwise every triage action
+// (keyboard shortcut or row button) throws "articles.some is not a function"
+// and silently does nothing.
+describe('useTriageMutations — patches infinite-query caches (article feeds)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    patchArticleStatePromise = Promise.resolve({});
+  });
+
+  function seedAndRender(article: WorkflowArticle) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const key = [ARTICLES_KEY, 'today', undefined];
+    queryClient.setQueryData(key, infiniteList([article]));
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useTriageMutations(), { wrapper });
+    return { queryClient, key, result };
+  }
+
+  it('setState removes a moved article from an infinite cache without throwing', async () => {
+    const article = makeArticle({ id: '42', state: 'today' });
+    const { queryClient, key, result } = seedAndRender(article);
+
+    act(() => result.current.setState(article, 'done', 'Done'));
+
+    await waitFor(() =>
+      expect(workflowApi.patchArticleState).toHaveBeenCalledWith('42', 'done', false)
+    );
+    expect(cachedItems(queryClient, key)).toEqual([]);
+  });
+
+  it('toggleStar patches an article in place in an infinite cache without throwing', async () => {
+    const article = makeArticle({ id: '7', starred: false });
+    const { queryClient, key, result } = seedAndRender(article);
+
+    act(() => result.current.toggleStar(article));
+
+    await waitFor(() => expect(workflowApi.patchArticleStar).toHaveBeenCalledWith('7', true));
+    expect(cachedItems(queryClient, key)[0]?.starred).toBe(true);
+  });
+
+  it('sendLater moves an article out of the today infinite cache without throwing', async () => {
+    const article = makeArticle({ id: '9', state: 'today' });
+    const { queryClient, key, result } = seedAndRender(article);
+
+    act(() => result.current.sendLater(article, 1));
+
+    await waitFor(() => expect(workflowApi.patchArticleLater).toHaveBeenCalledWith('9', 1));
+    expect(cachedItems(queryClient, key)).toEqual([]);
   });
 });
 

--- a/frontend/src/hooks/useTriageMutations.ts
+++ b/frontend/src/hooks/useTriageMutations.ts
@@ -1,4 +1,9 @@
-import { useQueryClient, useMutation, type QueryKey } from '@tanstack/react-query';
+import {
+  useQueryClient,
+  useMutation,
+  type QueryKey,
+  type InfiniteData,
+} from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 // Single shared ID so every triage toast replaces the previous one rather than
@@ -11,15 +16,21 @@ import {
   patchArticleStar,
   patchArticleLater,
   snapshot,
+  type TriageArticlePage,
 } from '../api/workflowApi';
 
 // ─── Query key helpers ───────────────────────────────────────────────────────
 
 export const ARTICLES_KEY = 'articles';
 
+// Article lists are loaded with `useInfiniteQuery`, so the cached value is an
+// `InfiniteData` page envelope — not a flat `WorkflowArticle[]`. All cache reads
+// and optimistic writes below operate through the `pages` structure.
+type ArticleListCache = InfiniteData<TriageArticlePage>;
+
 interface ArticleQuerySnapshot {
   queryKey: QueryKey;
-  articles: WorkflowArticle[];
+  data: ArticleListCache;
 }
 
 function articleMatchesQuery(queryKey: QueryKey, article: WorkflowArticle) {
@@ -38,15 +49,19 @@ function articleMatchesQuery(queryKey: QueryKey, article: WorkflowArticle) {
   return true;
 }
 
+function cacheContainsArticle(data: ArticleListCache | undefined, id: string): boolean {
+  return Boolean(data?.pages.some((page) => page.items.some((article) => article.id === id)));
+}
+
 function snapshotArticleQueries(
   queryClient: ReturnType<typeof useQueryClient>,
   id: string
 ): ArticleQuerySnapshot[] {
   return queryClient
-    .getQueriesData<WorkflowArticle[]>({ queryKey: [ARTICLES_KEY] })
-    .flatMap(([queryKey, articles]) => {
-      if (!articles?.some((article) => article.id === id)) return [];
-      return [{ queryKey, articles: [...articles] }];
+    .getQueriesData<ArticleListCache>({ queryKey: [ARTICLES_KEY] })
+    .flatMap(([queryKey, data]) => {
+      if (!data || !cacheContainsArticle(data, id)) return [];
+      return [{ queryKey, data }];
     });
 }
 
@@ -54,8 +69,8 @@ function restoreQuerySnapshots(
   queryClient: ReturnType<typeof useQueryClient>,
   snapshots: ArticleQuerySnapshot[]
 ) {
-  snapshots.forEach(({ queryKey, articles }) => {
-    queryClient.setQueryData(queryKey, articles);
+  snapshots.forEach(({ queryKey, data }) => {
+    queryClient.setQueryData(queryKey, data);
   });
 }
 
@@ -65,25 +80,37 @@ function applyPatchToCache(
   patch: Partial<WorkflowArticle>
 ) {
   queryClient
-    .getQueriesData<WorkflowArticle[]>({ queryKey: [ARTICLES_KEY] })
+    .getQueriesData<ArticleListCache>({ queryKey: [ARTICLES_KEY] })
     .forEach(([queryKey, old]) => {
       if (!old) return;
       let changed = false;
-      const next = old.flatMap((article) => {
-        if (article.id !== id) return [article];
-        changed = true;
-        const patched = { ...article, ...patch };
-        return articleMatchesQuery(queryKey, patched) ? [patched] : [];
+      const pages = old.pages.map((page) => {
+        const items = page.items.flatMap((article) => {
+          if (article.id !== id) return [article];
+          changed = true;
+          const patched = { ...article, ...patch };
+          return articleMatchesQuery(queryKey, patched) ? [patched] : [];
+        });
+        return { ...page, items };
       });
-      if (changed) queryClient.setQueryData(queryKey, next);
+      if (changed) queryClient.setQueryData<ArticleListCache>(queryKey, { ...old, pages });
     });
 }
 
 function restoreToCache(queryClient: ReturnType<typeof useQueryClient>, article: WorkflowArticle) {
-  queryClient.setQueriesData({ queryKey: [ARTICLES_KEY] }, (old: WorkflowArticle[] | undefined) => {
-    if (!old) return old;
-    return old.map((a) => (a.id === article.id ? article : a));
-  });
+  queryClient.setQueriesData<ArticleListCache>(
+    { queryKey: [ARTICLES_KEY] },
+    (old: ArticleListCache | undefined) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page) => ({
+          ...page,
+          items: page.items.map((a) => (a.id === article.id ? article : a)),
+        })),
+      };
+    }
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #673

## Problem
Keyboard triage shortcuts (`r`/`d`, `l`, `s`, `x`, `e`) and the Done/Skip/Star buttons in article rows did nothing on the Today/Later/Starred/Archive feeds. Only `o` (open) and `j`/`k`/Enter navigation still worked.

## Root cause
`ArticleListView` was migrated from `useQuery` (flat `WorkflowArticle[]`) to `useInfiniteQuery` in #534, so cached article-list data is now `{ pages: TriageArticlePage[], pageParams }`. The optimistic-update helpers in `useTriageMutations` still assumed a flat array and called `.some`/`.flatMap` on the cached value. `snapshotArticleQueries` runs first in `setState`/`sendLater`/`toggleStar` and threw `TypeError: articles.some is not a function` synchronously inside the keydown/click handler, so the action never fired.

Unit tests missed it because they seeded the cache with the obsolete flat-array shape that never occurs in production.

## Fix
- Rewrote `snapshotArticleQueries`, `applyPatchToCache`, `restoreToCache` (and the snapshot type) to read/write through the `InfiniteData<TriageArticlePage>` `pages` structure.
- Updated existing tests to seed the real infinite-query shape and added regression coverage that each triage action patches an `InfiniteData` cache without throwing.

## Verification
- New/updated tests fail before the fix (`TypeError: articles.some is not a function`) and pass after.
- Full frontend suite: 620 passed. eslint (`--max-warnings 0`), prettier, tsc all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)