### PR TITLE
fix(ci): self-enable GitHub Pages in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,8 @@ jobs:
         run: npm run build
 
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Problem

The **Docs site (GitHub Pages)** workflow [failed](https://github.com/lihor-hub/news-dashboard/actions/runs/28563673506) at the `actions/configure-pages@v5` step:

```
Get Pages site failed. Please verify that the repository has Pages enabled and
configured to build using GitHub Actions, or consider exploring the
`enablement` parameter for this action. Error: Not Found
```

At the time of that run, GitHub Pages was not yet enabled on the repo, so `configure-pages` got a `404` from the Pages API and aborted before the artifact could be uploaded/deployed.

## Fix

Set `enablement: true` on `actions/configure-pages@v5`. The action then enables Pages via the API (using the existing `pages: write` token permission) instead of failing when it isn't already enabled. This makes the docs deploy self-sufficient and prevents recurrence if Pages is ever toggled off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)