### PR TITLE
feat: subscribe to the daily brief as a podcast RSS feed (#654)

### DIFF
--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -258,6 +258,28 @@ def _touch_last_login(user_id: int) -> None:
         conn.execute("UPDATE users SET last_login_at=CURRENT_TIMESTAMP WHERE id=%s", (user_id,))
 
 
+def get_podcast_feed_token_version(user_id: int) -> int | None:
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT podcast_feed_token_version FROM users WHERE id=%s", (user_id,)
+        ).fetchone()
+        return int(row["podcast_feed_token_version"]) if row else None
+
+
+def bump_podcast_feed_token_version(user_id: int) -> int:
+    """Invalidate the user's current podcast feed token and return the new version."""
+    with connect() as conn:
+        row = conn.execute(
+            "UPDATE users SET podcast_feed_token_version = podcast_feed_token_version + 1"
+            " WHERE id=%s RETURNING podcast_feed_token_version",
+            (user_id,),
+        ).fetchone()
+        if row is None:
+            msg = f"user {user_id} not found"
+            raise ValueError(msg)
+        return int(row["podcast_feed_token_version"])
+
+
 # --------------------------------------------------------------------------- #
 # Bootstrap: create first admin from env vars on startup                       #
 # --------------------------------------------------------------------------- #

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -735,6 +735,35 @@ def update_briefing_script(
         )
 
 
