### PR TITLE
chore: remove stray PI-ATTEMPT-*.txt files from repo root

### DIFF
--- a/PI-ATTEMPT-632.txt
+++ b/PI-ATTEMPT-632.txt
@@ -1,1 +1,0 @@
-PI agent did not modify any files for issue #632

--- a/PI-ATTEMPT-633.txt
+++ b/PI-ATTEMPT-633.txt
@@ -1,1 +1,0 @@
-PI agent did not modify any files for issue #633

--- a/PI-ATTEMPT-635.txt
+++ b/PI-ATTEMPT-635.txt
@@ -1,1 +1,0 @@
-PI agent did not modify any files for issue #635

--- a/PI-ATTEMPT-636.txt
+++ b/PI-ATTEMPT-636.txt
@@ -1,1 +1,0 @@
-PI agent did not modify any files for issue #636

--- a/PI-ATTEMPT-750.txt
+++ b/PI-ATTEMPT-750.txt
@@ -1,1 +1,0 @@
-PI agent did not modify any files for issue #750


### PR DESCRIPTION
Closes #810

Removes five stray `PI-ATTEMPT-*.txt` files (632/633/635/636/750) that a PI agent accidentally committed to the repo root. Each contained only a single "PI agent did not modify any files for issue #NNN" line. Dead-file cleanup, no tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)