### PR TITLE
ci: generate SBOM and build provenance for releases (#628)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,11 @@ jobs:
     needs: [lint, test, helm-validate]
     runs-on: [self-hosted]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     outputs:
       image_tag: ${{ github.sha }}
     steps:
@@ -494,6 +499,7 @@ jobs:
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           push: true
@@ -502,6 +508,34 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:${{ github.sha }}
             ${{ env.IMAGE }}:latest
+
+      # SBOM (SPDX) for the exact image digest just pushed. Kept as a build
+      # artifact and attested below so consumers can verify contents.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
+      # Cryptographically ties the SBOM and the build to this repo's CI run.
+      # Verify with: gh attestation verify --repo <owner>/<repo> --owner <owner> <image>
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v3
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   # ── 10. DEPLOY ─────────────────────────────────────────────────────────────
   # Runs directly on the self-hosted runner (the mini PC itself) — no SSH hop

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -95,6 +95,28 @@ docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 ```
 
+### Verifying Image Provenance and SBOM
+
+Every image pushed to GHCR from a push to `main` is attested with a
+[SLSA build provenance](https://slsa.dev/) statement and a signed SBOM
+(SPDX), generated in `.github/workflows/ci.yml` and verifiable with the
+[GitHub CLI](https://cli.github.com/):
+
+```bash
+# Verify the image was built by this repo's CI (build provenance).
+gh attestation verify oci://ghcr.io/lihor-hub/news-dashboard:v1.21.0 \
+  --owner lihor-hub
+
+# Verify and inspect the SBOM attestation for the same image.
+gh attestation verify oci://ghcr.io/lihor-hub/news-dashboard:v1.21.0 \
+  --owner lihor-hub --predicate-type https://spdx.dev/Document
+```
+
+Both commands exit non-zero if the image digest doesn't match a
+signed attestation from this repository, or if the signature can't be
+verified against GitHub's Sigstore-backed OIDC identity. Substitute
+the tag with a specific commit SHA to verify an exact build.
+
 ## Environment Variables
 
 See the [README Configuration section](../README.md#configuration) for the complete list of environment variables.


### PR DESCRIPTION
Closes #628

## Summary
- Generate a Syft SPDX SBOM for the pushed container image digest in the `publish` job of `.github/workflows/ci.yml`, uploaded as a build artifact.
- Attest the SBOM with `actions/attest-sbom` and attest SLSA build provenance with `actions/attest-build-provenance`, both pushed to the GHCR registry for the image digest.
- Add `id-token: write` and `attestations: write` permissions scoped to the `publish` job (minimum needed for Sigstore-backed attestation).
- Document verification in `docs/SELF_HOSTING.md` under a new "Verifying Image Provenance and SBOM" section, showing `gh attestation verify` usage for both the build-provenance and SBOM predicates.

## Test plan
- [x] YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Pre-commit hooks passed (yaml check, trailing whitespace, etc.)
- [ ] CI passes on this PR (lint/test/helm-validate lanes; `publish`/attestation steps only run on push to `main` via the self-hosted runner, so they execute on merge, not on this PR)
- [ ] Manual verification post-merge: `gh attestation verify oci://ghcr.io/lihor-hub/news-dashboard:<sha> --owner lihor-hub`

Note: since `publish` only runs on push to `main` (self-hosted runner), the actual SBOM/provenance generation can't be exercised by this PR's CI — it will run on the first push to `main` after merge.