### PR TITLE
feat: add user-defined tags and collections (#652)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -508,6 +508,27 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_otps_user ON user_otps(user_id, expires_at DESC)",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_guest BOOLEAN NOT NULL DEFAULT FALSE",
+    """
+    CREATE TABLE IF NOT EXISTS user_tags (
+      id         SERIAL PRIMARY KEY,
+      user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name       TEXT NOT NULL,
+      color      TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (user_id, name)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS article_tags (
+      user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      article_id BIGINT  NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+      tag_id     INTEGER NOT NULL REFERENCES user_tags(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (user_id, article_id, tag_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_article_tags_user_tag ON article_tags(user_id, tag_id)",
+    "CREATE INDEX IF NOT EXISTS idx_article_tags_article ON article_tags(article_id)",
 ]
 
 

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -1137,6 +1137,7 @@ def list_articles(  # noqa: PLR0913
     offset: int = 0,
     db_path: Path | str | None = None,
     user_id: int | None = None,
+    tag_id: int | None = None,
 ) -> list[dict[str, Any]]:
     init_db(db_path)
     now = now_iso()
@@ -1152,6 +1153,7 @@ def list_articles(  # noqa: PLR0913
             offset=offset,
             db_path=db_path,
             now=now,
+            tag_id=tag_id,
         )
 
     # ── Legacy path (no user context) ─────────────────────────────────────────
@@ -1218,6 +1220,7 @@ def _list_articles_for_user(  # noqa: PLR0913
     offset: int,
     db_path: Path | str | None,
     now: str,
+    tag_id: int | None = None,
 ) -> list[dict[str, Any]]:
     """Article listing scoped to a specific user via user_article_state."""
     # Map legacy status → state
@@ -1262,6 +1265,12 @@ def _list_articles_for_user(  # noqa: PLR0913
     if category:
         art_clauses.append("a.category = %s")
         where_params.append(category)
+    if tag_id is not None:
+        art_clauses.append(
+            "EXISTS (SELECT 1 FROM article_tags at"
+            " WHERE at.article_id = a.id AND at.user_id = %s AND at.tag_id = %s)"
+        )
+        where_params.extend([user_id, tag_id])
 
     where = f"WHERE {' AND '.join(art_clauses)}"
 
@@ -1374,6 +1383,7 @@ def search_articles(  # noqa: PLR0912, PLR0913
     include_archived: bool = False,
     date_range: str = "all",
     user_id: int | None = None,
+    tag_id: int | None = None,
 ) -> list[dict[str, Any]]:
     init_db(db_path)
     tsquery = _search_tsquery(q)
@@ -1393,6 +1403,7 @@ def search_articles(  # noqa: PLR0912, PLR0913
             include_archived=include_archived,
             date_range=date_range,
             now_ts=now_ts,
+            tag_id=tag_id,
         )
 
     clauses: list[str] = []
@@ -1481,6 +1492,7 @@ def search_articles_page(  # noqa: PLR0913
     include_archived: bool = False,
     date_range: str = "all",
     user_id: int | None = None,
+    tag_id: int | None = None,
 ) -> dict[str, Any]:
     items = search_articles(
         q=q,
@@ -1494,6 +1506,7 @@ def search_articles_page(  # noqa: PLR0913
         include_archived=include_archived,
         date_range=date_range,
         user_id=user_id,
+        tag_id=tag_id,
     )
     total = count_search_articles(
         q=q,
@@ -1505,6 +1518,7 @@ def search_articles_page(  # noqa: PLR0913
         include_archived=include_archived,
         date_range=date_range,
         user_id=user_id,
+        tag_id=tag_id,
     )
     return {
         "items": items,
@@ -1525,6 +1539,7 @@ def count_search_articles(  # noqa: PLR0913
     include_archived: bool = False,
     date_range: str = "all",
     user_id: int | None = None,
+    tag_id: int | None = None,
 ) -> int:
     init_db(db_path)
     tsquery = _search_tsquery(q)
@@ -1542,6 +1557,7 @@ def count_search_articles(  # noqa: PLR0913
             include_archived=include_archived,
             date_range=date_range,
             now_ts=now_ts,
+            tag_id=tag_id,
         )
 
     clauses: list[str] = []
@@ -1605,6 +1621,7 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     include_archived: bool,
     date_range: str,
     now_ts: str,
+    tag_id: int | None = None,
 ) -> list[dict[str, Any]]:
     tsquery = _search_tsquery(q)
     clauses: list[str] = []
@@ -1646,6 +1663,13 @@ def _search_articles_for_user(  # noqa: PLR0912, PLR0913, PLR0915
     elif date_range == "month":
         clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
         where_params.append(now_ts)
+
+    if tag_id is not None:
+        clauses.append(
+            "EXISTS (SELECT 1 FROM article_tags at"
+            " WHERE at.article_id = a.id AND at.user_id = %s AND at.tag_id = %s)"
+        )
+        where_params.extend([user_id, tag_id])
 
     # Source subscription filter appended to WHERE
     src_filter = (
@@ -1725,6 +1749,7 @@ def _count_search_articles_for_user(  # noqa: PLR0913
     include_archived: bool,
     date_range: str,
     now_ts: str,
+    tag_id: int | None = None,
 ) -> int:
     tsquery = _search_tsquery(q)
     clauses: list[str] = []
@@ -1766,6 +1791,13 @@ def _count_search_articles_for_user(  # noqa: PLR0913
     elif date_range == "month":
         clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
         where_params.append(now_ts)
+
+    if tag_id is not None:
+        clauses.append(
+            "EXISTS (SELECT 1 FROM article_tags at"
+            " WHERE at.article_id = a.id AND at.user_id = %s AND at.tag_id = %s)"
+        )
+        where_params.extend([user_id, tag_id])
 
     src_filter = (
         "(src.owner_user_id IS NULL AND COALESCE(us_src.enabled, true)) OR src.owner_user_id = %s"

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -28,6 +28,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from psycopg.errors import UniqueViolation
 from psycopg.types.json import Jsonb
 from pydantic import BaseModel, Field, field_validator
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -770,12 +771,13 @@ def ingest_stream() -> StreamingResponse:
 
 
 @api.get("/api/articles")
-def articles(
+def articles(  # noqa: PLR0913
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
     status: Annotated[str | None, Query()] = None,
     state: Annotated[str | None, Query()] = None,
     starred: Annotated[bool | None, Query()] = None,
     category: Annotated[str | None, Query()] = None,
+    tag_id: Annotated[int | None, Query()] = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
     offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict[str, Any]:
@@ -784,6 +786,7 @@ def articles(
         state=state,
         starred=starred,
         category=category,
+        tag_id=tag_id,
         limit=limit + 1,
         offset=offset,
         user_id=current_user["id"],
@@ -808,6 +811,7 @@ def search(  # noqa: PLR0913
     starred_only: Annotated[bool, Query()] = False,
     include_archived: Annotated[bool, Query()] = False,
     date_range: Annotated[str, Query()] = "all",
+    tag_id: Annotated[int | None, Query()] = None,
 ) -> dict[str, Any]:
     return search_articles_page(
         q=q.strip(),
@@ -820,6 +824,7 @@ def search(  # noqa: PLR0913
         include_archived=include_archived,
         date_range=date_range,
         user_id=current_user["id"],
+        tag_id=tag_id,
     )
 
 
@@ -2436,6 +2441,138 @@ def summary(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
     return get_user_summary(user_id=current_user["id"])
+
+
+# ── Tags & Collections ────────────────────────────────────────────────────────
+
+
+class TagCreateRequest(BaseModel):
+    name: str
+    color: str | None = None
+
+
+class TagRenameRequest(BaseModel):
+    name: str
+
+
+class ArticleTagRequest(BaseModel):
+    tag_id: int
+
+
+@api.post("/api/tags")
+def create_tag_endpoint(
+    payload: TagCreateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.tags import create_tag
+
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name must not be empty")
+    try:
+        return create_tag(current_user["id"], name, payload.color)
+    except UniqueViolation as exc:
+        raise HTTPException(status_code=409, detail="tag already exists") from exc
+
+
+@api.get("/api/tags")
+def list_tags_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.tags import list_tags
+
+    return {"items": list_tags(current_user["id"])}
+
+
+@api.patch("/api/tags/{tag_id}")
+def rename_tag_endpoint(
+    tag_id: int,
+    payload: TagRenameRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.tags import rename_tag
+
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name must not be empty")
+    try:
+        tag = rename_tag(tag_id, current_user["id"], name)
+    except UniqueViolation as exc:
+        raise HTTPException(status_code=409, detail="tag already exists") from exc
+    if not tag:
+        raise HTTPException(status_code=404, detail="tag not found")
+    return tag
+
+
+@api.delete("/api/tags/{tag_id}")
+def delete_tag_endpoint(
+    tag_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.tags import delete_tag
+
+    if not delete_tag(tag_id, current_user["id"]):
+        raise HTTPException(status_code=404, detail="tag not found")
+    return {"deleted": True}
+
+
+@api.get("/api/tags/{tag_id}/articles")
+def list_articles_by_tag_endpoint(
+    tag_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    items = list_articles(
+        tag_id=tag_id,
+        limit=limit + 1,
+        offset=offset,
+        user_id=current_user["id"],
+    )
+    return {
+        "items": items[:limit],
+        "limit": limit,
+        "offset": offset,
+        "has_more": len(items) > limit,
+    }
+
+
+@api.get("/api/articles/{article_id}/tags")
+def list_article_tags_endpoint(
+    article_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.tags import list_tags_for_article
+
+    return {"items": list_tags_for_article(current_user["id"], article_id)}
+
+
+@api.post("/api/articles/{article_id}/tags")
+def add_article_tag_endpoint(
+    article_id: int,
+    payload: ArticleTagRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.tags import add_tag_to_article
+
+    if not get_article(article_id, user_id=current_user["id"]):
+        raise HTTPException(status_code=404, detail="article not found")
+    if not add_tag_to_article(current_user["id"], article_id, payload.tag_id):
+        raise HTTPException(status_code=404, detail="tag not found")
+    return {"added": True}
+
+
+@api.delete("/api/articles/{article_id}/tags/{tag_id}")
+def remove_article_tag_endpoint(
+    article_id: int,
+    tag_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.tags import remove_tag_from_article
+
+    if not remove_tag_from_article(current_user["id"], article_id, tag_id):
+        raise HTTPException(status_code=404, detail="article tag not found")
+    return {"removed": True}
 
 
 # ── Reading Goals & Quizzes ───────────────────────────────────────────────────

--- a/backend/news_dashboard/tags.py
+++ b/backend/news_dashboard/tags.py
@@ -1,0 +1,155 @@
+"""User-defined tags for organizing articles into free-form collections.
+
+Tags are per-user and orthogonal to Workflow State (see CONTEXT.md): an
+article can be ``done`` and tagged ``rust`` at the same time. A tag applies
+to an article via the ``article_tags`` join table; deleting a tag removes
+its associations without touching the article itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+
+
+def create_tag(
+    user_id: int,
+    name: str,
+    color: str | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_tags (user_id, name, color)
+            VALUES (%s, %s, %s)
+            RETURNING id, user_id, name, color, created_at
+            """,
+            (user_id, name.strip(), color),
+        ).fetchone()
+    return dict(row)
+
+
+def list_tags(
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT t.id, t.user_id, t.name, t.color, t.created_at,
+              COUNT(at.article_id) AS article_count
+            FROM user_tags t
+            LEFT JOIN article_tags at ON at.tag_id = t.id AND at.user_id = t.user_id
+            WHERE t.user_id = %s
+            GROUP BY t.id
+            ORDER BY t.name ASC
+            """,
+            (user_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def rename_tag(
+    tag_id: int,
+    user_id: int,
+    name: str,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE user_tags SET name = %s
+            WHERE id = %s AND user_id = %s
+            RETURNING id, user_id, name, color, created_at
+            """,
+            (name.strip(), tag_id, user_id),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def delete_tag(
+    tag_id: int,
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> bool:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        result = conn.execute(
+            "DELETE FROM user_tags WHERE id = %s AND user_id = %s",
+            (tag_id, user_id),
+        )
+        return bool(result.rowcount > 0)
+
+
+def add_tag_to_article(
+    user_id: int,
+    article_id: int,
+    tag_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> bool:
+    """Attach a tag to an article. Returns False if the tag isn't owned by user_id."""
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        owned = conn.execute(
+            "SELECT 1 FROM user_tags WHERE id = %s AND user_id = %s",
+            (tag_id, user_id),
+        ).fetchone()
+        if not owned:
+            return False
+        conn.execute(
+            """
+            INSERT INTO article_tags (user_id, article_id, tag_id)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (user_id, article_id, tag_id) DO NOTHING
+            """,
+            (user_id, article_id, tag_id),
+        )
+        return True
+
+
+def remove_tag_from_article(
+    user_id: int,
+    article_id: int,
+    tag_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> bool:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        result = conn.execute(
+            "DELETE FROM article_tags WHERE user_id = %s AND article_id = %s AND tag_id = %s",
+            (user_id, article_id, tag_id),
+        )
+        return bool(result.rowcount > 0)
+
+
+def list_tags_for_article(
+    user_id: int,
+    article_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT t.id, t.user_id, t.name, t.color, t.created_at
+            FROM article_tags at
+            JOIN user_tags t ON t.id = at.tag_id
+            WHERE at.user_id = %s AND at.article_id = %s
+            ORDER BY t.name ASC
+            """,
+            (user_id, article_id),
+        ).fetchall()
+    return [dict(r) for r in rows]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -180,7 +180,8 @@ def pg_clean(pg_url: str) -> str:
             "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
             " user_interest_profiles, user_settings, user_push_subscriptions,"
             " article_highlights, article_shares, user_events, briefing_articles, briefings,"
-            " ingest_run_sources, ingest_runs, scheduled_job_runs, articles, sources, users"
+            " ingest_run_sources, ingest_runs, scheduled_job_runs, article_tags, user_tags,"
+            " articles, sources, users"
             " RESTART IDENTITY CASCADE"
         )
     return pg_url

--- a/backend/tests/test_tags.py
+++ b/backend/tests/test_tags.py
@@ -1,0 +1,307 @@
+"""Tests for user-defined tags/collections (#652)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import create_user, require_auth
+from news_dashboard.db import connect
+from news_dashboard.ingest import list_articles, search_articles, sync_sources
+from news_dashboard.main import app
+from news_dashboard.tags import (
+    add_tag_to_article,
+    create_tag,
+    delete_tag,
+    list_tags,
+    list_tags_for_article,
+    remove_tag_from_article,
+    rename_tag,
+)
+
+
+@pytest.fixture
+def db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    return pg_clean
+
+
+def _make_user(db_path: str, username: str) -> int:
+    return int(create_user(username, "password123", db_path=db_path)["id"])
+
+
+def _insert_article(db_path: str, suffix: str = "1") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug,
+              source_name, category, kind, state)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/art{suffix}",
+                f"https://example.com/art{suffix}",
+                f"Article {suffix}",
+                "python-insider",
+                "Python Insider",
+                "python",
+                "rss_feed",
+                "today",
+            ),
+        ).fetchone()
+    return int(row["id"])
+
+
+def _authed_client(user_id: int) -> TestClient:
+    client = TestClient(app, raise_server_exceptions=True)
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": f"user-{user_id}",
+        "email": None,
+        "is_admin": False,
+    }
+    return client
+
+
+# ── Tag CRUD ─────────────────────────────────────────────────────────────────
+
+
+def test_create_and_list_tags(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", "#ff0000", db_path=db)
+    assert tag["name"] == "rust"
+    assert tag["color"] == "#ff0000"
+
+    tags = list_tags(alice, db_path=db)
+    assert len(tags) == 1
+    assert tags[0]["name"] == "rust"
+    assert tags[0]["article_count"] == 0
+
+
+def test_rename_tag(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    renamed = rename_tag(tag["id"], alice, "rustlang", db_path=db)
+    assert renamed is not None
+    assert renamed["name"] == "rustlang"
+
+
+def test_rename_tag_not_owned_returns_none(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    tag = create_tag(alice, "rust", db_path=db)
+    assert rename_tag(tag["id"], bob, "hijacked", db_path=db) is None
+
+
+def test_delete_tag_removes_associations_without_deleting_article(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    article_id = _insert_article(db)
+    assert add_tag_to_article(alice, article_id, tag["id"], db_path=db)
+
+    assert delete_tag(tag["id"], alice, db_path=db)
+    assert list_tags_for_article(alice, article_id, db_path=db) == []
+    # Article itself should still exist.
+    with connect(db) as conn:
+        row = conn.execute("SELECT id FROM articles WHERE id = %s", (article_id,)).fetchone()
+    assert row is not None
+
+
+def test_delete_tag_not_owned_returns_false(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    tag = create_tag(alice, "rust", db_path=db)
+    assert delete_tag(tag["id"], bob, db_path=db) is False
+
+
+def test_duplicate_tag_name_raises(db: str) -> None:
+    from psycopg.errors import UniqueViolation
+
+    alice = _make_user(db, "alice")
+    create_tag(alice, "rust", db_path=db)
+    with pytest.raises(UniqueViolation):
+        create_tag(alice, "rust", db_path=db)
+
+
+# ── Applying tags to articles ────────────────────────────────────────────────
+
+
+def test_add_and_remove_tag_on_article(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    article_id = _insert_article(db)
+
+    assert add_tag_to_article(alice, article_id, tag["id"], db_path=db)
+    tags = list_tags_for_article(alice, article_id, db_path=db)
+    assert [t["name"] for t in tags] == ["rust"]
+
+    assert remove_tag_from_article(alice, article_id, tag["id"], db_path=db)
+    assert list_tags_for_article(alice, article_id, db_path=db) == []
+
+
+def test_add_tag_to_article_idempotent(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    article_id = _insert_article(db)
+
+    assert add_tag_to_article(alice, article_id, tag["id"], db_path=db)
+    assert add_tag_to_article(alice, article_id, tag["id"], db_path=db)
+    tags = list_tags_for_article(alice, article_id, db_path=db)
+    assert len(tags) == 1
+
+
+def test_add_tag_not_owned_by_user_fails(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    tag = create_tag(alice, "rust", db_path=db)
+    article_id = _insert_article(db)
+
+    assert add_tag_to_article(bob, article_id, tag["id"], db_path=db) is False
+
+
+def test_tag_is_orthogonal_to_workflow_state(db: str) -> None:
+    """An article can be `done` and tagged, independently of its workflow state."""
+    from news_dashboard.ingest import transition_article_state
+
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    article_id = _insert_article(db)
+    add_tag_to_article(alice, article_id, tag["id"], db_path=db)
+
+    transition_article_state(article_id, "done", user_id=alice, db_path=db)
+
+    tags = list_tags_for_article(alice, article_id, db_path=db)
+    assert [t["name"] for t in tags] == ["rust"]
+    articles = list_articles(state="done", user_id=alice, db_path=db)
+    assert any(a["id"] == article_id for a in articles)
+
+
+# ── Filter by tag ─────────────────────────────────────────────────────────────
+
+
+def test_list_articles_filters_by_tag(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    tagged_id = _insert_article(db, "tagged")
+    untagged_id = _insert_article(db, "untagged")
+    add_tag_to_article(alice, tagged_id, tag["id"], db_path=db)
+
+    results = list_articles(tag_id=tag["id"], user_id=alice, db_path=db)
+    ids = {a["id"] for a in results}
+    assert tagged_id in ids
+    assert untagged_id not in ids
+
+
+def test_search_articles_filters_by_tag(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    tagged_id = _insert_article(db, "tagged")
+    untagged_id = _insert_article(db, "untagged")
+    add_tag_to_article(alice, tagged_id, tag["id"], db_path=db)
+
+    results = search_articles(q="", tag_id=tag["id"], user_id=alice, db_path=db)
+    ids = {a["id"] for a in results}
+    assert tagged_id in ids
+    assert untagged_id not in ids
+
+
+# ── Per-user isolation ────────────────────────────────────────────────────────
+
+
+def test_tags_are_private_per_user(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    create_tag(alice, "rust", db_path=db)
+
+    assert [t["name"] for t in list_tags(alice, db_path=db)] == ["rust"]
+    assert list_tags(bob, db_path=db) == []
+
+
+def test_article_tag_visibility_is_per_user(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    alice_tag = create_tag(alice, "rust", db_path=db)
+    bob_tag = create_tag(bob, "rust", db_path=db)
+    article_id = _insert_article(db)
+
+    add_tag_to_article(alice, article_id, alice_tag["id"], db_path=db)
+
+    assert [t["name"] for t in list_tags_for_article(alice, article_id, db_path=db)] == ["rust"]
+    assert list_tags_for_article(bob, article_id, db_path=db) == []
+
+    # Bob tagging the same article with his own tag doesn't leak to Alice's view.
+    add_tag_to_article(bob, article_id, bob_tag["id"], db_path=db)
+    assert len(list_tags_for_article(alice, article_id, db_path=db)) == 1
+    assert len(list_tags_for_article(bob, article_id, db_path=db)) == 1
+
+
+# ── API endpoints ─────────────────────────────────────────────────────────────
+
+
+def test_tag_endpoints_full_flow(db: str) -> None:
+    alice = _make_user(db, "alice")
+    article_id = _insert_article(db)
+    client = _authed_client(alice)
+
+    create_resp = client.post("/api/tags", json={"name": "rust", "color": "#ff0000"})
+    assert create_resp.status_code == 200
+    tag_id = create_resp.json()["id"]
+
+    list_resp = client.get("/api/tags")
+    assert list_resp.status_code == 200
+    assert list_resp.json()["items"][0]["name"] == "rust"
+
+    rename_resp = client.patch(f"/api/tags/{tag_id}", json={"name": "rustlang"})
+    assert rename_resp.status_code == 200
+    assert rename_resp.json()["name"] == "rustlang"
+
+    add_resp = client.post(f"/api/articles/{article_id}/tags", json={"tag_id": tag_id})
+    assert add_resp.status_code == 200
+
+    article_tags_resp = client.get(f"/api/articles/{article_id}/tags")
+    assert article_tags_resp.status_code == 200
+    assert article_tags_resp.json()["items"][0]["id"] == tag_id
+
+    by_tag_resp = client.get(f"/api/tags/{tag_id}/articles")
+    assert by_tag_resp.status_code == 200
+    assert any(a["id"] == article_id for a in by_tag_resp.json()["items"])
+
+    filtered_resp = client.get("/api/articles", params={"tag_id": tag_id})
+    assert filtered_resp.status_code == 200
+    assert any(a["id"] == article_id for a in filtered_resp.json()["items"])
+
+    remove_resp = client.delete(f"/api/articles/{article_id}/tags/{tag_id}")
+    assert remove_resp.status_code == 200
+
+    delete_resp = client.delete(f"/api/tags/{tag_id}")
+    assert delete_resp.status_code == 200
+
+    delete_again_resp = client.delete(f"/api/tags/{tag_id}")
+    assert delete_again_resp.status_code == 404
+
+
+def test_create_tag_endpoint_rejects_blank_name(db: str) -> None:
+    alice = _make_user(db, "alice")
+    client = _authed_client(alice)
+    response = client.post("/api/tags", json={"name": "   "})
+    assert response.status_code == 400
+
+
+def test_add_article_tag_endpoint_404s_for_missing_article(db: str) -> None:
+    alice = _make_user(db, "alice")
+    tag = create_tag(alice, "rust", db_path=db)
+    client = _authed_client(alice)
+    response = client.post("/api/articles/999999/tags", json={"tag_id": tag["id"]})
+    assert response.status_code == 404
+
+
+def test_add_article_tag_endpoint_404s_for_other_users_tag(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    tag = create_tag(alice, "rust", db_path=db)
+    article_id = _insert_article(db)
+    client = _authed_client(bob)
+    response = client.post(f"/api/articles/{article_id}/tags", json={"tag_id": tag["id"]})
+    assert response.status_code == 404

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -15,6 +15,8 @@ import { StarredPage } from './pages/StarredPage';
 import { FeedsPage } from './pages/FeedsPage';
 import { SourcesPage } from './pages/SourcesPage';
 import { ArchivePage } from './pages/ArchivePage';
+import { CollectionsPage } from './pages/CollectionsPage';
+import { CollectionDetailPage } from './pages/CollectionDetailPage';
 import { useAuth } from './contexts/auth';
 import { ShieldAlert } from 'lucide-react';
 
@@ -164,6 +166,8 @@ export const routes: RouteObject[] = [
       },
       { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
       { path: 'archive', element: <ArchivePage /> },
+      { path: 'collections', element: <CollectionsPage /> },
+      { path: 'collections/:tagId', element: <CollectionDetailPage /> },
       { path: 'settings', element: withSuspense(SettingsPage) },
       { path: 'admin', element: withSuspense(AdminPage) },
       {

--- a/frontend/src/__tests__/articleTags.test.tsx
+++ b/frontend/src/__tests__/articleTags.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ArticleTags } from '../components/article/ArticleTags';
+import * as tagsApi from '../api/tagsApi';
+import type { UserTag } from '../api/tagsApi';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+function makeTag(overrides: Partial<UserTag> = {}): UserTag {
+  return {
+    id: 1,
+    user_id: 1,
+    name: 'rust',
+    color: null,
+    created_at: '2026-06-16T10:00:00Z',
+    article_count: 0,
+    ...overrides,
+  };
+}
+
+function renderArticleTags() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ArticleTags articleId="42" />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ArticleTags', () => {
+  it('renders existing tags applied to the article', async () => {
+    vi.spyOn(tagsApi, 'fetchArticleTags').mockResolvedValue([makeTag()]);
+    vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([makeTag()]);
+
+    renderArticleTags();
+
+    await waitFor(() => {
+      expect(screen.getByText('rust')).toBeTruthy();
+    });
+  });
+
+  it('applies an existing tag from the dropdown', async () => {
+    vi.spyOn(tagsApi, 'fetchArticleTags').mockResolvedValue([]);
+    vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([makeTag({ name: 'python' })]);
+    const addSpy = vi.spyOn(tagsApi, 'addArticleTag').mockResolvedValue(undefined);
+
+    renderArticleTags();
+
+    await waitFor(() => {
+      expect(screen.getByText('Add tag')).toBeTruthy();
+    });
+    await userEvent.click(screen.getByText('Add tag'));
+
+    await waitFor(() => {
+      expect(screen.getByText('python')).toBeTruthy();
+    });
+    await userEvent.click(screen.getByText('python'));
+
+    await waitFor(() => {
+      expect(addSpy).toHaveBeenCalledWith('42', 1);
+    });
+  });
+
+  it('creates a new tag and applies it to the article', async () => {
+    vi.spyOn(tagsApi, 'fetchArticleTags').mockResolvedValue([]);
+    vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([]);
+    const createSpy = vi
+      .spyOn(tagsApi, 'createTag')
+      .mockResolvedValue(makeTag({ id: 7, name: 'golang' }));
+    const addSpy = vi.spyOn(tagsApi, 'addArticleTag').mockResolvedValue(undefined);
+
+    renderArticleTags();
+
+    await waitFor(() => {
+      expect(screen.getByText('Add tag')).toBeTruthy();
+    });
+    await userEvent.click(screen.getByText('Add tag'));
+
+    const input = screen.getByPlaceholderText('New tag…');
+    await userEvent.type(input, 'golang');
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith('golang');
+      expect(addSpy).toHaveBeenCalledWith('42', 7);
+    });
+  });
+
+  it('removes a tag from the article', async () => {
+    vi.spyOn(tagsApi, 'fetchArticleTags').mockResolvedValue([makeTag()]);
+    vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([makeTag()]);
+    const removeSpy = vi.spyOn(tagsApi, 'removeArticleTag').mockResolvedValue(undefined);
+
+    renderArticleTags();
+
+    await waitFor(() => {
+      expect(screen.getByText('rust')).toBeTruthy();
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Remove tag rust' }));
+
+    await waitFor(() => {
+      expect(removeSpy).toHaveBeenCalledWith('42', 1);
+    });
+  });
+});

--- a/frontend/src/__tests__/search.test.tsx
+++ b/frontend/src/__tests__/search.test.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SearchPage } from '../pages/SearchPage';
 import * as workflowApi from '../api/workflowApi';
 import * as api from '../api';
+import * as tagsApi from '../api/tagsApi';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 import type { Source } from '../types';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
@@ -30,6 +31,7 @@ function makeSource(overrides: Partial<Source> = {}): Source {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(api, 'fetchSources').mockResolvedValue([]);
+  vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([]);
 });
 
 function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
@@ -322,6 +324,51 @@ describe('SearchPage — source filter', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Source · 1/i })).toBeTruthy();
+    });
+  });
+});
+
+describe('SearchPage — tag filter', () => {
+  it('renders Tag filter group when tags are available', async () => {
+    vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([
+      { id: 1, user_id: 1, name: 'rust', color: null, created_at: '2026-01-01T00:00:00Z' },
+    ]);
+
+    renderSearch();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Tag/i })).toBeTruthy();
+    });
+  });
+
+  it('selecting a tag filters results by tag_id', async () => {
+    const spy = vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
+    vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([
+      { id: 3, user_id: 1, name: 'rust', color: null, created_at: '2026-01-01T00:00:00Z' },
+    ]);
+
+    renderSearch('?q=test');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Tag/i })).toBeTruthy();
+    });
+    await userEvent.click(screen.getByRole('button', { name: /^Tag/i }));
+    await userEvent.click(screen.getByText('rust'));
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ tagId: 3 }));
+    });
+  });
+
+  it('preselects a tag from URL params', async () => {
+    vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([
+      { id: 3, user_id: 1, name: 'rust', color: null, created_at: '2026-01-01T00:00:00Z' },
+    ]);
+
+    renderSearch('?q=test&tag=3');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Tag · rust/i })).toBeTruthy();
     });
   });
 });

