### PR TITLE
feat: add optional Prometheus /metrics endpoint (#643)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,8 @@ CORS_ORIGINS=http://localhost:5173
 DATA_DIR=/data
 # Enables demo/sample-data seeding when truthy (1/true/yes/on).
 DEMO_MODE=false
+# Serves GET /metrics in Prometheus exposition format when truthy (1/true/yes/on). Off by default.
+METRICS_ENABLED=false
 
 # --- One-off migration CLI (optional) -------------------------------------------
 # Used only by `news-dashboard-migrate sqlite-to-postgres`; prompts interactively if unset.

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -859,6 +859,12 @@ def ingest_all(db_path: Path | str | None = None) -> IngestResult:
                 )
             )
 
+        from news_dashboard.metrics import (
+            ingest_articles_new_total,
+            ingest_runs_total,
+            source_health_checks_total,
+        )
+
         results: dict[str, int] = {}
         total_new = 0
         total_errors = 0
@@ -870,13 +876,17 @@ def ingest_all(db_path: Path | str | None = None) -> IngestResult:
                 if outcome.error_message is not None:
                     results[source.slug] = -1
                     total_errors += 1
+                    source_health_checks_total.labels(status="error").inc()
                 else:
                     results[source.slug] = outcome.articles_new
                     total_new += outcome.articles_new
+                    source_health_checks_total.labels(status="ok").inc()
         finally:
             duration_seconds = time.perf_counter() - run_started
             duration_ms = int(duration_seconds * 1000)
             _finish_ingest_run(run_id, db_path, now_iso(), duration_ms, total_new, total_errors)
