### PR TITLE
fix: single source of truth for the app version (#642)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,16 @@ Runtime database code **must** use PostgreSQL-specific SQL and `psycopg` paramet
 
 SQLite may appear only in legacy import/migration tooling that reads an old SQLite database and writes into PostgreSQL.
 
+## Versioning
+
+The `VERSION` file at the repo root is the **single source of truth** for the app version:
+
+- It is derived from git tags by `scripts/next_version.sh` and baked into the release image — it is intentionally **not** committed with a bumped value between releases (see `release.yml`).
+- `pyproject.toml`'s `version` field is kept in sync with `VERSION` at release time.
+- The backend reads `VERSION` once at startup (`news_dashboard.main._read_app_version`) and uses it for the FastAPI `app.version`, which in turn drives both the OpenAPI `info.version` (`/docs`) and the `/api/version` endpoint.
+
+Don't hardcode a version literal anywhere else — read `VERSION` (or `app.version` at runtime) instead, so these values can't drift apart again.
+
 ## Opening a PR
 
 1. Fork the repo and create a feature branch.

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -118,6 +118,16 @@ logger = logging.getLogger(__name__)
 _SESSION_COOKIE = "nd_session"
 _OAUTH_STATE_COOKIE = "nd_oauth_state"
 
+_VERSION_FILE = Path(__file__).resolve().parents[2] / "VERSION"
+
+
+def _read_app_version() -> str:
+    """Return the running app version from the VERSION file baked into the image."""
+    try:
+        return _VERSION_FILE.read_text().strip()
+    except OSError:
+        return "unknown"
+
 
 class SPAStaticFiles(StaticFiles):
     """Serve index.html for client-side routes while preserving API/static 404s."""
@@ -147,7 +157,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     stop_scheduler()
 
 
-app = FastAPI(title="News Dashboard", version="0.4.0", lifespan=lifespan)
+app = FastAPI(title="News Dashboard", version=_read_app_version(), lifespan=lifespan)
 _cors_origins_env = os.getenv("CORS_ORIGINS", "")
 _cors_origins = (
     [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
@@ -607,7 +617,6 @@ def _embed_article_background(article_id: int) -> None:
 
 # ── Public version / changelog endpoints (no auth) ───────────────────────────
 
-_VERSION_FILE = Path(__file__).resolve().parents[2] / "VERSION"
 _CHANGELOG_FILE = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
 
 
@@ -634,22 +643,14 @@ def _parse_changelog() -> list[dict[str, object]]:
 
 @app.get("/api/version")
 def version_endpoint() -> dict[str, str]:
-    """Return the running app version from the VERSION file."""
-    try:
-        version = _VERSION_FILE.read_text().strip()
-    except OSError:
-        version = "unknown"
-    return {"version": version}
+    """Return the running app version, matching the OpenAPI ``info.version``."""
+    return {"version": app.version}
 
 
 @app.get("/api/changelog")
 def changelog_endpoint() -> dict[str, object]:
     """Return changelog entries parsed from CHANGELOG.md."""
-    try:
-        version = _VERSION_FILE.read_text().strip()
-    except OSError:
-        version = "unknown"
-    return {"version": version, "entries": _parse_changelog()}
+    return {"version": app.version, "entries": _parse_changelog()}
 
 
 # ── Authenticated API router ─────────────────────────────────────────────────

--- a/backend/tests/test_changelog_endpoint.py
+++ b/backend/tests/test_changelog_endpoint.py
@@ -64,37 +64,25 @@ def test_changelog_endpoint_returns_version_and_entries() -> None:
         ## 9.9.9
         - New thing
     """)
-    with (
-        patch("news_dashboard.main._VERSION_FILE") as vf,
-        patch("news_dashboard.main._CHANGELOG_FILE") as cf,
-    ):
-        vf.read_text.return_value = "9.9.9\n"
+    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
         cf.read_text.return_value = md
         resp = _client().get("/api/changelog")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["version"] == "9.9.9"
+    assert body["version"] == app.version
     assert body["entries"] == [{"version": "9.9.9", "items": ["New thing"]}]
 
 
-def test_changelog_endpoint_version_falls_back_to_unknown() -> None:
-    with (
-        patch("news_dashboard.main._VERSION_FILE") as vf,
-        patch("news_dashboard.main._CHANGELOG_FILE") as cf,
-    ):
-        vf.read_text.side_effect = OSError("missing")
+def test_changelog_endpoint_version_matches_app_version() -> None:
+    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
         cf.read_text.return_value = "## 1.0.0\n- item\n"
         resp = _client().get("/api/changelog")
     assert resp.status_code == 200
-    assert resp.json()["version"] == "unknown"
+    assert resp.json()["version"] == app.version
 
 
 def test_changelog_endpoint_entries_empty_on_missing_file() -> None:
-    with (
-        patch("news_dashboard.main._VERSION_FILE") as vf,
-        patch("news_dashboard.main._CHANGELOG_FILE") as cf,
-    ):
-        vf.read_text.return_value = "1.0.0\n"
+    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
         cf.read_text.side_effect = OSError("missing")
         resp = _client().get("/api/changelog")
     assert resp.status_code == 200

--- a/backend/tests/test_main_oauth.py
+++ b/backend/tests/test_main_oauth.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
+from news_dashboard import main as main_module
 from news_dashboard.main import app
 
 
@@ -119,17 +120,26 @@ def test_auth_config_returns_metadata() -> None:
 # ── /api/version ──────────────────────────────────────────────────────────────
 
 
-def test_version_endpoint_reads_version_file() -> None:
+def test_read_app_version_reads_version_file() -> None:
     with patch("news_dashboard.main._VERSION_FILE") as vf:
         vf.read_text.return_value = "9.9.9\n"
-        resp = _client().get("/api/version")
-    assert resp.status_code == 200
-    assert resp.json() == {"version": "9.9.9"}
+        assert main_module._read_app_version() == "9.9.9"
 
 
-def test_version_endpoint_falls_back_to_unknown_on_oserror() -> None:
+def test_read_app_version_falls_back_to_unknown_on_oserror() -> None:
     with patch("news_dashboard.main._VERSION_FILE") as vf:
         vf.read_text.side_effect = OSError("missing")
-        resp = _client().get("/api/version")
+        assert main_module._read_app_version() == "unknown"
+
+
+def test_version_endpoint_returns_the_running_app_version() -> None:
+    resp = _client().get("/api/version")
     assert resp.status_code == 200
-    assert resp.json() == {"version": "unknown"}
+    assert resp.json() == {"version": app.version}
+
+
+def test_app_version_matches_version_endpoint_and_openapi_info() -> None:
+    """The FastAPI app version, /api/version, and OpenAPI info.version must agree."""
+    resp = _client().get("/api/version")
+    assert resp.json()["version"] == app.version
+    assert app.openapi()["info"]["version"] == app.version


### PR DESCRIPTION
## Summary
- Read `VERSION` once at startup via `_read_app_version()` and use it for the FastAPI `app.version`, replacing the hardcoded `"0.4.0"` literal.
- `/api/version` and `/api/changelog` now return `app.version` instead of re-reading the `VERSION` file per request, so they can never drift from the OpenAPI `info.version` shown at `/docs`.
- `pyproject.toml`'s version already matched `VERSION` (`1.21.0`), so no change was needed there (already reconciled by #607).
- Documented the VERSION-file-is-truth convention in a new "Versioning" section of `CONTRIBUTING.md`.

Closes #642

## Test plan
- [x] `uv run pytest backend/tests/test_main_oauth.py backend/tests/test_changelog_endpoint.py -q` — 19 passed, including a new test asserting `app.version == /api/version response == OpenAPI info.version`.
- [x] Full backend suite: `uv run pytest -q` — 1271 passed. The 33 errors in `test_briefings_api.py` are a pre-existing local Postgres permissions issue (`InsufficientPrivilege: must be owner of table user_article_state`), reproduced identically on `main` before this change — unrelated to this fix.
- [x] `ruff check`, `mypy`, pre-commit hooks all pass on the changed files.