--- a/frontend/src/api/tagsApi.ts
+++ b/frontend/src/api/tagsApi.ts
@@ -1,0 +1,82 @@
+/** API layer for user-defined tags/collections (#652). */
+
+import { requestJson } from '../api';
+import { adaptArticle } from './workflowApi';
+import type { Article as LegacyArticle } from '../types';
+import type { TriageArticlePage } from './workflowApi';
+
+export interface UserTag {
+  id: number;
+  user_id: number;
+  name: string;
+  color: string | null;
+  created_at: string;
+  article_count?: number;
+}
+
+interface TagListResponse {
+  items: UserTag[];
+}
+
+interface ArticleTagApiPage {
+  items: LegacyArticle[];
+  limit?: number;
+  offset?: number;
+  has_more?: boolean;
+}
+
+export async function fetchTags(): Promise<UserTag[]> {
+  const data = await requestJson<TagListResponse>('/api/tags');
+  return data.items;
+}
+
+export async function createTag(name: string, color?: string): Promise<UserTag> {
+  return requestJson<UserTag>('/api/tags', {
+    method: 'POST',
+    body: JSON.stringify({ name, color: color ?? null }),
+  });
+}
+
+export async function renameTag(tagId: number, name: string): Promise<UserTag> {
+  return requestJson<UserTag>(`/api/tags/${tagId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function deleteTag(tagId: number): Promise<void> {
+  await requestJson(`/api/tags/${tagId}`, { method: 'DELETE' });
+}
+
+export async function fetchArticleTags(articleId: string | number): Promise<UserTag[]> {
+  const data = await requestJson<TagListResponse>(`/api/articles/${articleId}/tags`);
+  return data.items;
+}
+
+export async function addArticleTag(articleId: string | number, tagId: number): Promise<void> {
+  await requestJson(`/api/articles/${articleId}/tags`, {
+    method: 'POST',
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+}
+
+export async function removeArticleTag(articleId: string | number, tagId: number): Promise<void> {
+  await requestJson(`/api/articles/${articleId}/tags/${tagId}`, { method: 'DELETE' });
+}
+
+export async function fetchArticlesByTag(
+  tagId: number,
+  options: { limit?: number; offset?: number } = {}
+): Promise<TriageArticlePage> {
+  const params = new URLSearchParams();
+  if (options.limit) params.set('limit', String(options.limit));
+  if (options.offset) params.set('offset', String(options.offset));
+  const suffix = params.size ? `?${params}` : '';
+  const data = await requestJson<ArticleTagApiPage>(`/api/tags/${tagId}/articles${suffix}`);
+  return {
+    items: data.items.map(adaptArticle),
+    limit: data.limit ?? options.limit ?? data.items.length,
+    offset: data.offset ?? options.offset ?? 0,
+    hasMore: Boolean(data.has_more),
+  };
+}

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -171,6 +171,7 @@ export interface SearchFilters {
   starredOnly?: boolean;
   includeArchived?: boolean;
   dateRange?: 'all' | 'today' | 'week' | 'month';
+  tagId?: number;
   limit?: number;
   offset?: number;
 }
@@ -199,6 +200,7 @@ export async function searchArticlesFiltered(filters: SearchFilters): Promise<Se
   if (filters.starredOnly) params.set('starred_only', 'true');
   if (filters.includeArchived) params.set('include_archived', 'true');
   if (filters.dateRange && filters.dateRange !== 'all') params.set('date_range', filters.dateRange);
+  if (filters.tagId != null) params.set('tag_id', String(filters.tagId));
   filters.states?.forEach((s) => params.append('states', s));
   filters.categories?.forEach((c) => params.append('categories', c));
   filters.sources?.forEach((s) => params.append('sources', s));

--- a/frontend/src/components/article/ArticleTags.tsx
+++ b/frontend/src/components/article/ArticleTags.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { Plus, X, Tag as TagIcon } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  addArticleTag,
+  createTag,
+  fetchArticleTags,
+  fetchTags,
+  removeArticleTag,
+} from '@/api/tagsApi';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  articleId: string;
+}
+
+export function ArticleTags({ articleId }: Props) {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [newTagName, setNewTagName] = useState('');
+
+  const { data: articleTags = [] } = useQuery({
+    queryKey: ['articleTags', articleId],
+    queryFn: () => fetchArticleTags(articleId),
+  });
+
+  const { data: allTags = [] } = useQuery({
+    queryKey: ['tags'],
+    queryFn: fetchTags,
+    enabled: open,
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['articleTags', articleId] });
+    void queryClient.invalidateQueries({ queryKey: ['tags'] });
+  };
+
+  const addMutation = useMutation({
+    mutationFn: (tagId: number) => addArticleTag(articleId, tagId),
+    onSuccess: invalidate,
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (tagId: number) => removeArticleTag(articleId, tagId),
+    onSuccess: invalidate,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (name: string) => createTag(name),
+    onSuccess: async (tag) => {
+      invalidate();
+      await addMutation.mutateAsync(tag.id);
+      setNewTagName('');
+    },
+  });
+
+  const appliedIds = new Set(articleTags.map((t) => t.id));
+  const availableTags = allTags.filter((t) => !appliedIds.has(t.id));
+
+  function handleCreate() {
+    const name = newTagName.trim();
+    if (!name) return;
+    createMutation.mutate(name);
+  }
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-1.5" data-testid="article-tags">
+      {articleTags.map((tag) => (
+        <span
+          key={tag.id}
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[11px] font-medium text-foreground"
+          data-testid="article-tag-chip"
+        >
+          <TagIcon className="size-2.5" strokeWidth={2} style={{ color: tag.color ?? undefined }} />
+          {tag.name}
+          <button
+            type="button"
+            aria-label={`Remove tag ${tag.name}`}
+            onClick={() => removeMutation.mutate(tag.id)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3" strokeWidth={2} />
+          </button>
+        </span>
+      ))}
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className={cn(
+            'inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:border-border-strong'
+          )}
+        >
+          <Plus className="size-3" strokeWidth={2} />
+          Add tag
+        </button>
+        {open && (
+          <div className="absolute z-20 mt-1 min-w-[180px] rounded-md border border-border bg-popover shadow-md p-1.5">
+            <div className="flex items-center gap-1 mb-1.5">
+              <input
+                value={newTagName}
+                onChange={(e) => setNewTagName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreate();
+                }}
+                placeholder="New tag…"
+                className="h-7 flex-1 min-w-0 rounded border border-border bg-background px-2 text-xs outline-none focus:border-border-strong"
+              />
+              <button
+                type="button"
+                onClick={handleCreate}
+                disabled={!newTagName.trim() || createMutation.isPending}
+                className="h-7 px-2 rounded bg-foreground text-background text-xs disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+            {availableTags.length > 0 && (
+              <div className="max-h-40 overflow-y-auto">
+                {availableTags.map((tag) => (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    onClick={() => {
+                      addMutation.mutate(tag.id);
+                      setOpen(false);
+                    }}
+                    className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-surface"
+                  >
+                    <TagIcon
+                      className="size-3 shrink-0"
+                      strokeWidth={2}
+                      style={{ color: tag.color ?? undefined }}
+                    />
+                    <span className="truncate">{tag.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -14,6 +14,7 @@ import {
   Sparkles,
   Star,
   SlidersHorizontal,
+  Tag,
   Users,
   type LucideIcon,
 } from 'lucide-react';
@@ -43,6 +44,7 @@ export const secondaryNavigationItems: NavigationItem[] = [
   { to: '/feeds', label: 'Feeds', icon: Radio, shortcut: 'f' },
   { to: '/reading-dna', label: 'Reading DNA', icon: SlidersHorizontal },
   { to: '/archive', label: 'Archive', icon: Archive },
+  { to: '/collections', label: 'Collections', icon: Tag },
   { to: '/settings', label: 'Settings', icon: Settings },
 ];
 
@@ -136,6 +138,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/stats')) return 'Stats';
   if (pathname.startsWith('/reading-dna')) return 'Reading DNA';
   if (pathname.startsWith('/archive')) return 'Archive';
+  if (pathname.startsWith('/collections')) return 'Collections';
   if (pathname.startsWith('/settings')) return 'Settings';
   if (pathname.startsWith('/analytics')) return 'Analytics';
   if (pathname.startsWith('/admin')) return 'Users';

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -43,6 +43,7 @@ import { recommendationExplanation } from '@/lib/recommendation';
 import { trackArticleOpen, trackArticleClose } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 import { ShareDialog } from '@/components/ShareDialog';
+import { ArticleTags } from '@/components/article/ArticleTags';
 
 const LANGUAGE_NAMES: Record<string, string> = {
   en: 'English',
@@ -592,6 +593,9 @@ export function ArticlePage() {
             <h1 className="mt-3 text-[26px] md:text-[30px] font-semibold tracking-tight leading-tight">
               {showOriginal && article.originalTitle ? article.originalTitle : article.title}
             </h1>
+
+            {/* User-defined tags — independent of workflow state */}
+            {!shareId && <ArticleTags articleId={article.id} />}
 
             {/* Reading time — only shown once body is available */}
             {article.bodyStatus === 'ok' && article.body && (

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -1,0 +1,34 @@
+import { useParams } from 'react-router-dom';
+import { Tag as TagIcon } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { ArticleListView } from '@/components/article/ArticleListView';
+import { fetchArticlesByTag, fetchTags } from '@/api/tagsApi';
+
+export function CollectionDetailPage() {
+  const { tagId } = useParams<{ tagId: string }>();
+  const id = Number(tagId);
+
+  const { data: tags = [] } = useQuery({
+    queryKey: ['tags'],
+    queryFn: fetchTags,
+  });
+  const tag = tags.find((t) => t.id === id);
+
+  if (!Number.isFinite(id)) return null;
+
+  return (
+    <ArticleListView
+      title={tag?.name ?? 'Collection'}
+      description={({ loadedCount, hasMore, isLoading }) =>
+        isLoading ? '...' : `${loadedCount}${hasMore ? '+' : ''} tagged articles`
+      }
+      queryKey={['collection', id]}
+      queryFn={(params) => fetchArticlesByTag(id, params)}
+      empty={{
+        icon: TagIcon,
+        title: 'No articles yet',
+        subtitle: 'Tag articles from the reader to add them to this collection.',
+      }}
+    />
+  );
+}

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Tag as TagIcon, Trash2 } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { createTag, deleteTag, fetchTags } from '@/api/tagsApi';
+import { EmptyState } from '@/components/EmptyState';
+
+export function CollectionsPage() {
+  const queryClient = useQueryClient();
+  const [newTagName, setNewTagName] = useState('');
+
+  const { data: tags = [], isLoading } = useQuery({
+    queryKey: ['tags'],
+    queryFn: fetchTags,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (name: string) => createTag(name),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['tags'] });
+      setNewTagName('');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (tagId: number) => deleteTag(tagId),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['tags'] }),
+  });
+
+  function handleCreate() {
+    const name = newTagName.trim();
+    if (!name) return;
+    createMutation.mutate(name);
+  }
+
+  return (
+    <div>
+      <div className="px-4 md:px-5 pt-4 pb-3">
+        <h2 className="text-[22px] font-semibold tracking-tight">Collections</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Group articles into your own tags, independent of workflow state.
+        </p>
+      </div>
+
+      <div className="px-4 md:px-5 pb-4 flex items-center gap-2">
+        <input
+          value={newTagName}
+          onChange={(e) => setNewTagName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleCreate();
+          }}
+          placeholder="New collection name…"
+          className="h-9 flex-1 max-w-xs rounded-md border border-border bg-surface px-3 text-sm outline-none focus:border-border-strong"
+        />
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={!newTagName.trim() || createMutation.isPending}
+          className="h-9 px-3 rounded-md bg-foreground text-background text-sm font-medium disabled:opacity-50"
+        >
+          Create
+        </button>
+      </div>
+
+      {isLoading ? null : tags.length === 0 ? (
+        <EmptyState
+          icon={TagIcon}
+          title="No collections yet"
+          subtitle="Create a tag to start organizing articles into your own collections."
+        />
+      ) : (
+        <div className="divide-y divide-border border-t border-border">
+          {tags.map((tag) => (
+            <div
+              key={tag.id}
+              className="flex items-center justify-between gap-3 px-4 md:px-5 py-3 hover:bg-surface"
+            >
+              <Link to={`/collections/${tag.id}`} className="flex items-center gap-2 min-w-0">
+                <TagIcon
+                  className="size-4 shrink-0"
+                  strokeWidth={1.75}
+                  style={{ color: tag.color ?? undefined }}
+                />
+                <span className="text-sm font-medium truncate">{tag.name}</span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {tag.article_count ?? 0} {tag.article_count === 1 ? 'article' : 'articles'}
+                </span>
+              </Link>
+              <button
+                type="button"
+                aria-label={`Delete ${tag.name}`}
+                onClick={() => deleteMutation.mutate(tag.id)}
+                className="text-muted-foreground hover:text-destructive shrink-0"
+              >
+                <Trash2 className="size-4" strokeWidth={1.75} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -10,6 +10,7 @@ import { useFocusedArticle } from '@/contexts/focusedArticle';
 import { setReaderList } from '@/lib/readerList';
 import { searchArticlesFiltered } from '@/api/workflowApi';
 import { fetchSources } from '@/api';
+import { fetchTags } from '@/api/tagsApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { cn } from '@/lib/utils';
 
@@ -55,7 +56,8 @@ function encodedFilters(
   sources: string[],
   starredOnly: boolean,
   includeArchived: boolean,
-  dateRange: string
+  dateRange: string,
+  tagId: string
 ): URLSearchParams {
   const p = new URLSearchParams();
   if (q) p.set('q', q);
@@ -65,6 +67,7 @@ function encodedFilters(
   if (starredOnly) p.set('starred_only', '1');
   if (includeArchived) p.set('include_archived', '1');
   if (dateRange !== 'all') p.set('date_range', dateRange);
+  if (tagId) p.set('tag', tagId);
   return p;
 }
 
@@ -81,6 +84,7 @@ export function SearchPage() {
   const starredOnly = searchParams.get('starred_only') === '1';
   const includeArchived = searchParams.get('include_archived') === '1';
   const dateRange = searchParams.get('date_range') ?? 'all';
+  const tagId = searchParams.get('tag') ?? '';
 
   const [inputValue, setInputValue] = useState(q);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -103,6 +107,7 @@ export function SearchPage() {
     starredOnly?: boolean;
     includeArchived?: boolean;
     dateRange?: string;
+    tagId?: string;
   }) {
     setSearchParams(
       encodedFilters(
@@ -112,7 +117,8 @@ export function SearchPage() {
         overrides.sources ?? sources,
         overrides.starredOnly ?? starredOnly,
         overrides.includeArchived ?? includeArchived,
-        overrides.dateRange ?? dateRange
+        overrides.dateRange ?? dateRange,
+        overrides.tagId ?? tagId
       ),
       { replace: true }
     );
@@ -125,7 +131,8 @@ export function SearchPage() {
     sources.length ||
     starredOnly ||
     includeArchived ||
-    dateRange !== 'all';
+    dateRange !== 'all' ||
+    tagId;
 
   const { data: availableSources = [] } = useQuery({
     queryKey: ['sources'],
@@ -133,8 +140,24 @@ export function SearchPage() {
     staleTime: 5 * 60_000,
   });
 
+  const { data: availableTags = [] } = useQuery({
+    queryKey: ['tags'],
+    queryFn: fetchTags,
+    staleTime: 60_000,
+  });
+
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
-    queryKey: ['search', q, states, categories, sources, starredOnly, includeArchived, dateRange],
+    queryKey: [
+      'search',
+      q,
+      states,
+      categories,
+      sources,
+      starredOnly,
+      includeArchived,
+      dateRange,
+      tagId,
+    ],
     queryFn: ({ pageParam }) =>
       searchArticlesFiltered({
         q,
@@ -144,6 +167,7 @@ export function SearchPage() {
         starredOnly,
         includeArchived,
         dateRange: (dateRange || 'all') as 'all' | 'today' | 'week' | 'month',
+        tagId: tagId ? Number(tagId) : undefined,
         limit: SEARCH_PAGE_SIZE,
         offset: pageParam,
       }),
@@ -249,6 +273,18 @@ export function SearchPage() {
               selected={sources}
               onChange={(next) => updateParams({ sources: next })}
               render={(slug) => availableSources.find((s) => s.slug === slug)?.name ?? slug}
+            />
+          )}
+
+          {/* Tag group */}
+          {availableTags.length > 0 && (
+            <FilterGroup
+              label="Tag"
+              all={availableTags.map((t) => String(t.id))}
+              selected={tagId ? [tagId] : []}
+              onChange={(next) => updateParams({ tagId: next[next.length - 1] ?? '' })}
+              render={(id) => availableTags.find((t) => String(t.id) === id)?.name ?? id}
+              single
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
Implements #652 — user-defined tags/collections, orthogonal to Workflow State.

- **Backend**: new `user_tags` + `article_tags` tables (per-user, free-form, optional color); `tags.py` CRUD module (create/list/rename/delete tags, apply/remove a tag on an article, list an article's tags); `tag_id` filter threaded through `GET /api/articles` and `GET /api/search`; new endpoints:
  - `POST/GET /api/tags`, `PATCH/DELETE /api/tags/{tag_id}`
  - `GET /api/tags/{tag_id}/articles`
  - `GET/POST /api/articles/{article_id}/tags`, `DELETE /api/articles/{article_id}/tags/{tag_id}`
- **Frontend**: `ArticleTags` chip UI on the article reader (create/apply/remove tags inline); a single-select "Tag" filter on the Search page; new `/collections` page listing tags with article counts and `/collections/:tagId` showing tagged articles, wired into the nav.
- Deleting a tag removes its `article_tags` associations only (`ON DELETE CASCADE`) — articles are untouched.
- Tags never affect `user_article_state`; an article can be `done` and tagged at the same time (covered by a dedicated test).

**Scope note**: tag chips were added to the ArticlePage reader (where article data is already fetched) and to the Collections view, but intentionally not to every row in the main feed/search list, to avoid an N+1 tag lookup per article on high-traffic list endpoints. Happy to follow up with a batched `tags_by_article` endpoint if per-row chips are wanted.

## Test plan
- [x] Backend: `uv run pytest backend/tests/test_tags.py` — 18 tests covering tag CRUD, apply/remove, delete-tag-keeps-article, tag/workflow-state orthogonality, per-user isolation, and the full API flow.
- [x] Backend: full suite (`uv run pytest backend/tests/`) — 1270 passed (3 pre-existing failures/37 errors unrelated to this change, reproduced identically on `main` with no changes staged — missing-network/AI-config and Postgres-role environment issues).
- [x] Frontend: `articleTags.test.tsx` (apply/remove/create-and-apply a tag) and new `SearchPage — tag filter` tests — all passing; full frontend suite 651 passed (3 pre-existing unrelated failures from a missing `@sentry/react` install).
- [x] `ruff`, `mypy`, `ty`, `pyrefly`, `eslint`, `prettier`, `tsc` all clean via pre-commit hooks.

🤖 Generated with an autonomous agent run (issue-locking protocol; lock branch `agent-lock/issue-652`).