### PR TITLE
docs: refresh published documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,12 +3,13 @@
 Technical documentation for News Dashboard. For end-user documentation (how to
 use the app day to day), see the [User Guide](user-guide/README.md) instead.
 
-Architecture, product spec, authentication, HTTPS, Postgres backup, and CI
-runner guides have moved to the published docs site: **[docs.lihor.ro](https://docs.lihor.ro)**
-(source in [`website/docs/`](../website/docs)).
+Architecture, product spec, authentication, HTTPS, Postgres backup, CI runner,
+contributing, and end-user guides are published at
+**[docs.lihor.ro](https://docs.lihor.ro)** (source in
+[`website/docs/`](../website/docs)).
 
 | Doc | Description |
 |-----|--------------|
 | [SELF_HOSTING.md](SELF_HOSTING.md) | Running your own instance of News Dashboard. |
 | [adr/](adr/README.md) | Architecture Decision Records — context and rationale behind significant technical decisions. |
-| [user-guide/](user-guide/README.md) | End-user guide: concepts, Today Feed, sources, search, briefings, sharing. |
+| [user-guide/](user-guide/README.md) | Markdown mirror of the end-user guide; the published version lives at [docs.lihor.ro/docs/user-guide](https://docs.lihor.ro/docs/user-guide). |

--- a/website/docs/contributing/index.md
+++ b/website/docs/contributing/index.md
@@ -3,8 +3,62 @@
 How to set up a development environment, run tests, and submit changes to
 News Dashboard.
 
-:::info Content migration in progress
-This section is a placeholder. The existing
-[`CONTRIBUTING.md`](https://github.com/lihor-hub/news-dashboard/blob/main/CONTRIBUTING.md)
-will be migrated here as part of the docs content-migration issue.
-:::
+## Prerequisites
+
+- Python 3.14+
+- Node.js LTS
+- PostgreSQL 16+
+- A running PostgreSQL instance for backend tests and local development
+
+Start with the root
+[README local-development guide](https://github.com/lihor-hub/news-dashboard#local-development)
+for the full setup flow.
+
+## Quality gate
+
+Run the full check before opening a PR:
+
+```bash
+make check
+```
+
+Useful smaller lanes:
+
+| Target | What it does |
+|--------|--------------|
+| `make lint` | Ruff, ESLint, and Prettier checks. |
+| `make format` | Auto-format backend and frontend files. |
+| `make typecheck` | mypy and TypeScript checks. |
+| `make test` | Backend pytest and frontend Vitest suites. |
+| `make test-smoke` | Fast smoke tests for active development. |
+| `make test-e2e` | Playwright end-to-end tests. |
+| `make helm-validate` | Lint and render the Helm chart. |
+
+## Git workflow
+
+- Rebase on `origin/main` before pushing.
+- Keep branches fast-forwardable with `main`; resolve divergence by rebasing.
+- Do not use `git push --no-verify`.
+- Use Conventional Commit titles such as `fix: correct source health status`
+  or `docs: refresh self-hosting guide`.
+
+## PostgreSQL runtime rule
+
+Runtime database code must use PostgreSQL-specific SQL and psycopg `%s`
+parameters. Do not add SQLite runtime fallbacks, database-type sniffing,
+placeholder translation layers, or generic multi-database SQL.
+
+SQLite may appear only in legacy migration tooling that reads an old SQLite
+database and writes into PostgreSQL.
+
+## Opening a PR
+
+1. Pick or create an issue with clear acceptance criteria.
+2. Create a branch from an up-to-date `main`.
+3. Make the change and add or update tests where behavior changes.
+4. Run the relevant quality gate locally.
+5. Open a PR with a concise summary and link the issue with `Closes #123`.
+
+See the root
+[CONTRIBUTING.md](https://github.com/lihor-hub/news-dashboard/blob/main/CONTRIBUTING.md)
+for repository governance, versioning, and internationalization details.

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -21,11 +21,3 @@ instructions after you have completed the quick start in the README.
 Once you have an account and are signed in, see the [User Guide](/docs/user-guide)
 to learn about the Today Feed, sources and subscriptions, search, daily
 briefings, recommendations, reading history, and sharing.
-
-:::info Content migration in progress
-The detailed User Guide topics (Today Feed, sources, search, briefings,
-sharing) currently live in
-[`docs/user-guide/`](https://github.com/lihor-hub/news-dashboard/tree/main/docs/user-guide)
-and will be migrated into this site as part of the docs content-migration
-issue.
-:::

--- a/website/docs/self-hosting/index.md
+++ b/website/docs/self-hosting/index.md
@@ -3,14 +3,86 @@
 Running your own instance of News Dashboard via Docker, Docker Compose, or
 Helm.
 
+## Deployment options
+
+| Option | Best for |
+|--------|----------|
+| Docker Compose | Single-node deployments using the published GHCR image. |
+| Docker run | Small installations where you already manage PostgreSQL separately. |
+| Helm | Kubernetes deployments with bundled or external PostgreSQL. |
+
+For local development, use the root `docker-compose.yml`. For production, use
+`docker-compose.prod.yml` or Helm; the development compose file contains
+insecure local defaults.
+
+## Production Compose quick start
+
+1. Copy `.env.example` to `.env`.
+2. Set strong values for `SESSION_SECRET`, `BOOTSTRAP_ADMIN_USERNAME`,
+   `BOOTSTRAP_ADMIN_PASSWORD`, and `POSTGRES_PASSWORD`.
+3. Start the stack:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d
+   ```
+
+4. Verify health:
+
+   ```bash
+   curl http://localhost:8080/api/health
+   ```
+
+The application image is published as:
+
+```text
+ghcr.io/lihor-hub/news-dashboard:latest
+ghcr.io/lihor-hub/news-dashboard:v<version>
+ghcr.io/lihor-hub/news-dashboard:<commit-sha>
+```
+
+Pin a version or commit SHA for production instead of tracking `latest`.
+
+## Required configuration
+
+News Dashboard uses PostgreSQL at runtime. Configure either `DATABASE_URL` or
+the split `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, and
+`POSTGRES_PASSWORD` variables.
+
+At minimum, a production instance also needs:
+
+| Variable | Purpose |
+|----------|---------|
+| `SESSION_SECRET` | Signs sessions and, unless overridden, digest mark-read tokens. |
+| `BOOTSTRAP_ADMIN_USERNAME` | First admin username when no users exist. |
+| `BOOTSTRAP_ADMIN_PASSWORD` | First admin password when no users exist. |
+| `POSTGRES_PASSWORD` | Password for the bundled or configured PostgreSQL user. |
+
+See [Configuration](/docs/configuration) for authentication, HTTPS, backup, and
+integration guides.
+
+## Operations
+
+- Use `/api/live` for liveness checks; it does not require database access.
+- Use `/api/ready` for readiness checks; it verifies database connectivity.
+- Use `/api/health` for load-balancer or manual health checks.
+- Enable `/metrics` with `METRICS_ENABLED=true` only when you want Prometheus
+  exposition.
+- Enable `/docs`, `/redoc`, and `/openapi.json` with `ENABLE_API_DOCS=true`
+  only in trusted environments.
+
+To upgrade a Compose deployment, pull the pinned replacement image and restart:
+
+```bash
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
+
+To roll back, set the image tag to the previous known-good version and run the
+same pull/up commands.
+
+## More guides
+
 - [CI Runner Setup](ci-runner-setup)
-
-See [Configuration](/docs/configuration) for Keycloak authentication,
-Caddy/HTTPS, and Postgres backup guides.
-
-:::info Content migration in progress
-The full deployment walkthrough (Docker Compose vs. production, image tags,
-upgrading, rolling back) currently lives in
-[`docs/SELF_HOSTING.md`](https://github.com/lihor-hub/news-dashboard/blob/main/docs/SELF_HOSTING.md)
-and will be migrated here in a follow-up.
-:::
+- [Authentication](/docs/configuration/authentication)
+- [HTTPS with Caddy](/docs/configuration/https-caddy)
+- [PostgreSQL Backup and Restore](/docs/configuration/postgres-backup)

--- a/website/docs/user-guide/briefings.md
+++ b/website/docs/user-guide/briefings.md
@@ -1,0 +1,35 @@
+---
+title: Briefings
+sidebar_position: 6
+---
+
+# Briefings
+
+Briefings summarize the news discovered by your sources. The main briefing is
+the **Current-Day Report**, a generated overview of today's articles.
+
+## The Current-Day Report
+
+The report answers: "What happened today in my subscribed sources?" It includes
+all articles discovered during the current-day window, regardless of whether
+you have already triaged them.
+
+For each article, News Dashboard stores a short reason explaining why it
+surfaced. Reasons are combined and ordered by importance so the report reads as
+a compact daily overview.
+
+## Delivery
+
+Briefings can be read in the app. Depending on instance configuration, they can
+also be delivered through in-app notifications, push notifications, email, or
+generated podcast audio.
+
+Audio features require a configured server-side text-to-speech path. OpenAI TTS
+uses `OPENAI_API_KEY`; browser playback can use the device's built-in speech
+synthesis for in-app listening.
+
+## Privacy
+
+Briefings are generated from your account's source subscriptions and stored in
+the application database. Article content is sent to external providers only
+when you configure the relevant AI or TTS provider credentials.

--- a/website/docs/user-guide/concepts.md
+++ b/website/docs/user-guide/concepts.md
@@ -1,0 +1,50 @@
+---
+title: Concepts and terminology
+sidebar_position: 2
+---
+
+# Concepts and terminology
+
+News Dashboard uses a small vocabulary so product copy, documentation, and
+support conversations describe the same workflow.
+
+## Article
+
+An **article** is a news item discovered from a subscribed source. It has a
+title, URL, summary, source, publication date, tags, and optional extracted
+body text. Triage, search, briefings, recommendations, and sharing all operate
+on articles.
+
+## Workflow state
+
+**Workflow state** is your triage position for an article. It does not decide
+whether the article belongs to the day's news corpus.
+
+| State | Meaning |
+|-------|---------|
+| **Today** | In your active triage queue, waiting to be reviewed. |
+| **Later** | Interesting, but not right now. |
+| **Done** | Reviewed and finished. |
+| **Skipped** | Dismissed as not relevant. |
+| **Starred** | Saved as a permanent reference. |
+| **Snoozed** | Hidden until a later time. |
+| **Archived** | Tucked away from active views, but restorable. |
+
+## Today Feed
+
+The **Today Feed** is your active triage queue. Articles arrive from new
+ingestions and, when enabled, recommendations. You move them to Done, Later,
+Skipped, Starred, Snoozed, or Archived as you work through them.
+
+## Current-Day Report
+
+The **Current-Day Report** is a generated briefing that summarizes all news
+discovered in the current-day window from your available sources. It includes
+articles regardless of workflow state, so marking an item Done or Skipped does
+not remove it from the day's report.
+
+## Source subscription
+
+A **source subscription** is the set of feeds available to your account. A
+source can be an RSS or Atom feed, a GitHub releases feed, a trending feed, or
+a custom scraped page.

--- a/website/docs/user-guide/index.md
+++ b/website/docs/user-guide/index.md
@@ -3,8 +3,19 @@
 Day-to-day usage of News Dashboard: concepts, the Today Feed, sources,
 search, briefings, and sharing.
 
-:::info Content migration in progress
-This section is a placeholder. The existing user guide content in
-[`docs/user-guide/`](https://github.com/lihor-hub/news-dashboard/tree/main/docs/user-guide)
-will be migrated here as part of the docs content-migration issue.
-:::
+## Start here
+
+| Page | What it covers |
+|------|----------------|
+| [Concepts and terminology](concepts) | The product language: articles, workflow state, Today Feed, Current-Day Report, and source subscriptions. |
+| [Today Feed and triage](today-feed-triage) | How to process the active queue and what each triage state means. |
+| [Sources and subscriptions](sources) | Where articles come from and how to manage the feeds available to your account. |
+| [Search](search) | Finding articles across your history with PostgreSQL full-text search. |
+| [Briefings](briefings) | Current-Day Reports, scheduled delivery, and optional audio. |
+| [Recommendations](recommendations) | How personalized suggestions are scored and controlled. |
+| [Saved and read history](saved-history) | Later, Done, Starred, Archived, Reading DNA, and export behavior. |
+| [Sharing articles](sharing) | Sending articles to other users on the same instance. |
+
+If you do not have an account yet, begin with [Create a web account](/docs/getting-started/create-web-account).
+If you operate your own instance, read the [Self-Hosting guide](/docs/self-hosting)
+after the README quick start.

--- a/website/docs/user-guide/recommendations.md
+++ b/website/docs/user-guide/recommendations.md
@@ -1,0 +1,30 @@
+---
+title: Recommendations
+sidebar_position: 7
+---
+
+# Recommendations
+
+Recommendations surface articles that may be relevant based on your previous
+triage behavior.
+
+## How they work
+
+News Dashboard scores candidate articles using local signals such as source,
+category, tags, discovery time, and your past actions. Starring and marking
+Done are positive signals; skipping is a negative signal; Later is a mild
+positive signal.
+
+Recommendations appear in the Today Feed with a relevance indicator and a short
+"why recommended" explanation.
+
+## Controls
+
+Recommendation settings can control the mix ratio, minimum article age, and
+whether recommendations are enabled at all. Turning recommendations off returns
+the Today Feed to newly ingested articles only.
+
+## Privacy
+
+Recommendation scoring runs against your PostgreSQL data. No recommendation
+query or behavior data needs to leave your instance.

--- a/website/docs/user-guide/saved-history.md
+++ b/website/docs/user-guide/saved-history.md
@@ -1,0 +1,32 @@
+---
+title: Saved and read history
+sidebar_position: 8
+---
+
+# Saved and read history
+
+Your history is the set of articles you have moved out of active triage:
+Done, Later, Starred, Snoozed, and Archived.
+
+| View | Contains |
+|------|----------|
+| **Done** | Articles you have reviewed. |
+| **Later** | Articles set aside for future reading. |
+| **Starred** | Permanent references. |
+| **Archived** | Articles tucked out of normal views. |
+
+Each interaction records timestamps such as read, saved, starred, snoozed, or
+unsnoozed time. These timestamps power history views, search, analytics, and
+the Reading DNA summary.
+
+## Reading DNA
+
+Reading DNA is a private summary of your reading behavior: articles read, top
+categories, top sources, top tags, recent activity, and related trends when
+enabled.
+
+## Export and cleanup
+
+The app can export your personal state as JSON for backup or migration. The
+`user_events` table is pruned according to `ANALYTICS_RETENTION_DAYS`, which
+defaults to 180 days.

--- a/website/docs/user-guide/search.md
+++ b/website/docs/user-guide/search.md
@@ -1,0 +1,34 @@
+---
+title: Search
+sidebar_position: 5
+---
+
+# Search
+
+Search finds articles across your corpus by keyword, topic, or phrase. It uses
+PostgreSQL full-text search, so queries and article contents stay inside your
+instance.
+
+## Indexed fields
+
+The search index includes title, summary, reason, tags, source name, and, when
+article body extraction is enabled, extracted body text.
+
+Results are ranked by PostgreSQL relevance and can include articles in any
+workflow state: Today, Later, Done, Skipped, Starred, Snoozed, or Archived.
+
+## Using search
+
+Open search from the navigation or focus it with `/`. Results show the title,
+summary snippet, source, state, and publication date. Select a result to open
+the article in the main view.
+
+If you want to narrow results to a specific state, open that view first and use
+the search control there.
+
+## Full-text extraction
+
+Deeper body search depends on optional article body extraction. When enabled,
+the app fetches and caches article text, then indexes it alongside the normal
+metadata fields. This increases storage and ingestion work, so it is kept
+optional.

--- a/website/docs/user-guide/sharing.md
+++ b/website/docs/user-guide/sharing.md
@@ -1,0 +1,27 @@
+---
+title: Sharing articles
+sidebar_position: 9
+---
+
+# Sharing articles
+
+Sharing lets you send an article to another user on the same News Dashboard
+instance without exposing your personal triage state.
+
+## How sharing works
+
+The app creates a time-limited token and a share record that links sender,
+recipient, and article. When the recipient opens the share, the token is
+validated, the article opens in their account, and their own triage actions are
+recorded separately.
+
+The recipient can see the article and shared note, but not your private state,
+read timestamps, or personal notes.
+
+## Requirements
+
+Sharing requires both users to have accounts on the same instance. No external
+service is needed.
+
+Shares are single-use, expire automatically, and can be revoked before they are
+opened.

--- a/website/docs/user-guide/sources.md
+++ b/website/docs/user-guide/sources.md
@@ -1,0 +1,40 @@
+---
+title: Sources and subscriptions
+sidebar_position: 4
+---
+
+# Sources and subscriptions
+
+Sources are the feeds News Dashboard uses to discover articles. Your source
+subscription controls which feeds are active for your account.
+
+## Source kinds
+
+| Kind | What it means |
+|------|---------------|
+| `rss_feed` | A standard RSS or Atom feed. |
+| `github_release_feed` | A GitHub releases Atom feed. |
+| `trending_feed` | Hacker News or GitHub trending feeds. |
+| `scraped_page` | A custom parser for pages that do not expose a suitable feed. |
+
+Default sources cover Python, AI/LLM, agents, cloud infrastructure,
+engineering, trending news, and repositories. They are seeded when the instance
+is initialized.
+
+## Managing sources
+
+From the Sources page you can enable, disable, add, or remove sources. You can
+also inspect health information such as last checked time, last successful
+fetch, last error, fetched count, and inserted count.
+
+Only RSS/Atom feeds are added by pasting a URL. GitHub release and trending
+sources are selected from predefined options.
+
+## Noise controls
+
+Broad feeds are capped so one noisy source does not dominate the Today Feed.
+Typical caps are 15 to 20 items for broad trending feeds, 5 items for dense
+newsletter feeds, and around 50 items for curated blog feeds.
+
+On multi-user instances, source subscriptions are per-user. Your changes affect
+your account only.

--- a/website/docs/user-guide/today-feed-triage.md
+++ b/website/docs/user-guide/today-feed-triage.md
@@ -1,0 +1,43 @@
+---
+title: Today Feed and triage
+sidebar_position: 3
+---
+
+# Today Feed and triage
+
+The Today Feed is the main work surface in News Dashboard. It contains articles
+ready for review from the latest ingestion run and, when recommendations are
+enabled, older articles that may be relevant again.
+
+## Triage states
+
+- **Done** removes the article from Today and stores it in your read history.
+- **Later** moves the article to a separate read-it-later queue.
+- **Skipped** dismisses the article and gives the recommender negative feedback.
+- **Starred** keeps the article as a permanent reference.
+- **Snoozed** hides the article until the selected time.
+- **Archived** removes the article from active views while keeping it restorable.
+
+## Article cards
+
+Each card shows the article title, source, discovery time, summary, reason, and
+available triage actions. Recommendation badges and explanations appear when
+personalized recommendations are active.
+
+Triage actions update immediately. The Today Feed is designed for fast repeated
+decisions, so keyboard shortcuts are available on the feed:
+
+| Key | Action |
+|-----|--------|
+| `d` or `r` | Mark Done |
+| `s` | Star |
+| `l` | Send to Later |
+| `x` | Skip |
+| `o` | Open article |
+| `j` / `k` | Move to next or previous article |
+
+## Briefing independence
+
+Workflow state does not affect the [Current-Day Report](briefings#the-current-day-report).
+The report summarizes what was discovered today, not only what remains in your
+Today Feed.


### PR DESCRIPTION
Closes #839

## Summary
- Replace placeholder published docs pages for User Guide, Contributing, and Self-Hosting with real content
- Add Docusaurus User Guide pages for concepts, triage, sources, search, briefings, recommendations, history, and sharing
- Update the root docs index to point readers at the published docs site and its Markdown mirror

## Verification
- `cd website && npm install`
- `cd website && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)