### PR TITLE
docs: refresh agent skill instructions

### DIFF
--- a/.claude/skills/langfuse/SKILL.md
+++ b/.claude/skills/langfuse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse
-description: Interact with Langfuse and access its documentation. Use when needing to (1) query or modify Langfuse data programmatically via the CLI — traces, prompts, datasets, scores, sessions, and any other API resource, (2) look up Langfuse documentation, concepts, integration guides, or SDK usage, or (3) understand how any Langfuse feature works. This skill covers CLI-based API access (via npx) and multiple documentation retrieval methods.
+description: Use Langfuse. Trigger when querying or modifying Langfuse data, reading Langfuse docs, instrumenting traces, migrating prompts, managing datasets/scores/sessions, or debugging Langfuse usage.
 allowed-tools:
   - WebFetch(domain:langfuse.com)
   - Bash(curl *langfuse.com/*)
@@ -16,16 +16,17 @@ allowed-tools:
 
 # Langfuse
 
-This skill helps you use Langfuse effectively across all common workflows: instrumenting applications, migrating prompts, debugging traces, and accessing data programmatically.
+Use this for Langfuse data access, docs lookup, instrumentation, prompt
+migration, trace debugging, feedback scores, evaluation, and CI gates.
 
 ## Core Principles
 
-Follow these principles for ALL Langfuse work:
+Follow these for all Langfuse work:
 
-1. **Documentation First**: NEVER implement based on memory. Always fetch current docs before writing code (Langfuse updates frequently) See the section below on how to access documentation.
-2. **CLI for Data Access**: Use `langfuse-cli` when querying/modifying Langfuse data. See the section below on how to use the CLI.
-3. **Best Practices by Use Case**: Check the relevant reference file below for use-case-specific guidelines before implementing
-4. **Use latest Langfuse versions**: Unless the user specified otherwise or there's a good reason, always use the latest version of Langfuse SDKs/APIs.
+1. **Docs first**: fetch current docs before implementation.
+2. **CLI for data**: use `langfuse-cli` for Langfuse API data access.
+3. **Branch by use case**: read the relevant reference before implementing.
+4. **Current SDKs**: prefer latest Langfuse SDK/API guidance unless constrained.
 
 
 ## Use case specific references
@@ -43,7 +44,7 @@ Follow these principles for ALL Langfuse work:
 
 ## 1. Langfuse API via CLI
 
-Use the `langfuse-cli` to interact with the full Langfuse REST API from the command line. Run via npx (no install required):
+Use `langfuse-cli` for Langfuse REST API access. Run via npx:
 
 Start by discovering the schema and available arguments:
 
@@ -60,7 +61,7 @@ npx langfuse-cli api <resource> <action> --help
 
 ### Credentials
 
-Set environment variables before making calls:
+Set environment variables before calls:
 
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-...
@@ -68,31 +69,32 @@ export LANGFUSE_SECRET_KEY=sk-lf-...
 export LANGFUSE_BASE_URL=https://cloud.langfuse.com # example for EU cloud. For US cloud it's us.cloud.langfuse.com, and can also be a self-hosted URL. The server must always be specified in order to access Langfuse.
 ```
 If `LANGFUSE_BASE_URL` is used instead of `LANGFUSE_HOST`, run `export LANGFUSE_HOST="$LANGFUSE_BASE_URL"`.
-If not set, ask the user to set them in their shell or a `.env` file (do not ask them to paste keys into chat for security reasons). Keys are found in Langfuse UI → Settings → API Keys.
+If credentials are missing, ask the user to set them in a shell or `.env` file.
+Do not ask them to paste keys into chat.
 
 ### Detailed CLI Reference
 
-For common workflows, tips, and full usage patterns, see [references/cli.md](references/cli.md).
+For common workflows, see [references/cli.md](references/cli.md).
 
 ## 2. Langfuse Documentation
 
-Three methods to access Langfuse docs, in order of preference. **Always prefer your application's native web fetch and search tools** (e.g., `WebFetch`, `WebSearch`, `mcp_fetch`, etc.) over `curl` when available. The URLs and patterns below work with any fetching method — the `curl` examples are just illustrative.
+Three methods to access Langfuse docs. Prefer native web fetch/search tools over
+`curl` when available; the `curl` examples are illustrative.
 
 ### 2a. Documentation Index (llms.txt)
 
-Fetch the full index of all documentation pages:
+Fetch the full documentation index:
 
 ```bash
 curl -s https://langfuse.com/llms.txt
 ```
 
-Returns a structured list of every doc page with titles and URLs. Use this to discover the right page for a topic, then fetch that page directly.
-
-Alternatively, you can start on `https://langfuse.com/docs` and explore the site to find the page you need.
+Use this to find the right page, then fetch that page directly.
 
 ### 2b. Fetch Individual Pages as Markdown
 
-Any page listed in llms.txt can be fetched as markdown by appending `.md` to its path or by using `Accept: text/markdown` in the request headers. Use this when you know which page contains the information needed. Returns clean markdown with code examples and configuration details.
+Any listed page can be fetched as markdown by appending `.md` or using
+`Accept: text/markdown`.
 
 ```bash
 curl -s "https://langfuse.com/docs/observability/overview.md"
@@ -101,7 +103,7 @@ curl -s "https://langfuse.com/docs/observability/overview" -H "Accept: text/mark
 
 ### 2c. Search Documentation
 
-When you need to find information across all docs and github issues/discussions without knowing the specific page:
+Search when the relevant page is unclear:
 
 ```bash
 curl -s "https://langfuse.com/api/search-docs?query=<url-encoded-query>"
@@ -121,17 +123,18 @@ Returns a JSON response with:
   - `title`: page title
   - `source.content`: array of relevant text excerpts from the page
 
-Search is a great fallback if you cannot find the relevant pages or need more context. Especially useful when debugging issues as all GitHub Issues and Discussions are also indexed. Responses can be large — extract only the relevant portions.
+Search responses can be large; extract only the relevant portions.
 
 ### Documentation Workflow
 
-1. Start with **llms.txt** to orient — scan for relevant page titles
-2. **Fetch specific pages** when you identify the right one
-3. Fall back to **search** when the topic is unclear and you want more context
+1. Start with **llms.txt** to orient.
+2. Fetch specific pages when you identify the right one.
+3. Search when the topic is unclear.
 
 ## Skill Feedback
 
-When the user expresses that something about this skill is not working as expected, gives incorrect guidance, is missing information, or could be improved — offer to submit feedback to the Langfuse skill maintainers. This includes when:
+When the user says this skill is wrong, stale, missing coverage, or behaving
+badly, offer to submit feedback to the Langfuse skill maintainers. This includes:
 
 - The skill gave wrong or outdated instructions
 - A workflow didn't produce the expected result

--- a/.claude/skills/python-dev/SKILL.md
+++ b/.claude/skills/python-dev/SKILL.md
@@ -1,28 +1,19 @@
 ---
 name: python-dev
 description: >-
-  Standards and verification gate for writing Python in this repository. Use
-  this skill ANY time you create or edit a .py file, add or change a Python
-  dependency, write or fix a pytest test, or are about to commit/push Python
-  changes — even for a "small" edit. It tells you how to write code that passes
-  this project's ruff + mypy(strict) + ty + pyrefly + pytest gates the first
-  time, how to keep dependencies and lockfiles clean, what test patterns to
-  follow, and which project-specific gotchas (PostgreSQL-only, tz-aware
-  datetimes, no print) will otherwise bite you. Triggers on: Python, .py,
-  FastAPI, pytest, ruff, mypy, ty, pyrefly, type checker, backend changes,
-  "run the backend tests", "why does the type check fail".
+  Python standards and verification gate for this repo. Use when editing .py
+  files, Python dependencies, pytest tests, backend behavior, or investigating
+  ruff, mypy, ty, pyrefly, or pytest failures.
 ---
 
 # Python development in this repo
 
-The backend lives in `backend/news_dashboard/`, tests in `backend/tests/`. The
-toolchain is already configured and strict — your job is to write code that
-clears it on the first try, not to reinvent or relax it.
+The backend lives in `backend/news_dashboard/`, tests in `backend/tests/`.
+Write code that clears the configured gates without loosening them.
 
 ## 0. Detect before you act
 
-Never assume commands. This repo standardizes entry points in the `Makefile` —
-**prefer those**, they're what CI runs (`make check`). Confirm what exists:
+Prefer `Makefile` targets; they are what CI runs. Confirm what exists:
 
 ```bash
 ls Makefile pyproject.toml uv.lock 2>/dev/null   # what governs the project
@@ -40,13 +31,9 @@ Run `pip install -e '.[dev]'` (or `make install`) once if the tools aren't impor
 
 ## 1. While writing code — clear the gates by construction
 
-The ruff rule set here is large (see `[tool.ruff.lint]` in `pyproject.toml`) and
-**three** type checkers must all pass: `mypy` (strict, `warn_unreachable`), `ty`
-(Astral), and `pyrefly` (Meta) — configured under `[tool.mypy]`, `[tool.ty]`,
-and `[tool.pyrefly]`. They overlap but each catches things the others miss (e.g.
-pyrefly flags possibly-unbound locals, ty flags LSP-violating overrides), so
-write code that satisfies all three rather than the most lenient. The patterns
-that trip agents most often, and how to avoid them:
+The ruff rule set is large and **three** type checkers must pass: `mypy`
+(strict, `warn_unreachable`), `ty`, and `pyrefly`. Write to satisfy all three.
+Common traps:
 
 - **Type everything.** Strict mypy means every function needs annotated params
   and return type; no implicit `Any`. Public modules ship types (`py.typed`).
@@ -65,16 +52,13 @@ that trip agents most often, and how to avoid them:
 - **Comprehensions/simplify (`C4`/`SIM`/`RET`/`PERF`):** prefer the idiom ruff
   wants; when it flags, take the suggestion rather than `# noqa`.
 
-When you genuinely must suppress a finding, scope it to the one tool and one
-rule, with a reason: ruff → `# noqa: <CODE>`, mypy → `# type: ignore[<code>]`,
-ty → `# ty: ignore[<rule>]`, pyrefly → `# pyrefly: ignore[<rule>]`. Prefer
-fixing the code over suppressing; reserve ignores for genuine third-party or
-tool limitations (e.g. ty mis-resolving psycopg's overloaded `connect`). Never a
-blanket ignore, and never edit `pyproject.toml` to disable a rule to pass.
+Suppressions need one tool, one rule, and a reason: ruff `# noqa: <CODE>`,
+mypy `# type: ignore[<code>]`, ty `# ty: ignore[<rule>]`, pyrefly
+`# pyrefly: ignore[<rule>]`. Never blanket-ignore or loosen `pyproject.toml` to pass.
 
 ## 2. Project guardrails (don't regress these)
 
-These are decisions encoded in config/`AGENTS.md` that an unaware edit will undo:
+Preserve these repo decisions:
 
 - **PostgreSQL only.** Runtime code uses PostgreSQL SQL + psycopg param style.
   Do **not** add SQLite fallbacks, db-type sniffing, or placeholder-translation
@@ -83,26 +67,22 @@ These are decisions encoded in config/`AGENTS.md` that an unaware edit will undo
   intentional (avoids PEP 758 rewrites mypy can't parse). Leave it.
 - **Lazy imports are deliberate** (`PLC0415` ignored) for optional deps / startup
   cost / cycles — keep them where they are.
-- Config files (`pyproject.toml`, `.pre-commit-config.yaml`) are not yours to
-  loosen to pass checks. If a rule seems wrong, raise it; don't silently flip it.
+- Do not loosen `pyproject.toml` or `.pre-commit-config.yaml` to pass checks.
 
 ## 3. Tests — author them to this project's style
 
 - Framework is **pytest** with `flake8-pytest-style` (`PT`) enforced. Use
   `pytest.raises`, parametrize with `@pytest.mark.parametrize`, name fixtures
   clearly. `assert` is allowed in tests (per-file ignore), not in app code.
-- **Postgres in tests:** the suite uses `testcontainers[postgres]` but can also
-  hit a local Docker Postgres directly. Credentials live in `.env` at the project
-  root — **load it before running tests**:
+- **Postgres in tests:** credentials live in `.env` at the project root. Load it
+  before running tests:
   ```bash
   source .env && make test
   # or, if dotenv-cli is installed:
   dotenv make test
   ```
-  `.env` sets `TEST_DATABASE_URL` (and `DATABASE_URL`) to the local Docker
-  Postgres (`postgresql://news_dashboard:…@localhost:55432/news_dashboard_test`).
   When `TEST_DATABASE_URL` is present, `conftest.py` uses it directly instead of
-  spinning a container — so tests run faster and never skip on Docker availability.
+  spinning a container.
   Don't mock the DB into a fake; use the `pg_clean` fixture from `conftest.py`
   (gives a fresh-truncated Postgres URL per test). Read a neighbour test before
   writing a new one.

--- a/.claude/skills/report-issue/SKILL.md
+++ b/.claude/skills/report-issue/SKILL.md
@@ -1,33 +1,23 @@
 ---
 name: report-issue
 description: >-
-  Turn a reported problem or feature request into a fully-specified GitHub issue
-  that an autonomous agent can pick up and ship AFK — no further human context
-  needed. Use this WHENEVER the user wants to "report a problem", "file/open/create
-  an issue", "log a bug", "track this for later", or describes something to fix or
-  build but explicitly does NOT want it implemented right now. The skill
-  investigates the codebase to scope the request, writes a self-contained issue
-  (problem, current state, file references, scope, acceptance criteria, test
-  expectations), and labels it `ready-for-agent` so it can be picked up from the
-  backlog and solved autonomously. Do NOT use this when the user wants the change
-  implemented now — that is `tdd-ship`.
+  Create AFK-ready GitHub issues. Use when the user wants to report, file, log,
+  or track a bug/feature for later instead of implementing it now. Do not use
+  when the user wants the change shipped now; use tdd-ship.
 ---
 
 # Report a problem → AFK-ready GitHub issue
 
-The purpose of this skill is to capture work as a **GitHub issue specified well
-enough that an agent can implement it cold**, from the issue text alone, with no
-memory of the conversation that produced it. The issue is the handoff. If it is
-vague, the AFK agent guesses; if it is precise, the AFK agent ships.
+Capture work as a **GitHub issue specified well enough that an agent can
+implement it cold** from the issue text alone.
 
 Use this when the user wants to *record* work, not do it now. If they want it
 done immediately, use `tdd-ship` instead.
 
-## The contract: what "AFK-ready" means
+## AFK-ready contract
 
-The downstream agent starts from a cold checkout with only the issue body. So
-the body must stand alone. Before writing it, do the investigation the AFK agent
-would otherwise have to redo — then bake the answers into the issue.
+Before writing the issue, do the discovery the downstream agent would otherwise
+redo, then bake the answers into the body.
 
 A `ready-for-agent` issue MUST contain:
 
@@ -45,18 +35,15 @@ A `ready-for-agent` issue MUST contain:
    they live (match the repo's existing test conventions). The downstream flow
    is TDD, so this seeds the failing test.
 
-If you cannot fill in section 2 or 3 from the codebase, the issue is not ready —
-investigate first (read the relevant files, grep the call sites) or ask the user
-the one or two questions that unblock it. Do not file a hand-wavy issue.
+If sections 2 or 3 are missing, investigate more or ask the question that
+unblocks the spec. Do not file a vague issue.
 
 ## Workflow
 
 ### 1. Understand the report
 
-Read what the user described. If it is a bug, reproduce the reasoning: where in
-the code does it go wrong? If it is a feature, where does it slot in? Use the
-file/search tools to ground every claim. Spend the investigation budget here so
-the issue is self-contained — this is the whole value of the skill.
+Ground the report in the code. For a bug, identify where it goes wrong; for a
+feature, identify where it slots in. Use file/search tools for every claim.
 
 Only ask the user a question when the answer genuinely changes the spec and you
 cannot derive it from the code (e.g. a product decision like "leave TTS untraced
@@ -65,18 +52,15 @@ issue.
 
 ### 2. Choose labels
 
-Always apply `ready-for-agent` (the AFK-pickup marker: "Fully specified,
-AFK-ready: an agent can pick it up with no human context"). Add the matching
-domain label(s) so the backlog stays filterable — check `gh label list` and use
-what fits, e.g.:
+Always apply `ready-for-agent`. Add matching domain labels after checking
+`gh label list`, e.g.:
 
 - `bug` / `enhancement` — kind of work
 - `epic: ai`, `epic: automation`, `epic: content`, `epic: reader-ux` — area
 - `ci-cd`, `ux`, `documentation` — cross-cutting
 
-If a needed label doesn't exist, create it (`gh label create`) rather than
-forcing a poor fit. Never apply `ready-for-human` to an AFK issue — that label
-is for work that needs a person; the two are mutually exclusive.
+If a needed label doesn't exist, create it. Never apply `ready-for-human` to an
+AFK issue.
 
 ### 3. Create the issue
 
@@ -94,19 +78,13 @@ Match the repo's commit voice in the title (`fix:` / `feat:` / `chore:`).
 
 ### 4. Report back
 
-Give the user the issue URL and a one-line summary of what it asks for, plus the
-labels applied. Make clear it is queued for AFK pickup — you are NOT implementing
-it now. If, while scoping, you found the change is trivial or the user seems to
-want it done, offer `tdd-ship` as the next step rather than assuming.
+Give the user the issue URL, one-line summary, and labels. Make clear it is
+queued for AFK pickup, not implemented now.
 
 ## How AFK pickup works
 
 Issues labelled `ready-for-agent` form the autonomous backlog. An agent drains
-that pool and ships each one through the standard `tdd-ship` pipeline (branch →
-failing test → implement → PR that closes the issue → CI → auto-merge). Because
-this skill front-loads the specification, the AFK agent needs no conversation
-context — it reads the issue, implements exactly the scope, and the acceptance
-criteria tell it when it's done.
+that pool through `tdd-ship`.
 
 To dispatch the backlog, point an agent at the open `ready-for-agent` issues:
 
@@ -114,10 +92,7 @@ To dispatch the backlog, point an agent at the open `ready-for-agent` issues:
 gh issue list --label ready-for-agent --state open
 ```
 
-Then, for a chosen issue, run `tdd-ship` against it (e.g. "implement issue #NNN").
-This can be wired to a scheduled cloud agent / routine (see the `schedule` skill)
-so the queue is drained automatically on a cadence — each run picks the next open
-`ready-for-agent` issue and ships it.
+Then run `tdd-ship` against a chosen issue (for example, "implement issue #NNN").
 
 ## Guardrails
 

--- a/.claude/skills/tdd-ship/SKILL.md
+++ b/.claude/skills/tdd-ship/SKILL.md
@@ -1,47 +1,36 @@
 ---
 name: tdd-ship
 description: >-
-  The default end-to-end delivery workflow for this repo. Use this skill
-  WHENEVER a request will change a tracked file in the repository — fixing a
-  bug, adding a feature, refactoring, editing config, docs, or tests — even for
-  a one-line change. It drives the full pipeline: open a GitHub issue, branch,
-  write the failing test first (TDD), implement until green, open a PR that
-  closes the issue, wait for CI, and auto-merge once CI is green. Do NOT use it
-  for pure questions, explanations, research, or read-only investigation that
-  touch no files. Triggers on: "fix", "add", "implement", "change", "update",
-  "refactor", "rename", "bump", "tweak", or any phrasing that ends in a code or
-  file change.
+  Default delivery workflow for tracked repo changes. Use when the user asks to
+  fix, add, implement, update, refactor, rename, bump, tweak, or otherwise end
+  in a file change. Do not use for read-only questions or investigation.
 ---
 
 # TDD → Issue → PR → CI → Merge
 
-This is how work ships in this repo. Any request that ends in a changed file
-goes through the same pipeline, so changes are traceable (an issue), reviewable
-(a PR), test-backed (TDD), and verified (CI) before they reach `main`. The goal
-isn't ceremony — it's that nothing lands on `main` without a test proving it
-works and CI confirming it.
+This is how tracked changes ship in this repo: issue -> branch -> red/green
+TDD -> PR -> CI -> auto-merge.
 
 ## When this applies
 
-Apply the full pipeline when the request will modify a tracked file: code, a new
-feature, a bug fix, a refactor, config, Helm/deploy, docs, or tests.
+Apply the full pipeline when the request modifies a tracked file: code, config,
+docs, tests, or deploy files.
 
 Skip it for pure questions, explanations, research, or read-only investigation
 ("how does X work?", "where is Y defined?", "explain this") — answer those
 directly. If a question turns into "…so fix it," the pipeline kicks in at that
 point.
 
-If you're unsure whether a request is big enough to warrant the pipeline, it is.
-A one-line fix still gets an issue, a test, and a PR — that's the point.
+If the user explicitly asks to edit locally without a PR, honor that scope but
+keep the branch, tests, and reporting discipline.
 
 ## The pipeline
 
-Run these in order. Don't skip steps, and don't merge anything by hand outside
-this flow.
+Run these in order.
 
 ### 1. Open a GitHub issue
 
-Capture the intent before writing code, so the change has a tracked rationale.
+Capture the intent before writing code.
 
 ```bash
 gh issue create --title "<concise imperative title>" \
@@ -49,14 +38,9 @@ gh issue create --title "<concise imperative title>" \
   --label "ready-for-agent"
 ```
 
-Keep the title in the repo's voice (e.g. `fix:`/`feat:` style matches commits).
-Note the issue number — you'll reference it in the branch and the PR.
-
-**Always apply the `ready-for-agent` label** to every issue you open. The body
-must be fully specified — context, file references, and acceptance criteria as a
-checklist — so an agent can pick it up with no further human context. If you add
-the label to an existing issue, use `gh issue edit <issue#> --add-label
-"ready-for-agent"`.
+Keep the title in the repo's voice (`fix:`/`feat:` style matches commits).
+Always apply `ready-for-agent`; the issue body needs context, file references,
+scope, acceptance criteria, and test expectations.
 
 ### 2. Branch off an up-to-date `main`
 
@@ -76,11 +60,6 @@ Starting from an up-to-date `main` keeps the diff clean and avoids merge
 conflicts when you push.
 
 ### 3. TDD — write the failing test first
-
-This is the heart of the workflow. Write the test that describes the desired
-behavior **before** the implementation, watch it fail for the right reason, then
-make it pass. A test written after the code tends to assert what the code does,
-not what it should do — writing it first is what makes it a spec.
 
 - **Red**: add/modify a test that encodes the new behavior. Run it; confirm it
   fails because the behavior is missing (not because of a typo or import error).
@@ -102,15 +81,12 @@ into the worktree. Do not print secret values. It is enough to verify that
 `DATABASE_URL` and `TEST_DATABASE_URL` are present so the pre-push backend
 pytest hook can connect to PostgreSQL.
 
-Push only once the relevant tests and type/lint gates pass locally — CI runs the
-same gates, so green-locally is the cheapest way to a green PR.
+Push only after the relevant tests and type/lint gates pass locally.
 
 ### 4. Rebase on `origin/main`, open the PR, and queue it for merge
 
-`main` may have moved while you worked, so re-sync immediately before pushing.
-Rebase (don't merge) so the branch stays linear, re-run the gates if the rebase
-pulled anything in, push, open the PR, then immediately hand it to GitHub's merge
-queue:
+Rebase immediately before pushing, re-run gates if the rebase changes the base,
+push, open the PR, then queue auto-merge:
 
 ```bash
 git fetch origin && git rebase origin/main
@@ -120,19 +96,11 @@ gh pr create --fill --base main \
 gh pr merge --squash --auto
 ```
 
-The `Closes #<issue#>` line is required — it links the PR to the issue and
-auto-closes it on merge. End the PR body with the standard trailer:
+The `Closes #<issue#>` line is required. End the PR body with the standard trailer:
 `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
 
-Always open PRs with auto-merge enabled (`--auto`). Branch protection on `main`
-requires a merge queue, so `gh pr merge` does not merge directly. If required
-checks are still pending, it enables auto-merge; once the PR is eligible, GitHub
-adds it to the queue and creates a `merge_group` ref. The queue then waits for
-the required checks on that merge group before landing the PR. Do not pass
-`--delete-branch` when merge queue is enabled; `gh` rejects that flag for queued
-merges. A repo-level workflow (`.github/workflows/auto-merge.yml`) also enables
-auto-merge on every non-draft PR as a backstop, but don't rely on it — set
-`--auto` yourself.
+Always open PRs with auto-merge enabled (`--auto`). Branch protection uses a
+merge queue; do not pass `--delete-branch` with queued merges.
 
 Do not bypass the queue with `gh pr merge --admin` or a direct push to `main`.
 
@@ -145,19 +113,14 @@ gh pr checks --watch
 ```
 
 If a check fails, read the logs (`gh run view <run-id> --log-failed`), fix the
-cause on the branch, push, and let CI re-run. When the PR reaches the merge
-queue, CI runs again on the `merge_group` event for the temporary queue ref. The
-required checks are `Lint & typecheck` and `Test & build`; both must pass on the
-merge group before GitHub squash-merges the PR.
+cause on the branch, push, and let CI re-run. Required checks are `Lint &
+typecheck` and `Test & build`; both must pass on the PR and merge queue.
 
 ### 6. Confirm the merge completed
 
-Once CI is green, confirm auto-merge actually landed the PR (`gh pr view
-<pr#> --json state,mergedAt`). Then confirm the issue closed (the `Closes #`
-link handles it), delete the remote branch if GitHub did not delete it
-automatically, and report the merged PR and issue numbers back to the user.
-Only step in with `gh pr merge --squash --auto` if auto-merge was disabled (e.g.
-the PR was converted to a draft); do not use an admin merge to skip the queue.
+Once CI is green, confirm auto-merge landed (`gh pr view <pr#> --json
+state,mergedAt`), confirm the issue closed, delete the remote branch if GitHub
+did not, and report the PR/issue numbers.
 
 ## Reporting back
 

--- a/.claude/skills/typescript-dev/SKILL.md
+++ b/.claude/skills/typescript-dev/SKILL.md
@@ -1,29 +1,19 @@
 ---
 name: typescript-dev
 description: >-
-  Standards and verification gate for writing TypeScript/React in this
-  repository. Use this skill ANY time you create or edit a .ts/.tsx file, touch
-  vite/eslint/tsconfig, add an npm dependency, write or fix a vitest or
-  Playwright test, or are about to commit/push frontend changes — even for a
-  "small" edit. It tells you how to write code that passes this project's
-  eslint(--max-warnings 0) + prettier + tsc(strict) + vitest gates the first
-  time, when to write unit vs e2e tests, how to keep package.json/lockfile
-  clean, and which React/PWA gotchas will otherwise bite you. Triggers on:
-  TypeScript, React, .tsx, frontend, vite, eslint, prettier, tsc, vitest,
-  playwright, "run the frontend tests", "why does the build fail".
+  TypeScript/React standards and verification gate for this repo. Use when
+  editing .ts/.tsx files, Vite/ESLint/tsconfig, npm dependencies, frontend tests,
+  or investigating eslint, prettier, tsc, vitest, Playwright, or build failures.
 ---
 
 # TypeScript development in this repo
 
-The frontend is React + Vite + Tailwind in `frontend/src/`, with Radix UI,
-TanStack Query, Zustand, and React Router. Unit tests use **vitest** +
-Testing Library; end-to-end tests use **Playwright** in `e2e/`. The toolchain is
-already configured and strict — write code that clears it on the first try.
+The frontend is React + Vite + Tailwind in `frontend/src/`. Unit tests use
+vitest + Testing Library; end-to-end tests use Playwright in `e2e/`.
 
 ## 0. Detect before you act
 
-Prefer the canonical entry points. `npm` scripts (`package.json`) and `make`
-targets are what CI runs. Confirm what exists:
+Prefer `npm` scripts and `make` targets; they are what CI runs. Confirm what exists:
 
 ```bash
 cat package.json | sed -n '/"scripts"/,/}/p'
@@ -40,9 +30,8 @@ with no frontend tooling at all, read
 
 ## 1. While writing code — clear the gates by construction
 
-ESLint runs flat-config with `typescript-eslint`, `react-hooks`, and
-`react-refresh`, and the lint script uses **`--max-warnings 0`** — a warning is a
-failure. `tsc` builds with project references and strict typing. Common traps:
+ESLint uses `--max-warnings 0`; a warning is a failure. `tsc` is strict. Common
+traps:
 
 - **No `any`.** Type props, hooks, and API payloads. Prefer `unknown` + a
   narrowing check over `any`; derive types from Zod/response shapes where they
@@ -57,9 +46,9 @@ failure. `tsc` builds with project references and strict typing. Common traps:
   lint rules). Don't hand-format — run `npm run format`.
 - Honor `.prettierrc.json` / `.editorconfig`; don't override style inline.
 
-When a rule genuinely doesn't apply, use a scoped
-`// eslint-disable-next-line <rule> -- reason`, never a file-wide disable, and
-never edit `eslint.config.mjs`/`tsconfig.json` just to make your code pass.
+When a rule genuinely doesn't apply, use
+`// eslint-disable-next-line <rule> -- reason`. Never file-disable or loosen
+`eslint.config.mjs`/`tsconfig.json` to pass.
 
 ## 2. Project guardrails (don't regress these)
 


### PR DESCRIPTION
Closes #819

## Summary
- Shorten model-facing descriptions for the repo skills so invocation is branch-focused instead of body-sized.
- Prune duplicated workflow prose from tdd-ship, report-issue, language gates, and Langfuse while preserving the completion criteria and guardrails.
- Keep `.agents/skills` synchronized through the existing symlink to `.claude/skills`.

## Verification
- `python3` validation for skill frontmatter, local `.md` links, and `.agents/skills` symlink
- `git diff --check`
- pre-commit hooks on commit; code gates skipped because no code files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
