### PR TITLE
chore: update ioachim-hub references to lihor-hub in docs, CI, Helm (#609)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,7 @@ jobs:
       - name: helm template (production-like overrides)
         run: |
           helm template news-dashboard ./helm/news-dashboard \
-            --set "image.repository=ghcr.io/ioachim-hub/news-dashboard" \
+            --set "image.repository=ghcr.io/lihor-hub/news-dashboard" \
             --set "image.tag=abc1234" \
             --set "image.pullSecretName=ghcr-pull-secret" \
             --set "service.type=NodePort" \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ flowchart LR
   BuildFrontend --> Publish
 
   Publish --> Image["Docker build<br/>React build stage + Python runtime"]
-  Image --> GHCR["Push ghcr.io/ioachim-hub/news-dashboard:<sha>"]
+  Image --> GHCR["Push ghcr.io/lihor-hub/news-dashboard:<sha>"]
 
   GHCR --> Runner["Self-hosted runner<br/>mini PC"]
   Runner --> Pull["docker pull image"]

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -145,8 +145,8 @@ Privacy/security:
 Built via `Dockerfile` at repo root. Published to GHCR via GitHub Actions on every push to `main`.
 
 ```
-ghcr.io/ioachim-hub/news-dashboard:latest
-ghcr.io/ioachim-hub/news-dashboard:<sha>
+ghcr.io/lihor-hub/news-dashboard:latest
+ghcr.io/lihor-hub/news-dashboard:<sha>
 ```
 
 ### Kubernetes (Helm)

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -31,7 +31,7 @@ helm version
 
 ## Step 1 — Register the runner
 
-1. Go to **https://github.com/ioachim-hub/news-dashboard/settings/actions/runners**
+1. Go to **https://github.com/lihor-hub/news-dashboard/settings/actions/runners**
 2. Click **New self-hosted runner**
 3. Select **Linux / x64**
 4. Follow the on-screen download and configuration steps:
@@ -43,7 +43,7 @@ curl -o actions-runner-linux-x64.tar.gz -L <URL_FROM_GITHUB_UI>
 tar xzf actions-runner-linux-x64.tar.gz
 
 # Register — use the token shown on the GitHub UI; it expires in 1 hour
-./config.sh --url https://github.com/ioachim-hub/news-dashboard \
+./config.sh --url https://github.com/lihor-hub/news-dashboard \
             --token <REGISTRATION_TOKEN_FROM_GITHUB_UI> \
             --name ioachim-minipc \
             --labels self-hosted
@@ -64,7 +64,7 @@ sudo systemctl status "actions.runner.*"
 ```
 
 Check that the runner appears as **Idle** in the GitHub UI at
-`https://github.com/ioachim-hub/news-dashboard/settings/actions/runners`.
+`https://github.com/lihor-hub/news-dashboard/settings/actions/runners`.
 
 To manage the service later:
 
@@ -77,7 +77,7 @@ sudo systemctl restart "actions.runner.*"
 ## Step 3 — Environment variables and secrets
 
 The deploy workflow reads one GitHub Actions secret. Add it at
-**https://github.com/ioachim-hub/news-dashboard/settings/secrets/actions**:
+**https://github.com/lihor-hub/news-dashboard/settings/secrets/actions**:
 
 | Secret name  | Description |
 |--------------|-------------|

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/ioachim-hub/news-dashboard
+  repository: ghcr.io/lihor-hub/news-dashboard
   # CI overrides this with the commit SHA so Kubernetes always pulls the exact
   # image that was just built.  'latest' is only used for manual local deploys.
   tag: latest


### PR DESCRIPTION
## Summary
- Closes #609
- Updates GHCR image path references from `ghcr.io/ioachim-hub/news-dashboard` to `ghcr.io/lihor-hub/news-dashboard` in `helm/news-dashboard/values.yaml`, `.github/workflows/ci.yml`, `docs/ARCHITECTURE.md`, and `docs/PRODUCT_SPEC.md`.
- Updates GitHub UI URLs in `docs/runner-setup.md` to reference `github.com/lihor-hub/news-dashboard`.
- Leaves `.github/CODEOWNERS` and ADR "Deciders" entries unchanged — those reference the maintainer's personal `@ioachim-hub` handle, not the org/repo path, and are out of scope per the issue.

## Test plan
- [x] `git grep -n "ioachim-hub" -- .github/workflows/ci.yml helm/news-dashboard/values.yaml docs/ARCHITECTURE.md docs/PRODUCT_SPEC.md docs/runner-setup.md` returns no matches
- [x] `helm lint ./helm/news-dashboard` passes
- [x] `helm template ./helm/news-dashboard ...` renders and the image points at `ghcr.io/lihor-hub/news-dashboard`
- [x] Pre-commit hooks (yaml/whitespace/EOF checks) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)