### PR TITLE
chore: add CODEOWNERS and Dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default maintainer review for every change.
+* @ioachim-hub
+
+# Area-specific reminders; all currently route to the maintainer account.
+/backend/ @ioachim-hub
+/frontend/ @ioachim-hub
+/helm/ @ioachim-hub
+/.github/ @ioachim-hub

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Bucharest"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/Bucharest"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Bucharest"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:30"
+      timezone: "Europe/Bucharest"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      docker-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Closes #614

## Summary
- add CODEOWNERS with default maintainer review ownership and area-specific entries
- add weekly Dependabot updates for npm, uv, GitHub Actions, and Docker
- group minor/patch updates and cap open PRs per ecosystem
- add/use the dependencies label for Dependabot PRs

## Validation
- git diff --cached --check
- pre-commit config hooks during commit
- python YAML validation for .github/dependabot.yml
- python CODEOWNERS validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)