### PR TITLE
docs: add MAINTAINERS, GOVERNANCE, and a roadmap (#639)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ By participating in this project, you agree to abide by our
 - **[Good first issues](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aopen+label%3A%22good+first+issue%22)** — beginner-friendly tasks you can pick up cold.
 - **[Help wanted](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aopen+label%3A%22help+wanted%22)** — issues the maintainers would love help with.
 - **[docs.lihor.ro](https://docs.lihor.ro)** — the published documentation site (source in `website/`, preview with `cd website && npm install && npm run start`).
+- **[GOVERNANCE.md](GOVERNANCE.md)** — how decisions are made and how releases ship.
+- **[MAINTAINERS.md](MAINTAINERS.md)** — who maintains this project and how to become one.
+- **[ROADMAP.md](ROADMAP.md)** — near-term direction and how to propose roadmap items.
 
 ## Prerequisites
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,65 @@
+# Governance
+
+News Dashboard is a small, maintainer-led open source project. This document
+describes how decisions are made today. It's intentionally lightweight and
+will evolve as the project and contributor base grow — see
+[MAINTAINERS.md](MAINTAINERS.md) for who currently holds this role.
+
+## Decision model
+
+The project currently follows a **maintainer-led (BDFL-style)** model: the
+maintainer(s) listed in [MAINTAINERS.md](MAINTAINERS.md) have final say on
+scope, direction, and what gets merged. In practice, most day-to-day
+decisions happen through ordinary code review on pull requests — there's no
+separate approval process for small or routine changes.
+
+As more maintainers join, decisions will move toward lazy consensus among
+them (see below), with the original maintainer as tie-breaker.
+
+## How proposals are made
+
+The right venue depends on the size of the change:
+
+- **Bug fixes and small, well-scoped features** — open a
+  [GitHub Issue](https://github.com/lihor-hub/news-dashboard/issues) (or pick
+  up an existing one) and send a PR. See [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Open-ended ideas, questions, or anything that needs discussion before
+  code is written** — start a [GitHub Discussion](https://github.com/lihor-hub/news-dashboard/discussions).
+  See [SUPPORT.md](SUPPORT.md) for how issues and Discussions are split.
+- **Larger or architecturally significant changes** (new subsystems, breaking
+  API/schema changes, changes that affect the PostgreSQL-only runtime rule in
+  [CONTRIBUTING.md](CONTRIBUTING.md)) — open a Discussion or draft PR first so
+  the approach can be agreed on before significant implementation work
+  happens. There's no formal ADR (Architecture Decision Record) template yet;
+  until one exists, capture the rationale in the Discussion/PR description
+  and link it from the eventual PR.
+
+Lazy consensus applies: a proposal is considered accepted if no maintainer
+objects within a reasonable review window. Silence is not blocking; an
+explicit maintainer objection is.
+
+## Release and merge process
+
+- All changes land on `main` through pull requests — no direct pushes.
+- PRs require CI to pass (lint, type checks, backend and frontend test
+  suites) before merge; see the `make check` gate in
+  [CONTRIBUTING.md](CONTRIBUTING.md).
+- PRs are reviewed and merged by a maintainer (or, for agent-authored PRs
+  following the repo's autonomous-agent workflow, auto-merged once CI is
+  green and the PR closes a `ready-for-agent`-labeled issue).
+- Releases are versioned and recorded in [`CHANGELOG.md`](CHANGELOG.md);
+  container images are published via the CI/CD pipeline on merge to `main`.
+- Breaking changes (config, schema, API) must be called out explicitly in the
+  PR description and the changelog entry.
+
+## Code of Conduct
+
+All participation — issues, Discussions, PRs, and reviews — is governed by
+the [Code of Conduct](CODE_OF_CONDUCT.md). Report violations as described
+there.
+
+## Changing this document
+
+Governance changes go through the normal PR process, reviewed by the current
+maintainer(s). As the maintainer group grows, this document will be updated
+to reflect a more formal consensus process.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,35 @@
+# Maintainers
+
+This file lists the current maintainers of News Dashboard and the areas they
+look after. It should stay consistent with [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
+| Maintainer | Areas | GitHub |
+|---|---|---|
+| Ioachim Lihor | Overall project, backend, frontend, Helm/deploy, CI | [@ioachim-hub](https://github.com/ioachim-hub) |
+
+## What maintainers do
+
+- Review and merge pull requests.
+- Triage and label issues (see [CONTRIBUTING.md](CONTRIBUTING.md) for the
+  labeling conventions used, including `ready-for-agent` and `agent-taken-*`).
+- Cut releases and keep [`CHANGELOG.md`](CHANGELOG.md) up to date.
+- Uphold the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+See [GOVERNANCE.md](GOVERNANCE.md) for how decisions get made.
+
+## Becoming a maintainer
+
+There's no fixed track record requirement — this is a small project and the
+process is intentionally lightweight. In practice, someone becomes a
+maintainer by:
+
+1. Landing a handful of substantial, well-reviewed PRs over time.
+2. Showing sound judgment in code review or issue triage on existing PRs/issues.
+3. Being willing to take ownership of an area (e.g. backend ingestion, the
+   frontend PWA, CI/CD) rather than one-off drive-by contributions.
+
+If you're interested, open a [GitHub Discussion](https://github.com/lihor-hub/news-dashboard/discussions)
+proposing yourself, or ask an existing maintainer. The current maintainer(s)
+decide by consensus, per [GOVERNANCE.md](GOVERNANCE.md).
+
+New maintainers get added here and to `.github/CODEOWNERS` in the same PR.

--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ Enable auth before exposing an instance outside a trusted network. See
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, conventions, and how to land your first PR.
 Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
+The project is maintainer-led — see [MAINTAINERS.md](MAINTAINERS.md) for who's
+involved, [GOVERNANCE.md](GOVERNANCE.md) for how decisions get made, and
+[ROADMAP.md](ROADMAP.md) for near-term direction.
+
 New to the project? Browse [good first issues](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — beginner-friendly tasks with clear scope.
 
 Have a question or an open-ended feature idea? Use

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,59 @@
+# Roadmap
+
+This is a lightweight, living snapshot of near-term direction for News
+Dashboard. It's not a commitment or a schedule — see
+[GOVERNANCE.md](GOVERNANCE.md) for how priorities actually get decided.
+
+For granular, up-to-date status, the GitHub issue tracker is the source of
+truth. This roadmap gives the high-level "why" behind the current epics.
+
+## Now: OSS readiness
+
+Tracked in [epic: OSS readiness](https://github.com/lihor-hub/news-dashboard/issues/640).
+The project recently moved to the public `lihor-hub` org under the MIT
+license, and the current focus is making it a genuinely welcoming,
+self-hostable open source project:
+
+- **Community health** — CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, issue/PR
+  templates, CODEOWNERS, and this governance trio.
+- **Documentation site** — a Docusaurus site at [docs.lihor.ro](https://docs.lihor.ro)
+  with a Getting Started guide and user guide, replacing scattered `docs/`
+  markdown.
+- **Security & supply-chain CI** — CodeQL, dependency review, container
+  scanning, and SBOM/provenance for releases.
+- **Self-host adoption** — a publicly published container image, a
+  production `docker-compose` quickstart, an operations guide, and a demo
+  mode with seed data and a read-only guest account so people can try the
+  app before self-hosting it.
+- **Contributor onboarding** — Dev Containers/Codespaces, a curated `good
+  first issue` backlog, and Architecture Decision Records for larger
+  decisions.
+
+## Later: beyond OSS readiness
+
+Once the OSS-readiness epic is substantially done, expect the roadmap to
+shift back toward product work — reader experience, AI-powered features, and
+automation/delivery. Browse the `epic: *` labels
+([reader-ux](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aissue+is%3Aopen+label%3A%22epic%3A+reader-ux%22),
+[ai](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aissue+is%3Aopen+label%3A%22epic%3A+ai%22),
+[automation](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aissue+is%3Aopen+label%3A%22epic%3A+automation%22),
+[content](https://github.com/lihor-hub/news-dashboard/issues?q=is%3Aissue+is%3Aopen+label%3A%22epic%3A+content%22))
+for the current backlog in each area — that's a more accurate picture than
+anything a static roadmap file could promise.
+
+## Proposing roadmap items
+
+Roadmap direction is set the same way other proposals are, per
+[GOVERNANCE.md](GOVERNANCE.md#how-proposals-are-made):
+
+1. For a new epic or a significant shift in direction, open a
+   [GitHub Discussion](https://github.com/lihor-hub/news-dashboard/discussions)
+   to build consensus before filing issues.
+2. For a specific, well-scoped feature or fix, open a
+   [GitHub Issue](https://github.com/lihor-hub/news-dashboard/issues) directly.
+3. If it's accepted as a near-term priority, it gets folded into this file
+   (or a tracking epic issue) via a normal PR.
+
+This file will be updated periodically as epics complete and new priorities
+emerge — it does not need to track every issue, just the current "what and
+why" at a glance.


### PR DESCRIPTION
## Summary
- Add `MAINTAINERS.md` listing the current maintainer, areas of ownership, and how to become a maintainer
- Add `GOVERNANCE.md` describing the maintainer-led decision model, how proposals are made (issues vs. Discussions vs. larger design discussions), and the release/merge process
- Add `ROADMAP.md` covering near-term direction (OSS readiness epic: community health, docs site, security/supply-chain CI, self-host adoption, contributor onboarding) and how to propose roadmap items
- Cross-link the three docs from `CONTRIBUTING.md` (quick links) and the README's Contributing section
- `MAINTAINERS.md` is kept consistent with the existing `.github/CODEOWNERS`

Closes #639.

## Test plan
- [x] Docs-only change — no unit tests apply per issue's test expectations
- [x] Verified relative markdown links resolve to files present in the repo root
- [x] Verified `MAINTAINERS.md` matches `.github/CODEOWNERS`
- [ ] CI (lint/build) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)