### PR TITLE
chore: add GitHub issue/PR templates and SUPPORT.md (#613)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What's broken?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Self-hosted (Docker/Helm)
+        - Local development
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste any relevant logs, stack traces, or screenshots. This will be automatically formatted as code, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/lihor-hub/news-dashboard/blob/main/SUPPORT.md
+    about: See SUPPORT.md for how to get help and ask questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / goal
+      description: What problem does this solve, or what goal does it enable?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / acceptance criteria
+      description: What's in scope, and how would we know this is done?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Linked issue
+
+Closes #
+
+## Checklist
+
+- [ ] `make check` passed locally
+- [ ] Tests added or updated
+- [ ] Docs updated (README, docs/, or inline comments) if behavior changed

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# Support
+
+Looking for help with News Dashboard? Here's where to go.
+
+## Ask a question
+
+Open a [new issue](https://github.com/lihor-hub/news-dashboard/issues/new/choose)
+using the "Ask a question" link, or apply the `question` label to a
+[Feature request](https://github.com/lihor-hub/news-dashboard/issues/new?template=feature_request.yml)
+if the request doesn't fit a bug report.
+
+## Report a bug
+
+Use the [Bug report](https://github.com/lihor-hub/news-dashboard/issues/new?template=bug_report.yml)
+template.
+
+## Request a feature
+
+Use the [Feature request](https://github.com/lihor-hub/news-dashboard/issues/new?template=feature_request.yml)
+template.
+
+## Report a security vulnerability
+
+Do **not** open a public issue for security reports. See
+[SECURITY.md](SECURITY.md) for the private disclosure process.
+
+## Read the docs
+
+Start with the [README](README.md) for setup and configuration, and
+[CONTRIBUTING.md](CONTRIBUTING.md) for development workflow.


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` (auto-applies `bug` label) and `feature_request.yml` (auto-applies `enhancement` label) issue forms.
- Adds `.github/ISSUE_TEMPLATE/config.yml` disabling blank issues, linking to `SUPPORT.md` for questions (GitHub Discussions is not enabled on this repo).
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with a summary section, `Closes #` line, and a `make check` / tests / docs checklist.
- Adds `SUPPORT.md` pointing question-askers to the new issue templates and to `SECURITY.md` for vulnerability reports.

Closes #613

## Test plan
- [x] Validated all `.github/ISSUE_TEMPLATE/*.yml` files parse with `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/ISSUE_TEMPLATE/*.yml')]"`
- [x] Pre-commit hooks (trailing whitespace, EOF, YAML check) passed on commit
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)