### PR TITLE
chore: enable GitHub Discussions and route questions there (#638)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/lihor-hub/news-dashboard/blob/main/SUPPORT.md
-    about: See SUPPORT.md for how to get help and ask questions.
+    url: https://github.com/lihor-hub/news-dashboard/discussions/categories/q-a
+    about: Ask usage or setup questions in the Q&A discussion category.
+  - name: Share a feature idea
+    url: https://github.com/lihor-hub/news-dashboard/discussions/categories/ideas
+    about: Open-ended feature ideas go in the Ideas discussion category. Use the Feature request template instead if the request is fully specified.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,11 @@ Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 New to the project? Browse [good first issues](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — beginner-friendly tasks with clear scope.
 
+Have a question or an open-ended feature idea? Use
+[GitHub Discussions](https://github.com/lihor-hub/news-dashboard/discussions) instead of
+opening an issue — see [SUPPORT.md](SUPPORT.md) for details. Issues are reserved for
+actionable, specified bugs and feature requests.
+
 Keep runtime database code PostgreSQL-specific: psycopg parameters, PostgreSQL
 SQL, and existing database helpers. Do not add SQLite runtime fallbacks or
 generic multi-database layers.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,10 +4,18 @@ Looking for help with News Dashboard? Here's where to go.
 
 ## Ask a question
 
-Open a [new issue](https://github.com/lihor-hub/news-dashboard/issues/new/choose)
-using the "Ask a question" link, or apply the `question` label to a
-[Feature request](https://github.com/lihor-hub/news-dashboard/issues/new?template=feature_request.yml)
-if the request doesn't fit a bug report.
+Use [GitHub Discussions](https://github.com/lihor-hub/news-dashboard/discussions):
+
+- [Q&A](https://github.com/lihor-hub/news-dashboard/discussions/categories/q-a) for usage
+  and setup questions.
+- [Ideas](https://github.com/lihor-hub/news-dashboard/discussions/categories/ideas) for
+  open-ended feature ideas that aren't fully specified yet.
+- [Show and tell](https://github.com/lihor-hub/news-dashboard/discussions/categories/show-and-tell)
+  to share what you've built.
+- [Announcements](https://github.com/lihor-hub/news-dashboard/discussions/categories/announcements)
+  for project news.
+
+Issues are reserved for actionable, specified bugs and feature requests — see below.
 
 ## Report a bug
 
@@ -17,7 +25,8 @@ template.
 ## Request a feature
 
 Use the [Feature request](https://github.com/lihor-hub/news-dashboard/issues/new?template=feature_request.yml)
-template.
+template if the request is fully specified. For open-ended ideas, start a
+[Discussion](https://github.com/lihor-hub/news-dashboard/discussions/categories/ideas) instead.
 
 ## Report a security vulnerability
 


### PR DESCRIPTION
## Summary
Closes #638.

- Enabled GitHub Discussions on the repo (`has_discussions: true`), which auto-creates the default categories (General, Ideas, Q&A, Show and tell, Announcements).
- Updated `.github/ISSUE_TEMPLATE/config.yml` to point "Ask a question" and a new "Share a feature idea" contact link at the Discussions Q&A / Ideas categories instead of routing to SUPPORT.md/issues.
- Updated `SUPPORT.md` to lead with Discussions (Q&A, Ideas, Show and tell, Announcements) for open-ended questions/ideas, keeping issue templates for actionable bug reports/feature requests.
- Added a note in the README's Contributing section pointing readers to Discussions for questions/open-ended ideas.

## Note for maintainers
Discussions was enabled via the GitHub API as part of this change. Category names/descriptions use GitHub's defaults (Q&A, Ideas, Show and tell, Announcements) — rename/reorder them in repo Settings → Discussions if different wording is preferred. Category-level configuration (descriptions, pinned welcome posts) isn't scriptable via this PR and is left as a manual follow-up.

## Test plan
- [x] Config/docs-only change — no unit tests apply, per issue's test expectations.
- [x] Verified `.github/ISSUE_TEMPLATE/config.yml` is valid YAML (pre-commit `check yaml` hook passed).
- [x] Verified `has_discussions` is `true` on the repo via `gh api repos/lihor-hub/news-dashboard`.
- [ ] Manually click through the contact links once the PR is live to confirm the Discussions category URLs resolve (slugs are GitHub's defaults for newly created categories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)