### PR TITLE
docs: add .env.example as config source of truth (#616)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,74 +1,118 @@
-# News Dashboard - Production Environment Variables
-# Copy this file to .env and fill in the values
+# News Dashboard environment configuration.
+#
+# Copy this file to `.env` and fill in real values before running the app:
+#   cp .env.example .env
+#
+# `.env` is gitignored; this file is committed and must stay in sync with
+# every environment variable the backend reads (see backend/tests/test_env_example.py).
 
-# ===========================================
-# REQUIRED - Must be set for production
-# ===========================================
+# --- Database (required) -----------------------------------------------------
+# Either set DATABASE_URL directly, or the split POSTGRES_* parts below.
+DATABASE_URL=postgresql://news_dashboard:news-dashboard-local-password@localhost:5432/news_dashboard
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=news_dashboard
+POSTGRES_USER=news_dashboard
+POSTGRES_PASSWORD=news-dashboard-local-password
+# Startup connection retry tuning. Defaults: 30 attempts, 2.0s delay.
+DB_CONNECT_MAX_ATTEMPTS=30
+DB_CONNECT_RETRY_DELAY_SECONDS=2.0
 
-# PostgreSQL password
-POSTGRES_PASSWORD=your-secure-postgres-password
-
-# Session secret for signed cookies (generate with: python -c "import secrets; print(secrets.token_hex(32))")
-SESSION_SECRET=your-session-secret-here
-
-# Bootstrap admin account (created on first run if no users exist)
+# --- Auth & sessions (required) ----------------------------------------------
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+SESSION_SECRET=change-me-generate-a-random-hex-secret
+# Optional: sign one-click digest mark-read tokens independently of SESSION_SECRET.
+TOKEN_SECRET=
+# Optional: override bcrypt cost factor (default 12; tests use a lower value).
+BCRYPT_ROUNDS=
+# Days a login session stays valid. Default 30.
+SESSION_DAYS=30
+# First local admin account, created only when no users exist yet.
 BOOTSTRAP_ADMIN_USERNAME=admin
-BOOTSTRAP_ADMIN_PASSWORD=your-secure-admin-password
+BOOTSTRAP_ADMIN_PASSWORD=change-me
 
-# ===========================================
-# OPTIONAL - AI Features (uncomment as needed)
-# ===========================================
+# --- Keycloak SSO (optional) --------------------------------------------------
+# See docs/KEYCLOAK_AUTH.md.
+KEYCLOAK_AUTH_ENABLED=false
+KEYCLOAK_SERVER_URL=
+# Internal-network Keycloak URL for server-to-server calls; defaults to KEYCLOAK_SERVER_URL.
+KEYCLOAK_INTERNAL_SERVER_URL=
+KEYCLOAK_REALM=news-dashboard
+KEYCLOAK_CLIENT_ID=news-dashboard
+KEYCLOAK_CLIENT_SECRET=
+KEYCLOAK_ADMIN_CLIENT_ID=
+KEYCLOAK_ADMIN_CLIENT_SECRET=
+# Comma-separated Keycloak usernames granted admin privileges.
+KEYCLOAK_ADMIN_USERNAMES=
+# Public base URL of this app, used to build Keycloak redirect URIs. Default http://localhost:8080.
+NEWS_DASHBOARD_BASE_URL=http://localhost:8080
 
-# OpenAI API key for AI features (summaries, insights, TTS)
-# OPENAI_API_KEY=
+# --- AI / LLM (optional; required for Ask AI, embeddings, briefings, TTS) ----
+# Primary key/URL for chat, embeddings, Ask AI, and briefings (e.g. a self-hosted gateway).
+FREE_LLM_API_KEY=
+FREE_LLM_BASE_URL=
+# OpenAI credentials. Required for TTS/audio; also used as fallback when FREE_LLM_API_KEY is unset.
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+# Per-feature model overrides. Each has an internal default if unset.
+OPENAI_BRIEFING_MODEL=gpt-4o-mini
+OPENAI_ANSWER_MODEL=
+OPENAI_EMBEDDING_MODEL=
+OPENAI_INSIGHTS_MODEL=
+OPENAI_OPTIMIZER_MODEL=
+OPENAI_PERSPECTIVES_MODEL=
+OPENAI_QUIZ_MODEL=
 
-# Alternative free LLM configuration
-# FREE_LLM_API_KEY=
-# FREE_LLM_BASE_URL=
+# --- Tracing (optional) -------------------------------------------------------
+# Tracing activates only when both keys below are set; otherwise a plain OpenAI client is used.
+LANGFUSE_HOST=
+# LANGFUSE_BASE_URL is accepted as an alias for LANGFUSE_HOST.
+LANGFUSE_BASE_URL=
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
 
-# Langfuse tracing (optional, for debugging AI calls)
-# LANGFUSE_PUBLIC_KEY=
-# LANGFUSE_SECRET_KEY=
-# LANGFUSE_HOST=
+# --- Web Push notifications (optional) ---------------------------------------
+# Generate with: npx web-push generate-vapid-keys
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# Contact email used in VAPID claims. Default admin@example.com.
+VAPID_EMAIL=admin@example.com
 
-# ===========================================
-# OPTIONAL - Email/Digest
-# ===========================================
+# --- Email (optional) ---------------------------------------------------------
+# SMTP credentials for the daily digest email (digest.py).
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+DIGEST_TO=
+DIGEST_USER_ID=
+# Base URL used to build links (e.g. mark-read/article links) in digest emails. Default http://localhost:8000.
+APP_BASE_URL=http://localhost:8000
+# Gmail SMTP credentials for one-time-password sign-in emails (email.py); separate from the digest SMTP pair above.
+SMTP_USERNAME=
+SMTP_PASSWORD=
 
-# SMTP configuration for email digests
-# SMTP_HOST=
-# SMTP_PORT=587
-# SMTP_USERNAME=
-# SMTP_PASSWORD=
-# DIGEST_TO=admin@example.com
-# DIGEST_USER_ID=
+# --- Scheduler / ingestion -----------------------------------------------------
+INGEST_INTERVAL_MINUTES=30
+DIGEST_CRON=0 8 * * *
+BRIEFING_CRON=0 9 * * *
+RECOMMENDATIONS_CRON=30 7 * * *
+# Days to retain user_events before the daily cleanup job prunes them. Default 180.
+ANALYTICS_RETENTION_DAYS=180
 
-# ===========================================
-# OPTIONAL - Keycloak SSO
-# ===========================================
+# --- Misc / app ----------------------------------------------------------------
+# Comma-separated browser dev origins allowed by CORS.
+CORS_ORIGINS=http://localhost:5173
+# Directory where generated audio/data files (e.g. TTS) are cached. Default /data.
+DATA_DIR=/data
+# Enables demo/sample-data seeding when truthy (1/true/yes/on).
+DEMO_MODE=false
 
-# Keycloak authentication (leave disabled for local accounts)
-# KEYCLOAK_AUTH_ENABLED=false
-# KEYCLOAK_SERVER_URL=
-# KEYCLOAK_CLIENT_ID=news-dashboard
-# KEYCLOAK_CLIENT_SECRET=
-# KEYCLOAK_REALM=news-dashboard
+# --- One-off migration CLI (optional) -------------------------------------------
+# Used only by `news-dashboard-migrate sqlite-to-postgres`; prompts interactively if unset.
+SEED_USER=
+SEED_PASSWORD=
 
-# ===========================================
-# OPTIONAL - Web Push Notifications
-# ===========================================
-
-# VAPID keys for Web Push (generate with: npx web-push generate-vapid-keys)
-# VAPID_PUBLIC_KEY=
-# VAPID_PRIVATE_KEY=
-# VAPID_SUBJECT=mailto:admin@example.com
-
-# ===========================================
-# OPTIONAL - Customization
-# ===========================================
-
-# Allowed CORS origins (comma-separated)
-# CORS_ORIGINS=
-
-# Analytics retention in days (default: 90)
-# ANALYTICS_RETENTION_DAYS=90
+# --- Test-only (do not set in production) ---------------------------------------
+# Set automatically by pytest fixtures as a session-secret fallback in tests.
+TEST_SESSION_SECRET=

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ optional OpenAI features for embeddings, Ask AI, and briefings.
 
 ## Configuration
 
+Copy [`.env.example`](.env.example) to `.env` and fill in real values to get
+started; it enumerates every variable below plus a few advanced/internal
+knobs.
+
 Runtime storage is PostgreSQL only. Set `DATABASE_URL` or the split
 `POSTGRES_*` variables.
 
@@ -157,7 +161,7 @@ docker run --rm -d \
   postgres:16-alpine
 ```
 
-Set backend env:
+Set backend env (or copy `.env.example` to `.env` and adjust values):
 
 ```bash
 export DATABASE_URL=postgresql://news_dashboard:news-dashboard-local-password@localhost:5432/news_dashboard

--- a/backend/tests/test_env_example.py
+++ b/backend/tests/test_env_example.py
@@ -1,0 +1,58 @@
+"""Guard against drift between .env.example and the env vars the backend reads (issue #616).
+
+``.env.example`` is meant to be the single source of truth for configuration.
+This scans ``backend/news_dashboard`` source (not tests) for
+``os.environ.get("X")`` / ``os.getenv("X")`` calls with a literal name and
+asserts every var found there is documented in ``.env.example``, and vice
+versa (aside from a small, explicit allowlist of vars that are only read
+dynamically or are intentionally undocumented).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+SOURCE_DIR = REPO_ROOT / "backend" / "news_dashboard"
+
+_ENV_VAR_PATTERN = re.compile(r"os\.(?:environ\.get|getenv)\(\s*[\"']([A-Z][A-Z0-9_]*)[\"']")
+_ENV_EXAMPLE_LINE_PATTERN = re.compile(r"^([A-Z][A-Z0-9_]*)=")
+
+# TOKEN_SECRET is read dynamically via a tuple loop in digest.py, so the
+# literal-string scan below cannot discover it; it is still documented.
+_DYNAMIC_ONLY_VARS = {"TOKEN_SECRET"}
+
+
+def _vars_read_in_source() -> set[str]:
+    found: set[str] = set()
+    for path in SOURCE_DIR.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        found.update(_ENV_VAR_PATTERN.findall(text))
+    return found
+
+
+def _vars_in_env_example() -> set[str]:
+    documented: set[str] = set()
+    for line in ENV_EXAMPLE.read_text(encoding="utf-8").splitlines():
+        match = _ENV_EXAMPLE_LINE_PATTERN.match(line)
+        if match:
+            documented.add(match.group(1))
+    return documented
+
+
+def test_every_source_env_var_is_documented_in_env_example() -> None:
+    source_vars = _vars_read_in_source()
+    documented_vars = _vars_in_env_example()
+
+    missing = source_vars - documented_vars
+    assert not missing, f"env vars read in source but missing from .env.example: {sorted(missing)}"
+
+
+def test_every_documented_env_var_is_used_or_allowlisted() -> None:
+    source_vars = _vars_read_in_source()
+    documented_vars = _vars_in_env_example()
+
+    unused = documented_vars - source_vars - _DYNAMIC_ONLY_VARS
+    assert not unused, f".env.example vars not read anywhere in backend source: {sorted(unused)}"


### PR DESCRIPTION
Closes #616

## Summary
- Rewrote `.env.example` (previously a partial, production-only subset) to enumerate every environment variable read anywhere in `backend/news_dashboard`, grouped by area (database, auth/sessions, Keycloak, AI/LLM, tracing, web push, email, scheduler, misc, one-off migration CLI, test-only), each with a placeholder non-secret value and an inline comment.
- Secrets that need generation (`SESSION_SECRET`, VAPID keys) keep the generate-command guidance already documented in the README.
- Added `backend/tests/test_env_example.py`: scans `backend/news_dashboard` source for literal `os.environ.get("X")` / `os.getenv("X")` reads and asserts two-way parity with `.env.example` (minus a tiny, explicit allowlist for the one var read only dynamically), so future env vars can't drift out of sync with the example file.
- Confirmed `.gitignore` already ignores `.env` but not `.env.example` — no change needed there.
- Pointed the README `## Configuration` section and the `## Local Development` setup steps at `.env.example`.

## Test plan
- [x] `ruff check` / `ruff format --check` on the new test file
- [x] `mypy backend` (strict) — passes
- [x] `pytest backend/tests/test_env_example.py backend/tests/test_compose_auth_env.py -v` — 4 passed
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly) — all passed on commit