### PR TITLE
feat: add personal article highlights (#651)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -443,6 +443,19 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_share_annotations_share"
     " ON share_annotations(share_id, created_at)",
     """
+    CREATE TABLE IF NOT EXISTS article_highlights (
+      id               BIGSERIAL PRIMARY KEY,
+      user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      article_id       BIGINT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+      highlighted_text TEXT NOT NULL,
+      offset_chars     INTEGER NOT NULL DEFAULT 0,
+      note             TEXT,
+      created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_article_highlights_user_article"
+    " ON article_highlights(user_id, article_id, created_at)",
+    """
     CREATE TABLE IF NOT EXISTS share_messages (
       id          BIGSERIAL PRIMARY KEY,
       share_id    BIGINT NOT NULL REFERENCES article_shares(id) ON DELETE CASCADE,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -878,6 +878,53 @@ def article_audio(
     return FileResponse(path, media_type="audio/mpeg", filename=f"article-{article_id}.mp3")
 
 
+@api.get("/api/articles/{article_id}/highlights")
+def list_article_highlights(
+    article_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.personal_highlights import list_highlights
+
+    highlights = list_highlights(article_id, current_user["id"])
+    if highlights is None:
+        raise HTTPException(status_code=404, detail="article not found")
+    return {"items": highlights}
+
+
+@api.post("/api/articles/{article_id}/highlights")
+def add_article_highlight(
+    article_id: int,
+    payload: AddAnnotationRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.personal_highlights import add_highlight
+
+    highlight = add_highlight(
+        article_id,
+        current_user["id"],
+        highlighted_text=payload.highlighted_text,
+        offset_chars=payload.offset_chars,
+        note=payload.note,
+    )
+    if highlight is None:
+        raise HTTPException(status_code=404, detail="article not found")
+    return highlight
+
+
+@api.delete("/api/articles/{article_id}/highlights/{highlight_id}")
+def delete_article_highlight(
+    article_id: int,
+    highlight_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, bool]:
+    from news_dashboard.personal_highlights import delete_highlight
+
+    deleted = delete_highlight(article_id, current_user["id"], highlight_id)
+    if deleted is None:
+        raise HTTPException(status_code=404, detail="article not found")
+    return {"ok": deleted}
+
+
 @api.get("/api/articles/{article_id}/insights")
 def article_insights(
     article_id: int,

--- a/backend/news_dashboard/personal_highlights.py
+++ b/backend/news_dashboard/personal_highlights.py
@@ -1,0 +1,69 @@
+"""Private per-user article highlights.
+
+Runtime SQL is PostgreSQL-specific and uses psycopg ``%s`` parameters.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from news_dashboard.article_visibility import get_visible_article_row
+from news_dashboard.db import connect, row_to_dict
+
+
+def list_highlights(article_id: int, user_id: int) -> list[dict[str, Any]] | None:
+    """Return a user's highlights for a visible article, oldest first."""
+    with connect() as conn:
+        if get_visible_article_row(conn, article_id, user_id) is None:
+            return None
+        rows = conn.execute(
+            """
+            SELECT id, user_id, article_id, highlighted_text, offset_chars, note, created_at
+            FROM article_highlights
+            WHERE user_id = %s AND article_id = %s
+            ORDER BY created_at, id
+            """,
+            (user_id, article_id),
+        ).fetchall()
+    return [row_to_dict(row) for row in rows]
+
+
+def add_highlight(
+    article_id: int,
+    user_id: int,
+    *,
+    highlighted_text: str,
+    offset_chars: int = 0,
+    note: str | None = None,
+) -> dict[str, Any] | None:
+    """Create a private highlight for a visible article."""
+    clean_text = highlighted_text.strip()
+    clean_note = (note or "").strip() or None
+    with connect() as conn:
+        if get_visible_article_row(conn, article_id, user_id) is None:
+            return None
+        row = conn.execute(
+            """
+            INSERT INTO article_highlights
+              (user_id, article_id, highlighted_text, offset_chars, note)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING id, user_id, article_id, highlighted_text, offset_chars, note, created_at
+            """,
+            (user_id, article_id, clean_text, offset_chars, clean_note),
+        ).fetchone()
+    return row_to_dict(row)
+
+
+def delete_highlight(article_id: int, user_id: int, highlight_id: int) -> bool | None:
+    """Delete one private highlight for a visible article."""
+    with connect() as conn:
+        if get_visible_article_row(conn, article_id, user_id) is None:
+            return None
+        cursor = conn.execute(
+            """
+            DELETE FROM article_highlights
+            WHERE id = %s AND user_id = %s AND article_id = %s
+            """,
+            (highlight_id, user_id, article_id),
+        )
+        return bool(cursor.rowcount > 0)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -179,7 +179,7 @@ def pg_clean(pg_url: str) -> str:
         conn.execute(
             "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
             " user_interest_profiles, user_settings, user_push_subscriptions,"
-            " article_shares, user_events, briefing_articles, briefings,"
+            " article_highlights, article_shares, user_events, briefing_articles, briefings,"
             " ingest_run_sources, ingest_runs, scheduled_job_runs, articles, sources, users"
             " RESTART IDENTITY CASCADE"
         )

--- a/backend/tests/test_article_highlights.py
+++ b/backend/tests/test_article_highlights.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import create_user, require_auth
+from news_dashboard.db import connect
+from news_dashboard.ingest import sync_sources
+from news_dashboard.main import app
+from news_dashboard.personal_highlights import add_highlight, delete_highlight, list_highlights
+
+
+@pytest.fixture
+def db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    return pg_clean
+
+
+def _make_user(db_path: str, username: str) -> int:
+    return int(create_user(username, "password123", db_path=db_path)["id"])
+
+
+def _insert_article(db_path: str, suffix: str = "1") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug,
+              source_name, category, kind, state)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/highlight-{suffix}",
+                f"https://example.com/highlight-{suffix}",
+                f"Highlight Article {suffix}",
+                "python-insider",
+                "Python Insider",
+                "python",
+                "rss_feed",
+                "today",
+            ),
+        ).fetchone()
+    return int(row["id"])
+
+
+def _insert_private_article(db_path: str, *, owner_user_id: int) -> int:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES ('private-highlights', 'Private Highlights',
+                    'https://private.example.com/feed.xml', 'private', 'rss_feed', %s)
+            """,
+            (owner_user_id,),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug,
+              source_name, category, kind, state)
+            VALUES ('https://private.example.com/highlights',
+                    'https://private.example.com/highlights',
+                    'Private Highlight Article', 'private-highlights', 'Private Highlights',
+                    'private', 'rss_feed', 'today')
+            RETURNING id
+            """
+        ).fetchone()
+    return int(row["id"])
+
+
+def test_user_can_create_list_and_delete_private_highlights(db: str) -> None:
+    user_id = _make_user(db, "alice")
+    article_id = _insert_article(db)
+
+    created = add_highlight(
+        article_id,
+        user_id,
+        highlighted_text=" selected passage ",
+        offset_chars=14,
+        note=" remember this ",
+    )
+
+    assert created is not None
+    assert created["highlighted_text"] == "selected passage"
+    assert created["offset_chars"] == 14
+    assert created["note"] == "remember this"
+    assert list_highlights(article_id, user_id) == [created]
+    assert delete_highlight(article_id, user_id, int(created["id"])) is True
+    assert list_highlights(article_id, user_id) == []
+
+
+def test_highlights_are_isolated_by_user(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+
+    created = add_highlight(article_id, alice, highlighted_text="Alice only")
+
+    assert created is not None
+    assert list_highlights(article_id, bob) == []
+    assert delete_highlight(article_id, bob, int(created["id"])) is False
+    assert list_highlights(article_id, alice) == [created]
+
+
+def test_cross_user_private_article_access_is_rejected(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_private_article(db, owner_user_id=alice)
+
+    assert add_highlight(article_id, bob, highlighted_text="Nope") is None
+    assert list_highlights(article_id, bob) is None
+
+
+def test_highlight_api_is_auth_scoped(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    client = TestClient(app, raise_server_exceptions=True)
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": alice,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    create_response = client.post(
+        f"/api/articles/{article_id}/highlights",
+        json={"highlighted_text": "API passage", "offset_chars": 7, "note": "API note"},
+    )
+    assert create_response.status_code == 200
+    highlight_id = create_response.json()["id"]
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": bob,
+        "username": "bob",
+        "email": None,
+        "is_admin": False,
+    }
+    bob_list_response = client.get(f"/api/articles/{article_id}/highlights")
+    bob_delete_response = client.delete(f"/api/articles/{article_id}/highlights/{highlight_id}")
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": alice,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    alice_list_response = client.get(f"/api/articles/{article_id}/highlights")
+
+    assert bob_list_response.status_code == 200
+    assert bob_list_response.json()["items"] == []
+    assert bob_delete_response.status_code == 200
+    assert bob_delete_response.json() == {"ok": False}
+    assert alice_list_response.status_code == 200
+    assert alice_list_response.json()["items"][0]["id"] == highlight_id

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -150,6 +150,28 @@ describe('article list endpoints', () => {
     expect(calls[0].url).toBe('/api/articles/7/body');
   });
 
+  it('creates and deletes article highlights through article-scoped paths', async () => {
+    const { calls } = stubFetch(() => jsonOk({ id: 3 }));
+    await api.createArticleHighlight(7, {
+      highlighted_text: 'Important passage',
+      offset_chars: 12,
+      note: 'Remember this',
+    });
+    await api.deleteArticleHighlight(7, 3);
+
+    expect(calls[0].url).toBe('/api/articles/7/highlights');
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].init?.body).toBe(
+      JSON.stringify({
+        highlighted_text: 'Important passage',
+        offset_chars: 12,
+        note: 'Remember this',
+      })
+    );
+    expect(calls[1].url).toBe('/api/articles/7/highlights/3');
+    expect(calls[1].init?.method).toBe('DELETE');
+  });
+
   it('fetchSharedArticle hits the share-scoped article path', async () => {
     const { calls } = stubFetch(() => jsonOk({ id: 7 }));
     const a = await api.fetchSharedArticle(42);

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -22,6 +22,7 @@ vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(api, 'fetchArticleHighlights').mockResolvedValue([]);
 });
 
 function makeArticle(overrides: Partial<Article> = {}): Article {
@@ -121,6 +122,54 @@ describe('ArticlePage — rendering', () => {
     expect(fetchSharedArticleBodySpy).toHaveBeenCalledWith('123');
     expect(fetchArticleSpy).not.toHaveBeenCalled();
     expect(fetchArticleBodySpy).not.toHaveBeenCalled();
+  });
+
+  it('creates a private highlight from selected article text', async () => {
+    const article = makeArticle({
+      body_status: 'ok',
+      body: 'Full article text here.',
+    });
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(article);
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(article);
+    const createHighlight = vi.spyOn(api, 'createArticleHighlight').mockResolvedValue({
+      id: 5,
+      user_id: 1,
+      article_id: 42,
+      highlighted_text: 'article text',
+      offset_chars: 5,
+      note: 'use this later',
+      created_at: '2026-07-02T12:00:00Z',
+    });
+    vi.stubGlobal(
+      'prompt',
+      vi.fn(() => 'use this later')
+    );
+
+    renderReader('42', article);
+    await screen.findByText('Test Article Title');
+
+    const reader = document.querySelector('.reader-prose');
+    expect(reader).not.toBeNull();
+    const range = document.createRange();
+    range.selectNodeContents(reader!);
+    vi.spyOn(range, 'commonAncestorContainer', 'get').mockReturnValue(reader!);
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      rangeCount: 1,
+      toString: () => 'article text',
+      getRangeAt: () => range,
+      removeAllRanges: vi.fn(),
+    } as unknown as Selection);
+
+    fireEvent.mouseUp(reader!);
+    await userEvent.click(screen.getByRole('button', { name: 'Highlight' }));
+
+    await waitFor(() =>
+      expect(createHighlight).toHaveBeenCalledWith('42', {
+        highlighted_text: 'article text',
+        offset_chars: 5,
+        note: 'use this later',
+      })
+    );
   });
 
   it('shows source and reason', async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,7 @@ import type {
   AdminAnalytics,
   Article,
   ArticleCountsResult,
+  ArticleHighlight,
   ArticleStatus,
   ArticlesOverTimePoint,
   AskResponse,
@@ -115,6 +116,30 @@ export async function fetchArticle(id: number | string): Promise<Article> {
 
 export async function fetchArticleBody(id: number | string): Promise<Article> {
   return requestJson<Article>(`/api/articles/${id}/body`, { method: 'POST' });
+}
+
+export async function fetchArticleHighlights(id: number | string): Promise<ArticleHighlight[]> {
+  const data = await requestJson<{ items: ArticleHighlight[] }>(`/api/articles/${id}/highlights`);
+  return data.items;
+}
+
+export async function createArticleHighlight(
+  id: number | string,
+  payload: { highlighted_text: string; offset_chars?: number; note?: string | null }
+): Promise<ArticleHighlight> {
+  return requestJson<ArticleHighlight>(`/api/articles/${id}/highlights`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteArticleHighlight(
+  articleId: number | string,
+  highlightId: number | string
+): Promise<{ ok: boolean }> {
+  return requestJson<{ ok: boolean }>(`/api/articles/${articleId}/highlights/${highlightId}`, {
+    method: 'DELETE',
+  });
 }
 
 export async function fetchSharedArticle(shareId: number | string): Promise<Article> {

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -26,7 +26,10 @@ import { toast } from 'sonner';
 import {
   fetchArticle,
   fetchArticleBody,
+  createArticleHighlight,
+  deleteArticleHighlight,
   fetchArticleAudioUrl,
+  fetchArticleHighlights,
   fetchArticleInsights,
   fetchArticlePerspectives,
   fetchSharedArticle,
@@ -350,6 +353,36 @@ export function ArticlePage() {
   const [shareOpen, setShareOpen] = useState(false);
   const [selectedShareText, setSelectedShareText] = useState('');
   const [pendingShareHighlight, setPendingShareHighlight] = useState<{ text: string } | null>(null);
+  const highlightsQuery = useQuery({
+    queryKey: ['article-highlights', id],
+    queryFn: () => fetchArticleHighlights(id!),
+    enabled: Boolean(id) && !shareId,
+  });
+
+  const createHighlightMutation = useMutation({
+    mutationFn: ({ text, note }: { text: string; note: string | null }) =>
+      createArticleHighlight(id!, {
+        highlighted_text: text,
+        offset_chars: article?.body?.indexOf(text) ?? 0,
+        note,
+      }),
+    onSuccess: () => {
+      setSelectedShareText('');
+      window.getSelection()?.removeAllRanges();
+      void queryClient.invalidateQueries({ queryKey: ['article-highlights', id] });
+      toast('Highlight saved');
+    },
+    onError: () => toast.error('Could not save highlight'),
+  });
+
+  const deleteHighlightMutation = useMutation({
+    mutationFn: (highlightId: number) => deleteArticleHighlight(id!, highlightId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['article-highlights', id] });
+      toast('Highlight deleted');
+    },
+    onError: () => toast.error('Could not delete highlight'),
+  });
 
   function handleShare() {
     if (!article) return;
@@ -375,6 +408,12 @@ export function ArticlePage() {
     if (!article || !selectedShareText) return;
     setPendingShareHighlight({ text: selectedShareText });
     setShareOpen(true);
+  }
+
+  function handleHighlightSelected() {
+    if (!article || !selectedShareText || shareId) return;
+    const note = window.prompt('Add a private note to this highlight?')?.trim() ?? null;
+    createHighlightMutation.mutate({ text: selectedShareText, note });
   }
 
   // On-demand recommendation explanation — kept collapsed by default so the
@@ -778,6 +817,42 @@ export function ArticlePage() {
                 />
               )}
             </div>
+
+            {!shareId && highlightsQuery.data && highlightsQuery.data.length > 0 ? (
+              <section
+                className="mt-8 rounded-lg border border-border bg-surface/40 px-4 py-4"
+                aria-label="Personal highlights"
+              >
+                <div className="mb-3 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-subtle">
+                  <Highlighter className="size-3" strokeWidth={2} />
+                  Highlights
+                </div>
+                <ul className="space-y-3">
+                  {highlightsQuery.data.map((highlight) => (
+                    <li key={highlight.id} className="border-l-2 border-accent pl-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="text-[13px] leading-snug text-foreground">
+                          {highlight.highlighted_text}
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => deleteHighlightMutation.mutate(highlight.id)}
+                          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-surface hover:text-foreground"
+                          aria-label="Delete highlight"
+                        >
+                          <XIcon className="size-3.5" />
+                        </button>
+                      </div>
+                      {highlight.note ? (
+                        <p className="mt-1 text-[12px] leading-snug text-muted-foreground">
+                          {highlight.note}
+                        </p>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
           </article>
         </div>
       </div>
@@ -836,14 +911,27 @@ export function ArticlePage() {
         document.body
       )}
       {selectedShareText ? (
-        <button
-          type="button"
-          onClick={handleShareSelected}
-          className="fixed bottom-20 left-1/2 z-30 inline-flex -translate-x-1/2 items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground shadow-lg hover:bg-surface"
-        >
-          <Highlighter className="size-4" strokeWidth={1.75} />
-          Share selected text
-        </button>
+        <div className="fixed bottom-20 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 rounded-md border border-border bg-background p-1 shadow-lg">
+          {!shareId ? (
+            <button
+              type="button"
+              onClick={handleHighlightSelected}
+              className="inline-flex items-center gap-2 rounded px-3 py-2 text-sm font-medium text-foreground hover:bg-surface"
+            >
+              <Highlighter className="size-4" strokeWidth={1.75} />
+              Highlight
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={handleShareSelected}
+            aria-label="Share selected text"
+            className="inline-flex items-center gap-2 rounded px-3 py-2 text-sm font-medium text-foreground hover:bg-surface"
+          >
+            <Share2 className="size-4" strokeWidth={1.75} />
+            Share
+          </button>
+        </div>
       ) : null}
       <ShareDialog
         open={shareOpen}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -79,6 +79,16 @@ export interface ShareAnnotation {
   created_at: string;
 }
 
+export interface ArticleHighlight {
+  id: number;
+  user_id: number;
+  article_id: number;
+  highlighted_text: string;
+  offset_chars: number;
+  note?: string | null;
+  created_at: string;
+}
+
 export interface ShareMessage {
   id: number;
   share_id: number;


### PR DESCRIPTION
Closes #651

## Summary
- add private per-user article highlight storage with article-scoped create/list/delete endpoints
- wire the reader to save selected text with an optional note and show/delete saved highlights
- cover backend CRUD/isolation and frontend API/reader highlight creation flows

## Test results
- `.venv/bin/ruff check backend && .venv/bin/ruff format --check backend`
- `.venv/bin/mypy backend && .venv/bin/ty check backend && .venv/bin/pyrefly check backend`
- `npm run lint -- --max-warnings 0 && npm run format:check`
- `npm run typecheck`
- `source .env && .venv/bin/python -m pytest backend/tests/test_article_highlights.py -q`
- `npm run test:frontend -- frontend/src/__tests__/api.test.ts frontend/src/__tests__/articleReader.test.tsx`
- `npm run build`

Full backend suite note: `source .env && .venv/bin/python -m pytest --cov --cov-report=term-missing` reached 1330 passed, then 33 existing `backend/tests/test_briefings_api.py` setup errors from local DB ownership (`must be owner of table user_article_state`) during app startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)