### PR TITLE
test: consolidate slow/redundant Python coverage (#600)

### DIFF
--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -194,24 +194,22 @@ def test_postgres_schema_has_briefing_articles_table(pg_url: str) -> None:
     assert row is not None, "briefing_articles table missing after init_db"
 
 
-def test_postgres_briefings_content_column_is_jsonb(pg_url: str) -> None:
+@pytest.mark.parametrize(
+    ("column_name", "expected_type"),
+    [
+        ("content", "jsonb"),
+        ("created_at", "timestamp with time zone"),
+    ],
+)
+def test_postgres_briefings_column_types(pg_url: str, column_name: str, expected_type: str) -> None:
     with psycopg.connect(pg_url) as conn:
         row = conn.execute(
             "SELECT data_type FROM information_schema.columns"
-            " WHERE table_name = 'briefings' AND column_name = 'content'"
+            " WHERE table_name = 'briefings' AND column_name = %s",
+            (column_name,),
         ).fetchone()
     assert row is not None
-    assert row[0] == "jsonb"
-
-
-def test_postgres_briefings_created_at_is_timestamptz(pg_url: str) -> None:
-    with psycopg.connect(pg_url) as conn:
-        row = conn.execute(
-            "SELECT data_type FROM information_schema.columns"
-            " WHERE table_name = 'briefings' AND column_name = 'created_at'"
-        ).fetchone()
-    assert row is not None
-    assert row[0] == "timestamp with time zone"
+    assert row[0] == expected_type
 
 
 # ── get_latest_briefing ───────────────────────────────────────────────────────

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -472,46 +472,23 @@ def test_pg_private_source_visibility(pg_env: str) -> None:
 # ── schema correctness ────────────────────────────────────────────────────────
 
 
-def test_pg_user_article_state_starred_is_boolean(pg_clean: str) -> None:
-    """user_article_state.starred must be a boolean column in PostgreSQL."""
+@pytest.mark.parametrize(
+    ("table_name", "column_name"),
+    [
+        ("user_article_state", "starred"),
+        ("user_sources", "enabled"),
+        ("articles", "starred"),
+    ],
+)
+def test_pg_boolean_column_is_boolean(pg_clean: str, table_name: str, column_name: str) -> None:
+    """Boolean-typed columns must remain boolean in PostgreSQL."""
     import psycopg
 
     with psycopg.connect(pg_clean) as conn:
         row = conn.execute(
-            """
-            SELECT data_type FROM information_schema.columns
-            WHERE table_name = 'user_article_state' AND column_name = 'starred'
-            """,
-        ).fetchone()
-    assert row is not None
-    assert row[0] == "boolean"
-
-
-def test_pg_user_sources_enabled_is_boolean(pg_clean: str) -> None:
-    """user_sources.enabled must be a boolean column in PostgreSQL."""
-    import psycopg
-
-    with psycopg.connect(pg_clean) as conn:
-        row = conn.execute(
-            """
-            SELECT data_type FROM information_schema.columns
-            WHERE table_name = 'user_sources' AND column_name = 'enabled'
-            """,
-        ).fetchone()
-    assert row is not None
-    assert row[0] == "boolean"
-
-
-def test_pg_articles_starred_is_boolean(pg_clean: str) -> None:
-    """articles.starred must be a boolean column in PostgreSQL."""
-    import psycopg
-
-    with psycopg.connect(pg_clean) as conn:
-        row = conn.execute(
-            """
-            SELECT data_type FROM information_schema.columns
-            WHERE table_name = 'articles' AND column_name = 'starred'
-            """,
+            "SELECT data_type FROM information_schema.columns"
+            " WHERE table_name = %s AND column_name = %s",
+            (table_name, column_name),
         ).fetchone()
     assert row is not None
     assert row[0] == "boolean"

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -491,64 +491,42 @@ def test_validate_push_subscription_accepts_valid() -> None:
     )
 
 
