### PR TITLE
fix: make README version badge dynamic so it tracks releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml)
 [![Coverage Status](https://codecov.io/gh/lihor-hub/news-dashboard/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lihor-hub/news-dashboard)
 [![CodeQL](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml)
-[![Version](https://img.shields.io/badge/version-1.21.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/github/v/tag/lihor-hub/news-dashboard?filter=v*&sort=semver&label=version&color=blue)](https://github.com/lihor-hub/news-dashboard/releases/latest)
 [![License: MIT](https://img.shields.io/github/license/lihor-hub/news-dashboard)](LICENSE)
 
 Self-hosted technical news inbox for curated feeds, article triage, source

--- a/scripts/test_repo_metadata.py
+++ b/scripts/test_repo_metadata.py
@@ -22,6 +22,32 @@ class TestVersionConsistency(unittest.TestCase):
         )
 
 
+class TestReadmeVersionBadge(unittest.TestCase):
+    """The version lives in git tags, never committed (see scripts/next_version.sh).
+
+    A hardcoded ``version-X.Y.Z`` shields badge in the README therefore goes stale
+    on the next push to main. Require the badge to be the dynamic tag-based image
+    so it can never drift from the actual released version.
+    """
+
+    def test_readme_has_no_hardcoded_version_badge(self) -> None:
+        readme = (ROOT / "README.md").read_text()
+        m = re.search(r"img\.shields\.io/badge/version-\d+\.\d+\.\d+", readme)
+        assert m is None, (
+            "README.md pins a hardcoded version badge "
+            f"({m.group(0) if m else ''}); use the dynamic github/v/tag badge instead"
+        )
+
+    def test_readme_uses_dynamic_tag_badge(self) -> None:
+        readme = (ROOT / "README.md").read_text()
+        assert "img.shields.io/github/v/tag/lihor-hub/news-dashboard" in readme, (
+            "README.md should use the dynamic github/v/tag version badge"
+        )
+        assert "filter=v*" in readme, (
+            "README version badge must filter to v* tags (exclude android-/desktop- tags)"
+        )
+
+
 class TestNoPrivatePersonalPhrases(unittest.TestCase):
     _FORBIDDEN: ClassVar[list[str]] = ["private personal", "for Ioachim"]
     _EXTENSIONS: ClassVar[set[str]] = {".py", ".md", ".toml", ".ts", ".tsx", ".txt", ".rst"}


### PR DESCRIPTION
Closes #813

Replaces the hardcoded `version-1.21.0` shields badge in the README with a dynamic `github/v/tag` badge filtered to `v*` tags. The version is deliberately never committed (derived from git tags by `scripts/next_version.sh`), so any hardcoded number drifts on the next push to `main` — the latest release was already `v1.65.1`. The dynamic badge always reflects the newest release tag and links to the releases page.

Backed by a guard test in `scripts/test_repo_metadata.py` that forbids a hardcoded `version-X.Y.Z` badge and requires the dynamic form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)