### PR TITLE
fix: encode split PostgreSQL DSN settings (#572)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import psycopg
 from psycopg import sql
@@ -519,7 +519,10 @@ def active_database_url(database_url: str | None = None) -> str:
     password = os.getenv("POSTGRES_PASSWORD", "")
     database = os.getenv("POSTGRES_DB", "news_dashboard")
     port = os.getenv("POSTGRES_PORT", "5432")
-    return f"postgresql://{user}:{password}@{host}:{port}/{database}"
+    encoded_user = quote(user, safe="")
+    encoded_password = quote(password, safe="")
+    encoded_database = quote(database, safe="")
+    return f"postgresql://{encoded_user}:{encoded_password}@{host}:{port}/{encoded_database}"
 
 
 def describe_database(database_url: str | None = None) -> str:

--- a/backend/tests/test_database_config.py
+++ b/backend/tests/test_database_config.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote, urlsplit
+
 import pytest
 
 from news_dashboard.db import (
@@ -66,6 +68,24 @@ def test_active_database_url_builds_from_postgres_parts(monkeypatch: pytest.Monk
     monkeypatch.setenv("POSTGRES_PORT", "6543")
 
     assert active_database_url() == "postgresql://alice:pw@db.internal:6543/mydb"
+
+
+def test_active_database_url_encodes_postgres_parts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_HOST", "db.internal")
+    monkeypatch.setenv("POSTGRES_USER", "ali/ce@example")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "p/w#x:@ space")
+    monkeypatch.setenv("POSTGRES_DB", "my/db #1")
+    monkeypatch.setenv("POSTGRES_PORT", "6543")
+
+    parts = urlsplit(active_database_url())
+
+    assert parts.scheme == "postgresql"
+    assert parts.username == "ali%2Fce%40example"
+    assert parts.password == quote("p/w#x:@ space", safe="")
+    assert parts.hostname == "db.internal"
+    assert parts.port == 6543
+    assert parts.path == "/my%2Fdb%20%231"
 
 
 def test_describe_database_passes_through_url_without_password() -> None:


### PR DESCRIPTION
Closes #572

## Summary
- URL-encode split POSTGRES_USER, POSTGRES_PASSWORD, and POSTGRES_DB values when deriving DATABASE_URL
- Preserve explicit DATABASE_URL behavior unchanged
- Add regression coverage for URL-significant credential and database characters

## Test results
- pytest backend/tests/test_database_config.py backend/tests/test_runtime_postgres_only.py -q: 128 passed
- make lint: passed
- make typecheck: passed
- set -a; source .env; set +a; make test: backend 1216 passed; frontend 626 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)