### PR TITLE
docs: add contribution map, expand PR template, add response time SLA to governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,5 @@ Closes #
 - [ ] `make check` passed locally
 - [ ] Tests added or updated
 - [ ] Docs updated (README, docs/, or inline comments) if behavior changed
+- [ ] Breaking changes called out in the PR description and CHANGELOG
+- [ ] Screenshots or recording included for UI changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,23 @@ By participating in this project, you agree to abide by our
 - **[MAINTAINERS.md](MAINTAINERS.md)** — who maintains this project and how to become one.
 - **[ROADMAP.md](ROADMAP.md)** — near-term direction and how to propose roadmap items.
 
+## Where to start
+
+Not sure which part of the codebase to touch? Here is a quick map:
+
+| I want to… | Where to look |
+|---|---|
+| Add a new feed source or scraper | `backend/news_dashboard/ingest/` |
+| Work on the UI / React components | `frontend/src/` |
+| Add or improve translations (i18n) | `frontend/src/locales/` |
+| Write or fix backend tests | `backend/tests/` |
+| Improve Helm or Docker packaging | `helm/`, `Dockerfile`, `docker-compose.yml` |
+| Fix or expand the documentation | `website/docs/` |
+| Improve CI or GitHub Actions | `.github/workflows/` |
+| Work on the Android or desktop app | `android/`, `desktop/` |
+
+For deeper orientation, see the [Architecture Decision Records](docs/adr/) and the [Project Layout](README.md#project-layout) in the README.
+
 ## Prerequisites
 
 - Python 3.14+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,9 +30,8 @@ The right venue depends on the size of the change:
   API/schema changes, changes that affect the PostgreSQL-only runtime rule in
   [CONTRIBUTING.md](CONTRIBUTING.md)) — open a Discussion or draft PR first so
   the approach can be agreed on before significant implementation work
-  happens. There's no formal ADR (Architecture Decision Record) template yet;
-  until one exists, capture the rationale in the Discussion/PR description
-  and link it from the eventual PR.
+  happens. Significant decisions are captured as [Architecture Decision Records](docs/adr/)
+  in `docs/adr/`; use the template at `docs/adr/0000-template.md`.
 
 Lazy consensus applies: a proposal is considered accepted if no maintainer
 objects within a reasonable review window. Silence is not blocking; an
@@ -51,6 +50,13 @@ explicit maintainer objection is.
   container images are published via the CI/CD pipeline on merge to `main`.
 - Breaking changes (config, schema, API) must be called out explicitly in the
   PR description and the changelog entry.
+
+## Response time
+
+Maintainers aim to triage new issues within **1 week** and respond to open
+pull requests within **2 weeks**. Actual timelines may vary, but this is the
+target. If your issue or PR goes unacknowledged beyond that window, a polite
+ping on the thread is welcome.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Closes #854

- CONTRIBUTING.md: adds a "Where to start" table mapping contributor interests to code paths
- .github/PULL_REQUEST_TEMPLATE.md: adds "Breaking changes" and "Screenshots" checkboxes
- GOVERNANCE.md: adds a Response time section (1-week issue triage / 2-week PR review targets), and updates the stale ADR reference to reflect `docs/adr/` now exists with a template

🤖 Generated with [Claude Code](https://claude.com/claude-code)