### PR TITLE
docs: add SECURITY.md disclosure policy (#612)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ generic multi-database layers.
 Do not commit secrets, API keys, database credentials, or production session
 keys. Use environment variables or deployment secrets.
 
+See [SECURITY.md](SECURITY.md) for the vulnerability-disclosure policy and
+supported versions.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Preferred: use GitHub's private reporting form for this repository —
+[Report a vulnerability](https://github.com/lihor-hub/news-dashboard/security/advisories/new)
+(Security tab → "Report a vulnerability"). This opens a private advisory
+visible only to maintainers until a fix is ready.
+
+Fallback: if you cannot use GitHub's private reporting, email
+**ioachim.lihor@gmail.com** with:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof-of-concept if available.
+- Affected version or commit SHA.
+
+We will acknowledge reports within **5 business days** and aim to provide a
+fix or mitigation plan within **30 days**, depending on severity and
+complexity. Please give us a reasonable window to release a fix before any
+public disclosure.
+
+## Supported versions
+
+News Dashboard does not maintain long-lived release branches. Only the
+latest published release is supported with security fixes.
+
+| Version         | Supported          |
+| ---------------- | ------------------ |
+| Latest `1.x` release | :white_check_mark: |
+| Older `1.x` releases  | :x:                 |
+
+If you are running an older version, please upgrade to the latest release
+before reporting — the issue may already be fixed.
+
+## Security-relevant configuration
+
+This app has real security surface worth getting right when self-hosting:
+
+- **`SESSION_SECRET`** — signs session cookies and (unless `TOKEN_SECRET` is
+  set) digest mark-read tokens. Use a strong, unique, randomly generated
+  value in any deployment reachable outside your own machine.
+- **`BOOTSTRAP_ADMIN_USERNAME`** / **`BOOTSTRAP_ADMIN_PASSWORD`** — set the
+  first local admin account. Never leave these at their local-development
+  defaults in a reachable deployment.
+- **`FREE_LLM_API_KEY`** / **`OPENAI_API_KEY`** — third-party API credentials
+  for AI features. Treat as secrets; do not commit them.
+- **`VAPID_PRIVATE_KEY`** — private key for Web Push notifications.
+- **Keycloak (`KEYCLOAK_*`)** — optional external auth; when enabled, review
+  [docs/KEYCLOAK_AUTH.md](docs/KEYCLOAK_AUTH.md) for the trust model.
+
+See the [Configuration](README.md#configuration) table in the README for the
+full list of environment variables. Never commit secrets, API keys, database
+credentials, or production session values to the repository — use
+environment variables or your deployment platform's secret store.


### PR DESCRIPTION
## Summary

Closes #612.

- Adds `SECURITY.md` at the repo root with a private reporting channel (GitHub Security Advisories, with an email fallback), a response-time expectation, a "Supported Versions" table, and a summary of security-relevant configuration (`SESSION_SECRET`, bootstrap admin credentials, AI API keys, VAPID key, Keycloak).
- Adds a one-line pointer from `README.md`'s "Security" section to `SECURITY.md`, keeping the existing "no secrets in commits" guidance.

**Maintainer follow-up (not a file change):** consider enabling GitHub's "Private vulnerability reporting" toggle in repo Settings → Security so the linked reporting form works end-to-end.

No secret values are included — only environment variable names, consistent with the acceptance criteria.

## Test plan

- [x] Docs-only change; no unit tests apply.
- [x] Verified `SECURITY.md` exists and covers disclosure channel + supported versions table.
- [x] Verified README's Security section links to `SECURITY.md`.
- [x] `git commit` ran the repo's pre-commit hooks (trailing-whitespace, end-of-file-fixer) cleanly.
- [ ] GitHub "Security policy" community-health checkmark will appear automatically once merged to the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)