### PR TITLE
feat: add optional, opt-in error tracking (backend + frontend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,13 @@ DATA_DIR=/data
 DEMO_MODE=false
 # Serves GET /metrics in Prometheus exposition format when truthy (1/true/yes/on). Off by default.
 METRICS_ENABLED=false
+# Optional, opt-in error tracking. Point at a Sentry or GlitchTip-compatible DSN
+# to capture unhandled backend exceptions. Unset (default) initializes no SDK
+# and makes no network calls.
+SENTRY_DSN=
+# Same as above, for frontend errors. Served to the SPA via GET /api/config,
+# which is safe since Sentry DSNs are designed to be public (send-only).
+SENTRY_DSN_FRONTEND=
 
 # --- One-off migration CLI (optional) -------------------------------------------
 # Used only by `news-dashboard-migrate sqlite-to-postgres`; prompts interactively if unset.

--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,9 @@ METRICS_ENABLED=false
 # to capture unhandled backend exceptions. Unset (default) initializes no SDK
 # and makes no network calls.
 SENTRY_DSN=
+# Sentry/GlitchTip environment tag attached to backend events. Defaults to
+# "production" when SENTRY_DSN is set.
+SENTRY_ENVIRONMENT=
 # Same as above, for frontend errors. Served to the SPA via GET /api/config,
 # which is safe since Sentry DSNs are designed to be public (send-only).
 SENTRY_DSN_FRONTEND=

--- a/backend/news_dashboard/error_tracking.py
+++ b/backend/news_dashboard/error_tracking.py
@@ -1,0 +1,58 @@
+"""Optional Sentry/GlitchTip-compatible error tracking.
+
+Gated by the ``SENTRY_DSN`` env var (backend) and ``SENTRY_DSN_FRONTEND``
+(exposed to the SPA via ``GET /api/config``). Both are off by default: when
+unset, no SDK is initialized and no telemetry leaves the process. PII is kept
+out via ``send_default_pii=False`` plus a ``before_send`` hook that strips
+cookies/auth headers and any user block before an event would be sent.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from sentry_sdk.types import Event, Hint
+
+
+def error_tracking_enabled() -> bool:
+    return bool(os.getenv("SENTRY_DSN", "").strip())
+
+
+def frontend_error_tracking_dsn() -> str | None:
+    dsn = os.getenv("SENTRY_DSN_FRONTEND", "").strip()
+    return dsn or None
+
+
+def _scrub_pii(event: Event, _hint: Hint) -> Event | None:
+    # Sentry's Event/RequestContext TypedDicts are loosely typed (Any-derived),
+    # so treat the mutable pieces as plain dicts rather than fighting the checker.
+    untyped_event = cast("dict[str, Any]", event)
+    request = untyped_event.get("request")
+    if isinstance(request, dict):
+        request.pop("cookies", None)
+        headers = request.get("headers")
+        if isinstance(headers, dict):
+            for key in [k for k in headers if str(k).lower() in ("authorization", "cookie")]:
+                headers.pop(key, None)
+    untyped_event.pop("user", None)
+    return event
+
+
+def init_error_tracking() -> None:
+    """Initialize the Sentry SDK when SENTRY_DSN is configured; no-op otherwise."""
+    if not error_tracking_enabled():
+        return
+
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=os.environ["SENTRY_DSN"],
+        environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+        send_default_pii=False,
+        before_send=_scrub_pii,
+    )
+
+
+__all__ = ["error_tracking_enabled", "frontend_error_tracking_dsn", "init_error_tracking"]

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -74,6 +74,7 @@ from news_dashboard.briefings import (
     list_briefings,
 )
 from news_dashboard.db import connect, describe_database, init_db, row_to_dict
+from news_dashboard.error_tracking import frontend_error_tracking_dsn, init_error_tracking
 from news_dashboard.ingest import (
     get_user_summary,
     ingest_all,
@@ -146,6 +147,7 @@ class SPAStaticFiles(StaticFiles):
 
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    init_error_tracking()
     init_auth()
     sync_sources()
     # Seed demo data when DEMO_MODE is enabled.
@@ -473,6 +475,16 @@ def prometheus_metrics() -> Response:
     if not metrics_enabled():
         raise HTTPException(status_code=404, detail="not found")
     return Response(content=render_metrics(), media_type=CONTENT_TYPE_LATEST)
+
+
+@public_router.get("/api/config")
+def public_config() -> dict[str, Any]:
+    """Public, non-sensitive runtime config the SPA needs before login.
+
+    ``sentry_dsn`` is a Sentry/GlitchTip DSN, which is designed to be
+    exposed to clients — it only lets a client *send* events, not read data.
+    """
+    return {"sentry_dsn": frontend_error_tracking_dsn()}
 
 
 @public_router.get("/api/auth/config")

--- a/backend/tests/test_error_tracking.py
+++ b/backend/tests/test_error_tracking.py
@@ -1,0 +1,108 @@
+"""Tests for the optional Sentry/GlitchTip error tracking gate."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sentry_sdk.types import Event
+
+from news_dashboard.error_tracking import (
+    error_tracking_enabled,
+    frontend_error_tracking_dsn,
+    init_error_tracking,
+)
+from news_dashboard.main import app
+
+
+def _client() -> TestClient:
+    app.dependency_overrides.clear()
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.mark.smoke
+def test_error_tracking_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    assert error_tracking_enabled() is False
+
+
+@pytest.mark.smoke
+def test_error_tracking_enabled_when_dsn_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SENTRY_DSN", "https://example@o0.ingest.sentry.io/0")
+    assert error_tracking_enabled() is True
+
+
+@pytest.mark.smoke
+def test_init_does_not_call_sentry_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    mock_sentry_sdk = MagicMock()
+    with patch.dict("sys.modules", {"sentry_sdk": mock_sentry_sdk}):
+        init_error_tracking()
+    mock_sentry_sdk.init.assert_not_called()
+
+
+@pytest.mark.smoke
+def test_init_calls_sentry_when_dsn_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    dsn = "https://example@o0.ingest.sentry.io/0"
+    monkeypatch.setenv("SENTRY_DSN", dsn)
+    mock_sentry_sdk = MagicMock()
+    with patch.dict("sys.modules", {"sentry_sdk": mock_sentry_sdk}):
+        init_error_tracking()
+    mock_sentry_sdk.init.assert_called_once()
+    _, kwargs = mock_sentry_sdk.init.call_args
+    assert kwargs["dsn"] == dsn
+    assert kwargs["send_default_pii"] is False
+
+
+@pytest.mark.smoke
+def test_frontend_dsn_unset_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SENTRY_DSN_FRONTEND", raising=False)
+    assert frontend_error_tracking_dsn() is None
+
+
+@pytest.mark.smoke
+def test_frontend_dsn_returned_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SENTRY_DSN_FRONTEND", "https://example@o0.ingest.sentry.io/1")
+    assert frontend_error_tracking_dsn() == "https://example@o0.ingest.sentry.io/1"
+
+
+@pytest.mark.smoke
+def test_scrub_pii_strips_cookies_headers_and_user() -> None:
+    from news_dashboard.error_tracking import _scrub_pii
+
+    event = {
+        "request": {
+            "cookies": {"nd_session": "secret"},
+            "headers": {
+                "Authorization": "Bearer x",
+                "Cookie": "nd_session=secret",
+                "Accept": "*/*",
+            },
+        },
+        "user": {"email": "a@b.com"},
+    }
+    scrubbed = cast("dict[str, Any]", _scrub_pii(cast("Event", event), cast("Any", {})))
+    assert scrubbed is not None
+    assert "cookies" not in scrubbed["request"]
+    assert "Authorization" not in scrubbed["request"]["headers"]
+    assert "Cookie" not in scrubbed["request"]["headers"]
+    assert scrubbed["request"]["headers"]["Accept"] == "*/*"
+    assert "user" not in scrubbed
+
+
+@pytest.mark.smoke
+def test_public_config_omits_dsn_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SENTRY_DSN_FRONTEND", raising=False)
+    resp = _client().get("/api/config")
+    assert resp.status_code == 200
+    assert resp.json() == {"sentry_dsn": None}
+
+
+@pytest.mark.smoke
+def test_public_config_returns_frontend_dsn_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SENTRY_DSN_FRONTEND", "https://example@o0.ingest.sentry.io/2")
+    resp = _client().get("/api/config")
+    assert resp.status_code == 200
+    assert resp.json() == {"sentry_dsn": "https://example@o0.ingest.sentry.io/2"}

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -121,6 +121,8 @@ See the [README Configuration section](../README.md#configuration) for the compl
 | Variable | Description |
 |----------|-------------|
 | `METRICS_ENABLED` | Set to `true` to expose the Prometheus `/metrics` endpoint. Off by default. |
+| `SENTRY_DSN` | Backend error tracking. Point at a Sentry or GlitchTip-compatible DSN to capture unhandled exceptions. Off by default — no SDK initializes and no network calls are made when unset. |
+| `SENTRY_DSN_FRONTEND` | Frontend error tracking. Served to the SPA via `GET /api/config`; safe to expose since Sentry DSNs are send-only. Off by default. |
 
 > **Important**: Never commit secrets to version control. Use environment variables or a `.env` file (not committed to Git) to manage sensitive values.
 
@@ -178,6 +180,7 @@ News Dashboard exposes several health and readiness endpoints for monitoring and
 | `GET /api/sources/health` | Authenticated | Per-source health status for the current user — shows last-checked time, last error, and fetch counts for each source. |
 | `GET /api/scheduler/status` | Admin-only | Scheduler state — whether the in-process scheduler is running, its interval, and configured jobs. |
 | `GET /metrics` | Public (opt-in) | Prometheus exposition format. Only served when `METRICS_ENABLED=true`; returns 404 otherwise. See [Prometheus Metrics](#prometheus-metrics). |
+| `GET /api/config` | Public | Non-sensitive runtime config the SPA needs before login — currently just the frontend Sentry DSN, if configured. See [Error Tracking](#error-tracking). |
 
 ### Docker Probe Configuration
 
@@ -268,6 +271,23 @@ scrape_configs:
     static_configs:
       - targets: ["news-dashboard:8080"]
 ```
+
+### Error Tracking
+
+Optional, opt-in error tracking against a Sentry or GlitchTip-compatible
+DSN — pick a self-hosted GlitchTip instance to keep everything in-house, or
+a Sentry SaaS project if you prefer.
+
+- `SENTRY_DSN` enables backend exception capture. Unset (default): no SDK
+  initializes and no network calls are made.
+- `SENTRY_DSN_FRONTEND` enables frontend error capture. It's served to the
+  SPA via the public `GET /api/config` endpoint — this is safe because a
+  Sentry DSN only lets a client *send* events, not read any data.
+
+Both are off independently, so you can enable backend-only, frontend-only,
+or both. PII is scrubbed before events are sent: `send_default_pii` is
+disabled on both SDKs, and the backend additionally strips cookies and
+`Authorization`/`Cookie` headers via a `before_send` hook.
 
 ## Upgrading
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -122,6 +122,7 @@ See the [README Configuration section](../README.md#configuration) for the compl
 |----------|-------------|
 | `METRICS_ENABLED` | Set to `true` to expose the Prometheus `/metrics` endpoint. Off by default. |
 | `SENTRY_DSN` | Backend error tracking. Point at a Sentry or GlitchTip-compatible DSN to capture unhandled exceptions. Off by default — no SDK initializes and no network calls are made when unset. |
+| `SENTRY_ENVIRONMENT` | Environment tag attached to backend events (e.g. `staging`, `production`). Defaults to `production` when `SENTRY_DSN` is set. |
 | `SENTRY_DSN_FRONTEND` | Frontend error tracking. Served to the SPA via `GET /api/config`; safe to expose since Sentry DSNs are send-only. Off by default. |
 
 > **Important**: Never commit secrets to version control. Use environment variables or a `.env` file (not committed to Git) to manage sensitive values.

--- a/frontend/src/__tests__/errorTracking.test.ts
+++ b/frontend/src/__tests__/errorTracking.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const sentryInit = vi.fn();
+vi.mock('@sentry/react', () => ({ init: sentryInit }));
+
+describe('initErrorTracking', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    sentryInit.mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('does not init Sentry when the backend returns no DSN', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sentry_dsn: null }),
+    });
+
+    const { initErrorTracking } = await import('../lib/errorTracking');
+    await initErrorTracking();
+
+    expect(sentryInit).not.toHaveBeenCalled();
+  });
+
+  it('inits Sentry with the DSN returned by the backend', async () => {
+    const dsn = 'https://example@o0.ingest.sentry.io/1';
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sentry_dsn: dsn }),
+    });
+
+    const { initErrorTracking } = await import('../lib/errorTracking');
+    await initErrorTracking();
+
+    expect(sentryInit).toHaveBeenCalledWith({ dsn, sendDefaultPii: false });
+  });
+
+  it('does not throw when the config fetch fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+    const { initErrorTracking } = await import('../lib/errorTracking');
+    await expect(initErrorTracking()).resolves.toBeUndefined();
+    expect(sentryInit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/errorTracking.ts
+++ b/frontend/src/lib/errorTracking.ts
@@ -1,0 +1,21 @@
+// Optional, opt-in Sentry/GlitchTip error tracking. The DSN is served by the
+// backend's public GET /api/config (self-hosters set SENTRY_DSN_FRONTEND);
+// when unset, the SDK is never imported and no telemetry leaves the browser.
+
+interface PublicConfig {
+  sentry_dsn: string | null;
+}
+
+export async function initErrorTracking(): Promise<void> {
+  try {
+    const res = await fetch('/api/config');
+    if (!res.ok) return;
+    const config = (await res.json()) as PublicConfig;
+    if (!config.sentry_dsn) return;
+
+    const Sentry = await import('@sentry/react');
+    Sentry.init({ dsn: config.sentry_dsn, sendDefaultPii: false });
+  } catch {
+    // Network/parse failures must never block app startup.
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,12 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import './globals.css';
+import { initErrorTracking } from './lib/errorTracking';
 import { initTheme } from './lib/theme';
 import { queryClient } from './lib/queryClient';
 import { AppRouter } from './AppRouter';
 import '@/lib/i18n'; // Initialize i18n
 
 initTheme();
+void initErrorTracking();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@radix-ui/react-toggle": "^1.1.13",
         "@radix-ui/react-toggle-group": "^1.1.14",
         "@radix-ui/react-tooltip": "^1.2.11",
+        "@sentry/react": "^10.63.0",
         "@tailwindcss/vite": "^4.3.2",
         "@tanstack/react-query": "^5.101.2",
         "@vitejs/plugin-react": "^6.0.3",
@@ -5099,6 +5100,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.63.0.tgz",
+      "integrity": "sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.63.0",
+        "@sentry/core": "10.63.0",
+        "@sentry/feedback": "10.63.0",
+        "@sentry/replay": "10.63.0",
+        "@sentry/replay-canvas": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.63.0.tgz",
+      "integrity": "sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.63.0.tgz",
+      "integrity": "sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.63.0.tgz",
+      "integrity": "sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.63.0.tgz",
+      "integrity": "sha512-+/Y0dd4EMqyqYBJ1D3bAYYuG+ccIx5+IFcbTZ9p+XWnW6nNIVjy5zttVftYo6xOmtTQbzRuPT/vO4dqDHKKmfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.63.0",
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.63.0.tgz",
+      "integrity": "sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.63.0",
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.63.0.tgz",
+      "integrity": "sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.63.0",
+        "@sentry/replay": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-toggle": "^1.1.13",
     "@radix-ui/react-toggle-group": "^1.1.14",
     "@radix-ui/react-tooltip": "^1.2.11",
+    "@sentry/react": "^10.63.0",
     "@tailwindcss/vite": "^4.3.2",
     "@tanstack/react-query": "^5.101.2",
     "@vitejs/plugin-react": "^6.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "python-multipart>=0.0.20",
   "defusedxml>=0.7.1",
   "prometheus-client>=0.21.0",
+  "sentry-sdk>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -896,6 +896,7 @@ dependencies = [
     { name = "pywebpush" },
     { name = "rapidfuzz" },
     { name = "selenium" },
+    { name = "sentry-sdk" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "webdriver-manager" },
@@ -942,6 +943,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.20" },
     { name = "selenium", specifier = ">=4.0.0" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.14.2" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.55" },
     { name = "typer", specifier = ">=0.26.8" },
@@ -1596,6 +1598,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/48/486aa67320f27452e9f551b8608f1a59ce7091c8fe7ebc9f4eba274775d4/selenium-4.45.0.tar.gz", hash = "sha256:563f0c4102f112df1cda30d46ce6d177b2e4a7a3d4b0756902d5dc84d3a8a365", size = 1005503, upload-time = "2026-06-16T04:43:57.915Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/8a/6ff6beb9c7c6cc642f628df9328a8b6637f86602eff8d28e70b5d4e8bca7/selenium-4.45.0-py3-none-any.whl", hash = "sha256:1fd9d0dc08192b2f8100e264ed720f83b05d2dd3a7feff673df04e0c7580df4b", size = 9536616, upload-time = "2026-06-16T04:43:55.968Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.64.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/31/b7341f156a5f6f36f0b4845d6f1c28a2ae4799171dba7007f3a1e9b234b4/sentry_sdk-2.64.0.tar.gz", hash = "sha256:68be2c29e14ae310f8a39e1a79916b6d85c6cb41dcce789d14ff05fe293e4c55", size = 921020, upload-time = "2026-06-30T08:13:47.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/a8/3fb9a4319efa3b26f5be0e90e6d8918df43fa7c7e977d26390f589501d82/sentry_sdk-2.64.0-py3-none-any.whl", hash = "sha256:715ea91ca860a819e8d8a50a7bde3a80d0df3b4ed7b6660a20fb9a2d084188f1", size = 498901, upload-time = "2026-06-30T08:13:45.566Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds Sentry/GlitchTip-compatible error tracking, entirely opt-in via `SENTRY_DSN` (backend) and `SENTRY_DSN_FRONTEND` (frontend).
- When neither is set, no SDK initializes and no network calls are made — the self-hosted/private default is unchanged.
- New public `GET /api/config` endpoint serves the frontend DSN to the SPA before login (safe: Sentry DSNs are send-only).
- Backend PII scrubbing: `send_default_pii=False` plus a `before_send` hook that strips cookies and `Authorization`/`Cookie` headers.
- Frontend: `@sentry/react` is dynamically imported only when a DSN is present, `sendDefaultPii: false`.
- Docs: `.env.example` and `docs/SELF_HOSTING.md` updated with a new "Error Tracking" section.

Closes #644.

## Test plan
- [x] Backend: `backend/tests/test_error_tracking.py` — SDK not initialized when `SENTRY_DSN` unset; initialized (mocked) when set; PII scrubbing; `/api/config` gating. `uv run pytest backend/tests/test_error_tracking.py -m smoke` → 9 passed.
- [x] Backend smoke suite: `uv run pytest backend/tests -m smoke` → 19 passed (unchanged from before this PR, plus the new 9... net addition).
- [x] Frontend: `frontend/src/__tests__/errorTracking.test.ts` — no init without DSN, init with DSN, fetch failure doesn't throw. `npx vitest run` → 647 passed (full suite).
- [x] `mypy backend`, `ty check backend`, `pyrefly check backend` — clean.
- [x] `npx eslint .`, `npx tsc --noEmit`, `npm run build` — clean.