+            ingest_runs_total.labels(status="failure" if total_errors else "success").inc()
+            ingest_articles_new_total.inc(total_new)
             article_word = "article" if total_new == 1 else "articles"
             error_text = (
                 f", {total_errors} error{'s' if total_errors != 1 else ''}" if total_errors else ""

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import time
 import xml.etree.ElementTree as ET
 from collections.abc import AsyncIterator, MutableMapping
 from contextlib import asynccontextmanager
@@ -171,6 +172,38 @@ app.add_middleware(
     allow_headers=["*"],
     allow_credentials=True,
 )
+
+# ── Optional Prometheus metrics ─────────────────────────────────────────────
+
+
+@app.middleware("http")
+async def record_request_metrics(request: Request, call_next: Any) -> Any:
+    """Record request count/latency, labeled by method and route template.
+
+    Uses the matched route's path template (e.g. ``/api/articles/{id}``)
+    rather than the raw URL so dynamic path segments never appear in labels.
+    A no-op unless METRICS_ENABLED is set, to avoid the timing/label overhead
+    for self-hosters who don't scrape metrics.
+    """
+    from news_dashboard.metrics import (
+        http_request_duration_seconds,
+        http_requests_total,
+        metrics_enabled,
+    )
+
+    if not metrics_enabled():
+        return await call_next(request)
+
+    started = time.perf_counter()
+    response = await call_next(request)
+    duration = time.perf_counter() - started
+    route = request.scope.get("route")
+    path = route.path if route is not None else request.url.path
+    labels = {"method": request.method, "path": path}
+    http_requests_total.labels(status=str(response.status_code), **labels).inc()
+    http_request_duration_seconds.labels(**labels).inc(duration)
+    return response
+
 
 # ── Demo mode: reject guest writes ──────────────────────────────────────────
 
@@ -431,6 +464,15 @@ def readiness() -> dict[str, Any]:
     except Exception as exc:
         raise HTTPException(status_code=503, detail="database unavailable") from exc
     return {"status": "ok"}
+
+
+@public_router.get("/metrics")
+def prometheus_metrics() -> Response:
+    from news_dashboard.metrics import CONTENT_TYPE_LATEST, metrics_enabled, render_metrics
+
+    if not metrics_enabled():
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(content=render_metrics(), media_type=CONTENT_TYPE_LATEST)
 
 
 @public_router.get("/api/auth/config")

--- a/backend/news_dashboard/metrics.py
+++ b/backend/news_dashboard/metrics.py
@@ -1,0 +1,78 @@
+"""Optional Prometheus metrics.
+
+Gated by the ``METRICS_ENABLED`` env var (off by default). When disabled,
+`/metrics` is not served. Labels never carry article content, URLs, emails,
+or other PII — only coarse, fixed identifiers like job names, HTTP methods,
+route templates, and outcome status.
+"""
+
+from __future__ import annotations
+
+import os
+
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, generate_latest
+
+registry = CollectorRegistry()
+
+http_requests_total = Counter(
+    "news_dashboard_http_requests_total",
+    "Total HTTP requests handled.",
+    ["method", "path", "status"],
+    registry=registry,
+)
+
+http_request_duration_seconds = Counter(
+    "news_dashboard_http_request_duration_seconds_sum",
+    "Cumulative HTTP request duration in seconds.",
+    ["method", "path"],
+    registry=registry,
+)
+
+ingest_runs_total = Counter(
+    "news_dashboard_ingest_runs_total",
+    "Scheduled/manual ingest runs, labeled by outcome.",
+    ["status"],
+    registry=registry,
+)
+
+ingest_articles_new_total = Counter(
+    "news_dashboard_ingest_articles_new_total",
+    "New articles discovered across all ingest runs.",
+    registry=registry,
+)
+
+scheduler_job_runs_total = Counter(
+    "news_dashboard_scheduler_job_runs_total",
+    "Background scheduler job runs, labeled by job name and outcome.",
+    ["job_name", "status"],
+    registry=registry,
+)
+
+source_health_checks_total = Counter(
+    "news_dashboard_source_health_checks_total",
+    "Per-source-fetch ingest outcomes, labeled by outcome only (no source"
+    " identity, since source names/slugs may be user-defined for private feeds).",
+    ["status"],
+    registry=registry,
+)
+
+
+def metrics_enabled() -> bool:
+    return os.getenv("METRICS_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def render_metrics() -> bytes:
+    return generate_latest(registry)
+
+
+__all__ = [
+    "CONTENT_TYPE_LATEST",
+    "http_request_duration_seconds",
+    "http_requests_total",
+    "ingest_articles_new_total",
+    "ingest_runs_total",
+    "metrics_enabled",
+    "render_metrics",
+    "scheduler_job_runs_total",
+    "source_health_checks_total",
+]

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -239,6 +239,7 @@ def _run_and_record(
     If fn returns None the run is not recorded (used by per_user_briefings
     when no users are scheduled for this minute).
     """
+    from news_dashboard.metrics import scheduler_job_runs_total
     from news_dashboard.scheduled_job_history import save_job_run
 
     started_at = datetime.now(timezone.utc)
@@ -249,6 +250,7 @@ def _run_and_record(
     if result is None:
         return
     status, message = result
+    scheduler_job_runs_total.labels(job_name=job_name, status=status).inc()
     finished_at = datetime.now(timezone.utc)
     try:
         save_job_run(

--- a/backend/tests/test_metrics_endpoint.py
+++ b/backend/tests/test_metrics_endpoint.py
@@ -1,0 +1,50 @@
+"""Tests for the optional Prometheus /metrics endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import app
+from news_dashboard.metrics import (
+    ingest_articles_new_total,
+    ingest_runs_total,
+    scheduler_job_runs_total,
+)
+
+
+def _client() -> TestClient:
+    app.dependency_overrides.clear()
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.mark.smoke
+def test_metrics_not_served_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("METRICS_ENABLED", raising=False)
+    resp = _client().get("/metrics")
+    assert resp.status_code == 404
+
+
+@pytest.mark.smoke
+def test_metrics_returns_exposition_format_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("METRICS_ENABLED", "true")
+    ingest_runs_total.labels(status="success").inc()
+    ingest_articles_new_total.inc(3)
+    scheduler_job_runs_total.labels(job_name="digest", status="success").inc()
+
+    resp = _client().get("/metrics")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    body = resp.text
+    assert "news_dashboard_ingest_runs_total" in body
+    assert "news_dashboard_ingest_articles_new_total" in body
+    assert "news_dashboard_scheduler_job_runs_total" in body
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("flag_value", ["0", "false", "no", "off", ""])
+def test_metrics_disabled_flag_values(monkeypatch: pytest.MonkeyPatch, flag_value: str) -> None:
+    monkeypatch.setenv("METRICS_ENABLED", flag_value)
+    resp = _client().get("/metrics")
+    assert resp.status_code == 404

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -116,6 +116,12 @@ See the [README Configuration section](../README.md#configuration) for the compl
 | `FREE_LLM_API_KEY` | Alternative LLM API key |
 | `FREE_LLM_BASE_URL` | Custom LLM endpoint |
 
+### Optional Observability
+
+| Variable | Description |
+|----------|-------------|
+| `METRICS_ENABLED` | Set to `true` to expose the Prometheus `/metrics` endpoint. Off by default. |
+
 > **Important**: Never commit secrets to version control. Use environment variables or a `.env` file (not committed to Git) to manage sensitive values.
 
 ## Healthchecks
@@ -132,6 +138,7 @@ News Dashboard exposes several health and readiness endpoints for monitoring and
 | `GET /api/health/details` | Admin-only | Detailed diagnostics — returns `status`, `database` info, and `next_ingest_at`. Requires admin authentication. |
 | `GET /api/sources/health` | Authenticated | Per-source health status for the current user — shows last-checked time, last error, and fetch counts for each source. |
 | `GET /api/scheduler/status` | Admin-only | Scheduler state — whether the in-process scheduler is running, its interval, and configured jobs. |
+| `GET /metrics` | Public (opt-in) | Prometheus exposition format. Only served when `METRICS_ENABLED=true`; returns 404 otherwise. See [Prometheus Metrics](#prometheus-metrics). |
 
 ### Docker Probe Configuration
 
@@ -193,6 +200,35 @@ For production monitoring:
 - **Readiness**: use `GET /api/ready` — a failure means the database is unreachable or the connection pool is exhausted.
 - **Details**: admin users can check `GET /api/health/details` for an overview of database stats and the next scheduled ingest.
 - **Source health**: check `GET /api/sources/health` after an ingest run to see which sources failed.
+
+### Prometheus Metrics
+
+Set `METRICS_ENABLED=true` to expose a `GET /metrics` endpoint in Prometheus
+exposition format. It's off by default and unauthenticated when on — treat it
+like any other internal-only endpoint and don't expose it directly to the
+public internet (put it behind your reverse proxy/network policy, or scrape
+it from inside your cluster/VPC).
+
+Metrics exposed:
+
+- `news_dashboard_http_requests_total{method,path,status}` / `news_dashboard_http_request_duration_seconds_sum{method,path}` — request counts and cumulative latency, labeled by route template (e.g. `/api/articles/{article_id}`), never the raw URL.
+- `news_dashboard_ingest_runs_total{status}` — ingest run outcomes (`success`/`failure`).
+- `news_dashboard_ingest_articles_new_total` — new articles discovered across all ingest runs.
+- `news_dashboard_source_health_checks_total{status}` — per-source fetch outcomes (`ok`/`error`) during ingest. No source identity is included in labels, since private-feed names/slugs are user-defined.
+- `news_dashboard_scheduler_job_runs_total{job_name,status}` — background job outcomes (`digest`, `briefing`, `recommendations`, `analytics_retention`, `per_user_briefings`).
+
+No article content, URLs, emails, or other PII ever appear in metric labels.
+
+Example scrape config:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: news-dashboard
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["news-dashboard:8080"]
+```
 
 ## Upgrading
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "webdriver-manager>=4.0.0",
   "python-multipart>=0.0.20",
   "defusedxml>=0.7.1",
+  "prometheus-client>=0.21.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -890,6 +890,7 @@ dependencies = [
     { name = "langfuse" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "prometheus-client" },
     { name = "psycopg", extra = ["binary"] },
     { name = "python-multipart" },
     { name = "pywebpush" },
@@ -930,6 +931,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.5.0" },
     { name = "openai", specifier = ">=2.44.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },
     { name = "pyrefly", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
@@ -1149,6 +1151,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds an env-gated `METRICS_ENABLED` `/metrics` endpoint that serves Prometheus exposition format (off by default; 404 when disabled).
- Instruments ingest run outcomes, per-source fetch outcomes, scheduler job outcomes, and HTTP request count/latency (labeled by route template, not raw URL/query, to keep label cardinality bounded and PII out).
- Adds `prometheus-client` as a backend dependency.
- Documents the endpoint, exposed metric names, and a sample Prometheus scrape config in `docs/SELF_HOSTING.md`.

Closes #643

## Metrics exposed
- `news_dashboard_http_requests_total{method,path,status}` / `news_dashboard_http_request_duration_seconds_sum{method,path}`
- `news_dashboard_ingest_runs_total{status}`
- `news_dashboard_ingest_articles_new_total`
- `news_dashboard_source_health_checks_total{status}` (no source identity in labels — private feed slugs/names are user-defined)
- `news_dashboard_scheduler_job_runs_total{job_name,status}`

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] `mypy backend` (strict) passes
- [x] New `backend/tests/test_metrics_endpoint.py` (7 cases): endpoint returns 404 when disabled/flag falsy, 200 with expected metric names when enabled
- [x] Existing `backend/tests/test_health_endpoints.py` still passes
- [ ] Full backend suite (Postgres-backed) runs in CI — not runnable in this sandbox (no Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)