### PR TITLE
docs: add PRIVACY.md data-flow transparency (#645)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,74 @@
+# Privacy & Data Flow
+
+News Dashboard is "your private news platform" — reading, triage, and saved
+state stay in your own PostgreSQL database. This document lists every path
+by which data can leave your instance, the feature/env var that triggers it,
+and how to run with no outbound calls at all.
+
+## Data that stays local
+
+- Articles, feeds, sources, users, sessions, saved/read/starred/snoozed
+  state, ingest run history, and search all live in your PostgreSQL
+  database and are never sent anywhere.
+- Local usage analytics (`user_events` — page views, article opens, reading
+  duration) are recorded only in your database. See
+  [Local analytics](#local-analytics-user_events) below.
+
+## Outbound data flows
+
+| Feature | Triggering env var | What's sent | To whom |
+| --- | --- | --- | --- |
+| Embeddings, Ask AI, briefings, insights, chat completions | `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL`, or `OPENAI_API_KEY` / `OPENAI_BASE_URL` | Article titles/bodies and your prompts/questions, as needed for the feature | The configured LLM gateway (a self-hosted gateway if you point `FREE_LLM_*` at one, otherwise OpenAI) |
+| Text-to-speech / audio generation | `OPENAI_API_KEY` (always OpenAI; not replaceable by `FREE_LLM_*`) | Text to be synthesized into audio | OpenAI |
+| AI-fallback body fetch (Crawl4AI / deterministic extraction fallback) | Feature-internal; used when normal ingestion fails to extract article body | The article URL being fetched | The configured LLM/body-fetch backend |
+| LLM call tracing | `LANGFUSE_HOST` (or `LANGFUSE_BASE_URL`), `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` | Full request/response payloads for every OpenAI-compatible call (embeddings, Ask AI, briefings, insights, TTS, body fetch), each tagged with a descriptive trace name | Your configured Langfuse instance (only when **both** keys are set; otherwise tracing is inactive and no data is sent) |
+| Web Push notifications | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_EMAIL` | Push payload (notification title/body) and the subscription endpoint | The browser's push service (e.g. Mozilla/Google push endpoints), as chosen by the user's browser when they subscribe |
+| Backend error tracking | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` | Unhandled backend exception details (stack traces, request context) | The Sentry/GlitchTip-compatible endpoint at `SENTRY_DSN`. Unset by default — no SDK is initialized and no network calls are made |
+| Frontend error tracking | `SENTRY_DSN_FRONTEND` | Unhandled frontend JS exception details | The Sentry/GlitchTip-compatible endpoint at `SENTRY_DSN_FRONTEND`. Served to the SPA via `GET /api/config`; DSNs are send-only and designed to be public. Unset by default |
+| Keycloak login | `KEYCLOAK_AUTH_ENABLED`, `KEYCLOAK_SERVER_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET` | Login/authentication requests (standard OIDC flow) | Your configured Keycloak server. Optional; local password auth is used when disabled |
+
+All of the above are **off unless you set their env vars**, with the
+exception of the LLM features, which require an API key
+(`FREE_LLM_API_KEY` or `OPENAI_API_KEY`) to function at all — see
+[Requirements](README.md#requirements).
+
+## Running fully self-contained
+
+To run News Dashboard with zero outbound network calls:
+
+1. Point AI features at your own infrastructure — set `FREE_LLM_BASE_URL`
+   to a self-hosted OpenAI-compatible gateway, or leave both
+   `FREE_LLM_API_KEY` and `OPENAI_API_KEY` unset to disable AI features
+   entirely (embeddings, Ask AI, briefings, insights, TTS all become
+   unavailable).
+2. Leave `LANGFUSE_HOST`/`LANGFUSE_BASE_URL`, `LANGFUSE_PUBLIC_KEY`, and
+   `LANGFUSE_SECRET_KEY` unset — tracing only activates when both keys are
+   present.
+3. Leave `SENTRY_DSN` and `SENTRY_DSN_FRONTEND` unset — no error-tracking
+   SDK is initialized and no events are sent.
+4. Leave `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` unset to disable Web Push
+   notifications, or accept that push payloads transit the browser
+   vendor's push service when a user opts in.
+5. Leave `KEYCLOAK_AUTH_ENABLED` unset (or `false`) to use local password
+   auth only.
+
+With all of the above unset, every network call this app makes stays
+between the browser, the backend, and your PostgreSQL database.
+
+## Local analytics (`user_events`)
+
+The app records lightweight usage events (route views, article
+opens/closes, session heartbeats) in the `user_events` table to power the
+in-app stats/analytics views. This data:
+
+- Is stored only in your own PostgreSQL database — it is never transmitted
+  to any external service.
+- Is pruned automatically by a daily cleanup job after
+  `ANALYTICS_RETENTION_DAYS` days (default `180`).
+
+## See also
+
+- [Configuration](README.md#configuration) — full environment variable
+  reference.
+- [SECURITY.md](SECURITY.md) — vulnerability disclosure policy and
+  security-relevant configuration.

--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ Do not commit secrets, API keys, database credentials, or production session
 keys. Use environment variables or deployment secrets.
 
 See [SECURITY.md](SECURITY.md) for the vulnerability-disclosure policy and
-supported versions.
+supported versions, and [PRIVACY.md](PRIVACY.md) for what data leaves your
+instance and how to run fully self-contained.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,3 +54,7 @@ See the [Configuration](README.md#configuration) table in the README for the
 full list of environment variables. Never commit secrets, API keys, database
 credentials, or production session values to the repository — use
 environment variables or your deployment platform's secret store.
+
+See [PRIVACY.md](PRIVACY.md) for a full accounting of what data leaves your
+instance and when, including AI features, Langfuse tracing, Web Push, and
+error tracking.


### PR DESCRIPTION
## Summary

Closes #645.

- Adds `PRIVACY.md` enumerating every outbound data flow and its triggering feature/env var: AI/LLM features (`FREE_LLM_*` / `OPENAI_*`), TTS (always OpenAI), the AI-fallback body-fetch, Langfuse tracing (`LANGFUSE_*`), Web Push (`VAPID_*`), backend/frontend error tracking (`SENTRY_DSN`, `SENTRY_DSN_FRONTEND`), and Keycloak login.
- Documents how to run fully self-contained (self-hosted LLM gateway or AI disabled, no Langfuse, no Sentry, no push, local auth only) so no data leaves the box.
- Documents local analytics (`user_events`): stored only in PostgreSQL, pruned by `ANALYTICS_RETENTION_DAYS` (default 180).
- Links `PRIVACY.md` from both `README.md` (Security section) and `SECURITY.md`.

The docs-site mirror step from the issue is deferred — no Docusaurus site exists yet (tracked separately under the OSS-readiness epic, issue #619).

## Test plan

- [x] Env var names cross-checked against the README config table and `.env.example`.
- [x] All markdown links (`README.md#configuration`, `SECURITY.md`, `PRIVACY.md`) resolve to existing files/sections.
- Docs-only change; no unit tests apply.