### PR TITLE
docs: update codecov link in readme to point to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # News Dashboard
 
-![Coverage Status](https://codecov.io/gh/lihor-hub/news-dashboard/branch/main/graph/badge.svg)
+[![Coverage Status](https://codecov.io/gh/lihor-hub/news-dashboard/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lihor-hub/news-dashboard)
 [![CodeQL](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml)
 
 Self-hosted technical news inbox for curated feeds, article triage, source


### PR DESCRIPTION
Closes #737

Updates the Codecov badge link in README.md to point to the dashboard: https://app.codecov.io/gh/lihor-hub/news-dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)