+def list_briefings_with_script(
+    user_id: int,
+    limit: int = 50,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return the user's most recent briefings that already have a podcast script.
+
+    Used by the podcast RSS feed: only briefings a user has already generated a
+    script for are eligible episodes, so serving the feed never triggers new
+    (costly) AI script generation.
+    """
+    with connect(db_path, database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, created_at, title, summary, script
+            FROM briefings
+            WHERE user_id = %s AND script IS NOT NULL
+            ORDER BY created_at DESC
+            LIMIT %s
+            """,
+            (user_id, limit),
+        ).fetchall()
+        briefings = [row_to_dict(r) for r in rows]
+        for briefing in briefings:
+            briefing["script"] = _coerce_content(briefing.get("script"))
+        return briefings
+
+
 _CHAT_SYSTEM_PROMPT = """\
 You are the Briefing Q&A Assistant. Your job is to answer follow-up questions \
 about the daily briefing provided below. Ground every answer in the briefing \

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -508,6 +508,8 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_otps_user ON user_otps(user_id, expires_at DESC)",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_guest BOOLEAN NOT NULL DEFAULT FALSE",
+    "ALTER TABLE users ADD COLUMN IF NOT EXISTS podcast_feed_token_version"
+    " INTEGER NOT NULL DEFAULT 1",
     """
     CREATE TABLE IF NOT EXISTS user_tags (
       id         SERIAL PRIMARY KEY,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2064,6 +2064,72 @@ def briefings_list(
     return {"items": list_briefings(limit=limit, offset=offset, user_id=current_user["id"])}
 
 
+@api.get("/api/briefings/podcast-feed-token")
+def get_podcast_feed_token_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, str]:
+    """Return the user's current (revocable) podcast feed token and subscribe URL."""
+    from news_dashboard.auth import get_podcast_feed_token_version
+    from news_dashboard.podcast_feed import feed_url, make_feed_token
+
+    version = get_podcast_feed_token_version(current_user["id"])
+    if version is None:
+        raise HTTPException(status_code=404, detail="user not found")
+    token = make_feed_token(current_user["id"], version)
+    return {"token": token, "url": feed_url(token)}
+
+
+@api.post("/api/briefings/podcast-feed-token/regenerate")
+def regenerate_podcast_feed_token_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, str]:
+    """Revoke the user's current podcast feed token and issue a new one."""
+    from news_dashboard.auth import bump_podcast_feed_token_version
+    from news_dashboard.podcast_feed import feed_url, make_feed_token
+
+    version = bump_podcast_feed_token_version(current_user["id"])
+    token = make_feed_token(current_user["id"], version)
+    return {"token": token, "url": feed_url(token)}
+
+
+@api.get("/api/briefings/podcast.rss")
+def podcast_rss_feed_endpoint(token: Annotated[str, Query()]) -> Response:
+    """Serve the authenticated user's podcast feed of previously-generated briefs.
+
+    Authenticated via a revocable per-user token (not the session cookie), since
+    podcast clients cannot perform an interactive login.
+    """
+    from news_dashboard.briefings import list_briefings_with_script
+    from news_dashboard.podcast_feed import build_feed_xml, verify_feed_token
+    from news_dashboard.tts import (
+        TTSNotConfiguredError,
+        _podcast_audio_path,
+        generate_podcast_audio,
+    )
+
+    user_id = verify_feed_token(token)
+    if user_id is None:
+        raise HTTPException(status_code=403, detail="invalid or revoked podcast feed token")
+
+    briefings = list_briefings_with_script(user_id=user_id)
+    episodes = []
+    for briefing in briefings:
+        audio_path = _podcast_audio_path(briefing["id"])
+        if not audio_path.exists():
+            try:
+                generate_podcast_audio(briefing["id"], briefing["script"])
+            except (TTSNotConfiguredError, ValueError) as exc:
+                logger.warning(
+                    "Skipping podcast feed episode for briefing %d: %s", briefing["id"], exc
+                )
+                continue
+        briefing["audio_bytes"] = audio_path.stat().st_size
+        episodes.append(briefing)
+
+    xml = build_feed_xml(token=token, briefings=episodes)
+    return Response(content=xml, media_type="application/rss+xml")
+
+
 @api.get("/api/briefings/{briefing_id}")
 def briefings_detail(
     briefing_id: int,
@@ -2137,72 +2203,6 @@ def get_podcast_audio_endpoint(
         raise HTTPException(status_code=404, detail="podcast audio file not found")
 
     return FileResponse(audio_path, media_type="audio/mpeg", filename=f"podcast-{briefing_id}.mp3")
-
-
-@api.get("/api/briefings/podcast-feed-token")
-def get_podcast_feed_token_endpoint(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, str]:
-    """Return the user's current (revocable) podcast feed token and subscribe URL."""
-    from news_dashboard.auth import get_podcast_feed_token_version
-    from news_dashboard.podcast_feed import feed_url, make_feed_token
-
-    version = get_podcast_feed_token_version(current_user["id"])
-    if version is None:
-        raise HTTPException(status_code=404, detail="user not found")
-    token = make_feed_token(current_user["id"], version)
-    return {"token": token, "url": feed_url(token)}
-
-
-@api.post("/api/briefings/podcast-feed-token/regenerate")
-def regenerate_podcast_feed_token_endpoint(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, str]:
-    """Revoke the user's current podcast feed token and issue a new one."""
-    from news_dashboard.auth import bump_podcast_feed_token_version
-    from news_dashboard.podcast_feed import feed_url, make_feed_token
-
-    version = bump_podcast_feed_token_version(current_user["id"])
-    token = make_feed_token(current_user["id"], version)
-    return {"token": token, "url": feed_url(token)}
-
-
-@api.get("/api/briefings/podcast.rss")
-def podcast_rss_feed_endpoint(token: Annotated[str, Query()]) -> Response:
-    """Serve the authenticated user's podcast feed of previously-generated briefs.
-
-    Authenticated via a revocable per-user token (not the session cookie), since
-    podcast clients cannot perform an interactive login.
-    """
-    from news_dashboard.briefings import list_briefings_with_script
-    from news_dashboard.podcast_feed import build_feed_xml, verify_feed_token
-    from news_dashboard.tts import (
-        TTSNotConfiguredError,
-        _podcast_audio_path,
-        generate_podcast_audio,
-    )
-
-    user_id = verify_feed_token(token)
-    if user_id is None:
-        raise HTTPException(status_code=403, detail="invalid or revoked podcast feed token")
-
-    briefings = list_briefings_with_script(user_id=user_id)
-    episodes = []
-    for briefing in briefings:
-        audio_path = _podcast_audio_path(briefing["id"])
-        if not audio_path.exists():
-            try:
-                generate_podcast_audio(briefing["id"], briefing["script"])
-            except (TTSNotConfiguredError, ValueError) as exc:
-                logger.warning(
-                    "Skipping podcast feed episode for briefing %d: %s", briefing["id"], exc
-                )
-                continue
-        briefing["audio_bytes"] = audio_path.stat().st_size
-        episodes.append(briefing)
-
-    xml = build_feed_xml(token=token, briefings=episodes)
-    return Response(content=xml, media_type="application/rss+xml")
 
 
 @api.get("/api/briefings/{briefing_id}/podcast-audio")

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2139,6 +2139,96 @@ def get_podcast_audio_endpoint(
     return FileResponse(audio_path, media_type="audio/mpeg", filename=f"podcast-{briefing_id}.mp3")
 
 
+@api.get("/api/briefings/podcast-feed-token")
+def get_podcast_feed_token_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, str]:
+    """Return the user's current (revocable) podcast feed token and subscribe URL."""
+    from news_dashboard.auth import get_podcast_feed_token_version
+    from news_dashboard.podcast_feed import feed_url, make_feed_token
+
+    version = get_podcast_feed_token_version(current_user["id"])
+    if version is None:
+        raise HTTPException(status_code=404, detail="user not found")
+    token = make_feed_token(current_user["id"], version)
+    return {"token": token, "url": feed_url(token)}
+
+
+@api.post("/api/briefings/podcast-feed-token/regenerate")
+def regenerate_podcast_feed_token_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, str]:
+    """Revoke the user's current podcast feed token and issue a new one."""
+    from news_dashboard.auth import bump_podcast_feed_token_version
+    from news_dashboard.podcast_feed import feed_url, make_feed_token
+
+    version = bump_podcast_feed_token_version(current_user["id"])
+    token = make_feed_token(current_user["id"], version)
+    return {"token": token, "url": feed_url(token)}
+
+
+@api.get("/api/briefings/podcast.rss")
+def podcast_rss_feed_endpoint(token: Annotated[str, Query()]) -> Response:
+    """Serve the authenticated user's podcast feed of previously-generated briefs.
+
+    Authenticated via a revocable per-user token (not the session cookie), since
+    podcast clients cannot perform an interactive login.
+    """
+    from news_dashboard.briefings import list_briefings_with_script
+    from news_dashboard.podcast_feed import build_feed_xml, verify_feed_token
+    from news_dashboard.tts import (
+        TTSNotConfiguredError,
+        _podcast_audio_path,
+        generate_podcast_audio,
+    )
+
+    user_id = verify_feed_token(token)
+    if user_id is None:
+        raise HTTPException(status_code=403, detail="invalid or revoked podcast feed token")
+
+    briefings = list_briefings_with_script(user_id=user_id)
+    episodes = []
+    for briefing in briefings:
+        audio_path = _podcast_audio_path(briefing["id"])
+        if not audio_path.exists():
+            try:
+                generate_podcast_audio(briefing["id"], briefing["script"])
+            except (TTSNotConfiguredError, ValueError) as exc:
+                logger.warning(
+                    "Skipping podcast feed episode for briefing %d: %s", briefing["id"], exc
+                )
+                continue
+        briefing["audio_bytes"] = audio_path.stat().st_size
+        episodes.append(briefing)
+
+    xml = build_feed_xml(token=token, briefings=episodes)
+    return Response(content=xml, media_type="application/rss+xml")
+
+
+@api.get("/api/briefings/{briefing_id}/podcast-audio")
+def get_podcast_audio_by_token_endpoint(
+    briefing_id: int,
+    token: Annotated[str, Query()],
+) -> FileResponse:
+    """Serve podcast episode audio for a podcast-client feed subscription (token auth)."""
+    from news_dashboard.podcast_feed import verify_feed_token
+    from news_dashboard.tts import _podcast_audio_path
+
+    user_id = verify_feed_token(token)
+    if user_id is None:
+        raise HTTPException(status_code=403, detail="invalid or revoked podcast feed token")
+
+    briefing = get_briefing(briefing_id, user_id=user_id)
+    if not briefing:
+        raise HTTPException(status_code=404, detail="briefing not found")
+
+    audio_path = _podcast_audio_path(briefing_id)
+    if not audio_path.exists():
+        raise HTTPException(status_code=404, detail="podcast audio file not found")
+
+    return FileResponse(audio_path, media_type="audio/mpeg", filename=f"podcast-{briefing_id}.mp3")
+
+
 class BriefingCreateRequest(BaseModel):
     focus_prompt: str | None = Field(default=None, max_length=MAX_BRIEFING_FOCUS_PROMPT_LENGTH)
 

--- a/backend/news_dashboard/podcast_feed.py
+++ b/backend/news_dashboard/podcast_feed.py
@@ -1,0 +1,144 @@
+"""Per-user podcast RSS feed for daily briefings.
+
+Exposes a revocable, cookie-free feed URL so a standard podcast client can
+subscribe to previously-generated briefing audio. Tokens are HMAC-signed
+(same pattern as ``digest.py`` mark-read tokens) and bound to a per-user
+version counter stored on ``users.podcast_feed_token_version`` — bumping the
+counter instantly invalidates every token issued for the old version.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_SECRET_ENV_VARS = ("TOKEN_SECRET", "SESSION_SECRET", "TEST_SESSION_SECRET")
+
+
+def _token_signing_secret() -> str | None:
+    for env_var in _TOKEN_SECRET_ENV_VARS:
+        secret = os.getenv(env_var)
+        if secret:
+            return secret
+    return None
+
+
+def _require_token_signing_secret() -> str:
+    secret = _token_signing_secret()
+    if secret is not None:
+        return secret
+    msg = "TOKEN_SECRET or SESSION_SECRET env var is required to sign podcast feed tokens."
+    raise RuntimeError(msg)
+
+
+def _token_signature(user_id: int, version: int, secret: str) -> str:
+    msg = f"podcast-feed:{user_id}:{version}".encode()
+    return hmac.new(secret.encode(), msg, hashlib.sha256).hexdigest()[:32]
+
+
+def make_feed_token(user_id: int, version: int) -> str:
+    """Return a signed token for the given user and token version."""
+    signature = _token_signature(user_id, version, _require_token_signing_secret())
+    return f"{user_id}.{version}.{signature}"
+
+
+def verify_feed_token(token: str) -> int | None:
+    """Return the owning user_id if the token is validly signed and not revoked."""
+    from news_dashboard.auth import get_podcast_feed_token_version
+
+    try:
+        user_id_text, version_text, signature = token.split(".", 2)
+        user_id = int(user_id_text)
+        version = int(version_text)
+    except ValueError:
+        return None
+    secret = _token_signing_secret()
+    if secret is None:
+        return None
+    expected = _token_signature(user_id, version, secret)
+    if not hmac.compare_digest(expected, signature):
+        return None
+    current_version = get_podcast_feed_token_version(user_id)
+    if current_version is None or version != current_version:
+        return None
+    return user_id
+
+
+def _base_url() -> str:
+    return os.getenv("APP_BASE_URL", "http://localhost:8000")
+
+
+def feed_url(token: str) -> str:
+    return f"{_base_url()}/api/briefings/podcast.rss?token={token}"
+
+
+def audio_url(briefing_id: int, token: str) -> str:
+    return f"{_base_url()}/api/briefings/{briefing_id}/podcast-audio?token={token}"
+
+
+def _rfc2822(value: Any) -> str | None:
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return format_datetime(value)
+    return None
+
+
+def build_feed_xml(*, token: str, briefings: list[dict[str, Any]]) -> str:
+    """Build a podcast RSS 2.0 (+ iTunes tags) document for the given briefings.
+
+    Each entry in ``briefings`` must have ``id``, ``created_at``, ``title``,
+    ``summary``, and ``audio_bytes`` (size in bytes of the already-generated
+    MP3 for that briefing).
+    """
+    base = _base_url()
+    itunes_ns = "http://www.itunes.org/dtds/podcast-1.0.dtd"
+    atom_ns = "http://www.w3.org/2005/Atom"
+    ET.register_namespace("itunes", itunes_ns)
+    ET.register_namespace("atom", atom_ns)
+
+    rss = ET.Element("rss", version="2.0")
+    channel = ET.SubElement(rss, "channel")
+    ET.SubElement(channel, "title").text = "Your Daily Brief"
+    ET.SubElement(channel, "link").text = base
+    ET.SubElement(channel, "language").text = "en-us"
+    ET.SubElement(
+        channel, "description"
+    ).text = "Your personal daily news briefing, delivered as a podcast."
+    ET.SubElement(channel, f"{{{itunes_ns}}}author").text = "News Dashboard"
+    ET.SubElement(channel, f"{{{itunes_ns}}}explicit").text = "false"
+    atom_link = ET.SubElement(channel, f"{{{atom_ns}}}link")
+    atom_link.set("href", feed_url(token))
+    atom_link.set("rel", "self")
+    atom_link.set("type", "application/rss+xml")
+
+    for briefing in briefings:
+        briefing_id = briefing["id"]
+        item = ET.SubElement(channel, "item")
+        ET.SubElement(item, "title").text = briefing.get("title") or f"Briefing #{briefing_id}"
+        ET.SubElement(item, "description").text = briefing.get("summary") or ""
+        pub_date = _rfc2822(briefing.get("created_at"))
+        if pub_date:
+            ET.SubElement(item, "pubDate").text = pub_date
+        guid = ET.SubElement(item, "guid")
+        guid.set("isPermaLink", "false")
+        guid.text = f"briefing-{briefing_id}"
+        enclosure = ET.SubElement(item, "enclosure")
+        enclosure.set("url", audio_url(briefing_id, token))
+        enclosure.set("length", str(briefing.get("audio_bytes") or 0))
+        enclosure.set("type", "audio/mpeg")
+
+    return ET.tostring(rss, encoding="unicode", xml_declaration=True)

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -123,7 +123,9 @@ def generate_audio(
 
 def _podcast_audio_path(briefing_id: int, data_dir: Path | None = None) -> Path:
     base = data_dir if data_dir is not None else _data_dir()
-    return base / "audio" / f"podcast-{briefing_id}.mp3"
+    # int() coerces briefing_id to a plain digit string, so it cannot carry
+    # path-traversal or separator characters into the constructed path.
+    return base / "audio" / f"podcast-{int(briefing_id)}.mp3"
 
 
 def generate_podcast_audio(

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -376,6 +376,143 @@ def test_get_podcast_audio_endpoint_not_found(client: TestClient, monkeypatch: A
     assert resp.json()["detail"] == "podcast audio file not found"
 
 
+# ── Podcast RSS feed (#654) ────────────────────────────────────────────────────
+
+
+def test_get_podcast_feed_token_endpoint_returns_token_and_url(
+    client: TestClient, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    resp = client.get("/api/briefings/podcast-feed-token")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["token"].startswith("1.1.")
+    assert data["url"].endswith(f"/api/briefings/podcast.rss?token={data['token']}")
+
+
+def test_regenerate_podcast_feed_token_endpoint_issues_new_token(
+    client: TestClient, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr("news_dashboard.auth.bump_podcast_feed_token_version", lambda _uid: 2)
+    resp = client.post("/api/briefings/podcast-feed-token/regenerate")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["token"].startswith("1.2.")
+
+
+def test_podcast_rss_feed_valid_token_returns_episode(
+    client: TestClient, monkeypatch: Any, tmp_path: Path
+) -> None:
+    from news_dashboard.podcast_feed import make_feed_token
+
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = make_feed_token(1, 1)
+
+    briefing = {
+        "id": 7,
+        "created_at": "2026-06-13T12:00:00+00:00",
+        "title": "AI Frameworks",
+        "summary": "New agent frameworks.",
+        "script": [{"speaker": "Alex", "voice": "onyx", "text": "hi"}],
+    }
+    monkeypatch.setattr(
+        "news_dashboard.briefings.list_briefings_with_script", lambda **_: [briefing]
+    )
+
+    audio_file = tmp_path / "podcast-7.mp3"
+    audio_file.write_bytes(b"audio-bytes")
+    monkeypatch.setattr("news_dashboard.tts._podcast_audio_path", lambda *_a, **_k: audio_file)
+
+    resp = client.get(f"/api/briefings/podcast.rss?token={token}")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/rss+xml")
+    body = resp.text
+    assert "<title>AI Frameworks</title>" in body
+    assert f"/api/briefings/7/podcast-audio?token={token}" in body
+    assert 'length="11"' in body
+
+
+def test_podcast_rss_feed_skips_episode_missing_audio_and_tts_unconfigured(
+    client: TestClient, monkeypatch: Any
+) -> None:
+    from news_dashboard.podcast_feed import make_feed_token
+    from news_dashboard.tts import TTSNotConfiguredError
+
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = make_feed_token(1, 1)
+
+    briefing = {
+        "id": 8,
+        "created_at": "2026-06-13T12:00:00+00:00",
+        "title": "Untranscribed",
+        "summary": "",
+        "script": [{"speaker": "Alex", "voice": "onyx", "text": "hi"}],
+    }
+    monkeypatch.setattr(
+        "news_dashboard.briefings.list_briefings_with_script", lambda **_: [briefing]
+    )
+
+    from pathlib import Path as PathType
+
+    mock_path = MagicMock(spec=PathType)
+    mock_path.exists.return_value = False
+    monkeypatch.setattr("news_dashboard.tts._podcast_audio_path", lambda *_a, **_k: mock_path)
+
+    def _raise(*_a: Any, **_k: Any) -> None:
+        msg = "OPENAI_API_KEY is not configured"
+        raise TTSNotConfiguredError(msg)
+
+    monkeypatch.setattr("news_dashboard.tts.generate_podcast_audio", _raise)
+
+    resp = client.get(f"/api/briefings/podcast.rss?token={token}")
+    assert resp.status_code == 200
+    assert "Untranscribed" not in resp.text
+
+
+def test_podcast_rss_feed_invalid_token_returns_403(client: TestClient) -> None:
+    resp = client.get("/api/briefings/podcast.rss?token=bogus")
+    assert resp.status_code == 403
+
+
+def test_podcast_rss_feed_revoked_token_returns_403(client: TestClient, monkeypatch: Any) -> None:
+    from news_dashboard.podcast_feed import make_feed_token
+
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = make_feed_token(1, 1)
+
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 2)
+    resp = client.get(f"/api/briefings/podcast.rss?token={token}")
+    assert resp.status_code == 403
+
+
+def test_get_podcast_audio_by_token_endpoint_success(
+    client: TestClient, monkeypatch: Any, tmp_path: Path
+) -> None:
+    from news_dashboard.podcast_feed import make_feed_token
+
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = make_feed_token(1, 1)
+
+    briefing = dict(_SAMPLE_BRIEFING)
+    monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: briefing)
+
+    audio_file = tmp_path / "podcast-1.mp3"
+    audio_file.write_bytes(b"podcast-data")
+    monkeypatch.setattr("news_dashboard.tts._podcast_audio_path", lambda *_a, **_k: audio_file)
+
+    resp = client.get(f"/api/briefings/1/podcast-audio?token={token}")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "audio/mpeg"
+    assert resp.read() == b"podcast-data"
+
+
+def test_get_podcast_audio_by_token_endpoint_invalid_token_returns_403(
+    client: TestClient,
+) -> None:
+    resp = client.get("/api/briefings/1/podcast-audio?token=bogus")
+    assert resp.status_code == 403
+
+
 # ── POST /api/briefings/{id}/chat ─────────────────────────────────────────────
 
 

--- a/backend/tests/test_podcast_feed.py
+++ b/backend/tests/test_podcast_feed.py
@@ -1,0 +1,72 @@
+"""Unit tests for the podcast feed token and RSS-generation helpers (#654)."""
+
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard import podcast_feed
+
+
+def test_token_roundtrip_verifies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = podcast_feed.make_feed_token(7, 1)
+    assert podcast_feed.verify_feed_token(token) == 7
+
+
+def test_token_rejected_after_version_bump(monkeypatch: pytest.MonkeyPatch) -> None:
+    token = podcast_feed.make_feed_token(7, 1)
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 2)
+    assert podcast_feed.verify_feed_token(token) is None
+
+
+def test_token_rejects_garbage() -> None:
+    assert podcast_feed.verify_feed_token("not-a-token") is None
+
+
+def test_token_rejects_tampered_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = podcast_feed.make_feed_token(7, 1)
+    tampered = token[:-1] + ("0" if token[-1] != "0" else "1")
+    assert podcast_feed.verify_feed_token(tampered) is None
+
+
+def test_token_rejects_wrong_user_id_substitution(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = podcast_feed.make_feed_token(7, 1)
+    replayed = token.replace("7.", "8.", 1)
+    assert podcast_feed.verify_feed_token(replayed) is None
+
+
+def test_missing_token_secret_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TOKEN_SECRET", raising=False)
+    monkeypatch.delenv("SESSION_SECRET", raising=False)
+    monkeypatch.delenv("TEST_SESSION_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        podcast_feed.make_feed_token(7, 1)
+
+
+def test_build_feed_xml_includes_enclosure_and_self_link() -> None:
+    token = "1.1.deadbeef"  # noqa: S105
+    xml = podcast_feed.build_feed_xml(
+        token=token,
+        briefings=[
+            {
+                "id": 3,
+                "created_at": "2026-06-13T12:00:00+00:00",
+                "title": "Daily Brief",
+                "summary": "A summary.",
+                "audio_bytes": 1234,
+            }
+        ],
+    )
+    assert "<title>Daily Brief</title>" in xml
+    assert 'length="1234"' in xml
+    assert 'type="audio/mpeg"' in xml
+    assert f"podcast.rss?token={token}" in xml
+    assert f"/api/briefings/3/podcast-audio?token={token}" in xml
+
+
+def test_build_feed_xml_handles_no_episodes() -> None:
+    xml = podcast_feed.build_feed_xml(token="1.1.deadbeef", briefings=[])  # noqa: S106
+    assert "<rss" in xml
+    assert "<item>" not in xml

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -414,6 +414,21 @@ export async function generateBriefingPodcast(id: number): Promise<{ url: string
   return requestJson<{ url: string }>(`/api/briefings/${id}/podcast`, { method: 'POST' });
 }
 
+export interface PodcastFeedToken {
+  token: string;
+  url: string;
+}
+
+export async function fetchPodcastFeedToken(): Promise<PodcastFeedToken> {
+  return requestJson<PodcastFeedToken>('/api/briefings/podcast-feed-token');
+}
+
+export async function regeneratePodcastFeedToken(): Promise<PodcastFeedToken> {
+  return requestJson<PodcastFeedToken>('/api/briefings/podcast-feed-token/regenerate', {
+    method: 'POST',
+  });
+}
+
 export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;

--- a/frontend/src/pages/BriefingsHistoryPage.tsx
+++ b/frontend/src/pages/BriefingsHistoryPage.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { Newspaper, AlertCircle, ChevronRight } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Newspaper, AlertCircle, ChevronRight, Check, Copy, RefreshCw, Rss } from 'lucide-react';
+import { toast } from 'sonner';
 import { Skeleton } from '@/components/ui/skeleton';
-import { fetchBriefings } from '@/api';
+import { Button } from '@/components/ui/button';
+import { fetchBriefings, fetchPodcastFeedToken, regeneratePodcastFeedToken } from '@/api';
 import { formatDate, formatWindow } from '@/lib/briefingUtils';
 import type { Briefing } from '@/types';
 
@@ -55,6 +58,67 @@ function BriefingRow({ briefing }: { briefing: Briefing }) {
   );
 }
 
+function PodcastFeedCard() {
+  const queryClient = useQueryClient();
+  const [copied, setCopied] = useState(false);
+  const { data, isLoading } = useQuery({
+    queryKey: ['briefings', 'podcast-feed-token'],
+    queryFn: fetchPodcastFeedToken,
+  });
+
+  const regenerate = useMutation({
+    mutationFn: regeneratePodcastFeedToken,
+    onSuccess: (token) => {
+      queryClient.setQueryData(['briefings', 'podcast-feed-token'], token);
+      toast('Podcast feed URL regenerated — the old link no longer works');
+    },
+    onError: () => toast('Failed to regenerate podcast feed URL'),
+  });
+
+  const copyUrl = () => {
+    if (!data) return;
+    void navigator.clipboard.writeText(data.url).then(() => {
+      setCopied(true);
+      toast('Podcast feed URL copied');
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div className="mx-4 md:mx-5 mb-3 rounded-lg border border-border bg-surface px-4 py-3 flex items-center gap-3">
+      <Rss className="size-4 text-accent shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-foreground">Subscribe as a podcast</div>
+        <div className="text-xs text-muted-foreground mt-0.5">
+          Listen to your daily brief in any podcast app using your personal feed link.
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={copyUrl}
+          disabled={isLoading || !data}
+        >
+          {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+          {copied ? 'Copied' : 'Copy feed URL'}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label="Regenerate podcast feed URL (revokes the old one)"
+          onClick={() => regenerate.mutate()}
+          disabled={regenerate.isPending}
+        >
+          <RefreshCw className={`size-3.5 ${regenerate.isPending ? 'animate-spin' : ''}`} />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function HistorySkeleton() {
   return (
     <div className="divide-y divide-border">
@@ -85,6 +149,8 @@ export function BriefingsHistoryPage() {
         <h2 className="text-[22px] font-semibold tracking-tight">Briefing History</h2>
         <p className="text-xs text-muted-foreground mt-0.5">All generated daily briefs</p>
       </div>
+
+      <PodcastFeedCard />
 
       {isLoading ? (
         <HistorySkeleton />


### PR DESCRIPTION
## Summary

Closes #654.

Exposes the daily brief as a standard, per-user podcast RSS feed so it can be subscribed to from any podcast client, without needing an interactive browser session.

- `GET /api/briefings/podcast.rss?token=...` — RSS 2.0 (+ iTunes tags) feed listing the user's briefings that already have a generated podcast script, with `<enclosure>` audio.
- `GET /api/briefings/{id}/podcast-audio?token=...` — serves the episode MP3, authenticated via the same feed token (podcast clients can't use the session cookie).
- `GET /api/briefings/podcast-feed-token` / `POST /api/briefings/podcast-feed-token/regenerate` — fetch or revoke-and-reissue the user's feed token.
- Token is HMAC-signed (same pattern as the existing digest mark-read token) and bound to a per-user `podcast_feed_token_version` column; regenerating bumps the version, instantly invalidating the old link — no dedicated token table needed.
- The feed only includes briefings that already have a podcast script (`list_briefings_with_script`), so polling the feed never triggers new AI script generation — at most a cached TTS audio synthesis from an already-generated script. Episodes that fail to synthesize (e.g. `OPENAI_API_KEY` not configured) are skipped rather than breaking the whole feed.
- Frontend: a "Subscribe as a podcast" card on the Briefing History page with copy-feed-URL and regenerate/revoke actions.

## Test plan

- [x] `backend/tests/test_podcast_feed.py` — token round-trip, revocation-after-bump, tampering/garbage rejection, missing-secret fail-closed, RSS XML structure (all pass locally, no DB dependency).
- [x] `backend/tests/test_briefings_api.py` — new endpoint tests for token issuance/regeneration, RSS feed (valid/invalid/revoked token, episode skip on TTS failure), and token-authenticated audio serving. These require Postgres (via `TestClient` app lifespan) and could not run in this sandbox (no Docker); they follow the existing file's established mocking patterns and should run in CI's Postgres service container.
- [x] `make lint` (backend ruff) — clean.
- [x] `make typecheck` (mypy/ty/pyrefly) — clean, no new errors.
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck` — clean.
- [x] `npm run test:frontend` — 656/656 passing.
- [x] `npm run build` — succeeds.
- [x] pre-commit hooks (mypy, ty, pyrefly, ruff, eslint, prettier, tsc) — all passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)