### PR TITLE
feat: share selected article passages (#584)

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -170,6 +170,39 @@ describe('article list endpoints', () => {
   });
 });
 
+describe('share endpoints', () => {
+  it('returns the created share and posts share annotations', async () => {
+    const { calls } = stubFetch((url) => {
+      if (url === '/api/articles/7/share') {
+        return jsonOk({ id: 42, article_id: 7 });
+      }
+      return jsonOk({
+        id: 9,
+        share_id: 42,
+        highlighted_text: 'Important passage',
+        offset_chars: 0,
+        note: null,
+        created_at: '2026-07-01T00:00:00Z',
+      });
+    });
+
+    const share = await api.shareArticle(7, 2, 'read this');
+    const annotation = await api.createShareAnnotation(share.id, {
+      highlighted_text: 'Important passage',
+      offset_chars: 0,
+    });
+
+    expect(share.id).toBe(42);
+    expect(annotation.highlighted_text).toBe('Important passage');
+    expect(calls[0].url).toBe('/api/articles/7/share');
+    expect(calls[0].init?.body).toBe(JSON.stringify({ to_user_id: 2, note: 'read this' }));
+    expect(calls[1].url).toBe('/api/shares/42/annotations');
+    expect(calls[1].init?.body).toBe(
+      JSON.stringify({ highlighted_text: 'Important passage', offset_chars: 0, note: null })
+    );
+  });
+});
+
 describe('fetchArticleAudioUrl', () => {
   it('returns an object URL from the audio blob', async () => {
     const blob = new Blob(['x']);

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -679,6 +679,29 @@ describe('ArticlePage — Share button', () => {
 
     expect(clipboardMock).toHaveBeenCalledWith('https://example.com/article');
   });
+
+  it('opens the share dialog with selected article text', async () => {
+    vi.spyOn(api, 'fetchShareableUsers').mockResolvedValue([]);
+    const selection = {
+      toString: () => 'Full article text',
+      rangeCount: 1,
+      getRangeAt: () => ({
+        commonAncestorContainer:
+          document.querySelector('.reader-prose')?.firstChild ?? document.body,
+      }),
+    };
+    vi.spyOn(window, 'getSelection').mockReturnValue(selection as unknown as Selection);
+
+    renderReader();
+    await waitFor(() => screen.getByText('Full article text.'));
+
+    fireEvent.mouseUp(document.querySelector('.reader-prose')!);
+    await userEvent.click(await screen.findByRole('button', { name: /share selected text/i }));
+    await userEvent.click(await screen.findByText('Send inside the platform'));
+
+    expect(await screen.findByText('Selected passage')).toBeTruthy();
+    expect(screen.getByText('Full article text')).toBeTruthy();
+  });
 });
 
 // ─── Triage actions navigate back ────────────────────────────────────────────

--- a/frontend/src/__tests__/shareDialog.test.tsx
+++ b/frontend/src/__tests__/shareDialog.test.tsx
@@ -40,7 +40,7 @@ describe('ShareDialog', () => {
       { id: 2, username: 'alice', email: 'alice@example.com' },
       { id: 3, username: 'bob', email: null },
     ]);
-    const shareSpy = vi.spyOn(api, 'shareArticle').mockResolvedValue();
+    const shareSpy = vi.spyOn(api, 'shareArticle').mockResolvedValue({ id: 42 } as never);
     const { onOpenChange } = renderDialog();
 
     await userEvent.click(screen.getByText('Send inside the platform'));
@@ -49,6 +49,36 @@ describe('ShareDialog', () => {
     await userEvent.click(screen.getByText('alice'));
     await waitFor(() => expect(shareSpy).toHaveBeenCalledWith(7, 2, ''));
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('attaches selected passage as an annotation after creating the share', async () => {
+    vi.spyOn(api, 'fetchShareableUsers').mockResolvedValue([
+      { id: 2, username: 'alice', email: null },
+    ]);
+    vi.spyOn(api, 'shareArticle').mockResolvedValue({ id: 42 } as never);
+    const annotationSpy = vi.spyOn(api, 'createShareAnnotation').mockResolvedValue({} as never);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <ShareDialog
+          open
+          onOpenChange={vi.fn()}
+          article={{ id: 7, title: 'Big News', url: 'https://example.com/x' }}
+          pendingHighlight={{ text: 'Important selected text' }}
+        />
+      </QueryClientProvider>
+    );
+
+    await userEvent.click(screen.getByText('Send inside the platform'));
+    await userEvent.click(await screen.findByText('alice'));
+
+    await waitFor(() =>
+      expect(annotationSpy).toHaveBeenCalledWith(42, {
+        highlighted_text: 'Important selected text',
+        offset_chars: 0,
+        note: null,
+      })
+    );
   });
 
   it('uses the Web Share API for external sharing when available', async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -26,6 +26,7 @@ import type {
   RecommendationPreferences,
   ReceivedShare,
   ShareDetail,
+  ShareAnnotation,
   ShareMessage,
   SaveOnboardingProfileRequest,
   ShareableUser,
@@ -554,10 +555,30 @@ export async function shareArticle(
   articleId: number,
   toUserId: number,
   note?: string
-): Promise<void> {
-  await requestJson(`/api/articles/${articleId}/share`, {
+): Promise<ReceivedShare> {
+  return requestJson<ReceivedShare>(`/api/articles/${articleId}/share`, {
     method: 'POST',
     body: JSON.stringify({ to_user_id: toUserId, note: note ?? null }),
+  });
+}
+
+export interface CreateShareAnnotationPayload {
+  highlighted_text: string;
+  offset_chars?: number;
+  note?: string | null;
+}
+
+export async function createShareAnnotation(
+  shareId: number,
+  payload: CreateShareAnnotationPayload
+): Promise<ShareAnnotation> {
+  return requestJson<ShareAnnotation>(`/api/shares/${shareId}/annotations`, {
+    method: 'POST',
+    body: JSON.stringify({
+      highlighted_text: payload.highlighted_text,
+      offset_chars: payload.offset_chars ?? 0,
+      note: payload.note ?? null,
+    }),
   });
 }
 

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { fetchShareableUsers, shareArticle } from '@/api';
+import { createShareAnnotation, fetchShareableUsers, shareArticle } from '@/api';
 
 export interface ShareTarget {
   id: number;
@@ -23,6 +23,10 @@ interface ShareDialogProps {
   article: ShareTarget | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  pendingHighlight?: {
+    text: string;
+    note?: string;
+  } | null;
 }
 
 type Mode = 'choose' | 'internal';
@@ -33,7 +37,7 @@ type Mode = 'choose' | 'internal';
  *      OS share sheet / clipboard (external).
  *   2. For internal, pick a recipient and optionally add a note.
  */
-export function ShareDialog({ article, open, onOpenChange }: ShareDialogProps) {
+export function ShareDialog({ article, open, onOpenChange, pendingHighlight }: ShareDialogProps) {
   const [mode, setMode] = useState<Mode>('choose');
   const [query, setQuery] = useState('');
   const [note, setNote] = useState('');
@@ -81,7 +85,20 @@ export function ShareDialog({ article, open, onOpenChange }: ShareDialogProps) {
     if (!article) return;
     setSendingTo(userId);
     try {
-      await shareArticle(article.id, userId, note);
+      const share = await shareArticle(article.id, userId, note);
+      if (pendingHighlight?.text) {
+        try {
+          await createShareAnnotation(share.id, {
+            highlighted_text: pendingHighlight.text,
+            offset_chars: 0,
+            note: pendingHighlight.note ?? null,
+          });
+        } catch {
+          toast.error('Article shared, but the selected passage could not be attached');
+          close();
+          return;
+        }
+      }
       toast.success(`Sent to ${username}`);
       close();
     } catch {
@@ -157,6 +174,14 @@ export function ShareDialog({ article, open, onOpenChange }: ShareDialogProps) {
               onChange={(e) => setNote(e.target.value)}
               maxLength={500}
             />
+            {pendingHighlight?.text ? (
+              <div className="rounded-md border border-border bg-surface/70 px-3 py-2">
+                <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Selected passage
+                </div>
+                <p className="line-clamp-3 text-sm text-foreground">{pendingHighlight.text}</p>
+              </div>
+            ) : null}
             <div className="max-h-56 overflow-y-auto rounded-md border border-border">
               {usersQuery.isLoading ? (
                 <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -17,6 +17,7 @@ import {
   Volume2,
   Square,
   Share2,
+  Highlighter,
   Sparkles,
   Lightbulb,
   Scale,
@@ -343,9 +344,32 @@ export function ArticlePage() {
   }
 
   const [shareOpen, setShareOpen] = useState(false);
+  const [selectedShareText, setSelectedShareText] = useState('');
+  const [pendingShareHighlight, setPendingShareHighlight] = useState<{ text: string } | null>(null);
 
   function handleShare() {
     if (!article) return;
+    setPendingShareHighlight(null);
+    setShareOpen(true);
+  }
+
+  function selectedTextWithinReader(): string {
+    const selection = window.getSelection();
+    const text = selection?.toString().trim() ?? '';
+    if (!selection || !text || selection.rangeCount === 0) return '';
+    const reader = document.querySelector('.reader-prose');
+    const container = selection.getRangeAt(0).commonAncestorContainer;
+    if (!reader?.contains(container)) return '';
+    return text;
+  }
+
+  function updateSelectedShareText() {
+    setSelectedShareText(selectedTextWithinReader());
+  }
+
+  function handleShareSelected() {
+    if (!article || !selectedShareText) return;
+    setPendingShareHighlight({ text: selectedShareText });
     setShareOpen(true);
   }
 
@@ -740,6 +764,8 @@ export function ArticlePage() {
               ) : (
                 <div
                   className="reader-prose"
+                  onMouseUp={updateSelectedShareText}
+                  onKeyUp={updateSelectedShareText}
                   dangerouslySetInnerHTML={{
                     __html: renderBody(
                       showOriginal && article.originalBody ? article.originalBody : article.body
@@ -805,10 +831,21 @@ export function ArticlePage() {
         </div>,
         document.body
       )}
+      {selectedShareText ? (
+        <button
+          type="button"
+          onClick={handleShareSelected}
+          className="fixed bottom-20 left-1/2 z-30 inline-flex -translate-x-1/2 items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground shadow-lg hover:bg-surface"
+        >
+          <Highlighter className="size-4" strokeWidth={1.75} />
+          Share selected text
+        </button>
+      ) : null}
       <ShareDialog
         open={shareOpen}
         onOpenChange={setShareOpen}
         article={{ id: Number(article.id), title: article.title, url: article.url }}
+        pendingHighlight={pendingShareHighlight}
       />
     </div>
   );


### PR DESCRIPTION
Closes #584

## Summary
- adds a selected-text share affordance in the article reader
- returns the created share from the frontend share helper and adds an annotation helper
- attaches the selected passage through the existing share annotation endpoint after internal share creation
- keeps whole-article sharing unchanged when no text is selected

## Tests
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:frontend
- npm run build

Note: Vitest still prints existing localhost:3000 ECONNREFUSED noise, but all 54 files / 629 tests pass.

Generated by codex automation.