### PR TITLE
fix: throttle passwordless OTP requests and login attempts (#595)

### DIFF
--- a/backend/news_dashboard/login_throttle.py
+++ b/backend/news_dashboard/login_throttle.py
@@ -1,7 +1,11 @@
-"""In-process throttle for failed password-login attempts.
+"""In-process throttle for failed password-login and OTP attempts.
 
-Keys on normalized username only; client address is excluded because
+Keys on a caller-supplied string only; client address is excluded because
 reverse-proxy deployments may not expose the original remote address reliably.
+Password login keys on the normalized username. OTP endpoints use prefixed
+compound keys (e.g. ``otp-request:<email>``, ``otp-login:<email>``) so the
+same counters can rate-limit distinct actions for the same identity without
+colliding with each other or with password-login state.
 
 Window: 15 minutes / 5 failures → HTTP 429.  A successful login clears the
 recorded failures for that key so legitimate users are never permanently locked.
@@ -17,7 +21,7 @@ from datetime import datetime, timezone
 _WINDOW_SECONDS: int = 15 * 60
 _MAX_FAILURES: int = 5
 
-# Protected by _lock; maps normalised username → list[datetime (utc)]
+# Protected by _lock; maps normalised key → list[datetime (utc)]
 _failures: dict[str, list[datetime]] = defaultdict(list)
 _lock = threading.Lock()
 
@@ -46,27 +50,27 @@ def _prune(key: str, now: datetime) -> None:
     _failures[key] = [ts for ts in _failures[key] if ts.timestamp() >= cutoff]
 
 
-def is_throttled(username: str) -> bool:
-    """Return True if *username* has too many recent failures."""
-    key = username.strip().lower()
+def is_throttled(key: str) -> bool:
+    """Return True if *key* has too many recent failures."""
+    key = key.strip().lower()
     now = _now()
     with _lock:
         _prune(key, now)
         return len(_failures[key]) >= _MAX_FAILURES
 
 
-def record_failure(username: str) -> None:
-    """Record one failed attempt for *username*."""
-    key = username.strip().lower()
+def record_failure(key: str) -> None:
+    """Record one failed attempt for *key*."""
+    key = key.strip().lower()
     now = _now()
     with _lock:
         _prune(key, now)
         _failures[key].append(now)
 
 
-def clear_failures(username: str) -> None:
-    """Clear all recorded failures for *username* (call after successful login)."""
-    key = username.strip().lower()
+def clear_failures(key: str) -> None:
+    """Clear all recorded failures for *key* (call after a successful attempt)."""
+    key = key.strip().lower()
     with _lock:
         _failures.pop(key, None)
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -466,6 +466,11 @@ def logout(response: Response) -> dict[str, str]:
 def otp_request(payload: OTPRequestPayload, background_tasks: BackgroundTasks) -> dict[str, str]:
     from news_dashboard.email import send_otp_email
 
+    request_key = f"otp-request:{payload.email.strip().lower()}"
+    if is_throttled(request_key):
+        raise HTTPException(status_code=429, detail="Too many code requests; try again later")
+    record_failure(request_key)
+
     user = get_user_by_email(payload.email)
     if user:
         otp = create_otp_for_user(int(user["id"]))
@@ -476,9 +481,15 @@ def otp_request(payload: OTPRequestPayload, background_tasks: BackgroundTasks) -
 
 @public_router.post("/api/auth/otp/login")
 def otp_login(payload: OTPLoginPayload, response: Response) -> dict[str, Any]:
+    login_key = f"otp-login:{payload.email.strip().lower()}"
+    if is_throttled(login_key):
+        raise HTTPException(status_code=429, detail="Too many code attempts; try again later")
+
     user = consume_otp(payload.email, payload.otp)
     if not user:
+        record_failure(login_key)
         raise HTTPException(status_code=401, detail="Invalid or expired code")
+    clear_failures(login_key)
     token = create_session_token(int(user["id"]), bool(user["is_admin"]))
     response.set_cookie(
         key=_SESSION_COOKIE,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -483,7 +483,9 @@ def test_otp_expired_rejected(tmp_db: str) -> None:
     assert consume_otp("exp@example.com", "000000") is None
 
 
-def test_otp_request_endpoint_returns_sent_for_unknown_email(tmp_db: str) -> None:
+def test_otp_request_endpoint_returns_sent_for_unknown_email(
+    tmp_db: str, clean_throttle: None
+) -> None:
     client = _fresh_client()
     resp = client.post("/api/auth/otp/request", json={"email": "ghost@example.com"})
     assert resp.status_code == 200
@@ -514,7 +516,7 @@ def test_otp_login_endpoint_full_flow(tmp_db: str, monkeypatch: pytest.MonkeyPat
     assert "nd_session" in resp.cookies
 
 
-def test_otp_login_endpoint_bad_code(tmp_db: str) -> None:
+def test_otp_login_endpoint_bad_code(tmp_db: str, clean_throttle: None) -> None:
     create_user("bad_otp", "pw", email="bad@example.com")
     client = _fresh_client()
     resp = client.post("/api/auth/otp/login", json={"email": "bad@example.com", "otp": "000000"})
@@ -682,3 +684,64 @@ def test_throttle_does_not_affect_keycloak_mode(
     # Keycloak mode should still return 409, not 429
     resp = client.post("/api/auth/login", json={"username": "anyuser", "password": "pw"})
     assert resp.status_code == 409
+
+
+# ── OTP throttle ───────────────────────────────────────────────────────────────
+
+
+def test_otp_request_throttles_known_email(
+    tmp_db: str, clean_throttle: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import news_dashboard.email as email_mod
+
+    monkeypatch.setattr(email_mod, "send_otp_email", lambda *_args: None)
+    create_user("otp_req_known", "pw", email="reqknown@example.com")
+    client = _fresh_client()
+    for _ in range(5):
+        resp = client.post("/api/auth/otp/request", json={"email": "reqknown@example.com"})
+        assert resp.status_code == 200
+    resp = client.post("/api/auth/otp/request", json={"email": "reqknown@example.com"})
+    assert resp.status_code == 429
+
+
+def test_otp_request_throttles_unknown_email_at_same_threshold(
+    tmp_db: str, clean_throttle: None
+) -> None:
+    client = _fresh_client()
+    for _ in range(5):
+        resp = client.post("/api/auth/otp/request", json={"email": "ghost2@example.com"})
+        assert resp.status_code == 200
+    resp = client.post("/api/auth/otp/request", json={"email": "ghost2@example.com"})
+    assert resp.status_code == 429
+
+
+def test_otp_login_throttles_after_repeated_bad_codes(tmp_db: str, clean_throttle: None) -> None:
+    create_user("otp_login_throttled", "pw", email="throttled@example.com")
+    client = _fresh_client()
+    for _ in range(5):
+        resp = client.post(
+            "/api/auth/otp/login", json={"email": "throttled@example.com", "otp": "000000"}
+        )
+        assert resp.status_code == 401
+    resp = client.post(
+        "/api/auth/otp/login", json={"email": "throttled@example.com", "otp": "000000"}
+    )
+    assert resp.status_code == 429
+
+
+def test_otp_login_success_clears_throttle(tmp_db: str, clean_throttle: None) -> None:
+    user = create_user("otp_login_clear", "pw", email="clear@example.com")
+    client = _fresh_client()
+    for _ in range(4):
+        resp = client.post(
+            "/api/auth/otp/login", json={"email": "clear@example.com", "otp": "000000"}
+        )
+        assert resp.status_code == 401
+
+    otp = create_otp_for_user(user["id"])
+    resp = client.post("/api/auth/otp/login", json={"email": "clear@example.com", "otp": otp})
+    assert resp.status_code == 200
+
+    # Failure counter was cleared, so more wrong attempts still return 401, not 429
+    resp = client.post("/api/auth/otp/login", json={"email": "clear@example.com", "otp": "000000"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Closes #595.

The OTP endpoints (`/api/auth/otp/request`, `/api/auth/otp/login`) did not use the existing login throttle, so a client could:
- repeatedly request new OTP codes for the same email (delivery noise, replacing active codes), and
- repeatedly submit wrong 6-digit codes during the 10-minute TTL,

without hitting any server-side rate limit.

- Generalized `backend/news_dashboard/login_throttle.py` to key on an arbitrary caller-supplied string (renamed the `username` parameter to `key`) rather than duplicating the throttle logic for OTP.
- Applied the throttle to both OTP endpoints using prefixed compound keys, `otp-request:<email>` and `otp-login:<email>`, so OTP throttling never collides with password-login throttle state (which keys on bare usernames).
- `otp/request` checks/records the attempt **before** the user lookup, so known and unknown emails hit the same 429 threshold — anti-enumeration behavior is preserved.
- `otp/login` clears its failure counter on a successful code (mirrors password-login behavior); existing password-login throttle is untouched.
- Both endpoints return a generic `429` message that does not reveal account existence.

## Test plan

- [x] `make lint` (ruff check + format) — passing
- [x] `make typecheck` (mypy strict, ty, pyrefly) — passing
- [x] `backend/tests/test_auth.py` — 58 passed (added: `test_otp_request_throttles_known_email`, `test_otp_request_throttles_unknown_email_at_same_threshold`, `test_otp_login_throttles_after_repeated_bad_codes`, `test_otp_login_success_clears_throttle`)
- [x] Verified existing password-login throttle tests still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)