### PR TITLE
feat: continuous audio listen queue for the feed (#655)

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, RouterProvider, Navigate, type RouteObject } from 
 import { Loader2 } from 'lucide-react';
 import { FocusedArticleProvider } from './contexts/focusedArticle';
 import { AuthProvider } from './contexts/auth';
+import { ListenQueueProvider } from './contexts/listenQueue';
 import { RequireAuth } from './components/RequireAuth';
 import { AppShell } from './components/AppShell';
 import { LoginPage } from './pages/LoginPage';
@@ -201,7 +202,9 @@ export function AppRouter() {
   return (
     <AuthProvider>
       <FocusedArticleProvider>
-        <RouterProvider router={router} />
+        <ListenQueueProvider>
+          <RouterProvider router={router} />
+        </ListenQueueProvider>
       </FocusedArticleProvider>
     </AuthProvider>
   );

--- a/frontend/src/__tests__/articleListView.test.tsx
+++ b/frontend/src/__tests__/articleListView.test.tsx
@@ -4,15 +4,32 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import { ListenQueueProvider } from '../contexts/listenQueue';
+import { ListenQueuePlayer } from '../components/ListenQueuePlayer';
 import { ArticleListView } from '../components/article/ArticleListView';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 import type { TriageArticlePage } from '../api/workflowApi';
 import { Inbox } from 'lucide-react';
+import * as api from '../api';
 
 vi.mock('../hooks/useTriageMutations', () => ({
   useTriageMutations: () => ({ setState: vi.fn(), toggleStar: vi.fn(), sendLater: vi.fn() }),
   ARTICLES_KEY: 'articles',
 }));
+
+vi.spyOn(api, 'fetchArticleAudioUrl').mockResolvedValue('blob:fake');
+vi.stubGlobal(
+  'Audio',
+  vi.fn().mockImplementation(function AudioMock() {
+    return {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      play: vi.fn().mockResolvedValue(undefined),
+      pause: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
+  })
+);
 
 function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
   return {
@@ -58,24 +75,27 @@ function renderArticleList(
   return render(
     <QueryClientProvider client={queryClient}>
       <FocusedArticleProvider>
-        <MemoryRouter initialEntries={['/today']}>
-          <Routes>
-            <Route
-              path="/today"
-              element={
-                <ArticleListView
-                  title="Today"
-                  description={({ count }) => `${count} unhandled`}
-                  queryKey={['articles', 'today']}
-                  queryFn={queryFn}
-                  empty={{ icon: Inbox, title: 'Queue clear' }}
-                  showCategoryFilter
-                />
-              }
-            />
-            <Route path="/a/:id" element={<div data-testid="reader">Reader</div>} />
-          </Routes>
-        </MemoryRouter>
+        <ListenQueueProvider>
+          <MemoryRouter initialEntries={['/today']}>
+            <Routes>
+              <Route
+                path="/today"
+                element={
+                  <ArticleListView
+                    title="Today"
+                    description={({ count }) => `${count} unhandled`}
+                    queryKey={['articles', 'today']}
+                    queryFn={queryFn}
+                    empty={{ icon: Inbox, title: 'Queue clear' }}
+                    showCategoryFilter
+                  />
+                }
+              />
+              <Route path="/a/:id" element={<div data-testid="reader">Reader</div>} />
+            </Routes>
+            <ListenQueuePlayer />
+          </MemoryRouter>
+        </ListenQueueProvider>
       </FocusedArticleProvider>
     </QueryClientProvider>
   );
@@ -134,6 +154,28 @@ describe('ArticleListView', () => {
     expect(queryFn).toHaveBeenNthCalledWith(1, { limit: 100, offset: 0 });
     expect(queryFn).toHaveBeenNthCalledWith(2, { limit: 100, offset: 1 });
     expect(screen.getByText('2 unhandled')).toBeTruthy();
+  });
+});
+
+describe('ArticleListView — listen queue', () => {
+  it('starting the queue from the feed sets the first article as current', async () => {
+    renderArticleList(() =>
+      Promise.resolve(
+        page([makeArticle({ id: '1', title: 'First' }), makeArticle({ id: '2', title: 'Second' })])
+      )
+    );
+    await waitFor(() => expect(screen.getByText('First')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: /listen/i }));
+
+    expect(screen.getByRole('region', { name: /listen queue player/i })).toBeTruthy();
+  });
+
+  it('does not render a Listen button when the feed is empty', async () => {
+    renderArticleList(() => Promise.resolve(page([])));
+    await waitFor(() => expect(screen.getByText('Queue clear')).toBeTruthy());
+
+    expect(screen.queryByRole('button', { name: /listen/i })).toBeNull();
   });
 });
 

--- a/frontend/src/__tests__/listenQueue.test.tsx
+++ b/frontend/src/__tests__/listenQueue.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ListenQueueProvider, useListenQueue } from '../contexts/listenQueue';
+import * as api from '../api';
+import * as workflowApi from '../api/workflowApi';
+import type { WorkflowArticle } from '../lib/workflowTypes';
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeAudio {
+  src = '';
+  currentTime = 0;
+  duration = 0;
+  paused = true;
+  listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(event: string, cb: Listener) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(cb);
+  }
+
+  removeEventListener(event: string, cb: Listener) {
+    this.listeners.get(event)?.delete(cb);
+  }
+
+  dispatch(event: string) {
+    this.listeners.get(event)?.forEach((cb) => cb());
+  }
+
+  play() {
+    this.paused = false;
+    this.dispatch('play');
+    return Promise.resolve();
+  }
+
+  pause() {
+    this.paused = true;
+    this.dispatch('pause');
+  }
+
+  removeAttribute() {
+    this.src = '';
+  }
+}
+
+let lastAudio: FakeAudio;
+
+function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
+  return {
+    id: '1',
+    title: 'An article',
+    sourceId: 'source',
+    sourceName: 'Source',
+    category: 'ai-llm',
+    url: 'https://example.com/a',
+    publishedAt: '2026-06-16T10:00:00Z',
+    ingestedAt: '2026-06-16T11:00:00Z',
+    reason: 'why',
+    summary: 'summary',
+    signal: 'high',
+    tags: [],
+    bodyStatus: 'missing',
+    state: 'today',
+    starred: false,
+    ...overrides,
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ListenQueueProvider>{children}</ListenQueueProvider>;
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'Audio',
+    vi.fn().mockImplementation(function AudioMock() {
+      lastAudio = new FakeAudio();
+      return lastAudio;
+    })
+  );
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:fake'),
+    revokeObjectURL: vi.fn(),
+  });
+  vi.spyOn(api, 'fetchArticleAudioUrl').mockImplementation((id) =>
+    Promise.resolve(`blob:fake-${id}`)
+  );
+  vi.spyOn(workflowApi, 'patchArticleState').mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ListenQueueProvider', () => {
+  it('builds a queue from a feed and starts playback on the first item', async () => {
+    const { result } = renderHook(() => useListenQueue(), { wrapper });
+    const articles = [
+      makeArticle({ id: '1', title: 'First' }),
+      makeArticle({ id: '2', title: 'Second' }),
+    ];
+
+    act(() => {
+      result.current.start(articles);
+    });
+
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+    expect(result.current.queue).toHaveLength(2);
+    await waitFor(() => expect(result.current.isPlaying).toBe(true));
+    expect(lastAudio.src).toBe('blob:fake-1');
+  });
+
+  it('auto-advances to the next article when the current one ends', async () => {
+    const { result } = renderHook(() => useListenQueue(), { wrapper });
+    const articles = [makeArticle({ id: '1' }), makeArticle({ id: '2' })];
+
+    act(() => {
+      result.current.start(articles);
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+
+    act(() => {
+      lastAudio.dispatch('ended');
+    });
+
+    await waitFor(() => expect(result.current.current?.id).toBe('2'));
+    expect(result.current.currentIndex).toBe(1);
+  });
+
+  it('stops the queue when the last article ends', async () => {
+    const { result } = renderHook(() => useListenQueue(), { wrapper });
+    const articles = [makeArticle({ id: '1' })];
+
+    act(() => {
+      result.current.start(articles);
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+
+    act(() => {
+      lastAudio.dispatch('ended');
+    });
+
+    await waitFor(() => expect(result.current.current).toBeNull());
+  });
+
+  it('marks the article done on finish when markDoneOnFinish is enabled', async () => {
+    const { result } = renderHook(() => useListenQueue(), { wrapper });
+    const articles = [makeArticle({ id: '1' }), makeArticle({ id: '2' })];
+
+    act(() => {
+      result.current.start(articles);
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+
+    act(() => {
+      lastAudio.dispatch('ended');
+    });
+
+    await waitFor(() =>
+      expect(workflowApi.patchArticleState).toHaveBeenCalledWith('1', 'done', false)
+    );
+  });
+
+  it('skip forward and back move the active item', async () => {
+    const { result } = renderHook(() => useListenQueue(), { wrapper });
+    const articles = [makeArticle({ id: '1' }), makeArticle({ id: '2' }), makeArticle({ id: '3' })];
+
+    act(() => {
+      result.current.start(articles);
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+
+    act(() => {
+      result.current.next();
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('2'));
+
+    act(() => {
+      result.current.prev();
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+  });
+
+  it('seek updates currentTime on the underlying audio element', async () => {
+    const { result } = renderHook(() => useListenQueue(), { wrapper });
+    const articles = [makeArticle({ id: '1' })];
+
+    act(() => {
+      result.current.start(articles);
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+
+    act(() => {
+      result.current.seek(42);
+    });
+
+    expect(lastAudio.currentTime).toBe(42);
+    expect(result.current.currentTime).toBe(42);
+  });
+
+  it('stop clears the queue and playback state', async () => {
+    const { result } = renderHook(() => useListenQueue(), { wrapper });
+    const articles = [makeArticle({ id: '1' })];
+
+    act(() => {
+      result.current.start(articles);
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('1'));
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(result.current.queue).toHaveLength(0);
+    expect(result.current.current).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/listenQueuePlayer.test.tsx
+++ b/frontend/src/__tests__/listenQueuePlayer.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ListenQueueProvider, useListenQueue } from '../contexts/listenQueue';
+import { ListenQueuePlayer } from '../components/ListenQueuePlayer';
+import * as api from '../api';
+import type { WorkflowArticle } from '../lib/workflowTypes';
+
+function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
+  return {
+    id: '1',
+    title: 'An article',
+    sourceId: 'source',
+    sourceName: 'Source',
+    category: 'ai-llm',
+    url: 'https://example.com/a',
+    publishedAt: '2026-06-16T10:00:00Z',
+    ingestedAt: '2026-06-16T11:00:00Z',
+    reason: 'why',
+    summary: 'summary',
+    signal: 'high',
+    tags: [],
+    bodyStatus: 'missing',
+    state: 'today',
+    starred: false,
+    ...overrides,
+  };
+}
+
+function Starter({ articles }: { articles: WorkflowArticle[] }) {
+  const { start } = useListenQueue();
+  return (
+    <button type="button" onClick={() => start(articles)}>
+      start
+    </button>
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(api, 'fetchArticleAudioUrl').mockResolvedValue('blob:fake');
+  vi.stubGlobal(
+    'Audio',
+    vi.fn().mockImplementation(function AudioMock() {
+      return {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        play: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn(),
+        removeAttribute: vi.fn(),
+      };
+    })
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function renderPlayer(articles: WorkflowArticle[]) {
+  return render(
+    <MemoryRouter>
+      <ListenQueueProvider>
+        <Starter articles={articles} />
+        <ListenQueuePlayer />
+      </ListenQueueProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('ListenQueuePlayer', () => {
+  it('renders nothing when no queue is active', () => {
+    renderPlayer([makeArticle()]);
+    expect(screen.queryByRole('region', { name: /listen queue player/i })).toBeNull();
+  });
+
+  it('shows the current article and position once a queue starts', async () => {
+    renderPlayer([
+      makeArticle({ id: '1', title: 'First' }),
+      makeArticle({ id: '2', title: 'Second' }),
+    ]);
+
+    fireEvent.click(screen.getByText('start'));
+
+    await waitFor(() => expect(screen.getByText('First')).toBeTruthy());
+    expect(screen.getByText('1/2')).toBeTruthy();
+  });
+
+  it('closing the player clears the queue', async () => {
+    renderPlayer([makeArticle({ id: '1', title: 'First' })]);
+    fireEvent.click(screen.getByText('start'));
+    await waitFor(() => expect(screen.getByText('First')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: /close player/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('region', { name: /listen queue player/i })).toBeNull()
+    );
+  });
+
+  it('previous is disabled on the first item and next is disabled on the last', async () => {
+    renderPlayer([makeArticle({ id: '1' })]);
+    fireEvent.click(screen.getByText('start'));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Previous' })).toBeTruthy());
+
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -12,6 +12,7 @@ import { AppShell } from '../components/AppShell';
 import { CommandPalette } from '../components/CommandPalette';
 import { ShortcutOverlay } from '../components/ShortcutOverlay';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import { ListenQueueProvider } from '../contexts/listenQueue';
 import { AuthProvider } from '../contexts/auth';
 import * as api from '../api';
 
@@ -60,7 +61,9 @@ function renderShell(initialPath = '/') {
       <AuthProvider>
         <MemoryRouter initialEntries={[initialPath]}>
           <FocusedArticleProvider>
-            <AppShell />
+            <ListenQueueProvider>
+              <AppShell />
+            </ListenQueueProvider>
           </FocusedArticleProvider>
         </MemoryRouter>
       </AuthProvider>
@@ -274,7 +277,9 @@ describe('#105 — g-key shortcuts via AppShell', () => {
         <AuthProvider>
           <MemoryRouter initialEntries={['/today']}>
             <FocusedArticleProvider>
-              <AppShell />
+              <ListenQueueProvider>
+                <AppShell />
+              </ListenQueueProvider>
             </FocusedArticleProvider>
           </MemoryRouter>
         </AuthProvider>
@@ -291,7 +296,9 @@ describe('#105 — g-key shortcuts via AppShell', () => {
         <AuthProvider>
           <MemoryRouter initialEntries={['/']}>
             <FocusedArticleProvider>
-              <AppShell />
+              <ListenQueueProvider>
+                <AppShell />
+              </ListenQueueProvider>
             </FocusedArticleProvider>
           </MemoryRouter>
         </AuthProvider>

--- a/frontend/src/__tests__/triagePages.test.tsx
+++ b/frontend/src/__tests__/triagePages.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
+import { ListenQueueProvider } from '../contexts/listenQueue';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 import { InboxPage } from '../pages/InboxPage';
 import { LaterPage } from '../pages/LaterPage';
@@ -54,7 +55,9 @@ function renderPage(ui: React.ReactElement, route = '/') {
   return render(
     <QueryClientProvider client={queryClient}>
       <FocusedArticleProvider>
-        <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+        <ListenQueueProvider>
+          <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+        </ListenQueueProvider>
       </FocusedArticleProvider>
     </QueryClientProvider>
   );

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { CommandPalette } from './CommandPalette';
 import { ShortcutOverlay } from './ShortcutOverlay';
 import { WhatsNewDialog } from './WhatsNewDialog';
 import { OnboardingWizard } from './OnboardingWizard';
+import { ListenQueuePlayer } from './ListenQueuePlayer';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
 import { useOnboardingWizard } from '@/hooks/useOnboardingWizard';
 import { useElectronBriefNotifier } from '@/hooks/useElectronBriefNotifier';
@@ -343,6 +344,7 @@ export function AppShell() {
       <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
       <WhatsNewDialog state={whatsNew} />
       <OnboardingWizard open={onboarding.open} onClose={onboarding.skip} />
+      <ListenQueuePlayer />
     </div>
   );
 }

--- a/frontend/src/components/ListenQueuePlayer.tsx
+++ b/frontend/src/components/ListenQueuePlayer.tsx
@@ -1,0 +1,107 @@
+import { Link } from 'react-router-dom';
+import { Loader2, Pause, Play, SkipBack, SkipForward, X } from 'lucide-react';
+import { useListenQueue } from '@/contexts/listenQueue';
+import { cn } from '@/lib/utils';
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export function ListenQueuePlayer() {
+  const {
+    current,
+    currentIndex,
+    queue,
+    isPlaying,
+    isLoading,
+    currentTime,
+    duration,
+    playPause,
+    next,
+    prev,
+    seek,
+    stop,
+  } = useListenQueue();
+
+  if (!current) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Listen queue player"
+      className="fixed inset-x-0 bottom-[68px] z-40 border-t border-border bg-background/95 backdrop-blur md:bottom-0"
+    >
+      <input
+        type="range"
+        aria-label="Seek"
+        min={0}
+        max={duration || 0}
+        step={1}
+        value={Math.min(currentTime, duration || 0)}
+        onChange={(e) => seek(Number(e.target.value))}
+        className="h-1 w-full cursor-pointer appearance-none bg-transparent accent-primary"
+      />
+      <div className="flex items-center gap-3 px-3 py-2 md:px-5">
+        <Link
+          to={`/a/${current.id}`}
+          className="min-w-0 flex-1 truncate text-sm font-medium hover:underline"
+        >
+          {current.title}
+        </Link>
+        <span className="hidden shrink-0 text-xs text-muted-foreground tabular-nums sm:inline">
+          {formatTime(currentTime)} / {formatTime(duration)}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+          {currentIndex + 1}/{queue.length}
+        </span>
+        <button
+          type="button"
+          aria-label="Previous"
+          onClick={prev}
+          disabled={currentIndex <= 0}
+          className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
+        >
+          <SkipBack className="size-4" />
+        </button>
+        <button
+          type="button"
+          aria-label={isPlaying ? 'Pause' : 'Play'}
+          onClick={playPause}
+          disabled={isLoading}
+          className={cn(
+            'shrink-0 rounded-full bg-primary p-2 text-primary-foreground hover:bg-primary/90',
+            isLoading && 'opacity-60'
+          )}
+        >
+          {isLoading ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : isPlaying ? (
+            <Pause className="size-4" />
+          ) : (
+            <Play className="size-4" />
+          )}
+        </button>
+        <button
+          type="button"
+          aria-label="Next"
+          onClick={next}
+          disabled={currentIndex >= queue.length - 1}
+          className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
+        >
+          <SkipForward className="size-4" />
+        </button>
+        <button
+          type="button"
+          aria-label="Close player"
+          onClick={stop}
+          className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-muted"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/article/ArticleListView.tsx
+++ b/frontend/src/components/article/ArticleListView.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery, type QueryKey } from '@tanstack/react-query';
-import type { LucideIcon } from 'lucide-react';
+import { Headphones, type LucideIcon } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
 import { CategoryFilter } from '@/components/CategoryFilter';
 import { EmptyState } from '@/components/EmptyState';
 import { useFocusedArticle } from '@/contexts/focusedArticle';
+import { useListenQueue } from '@/contexts/listenQueue';
 import { useArticleListNav } from '@/hooks/useArticleListNav';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { setReaderList } from '@/lib/readerList';
@@ -66,6 +67,7 @@ export function ArticleListView({
     setReaderList(list.map((article) => article.id));
   }, [list]);
 
+  const { start: startListenQueue } = useListenQueue();
   const mutations = useTriageMutations();
   const { focused } = useArticleListNav(
     list,
@@ -81,16 +83,28 @@ export function ArticleListView({
 
   return (
     <div>
-      <div className="px-4 md:px-5 pt-4 pb-3">
-        <h2 className="text-[22px] font-semibold tracking-tight">{title}</h2>
-        <p className="text-xs text-muted-foreground mt-0.5">
-          {description({
-            count: list.length,
-            loadedCount: list.length,
-            hasMore,
-            isLoading,
-          })}
-        </p>
+      <div className="flex items-start justify-between gap-3 px-4 md:px-5 pt-4 pb-3">
+        <div>
+          <h2 className="text-[22px] font-semibold tracking-tight">{title}</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {description({
+              count: list.length,
+              loadedCount: list.length,
+              hasMore,
+              isLoading,
+            })}
+          </p>
+        </div>
+        {list.length > 0 && (
+          <button
+            type="button"
+            onClick={() => startListenQueue(list)}
+            className="flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
+          >
+            <Headphones className="size-3.5" />
+            Listen
+          </button>
+        )}
       </div>
       {showCategoryFilter && <CategoryFilter />}
       {banner}

--- a/frontend/src/contexts/listenQueue.tsx
+++ b/frontend/src/contexts/listenQueue.tsx
@@ -1,0 +1,266 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { fetchArticleAudioUrl } from '@/api';
+import { patchArticleState } from '@/api/workflowApi';
+import type { WorkflowArticle } from '@/lib/workflowTypes';
+import {
+  getMarkDoneOnFinish,
+  setMarkDoneOnFinish as persistMarkDoneOnFinish,
+} from '@/lib/listenQueueSettings';
+import { trackFeature } from '@/lib/analytics';
+
+interface ListenQueueContextValue {
+  queue: WorkflowArticle[];
+  currentIndex: number;
+  current: WorkflowArticle | null;
+  isPlaying: boolean;
+  isLoading: boolean;
+  currentTime: number;
+  duration: number;
+  markDoneOnFinish: boolean;
+  setMarkDoneOnFinish: (value: boolean) => void;
+  start: (articles: WorkflowArticle[], startIndex?: number) => void;
+  stop: () => void;
+  playPause: () => void;
+  next: () => void;
+  prev: () => void;
+  seek: (time: number) => void;
+}
+
+const ListenQueueContext = createContext<ListenQueueContextValue | null>(null);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useListenQueue(): ListenQueueContextValue {
+  const ctx = useContext(ListenQueueContext);
+  if (!ctx) throw new Error('useListenQueue must be used within a ListenQueueProvider');
+  return ctx;
+}
+
+export function ListenQueueProvider({ children }: { children: ReactNode }) {
+  const [queue, setQueue] = useState<WorkflowArticle[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [markDoneOnFinish, setMarkDoneOnFinishState] = useState(getMarkDoneOnFinish);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const urlCacheRef = useRef<Map<string, string>>(new Map());
+  const queueRef = useRef(queue);
+  const indexRef = useRef(currentIndex);
+  const markDoneRef = useRef(markDoneOnFinish);
+
+  useEffect(() => {
+    queueRef.current = queue;
+  }, [queue]);
+  useEffect(() => {
+    indexRef.current = currentIndex;
+  }, [currentIndex]);
+  useEffect(() => {
+    markDoneRef.current = markDoneOnFinish;
+  }, [markDoneOnFinish]);
+
+  const revokeAll = useCallback(() => {
+    urlCacheRef.current.forEach((url) => URL.revokeObjectURL(url));
+    urlCacheRef.current.clear();
+  }, []);
+
+  const loadAudioUrl = useCallback(async (article: WorkflowArticle): Promise<string> => {
+    const cached = urlCacheRef.current.get(article.id);
+    if (cached) return cached;
+    const url = await fetchArticleAudioUrl(article.id);
+    urlCacheRef.current.set(article.id, url);
+    return url;
+  }, []);
+
+  const prefetchNext = useCallback(
+    (index: number) => {
+      const nextArticle = queueRef.current[index + 1];
+      if (!nextArticle) return;
+      if (urlCacheRef.current.has(nextArticle.id)) return;
+      void loadAudioUrl(nextArticle).catch(() => {
+        // Prefetch failures are silent; playback will retry on demand.
+      });
+    },
+    [loadAudioUrl]
+  );
+
+  const playIndex = useCallback(
+    (index: number) => {
+      const article = queueRef.current[index];
+      const audio = audioRef.current;
+      if (!article || !audio) return;
+      indexRef.current = index;
+      setIsLoading(true);
+      setCurrentIndex(index);
+      void loadAudioUrl(article)
+        .then((url) => {
+          audio.src = url;
+          setIsLoading(false);
+          return audio.play();
+        })
+        .then(() => {
+          setIsPlaying(true);
+          prefetchNext(index);
+        })
+        .catch(() => {
+          setIsLoading(false);
+          setIsPlaying(false);
+        });
+    },
+    [loadAudioUrl, prefetchNext]
+  );
+
+  const stop = useCallback(() => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.removeAttribute('src');
+    }
+    revokeAll();
+    setQueue([]);
+    setCurrentIndex(-1);
+    setIsPlaying(false);
+    setIsLoading(false);
+    setCurrentTime(0);
+    setDuration(0);
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.metadata = null;
+      navigator.mediaSession.playbackState = 'none';
+    }
+  }, [revokeAll]);
+
+  const start = useCallback(
+    (articles: WorkflowArticle[], startIndex = 0) => {
+      if (articles.length === 0) return;
+      revokeAll();
+      queueRef.current = articles;
+      setQueue(articles);
+      trackFeature('listen_queue_start');
+      playIndex(startIndex);
+    },
+    [playIndex, revokeAll]
+  );
+
+  const next = useCallback(() => {
+    const nextIndex = indexRef.current + 1;
+    if (nextIndex >= queueRef.current.length) {
+      stop();
+      return;
+    }
+    playIndex(nextIndex);
+  }, [playIndex, stop]);
+
+  const prev = useCallback(() => {
+    const prevIndex = indexRef.current - 1;
+    if (prevIndex < 0) return;
+    playIndex(prevIndex);
+  }, [playIndex]);
+
+  const playPause = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio || indexRef.current < 0) return;
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+    } else {
+      void audio.play().then(() => setIsPlaying(true));
+    }
+  }, [isPlaying]);
+
+  const seek = useCallback((time: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = time;
+    setCurrentTime(time);
+  }, []);
+
+  const setMarkDoneOnFinish = useCallback((value: boolean) => {
+    setMarkDoneOnFinishState(value);
+    persistMarkDoneOnFinish(value);
+  }, []);
+
+  useEffect(() => {
+    const audio = new Audio();
+    audioRef.current = audio;
+    const cache = urlCacheRef.current;
+
+    const handleEnded = () => {
+      const article = queueRef.current[indexRef.current];
+      if (article && markDoneRef.current) {
+        void patchArticleState(article.id, 'done', article.starred).catch(() => {
+          // Best-effort — playback should still advance even if marking done fails.
+        });
+      }
+      next();
+    };
+    const handleTimeUpdate = () => setCurrentTime(audio.currentTime);
+    const handleLoadedMetadata = () => setDuration(audio.duration || 0);
+    const handlePlay = () => setIsPlaying(true);
+    const handlePause = () => setIsPlaying(false);
+
+    audio.addEventListener('ended', handleEnded);
+    audio.addEventListener('timeupdate', handleTimeUpdate);
+    audio.addEventListener('loadedmetadata', handleLoadedMetadata);
+    audio.addEventListener('play', handlePlay);
+    audio.addEventListener('pause', handlePause);
+
+    return () => {
+      audio.removeEventListener('ended', handleEnded);
+      audio.removeEventListener('timeupdate', handleTimeUpdate);
+      audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      audio.removeEventListener('play', handlePlay);
+      audio.removeEventListener('pause', handlePause);
+      audio.pause();
+      cache.forEach((url) => URL.revokeObjectURL(url));
+      cache.clear();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!('mediaSession' in navigator)) return;
+    const article = queue[currentIndex];
+    if (!article) return;
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: article.title,
+      artist: article.sourceName,
+    });
+    navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused';
+    navigator.mediaSession.setActionHandler('play', playPause);
+    navigator.mediaSession.setActionHandler('pause', playPause);
+    navigator.mediaSession.setActionHandler('previoustrack', prev);
+    navigator.mediaSession.setActionHandler('nexttrack', next);
+    navigator.mediaSession.setActionHandler('seekto', (details) => {
+      if (typeof details.seekTime === 'number') seek(details.seekTime);
+    });
+  }, [queue, currentIndex, isPlaying, playPause, prev, next, seek]);
+
+  const value: ListenQueueContextValue = {
+    queue,
+    currentIndex,
+    current: currentIndex >= 0 ? (queue[currentIndex] ?? null) : null,
+    isPlaying,
+    isLoading,
+    currentTime,
+    duration,
+    markDoneOnFinish,
+    setMarkDoneOnFinish,
+    start,
+    stop,
+    playPause,
+    next,
+    prev,
+    seek,
+  };
+
+  return <ListenQueueContext.Provider value={value}>{children}</ListenQueueContext.Provider>;
+}

--- a/frontend/src/lib/listenQueueSettings.ts
+++ b/frontend/src/lib/listenQueueSettings.ts
@@ -1,0 +1,10 @@
+const MARK_DONE_KEY = 'listenQueue.markDoneOnFinish';
+
+export function getMarkDoneOnFinish(): boolean {
+  const stored = localStorage.getItem(MARK_DONE_KEY);
+  return stored === null ? true : stored === 'true';
+}
+
+export function setMarkDoneOnFinish(value: boolean): void {
+  localStorage.setItem(MARK_DONE_KEY, String(value));
+}


### PR DESCRIPTION
Closes #655

## Summary
- Adds a "Listen" button to feed lists (Today/Later/Starred/Archive/Collections) that builds a playlist from the currently loaded articles and plays them back-to-back via a new `ListenQueueProvider`.
- Adds a persistent mini-player (`ListenQueuePlayer`) mounted in `AppShell` — play/pause, skip forward/back, seek, and a close button — that survives navigation between pages.
- Reuses the existing per-article TTS endpoint (`POST /api/articles/{id}/audio`) and prefetches the next article's audio while the current one plays for smoother transitions.
- Wires into the Media Session API so lock-screen / hardware media-key controls (play/pause/next/prev/seek) work on mobile.
- Optionally marks each article `done` as it finishes playing, toggleable via `frontend/src/lib/listenQueueSettings.ts` (persisted to `localStorage`, defaults on).

## Implementation notes
- `frontend/src/contexts/listenQueue.tsx` owns queue/playback state and a single `<audio>` element; blob URLs are cached per-article and revoked on stop/unmount.
- `frontend/src/components/ListenQueuePlayer.tsx` is the UI; it renders nothing when no queue is active.
- `ArticleListView` gained the "Listen" entry point, so it's available from every feed view built on that component.

## Test plan
- Added `frontend/src/__tests__/listenQueue.test.tsx`: queue building, auto-advance on `ended`, stop on last item, mark-done-on-finish, skip forward/back, seek, and stop/cleanup — audio element mocked.
- Added `frontend/src/__tests__/listenQueuePlayer.test.tsx`: mini-player renders/hides correctly, shows position, close clears the queue, prev/next disabled at queue bounds.
- Updated `articleListView.test.tsx`, `triagePages.test.tsx`, and `routing.test.tsx` to wrap with the new provider (real `AppShell`/`ArticleListView` now depend on it).
- Full frontend suite: `npm run test:frontend` — 669/669 passing (run 3x to rule out flakiness).
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run build` all clean (pre-existing failures in `errorTracking.ts` and 3 unrelated files are untouched by this change).
- Did not exercise this manually in a running browser session — this is an unattended/AFK run and the app requires a Docker/Postgres-backed auth flow to log in; verification here relies on the unit test suite above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)