### PR TITLE
docs: add README badges and screenshots (#615)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # News Dashboard
 
+[![CI](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml)
 [![Coverage Status](https://codecov.io/gh/lihor-hub/news-dashboard/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lihor-hub/news-dashboard)
 [![CodeQL](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml)
+[![Version](https://img.shields.io/badge/version-1.21.0-blue)](CHANGELOG.md)
+[![License: MIT](https://img.shields.io/github/license/lihor-hub/news-dashboard)](LICENSE)
 
 Self-hosted technical news inbox for curated feeds, article triage, source
 health, search, briefings, and saved/read history.
@@ -19,6 +22,13 @@ optional OpenAI features for embeddings, Ask AI, and briefings.
 - Optional Keycloak login.
 - Optional OpenAI embeddings, Ask AI, and generated briefings.
 - Docker, Helm, and GitHub Actions deployment support.
+
+## Screenshots
+
+> TODO: these are placeholders generated without a running instance. Replace
+> with real captures of the Today feed and the Ask AI / briefing view.
+
+![Today feed placeholder](docs/assets/screenshot-dashboard.svg)
 
 ## Stack
 

--- a/docs/assets/screenshot-dashboard.svg
+++ b/docs/assets/screenshot-dashboard.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0f172a"/>
+  <rect x="20" y="20" width="920" height="60" rx="8" fill="#1e293b"/>
+  <text x="40" y="57" font-family="monospace" font-size="22" fill="#e2e8f0">News Dashboard — Today</text>
+  <rect x="20" y="100" width="280" height="420" rx="8" fill="#1e293b"/>
+  <rect x="316" y="100" width="624" height="420" rx="8" fill="#1e293b"/>
+  <text x="480" y="320" font-family="monospace" font-size="26" fill="#64748b" text-anchor="middle">Screenshot placeholder</text>
+  <text x="480" y="356" font-family="monospace" font-size="16" fill="#475569" text-anchor="middle">TODO: replace with a real capture of the Today feed</text>
+</svg>


### PR DESCRIPTION
Closes #615

## Summary
- Add a CI status badge, version badge, and license badge to the README badge row (alongside the existing coverage/CodeQL badges).
- Add a "Screenshots" section after "Features" with a placeholder SVG image (`docs/assets/screenshot-dashboard.svg`) and a `TODO` note, since capturing a live screenshot of a running instance isn't feasible in this AFK session.

## Test plan
- [x] Docs-only change; no unit tests apply.
- [ ] CI passes (lint/format hooks already ran clean locally via pre-commit).
- [ ] Manually verify badges resolve and the screenshot section renders without 404s in GitHub's markdown preview.