-def test_validate_push_subscription_rejects_http_scheme() -> None:
-    with pytest.raises(ValueError, match="https"):
-        validate_push_subscription("http://ep.example.com/push", "key", "auth")
-
-
-def test_validate_push_subscription_rejects_relative_url() -> None:
-    with pytest.raises(ValueError, match="https"):
-        validate_push_subscription("/push/v1/endpoint", "key", "auth")
-
-
-def test_validate_push_subscription_rejects_empty_endpoint() -> None:
-    with pytest.raises(ValueError, match="https"):
-        validate_push_subscription("", "key", "auth")
-
-
-def test_validate_push_subscription_rejects_localhost() -> None:
-    with pytest.raises(ValueError, match="non-public"):
-        validate_push_subscription("https://127.0.0.1/push", "key", "auth")
-
-
-def test_validate_push_subscription_rejects_loopback_ipv6() -> None:
-    with pytest.raises(ValueError, match="non-public"):
-        validate_push_subscription("https://[::1]/push", "key", "auth")
-
-
-def test_validate_push_subscription_rejects_private_ip() -> None:
-    with pytest.raises(ValueError, match="non-public"):
-        validate_push_subscription("https://192.168.1.1/push", "key", "auth")
-
-
-def test_validate_push_subscription_rejects_link_local() -> None:
-    with pytest.raises(ValueError, match="non-public"):
-        validate_push_subscription("https://169.254.1.1/push", "key", "auth")
-
-
-def test_validate_push_subscription_rejects_empty_p256dh() -> None:
-    with pytest.raises(ValueError, match="p256dh"):
-        validate_push_subscription("https://ep.example.com/push", "", "auth")
-
-
-def test_validate_push_subscription_rejects_empty_auth() -> None:
-    with pytest.raises(ValueError, match="auth"):
-        validate_push_subscription("https://ep.example.com/push", "key", "")
-
-
-def test_validate_push_subscription_rejects_oversized_endpoint() -> None:
-    with pytest.raises(ValueError, match="too long"):
-        validate_push_subscription("https://ep.example.com/" + "a" * 2100, "key", "auth")
-
-
-def test_validate_push_subscription_rejects_non_base64url_p256dh() -> None:
-    with pytest.raises(ValueError, match="base64url"):
-        validate_push_subscription("https://ep.example.com/push", "key with spaces!", "auth")
-
-
-def test_validate_push_subscription_rejects_non_base64url_auth() -> None:
-    with pytest.raises(ValueError, match="base64url"):
-        validate_push_subscription("https://ep.example.com/push", "validkey", "auth with spaces!")
+@pytest.mark.parametrize(
+    ("endpoint", "p256dh", "auth", "match"),
+    [
+        ("http://ep.example.com/push", "key", "auth", "https"),
+        ("/push/v1/endpoint", "key", "auth", "https"),
+        ("", "key", "auth", "https"),
+        ("https://127.0.0.1/push", "key", "auth", "non-public"),
+        ("https://[::1]/push", "key", "auth", "non-public"),
+        ("https://192.168.1.1/push", "key", "auth", "non-public"),
+        ("https://169.254.1.1/push", "key", "auth", "non-public"),
+        ("https://ep.example.com/push", "", "auth", "p256dh"),
+        ("https://ep.example.com/push", "key", "", "auth"),
+        ("https://ep.example.com/" + "a" * 2100, "key", "auth", "too long"),
+        ("https://ep.example.com/push", "key with spaces!", "auth", "base64url"),
+        ("https://ep.example.com/push", "validkey", "auth with spaces!", "base64url"),
+    ],
+    ids=[
+        "http-scheme",
+        "relative-url",
+        "empty-endpoint",
+        "localhost",
+        "loopback-ipv6",
+        "private-ip",
+        "link-local",
+        "empty-p256dh",
+        "empty-auth",
+        "oversized-endpoint",
+        "non-base64url-p256dh",
+        "non-base64url-auth",
+    ],
+)
+def test_validate_push_subscription_rejects_invalid_input(
+    endpoint: str, p256dh: str, auth: str, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        validate_push_subscription(endpoint, p256dh, auth)
 
 
 # ── Subscribe endpoint validation integration ──────────────────────────────────

--- a/backend/tests/test_search_filters.py
+++ b/backend/tests/test_search_filters.py
@@ -286,39 +286,30 @@ def client(api_db: str) -> TestClient:
     return TestClient(app)
 
 
-def test_search_endpoint_defaults(client: TestClient) -> None:
-    resp = client.get("/api/search")
-    assert resp.status_code == 200
-    assert "items" in resp.json()
-
-
-def test_search_endpoint_with_q(client: TestClient) -> None:
-    resp = client.get("/api/search?q=python")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "items" in data
-
-
-def test_search_endpoint_state_filter(client: TestClient) -> None:
-    resp = client.get("/api/search?states=today&states=done")
-    assert resp.status_code == 200
-    assert "items" in resp.json()
-
-
-def test_search_endpoint_category_filter(client: TestClient) -> None:
-    resp = client.get("/api/search?categories=python&categories=ai-llm")
-    assert resp.status_code == 200
-    assert "items" in resp.json()
-
-
-def test_search_endpoint_starred_only(client: TestClient) -> None:
-    resp = client.get("/api/search?starred_only=true")
-    assert resp.status_code == 200
-    assert "items" in resp.json()
-
-
-def test_search_endpoint_include_archived(client: TestClient) -> None:
-    resp = client.get("/api/search?include_archived=true")
+@pytest.mark.parametrize(
+    "query_string",
+    [
+        "",
+        "?q=python",
+        "?states=today&states=done",
+        "?categories=python&categories=ai-llm",
+        "?starred_only=true",
+        "?include_archived=true",
+        "?q=python&states=today&categories=python"
+        "&starred_only=false&include_archived=false&date_range=week",
+    ],
+    ids=[
+        "defaults",
+        "with_q",
+        "state_filter",
+        "category_filter",
+        "starred_only",
+        "include_archived",
+        "all_filters",
+    ],
+)
+def test_search_endpoint_accepts_filter_combinations(client: TestClient, query_string: str) -> None:
+    resp = client.get(f"/api/search{query_string}")
     assert resp.status_code == 200
     assert "items" in resp.json()
 
@@ -328,15 +319,6 @@ def test_search_endpoint_date_range(client: TestClient, api_db: Path) -> None:
     for dr in ["today", "week", "month"]:
         resp = client.get(f"/api/search?date_range={dr}")
         assert resp.status_code == 200, f"Failed for date_range={dr}"
-
-
-def test_search_endpoint_all_filters(client: TestClient) -> None:
-    resp = client.get(
-        "/api/search?q=python&states=today&categories=python"
-        "&starred_only=false&include_archived=false&date_range=week"
-    )
-    assert resp.status_code == 200
-    assert "items" in resp.json()
 
 
 def test_search_endpoint_returns_matching_articles(client: TestClient, api_db: Path) -> None:

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -6,6 +6,8 @@ import contextlib
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect
 from news_dashboard.ingest import (
@@ -413,24 +415,18 @@ def test_generic_reason_not_tracked_under() -> None:
 # ──────────────────────────────────────────────
 
 
-def test_infer_tags_python() -> None:
-    tags = infer_tags("New Python 3.14 typing improvements with mypy support")
-    assert "python" in tags
-
-
-def test_infer_tags_release() -> None:
-    tags = infer_tags("Release v2.1.0 of some library with changelog")
-    assert "release" in tags
-
-
-def test_infer_tags_security() -> None:
-    tags = infer_tags("Critical CVE found in popular package")
-    assert "security" in tags
-
-
-def test_infer_tags_agents() -> None:
-    tags = infer_tags("LangGraph adds new multi-agent orchestration workflow")
-    assert "agents" in tags
+@pytest.mark.parametrize(
+    ("title", "expected_tag"),
+    [
+        ("New Python 3.14 typing improvements with mypy support", "python"),
+        ("Release v2.1.0 of some library with changelog", "release"),
+        ("Critical CVE found in popular package", "security"),
+        ("LangGraph adds new multi-agent orchestration workflow", "agents"),
+    ],
+)
+def test_infer_tags(title: str, expected_tag: str) -> None:
+    tags = infer_tags(title)
+    assert expected_tag in tags
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #600.

Consolidates several groups of near-duplicate test functions into single `@pytest.mark.parametrize` tests, reducing boilerplate while keeping identical test-case coverage:

- `test_push_notifications.py`: 12 separate `test_validate_push_subscription_rejects_*` unit tests → 1 parametrized test with 12 cases.
- `test_postgres_types.py`: 3 separate boolean-column tests → 1 parametrized test.
- `test_briefings_db.py`: 2 separate column-type tests (`jsonb`, `timestamptz`) → 1 parametrized test.
- `test_source_health.py`: 4 separate `test_infer_tags_*` tests → 1 parametrized test.
- `test_search_filters.py`: 6 separate `/api/search` filter-combination smoke tests → 1 parametrized test.

No PostgreSQL-only behavior changed — all tests still run against a live PostgreSQL instance (no SQLite/fake-DB fallbacks were introduced). Total collected test count is unchanged (1217 test cases before and after); only the amount of duplicated test-function code was reduced (~167 lines removed, ~98 added).

## Test plan

- [x] `uv run ruff check` / `ruff format --check` on changed files — clean
- [x] `uv run mypy` (strict) on changed files — clean
- [x] Full backend suite: `1217 passed` locally against Postgres, before and after the change
- [x] `pre-commit run --all-files` (ruff, mypy, ty, pyrefly) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)