### PR TITLE
chore: configure UI Sentry DSN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,7 @@ SENTRY_ENVIRONMENT=
 SENTRY_RELEASE=
 # Same as above, for frontend errors. Served to the SPA via GET /api/config,
 # which is safe since Sentry DSNs are designed to be public (send-only).
+# In production, store this as the SENTRY_DSN_FRONTEND GitHub Actions secret.
 SENTRY_DSN_FRONTEND=
 
 # --- One-off migration CLI (optional) -------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,6 +569,10 @@ jobs:
   # │                   tracking. Stored as a secret and exposed to pods as │
   # │                   SENTRY_DSN.                                        │
   # │                                                                      │
+  # │  SENTRY_DSN_      Optional Sentry project DSN for frontend/UI error   │
+  # │  FRONTEND         tracking. Stored as a secret and exposed publicly   │
+  # │                   through GET /api/config as SENTRY_DSN_FRONTEND.     │
+  # │                                                                      │
   # │                   SHORTCUT: if you make the GHCR package public      │
   # │                   (repo Settings → Packages → Change visibility),    │
   # │                   you can skip GHCR_TOKEN entirely and remove the    │
@@ -603,6 +607,7 @@ jobs:
           VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
           VAPID_EMAIL: ${{ vars.VAPID_EMAIL }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_DSN_FRONTEND: ${{ secrets.SENTRY_DSN_FRONTEND }}
         run: |
           set -euo pipefail
 
@@ -683,9 +688,16 @@ jobs:
           fi
 
           sentry_helm_args=()
+          sentry_secret_args=()
           if [ -n "$SENTRY_DSN" ]; then
+            sentry_secret_args+=(--from-literal=SENTRY_DSN="$SENTRY_DSN")
+          fi
+          if [ -n "$SENTRY_DSN_FRONTEND" ]; then
+            sentry_secret_args+=(--from-literal=SENTRY_DSN_FRONTEND="$SENTRY_DSN_FRONTEND")
+          fi
+          if [ ${#sentry_secret_args[@]} -gt 0 ]; then
             kubectl -n news-dashboard create secret generic news-dashboard-sentry \
-              --from-literal=SENTRY_DSN="$SENTRY_DSN" \
+              "${sentry_secret_args[@]}" \
               --dry-run=client -o yaml | kubectl apply -f -
             sentry_helm_args+=(--set app.sentry.existingSecret=news-dashboard-sentry)
             sentry_helm_args+=(--set-string app.sentry.environment=production)

--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -135,6 +135,7 @@ def test_helm_template_app_and_ingest_receive_sentry_env() -> None:
     output = _render_chart(
         "app.sentry.existingSecret=sentry-credentials",
         "app.sentry.dsnKey=CUSTOM_SENTRY_DSN",
+        "app.sentry.frontendDsnKey=CUSTOM_SENTRY_DSN_FRONTEND",
         "app.sentry.environment=production",
         "app.sentry.release=news-dashboard@abc123",
     )
@@ -147,6 +148,9 @@ def test_helm_template_app_and_ingest_receive_sentry_env() -> None:
     sentry_dsn = _env_entry(deployment_env, "SENTRY_DSN")
     assert 'name: "sentry-credentials"' in sentry_dsn
     assert 'key: "CUSTOM_SENTRY_DSN"' in sentry_dsn
+    frontend_sentry_dsn = _env_entry(deployment_env, "SENTRY_DSN_FRONTEND")
+    assert 'name: "sentry-credentials"' in frontend_sentry_dsn
+    assert 'key: "CUSTOM_SENTRY_DSN_FRONTEND"' in frontend_sentry_dsn
     assert _env_entry(deployment_env, "SENTRY_ENVIRONMENT") == (
         '- name: SENTRY_ENVIRONMENT\n  value: "production"'
     )

--- a/frontend/src/__tests__/errorTracking.test.ts
+++ b/frontend/src/__tests__/errorTracking.test.ts
@@ -36,7 +36,7 @@ describe('initErrorTracking', () => {
     const { initErrorTracking } = await import('../lib/errorTracking');
     await initErrorTracking();
 
-    expect(sentryInit).toHaveBeenCalledWith({ dsn, sendDefaultPii: false });
+    expect(sentryInit).toHaveBeenCalledWith({ dsn, sendDefaultPii: true });
   });
 
   it('does not throw when the config fetch fails', async () => {

--- a/frontend/src/lib/errorTracking.ts
+++ b/frontend/src/lib/errorTracking.ts
@@ -14,7 +14,7 @@ export async function initErrorTracking(): Promise<void> {
     if (!config.sentry_dsn) return;
 
     const Sentry = await import('@sentry/react');
-    Sentry.init({ dsn: config.sentry_dsn, sendDefaultPii: false });
+    Sentry.init({ dsn: config.sentry_dsn, sendDefaultPii: true });
   } catch {
     // Network/parse failures must never block app startup.
   }

--- a/helm/news-dashboard/templates/_helpers.tpl
+++ b/helm/news-dashboard/templates/_helpers.tpl
@@ -57,6 +57,12 @@
       name: {{ .Values.app.sentry.existingSecret | quote }}
       key: {{ .Values.app.sentry.dsnKey | default "SENTRY_DSN" | quote }}
       optional: true
+- name: SENTRY_DSN_FRONTEND
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.sentry.existingSecret | quote }}
+      key: {{ .Values.app.sentry.frontendDsnKey | default "SENTRY_DSN_FRONTEND" | quote }}
+      optional: true
 {{- end }}
 {{- if .Values.app.sentry.environment }}
 - name: SENTRY_ENVIRONMENT

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -97,9 +97,10 @@ app:
     # VAPID claims email address. Omit or leave empty to default safely.
     email: ""
   sentry:
-    # Optional: pre-existing Secret with SENTRY_DSN.
+    # Optional: pre-existing Secret with SENTRY_DSN and/or SENTRY_DSN_FRONTEND.
     existingSecret: ""
     dsnKey: SENTRY_DSN
+    frontendDsnKey: SENTRY_DSN_FRONTEND
     # Sentry environment tag. Leave empty to let the SDK default to production.
     environment: ""
     # Optional release identifier, usually set by CI to the deployed commit SHA.


### PR DESCRIPTION
Follow-up to #845.\n\n## Summary\n- wire SENTRY_DSN_FRONTEND from GitHub Actions into the deployment secret\n- expose the frontend Sentry DSN through the existing /api/config path\n- initialize @sentry/react with sendDefaultPii=true for the UI project\n- cover the frontend DSN Helm wiring and React init behavior in tests\n\n## Verification\n- .venv/bin/pytest backend/tests/test_error_tracking.py backend/tests/test_env_example.py backend/tests/test_chart_render.py -q\n- npm run test:frontend --silent -- frontend/src/__tests__/errorTracking.test.ts\n- npm run lint --silent\n- npm run format:check --silent\n- npm run typecheck --silent\n- PATH="/Users/ioachimlihor/.codex/worktrees/f784/news-dashboard/.venv/bin:/Users/ioachimlihor/.codex/tmp/arg0/codex-arg0g8LKPh:/Users/ioachimlihor/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/opt/python@3.14/libexec/bin:/Users/ioachimlihor/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Applications/Codex.app/Contents/Resources" ruff check backend/tests/test_chart_render.py\n- PATH="/Users/ioachimlihor/.codex/worktrees/f784/news-dashboard/.venv/bin:/Users/ioachimlihor/.codex/tmp/arg0/codex-arg0g8LKPh:/Users/ioachimlihor/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/opt/python@3.14/libexec/bin:/Users/ioachimlihor/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Applications/Codex.app/Contents/Resources" mypy backend/tests/test_chart_render.py\n- PATH="/Users/ioachimlihor/.codex/worktrees/f784/news-dashboard/.venv/bin:/Users/ioachimlihor/.codex/tmp/arg0/codex-arg0g8LKPh:/Users/ioachimlihor/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/opt/python@3.14/libexec/bin:/Users/ioachimlihor/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Applications/Codex.app/Contents/Resources" ty check backend/tests/test_chart_render.py\n- PATH="/Users/ioachimlihor/.codex/worktrees/f784/news-dashboard/.venv/bin:/Users/ioachimlihor/.codex/tmp/arg0/codex-arg0g8LKPh:/Users/ioachimlihor/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/opt/python@3.14/libexec/bin:/Users/ioachimlihor/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Applications/Codex.app/Contents/Resources" pyrefly check backend/tests/test_chart_render.py\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)