### PR TITLE
chore: add project metadata URLs and improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,6 +42,22 @@ body:
         - Other
     validations:
       required: true
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      description: Find this at `/api/version` or in the Settings page.
+      placeholder: "e.g. v1.21.0"
+    validations:
+      required: true
+  - type: input
+    id: browser_os
+    attributes:
+      label: Browser and OS (for UI bugs)
+      description: Leave blank for backend-only issues.
+      placeholder: "e.g. Chrome 125 on macOS 14"
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,13 @@
 {
   "name": "news-dashboard",
+  "version": "0.0.0",
+  "description": "Self-hosted technical news inbox with AI briefings, source health, and article triage",
+  "keywords": ["news", "rss", "self-hosted", "ai", "briefings", "fastapi", "react", "postgresql"],
+  "homepage": "https://docs.lihor.ro",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lihor-hub/news-dashboard.git"
+  },
   "private": true,
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,13 @@ dev = [
 news-dashboard = "news_dashboard.cli:app"
 news-dashboard-migrate = "news_dashboard.migrate:app"
 
+[project.urls]
+Homepage = "https://docs.lihor.ro"
+Repository = "https://github.com/lihor-hub/news-dashboard"
+Documentation = "https://docs.lihor.ro"
+Changelog = "https://github.com/lihor-hub/news-dashboard/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/lihor-hub/news-dashboard/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
Closes #856
Closes #857

- pyproject.toml: adds `[project.urls]` table (Homepage, Repository, Documentation, Changelog, Bug Tracker)
- package.json: adds description, keywords, homepage, repository fields
- bug_report.yml: adds required "App version" field and optional "Browser and OS" field

Note: also fixes pre-existing prettier formatting in 3 unrelated frontend files that the pre-commit hook flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)