### PR TITLE
fix: make release changelog AI-generated and customer-facing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,6 @@ jobs:
         id: ai
         continue-on-error: true
         env:
-          PI_EXTENSION: "$HOME/pi/packages/coding-agent/examples/extensions/lihor-provider"
           SYSTEM_PROMPT: |
             You write the "What's new" notes that everyday users of a news
             dashboard app see in an in-app popup after the app updates. Your
@@ -469,6 +468,9 @@ jobs:
             Commits for release ${{ steps.version.outputs.tag }}:
             ${{ steps.log.outputs.commits }}
         run: |
+          # Define the extension path here so $HOME expands — a "$HOME/…" value
+          # set in a YAML env: block is passed to pi as a literal, unexpanded.
+          PI_EXTENSION="$HOME/pi/packages/coding-agent/examples/extensions/lihor-provider"
           changelog=$(pi -e "$PI_EXTENSION" -p "$SYSTEM_PROMPT
 
           $PROMPT")
@@ -485,9 +487,12 @@ jobs:
           COMMITS: ${{ steps.log.outputs.commits }}
         run: |
           echo "$V" > VERSION
-          # Fall back to raw commit subjects if inference returned nothing.
+          # If inference returned nothing, fall back to a user-facing summary of
+          # the commits — never the raw "chore:/ci:" subjects a customer can't read.
           BODY="$NOTES"
-          [ -z "$(printf '%s' "$BODY" | tr -d '[:space:]')" ] && BODY="$COMMITS"
+          if [ -z "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
+            BODY=$(printf '%s\n' "$COMMITS" | python3 scripts/humanize_commits.py)
+          fi
           printf '%s\n' "$BODY" | python3 scripts/update_changelog.py --version "$V"
 
       - uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
         id: ai
         continue-on-error: true
         env:
-          PI_EXTENSION: "$HOME/pi/packages/coding-agent/examples/extensions/lihor-provider"
           SYSTEM_PROMPT: |
             You write the "What's new" notes that everyday users of a news
             dashboard app see in an in-app popup after the app updates. Your
@@ -111,10 +110,19 @@ jobs:
           PROMPT: |
             Commits for release ${{ steps.version.outputs.tag }}:
             ${{ steps.log.outputs.commits }}
+          COMMITS: ${{ steps.log.outputs.commits }}
         run: |
+          # Define the extension path here so $HOME expands — a "$HOME/…" value
+          # set in a YAML env: block is passed to pi as a literal, unexpanded.
+          PI_EXTENSION="$HOME/pi/packages/coding-agent/examples/extensions/lihor-provider"
           changelog=$(pi -e "$PI_EXTENSION" -p "$SYSTEM_PROMPT
 
-          $PROMPT")
+          $PROMPT" || true)
+          # If inference returned nothing, fall back to a user-facing summary of
+          # the commits — never the raw "chore:/ci:" subjects a customer can't read.
+          if [ -z "$(printf '%s' "$changelog" | tr -d '[:space:]')" ]; then
+            changelog=$(printf '%s\n' "$COMMITS" | python3 scripts/humanize_commits.py)
+          fi
           {
             echo "response<<EOF"
             echo "$changelog"

--- a/frontend/src/__tests__/whatsNew.test.tsx
+++ b/frontend/src/__tests__/whatsNew.test.tsx
@@ -108,11 +108,20 @@ describe('WhatsNewDialog', () => {
     };
   }
 
-  it('renders version and items when open', () => {
+  it('renders a friendly heading, version, and items when open', () => {
     render(<WhatsNewDialog state={makeState()} />);
-    expect(screen.getByText("What's new in v1.15.3")).toBeTruthy();
+    expect(screen.getByText(/What's new/)).toBeTruthy();
+    expect(screen.getByText('Version 1.15.3')).toBeTruthy();
     expect(screen.getByText('Show relevance score')).toBeTruthy();
     expect(screen.getByText('Invalidate cache')).toBeTruthy();
+  });
+
+  it('shows a graceful message when a release has no user-facing items', () => {
+    render(<WhatsNewDialog state={makeState({ items: [] })} />);
+    expect(screen.getByText(/What's new/)).toBeTruthy();
+    expect(screen.getByText(/behind-the-scenes improvements/i)).toBeTruthy();
+    // No empty bullet list is rendered.
+    expect(screen.queryByRole('list')).toBeNull();
   });
 
   it('calls dismiss when Got it is clicked', () => {
@@ -124,6 +133,6 @@ describe('WhatsNewDialog', () => {
 
   it('renders nothing when open is false', () => {
     render(<WhatsNewDialog state={makeState({ open: false })} />);
-    expect(screen.queryByText("What's new in v1.15.3")).toBeNull();
+    expect(screen.queryByText(/What's new/)).toBeNull();
   });
 });

--- a/frontend/src/components/WhatsNewDialog.tsx
+++ b/frontend/src/components/WhatsNewDialog.tsx
@@ -3,6 +3,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -14,6 +15,7 @@ interface WhatsNewDialogProps {
 
 export function WhatsNewDialog({ state }: WhatsNewDialogProps) {
   const { open, version, items, dismiss } = state;
+  const hasItems = items.length > 0;
   return (
     <Dialog
       open={open}
@@ -23,17 +25,30 @@ export function WhatsNewDialog({ state }: WhatsNewDialogProps) {
     >
       <DialogContent className="max-w-sm">
         <DialogHeader>
-          <DialogTitle>What's new in v{version}</DialogTitle>
+          <DialogTitle>✨ What's new</DialogTitle>
+          <DialogDescription>
+            {hasItems
+              ? "We've been busy — here's what's new for you in this update."
+              : 'Thanks for keeping the app up to date.'}
+          </DialogDescription>
         </DialogHeader>
-        <ul className="mt-1 space-y-1.5 text-sm text-foreground">
-          {items.map((item) => (
-            <li key={item} className="flex gap-2">
-              <span className="mt-0.5 text-muted-foreground select-none">•</span>
-              <span>{item}</span>
-            </li>
-          ))}
-        </ul>
-        <DialogFooter>
+        {hasItems ? (
+          <ul className="mt-1 space-y-1.5 text-sm text-foreground">
+            {items.map((item) => (
+              <li key={item} className="flex gap-2">
+                <span className="mt-0.5 text-muted-foreground select-none">•</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-1 text-sm text-muted-foreground">
+            This update brings behind-the-scenes improvements to keep everything running smoothly
+            and reliably.
+          </p>
+        )}
+        <DialogFooter className="items-center sm:justify-between">
+          <span className="text-xs text-muted-foreground">Version {version}</span>
           <Button size="sm" onClick={dismiss}>
             Got it
           </Button>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,13 @@ ban-relative-imports = "all"
   "S603",    # subprocess calls git with trusted CI-controlled arguments
   "T201",    # print is the intended CLI output for shell consumption
 ]
+"scripts/humanize_commits.py" = [
+  "T201",    # print is the intended CLI output for shell consumption
+]
+"scripts/test_humanize_commits.py" = [
+  "S101",    # asserts are the point of tests
+  "PT009",   # plain assert is preferred over self.assertEqual here
+]
 "scripts/test_bump_version.py" = [
   "S101",    # asserts are the point of tests
   "PT009",   # plain assert is preferred over self.assertEqual here

--- a/scripts/humanize_commits.py
+++ b/scripts/humanize_commits.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Turn raw git commit subjects into user-facing "What's new" bullets.
+
+This is the *fallback* for the release changelog: the CI/release pipeline first
+asks an LLM to write friendly notes from the commits, but if that call fails or
+returns nothing we must still produce something a non-developer can read — never
+raw Conventional Commit subjects like "chore: bump deps" or "ci: fix pipeline".
+
+The transform is deliberately conservative:
+  - Commits whose type has no visible effect for users (chore, ci, test, docs,
+    refactor, build, style, perf-infra, etc.) are dropped.
+  - Remaining commits keep only their human part: the "type(scope): " prefix and
+    trailing PR/issue references like " (#123)" are stripped, and the first
+    letter is capitalized.
+  - If nothing user-facing survives, we emit a single reassuring bullet rather
+    than an empty changelog.
+
+Stdlib only: this runs on the CI runner's system python3 with no dependencies,
+matching update_changelog.py.
+
+CLI usage:
+    git log --pretty='- %s' RANGE | python3 scripts/humanize_commits.py
+"""
+
+from __future__ import annotations
+
+import re
+
+_STABILITY_BULLET = "- Stability and performance improvements."
+
+# Conventional Commit types that carry no user-visible change.
+_INTERNAL_TYPES = frozenset(
+    {"chore", "ci", "test", "tests", "docs", "doc", "refactor", "build", "style"}
+)
+
+# "type" or "type(scope)" followed by "!" (breaking) and a colon, at line start.
+_PREFIX_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?!?:\s*")
+# Trailing " (#123)" / " (#123) (#456)" PR or issue references.
+_PR_REF_RE = re.compile(r"(?:\s*\(#\d+\))+\s*$")
+
+
+def _clean_subject(subject: str) -> str | None:
+    """Return a user-facing bullet body for ``subject``, or ``None`` to drop it.
+
+    ``subject`` is a single commit subject, optionally with a leading "- ".
+    """
+    text = subject.strip()
+    if text.startswith("- "):
+        text = text[2:].strip()
+    if not text:
+        return None
+
+    match = _PREFIX_RE.match(text)
+    if match:
+        if match.group("type") in _INTERNAL_TYPES:
+            return None
+        text = text[match.end() :]
+
+    text = _PR_REF_RE.sub("", text).strip()
+    if not text:
+        return None
+
+    return text[0].upper() + text[1:]
+
+
+def humanize_commits(commits: str) -> str:
+    """Return markdown bullet lines summarizing ``commits`` for end users.
+
+    ``commits`` is newline-separated commit subjects (each optionally prefixed
+    with "- "). Internal commits are dropped and prefixes/PR refs stripped; if
+    nothing user-facing remains, a single stability bullet is returned.
+    """
+    bullets = [
+        f"- {body}" for line in commits.splitlines() if (body := _clean_subject(line)) is not None
+    ]
+    if not bullets:
+        return _STABILITY_BULLET
+    return "\n".join(bullets)
+
+
+def main() -> None:
+    import sys
+
+    print(humanize_commits(sys.stdin.read()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_humanize_commits.py
+++ b/scripts/test_humanize_commits.py
@@ -1,0 +1,61 @@
+"""Unit tests for humanize_commits.py — stdlib only, no pytest required.
+
+Run:  python3 -m unittest scripts/test_humanize_commits.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from humanize_commits import humanize_commits
+
+_INTERNAL_ONLY = """- chore: make API docs exposure configurable (#646) (#817)
+- ci: generate SBOM and build provenance for releases (#814)
+- docs: rewrite the contributing guide
+- test: add coverage for the parser
+- refactor: extract helper
+- build(deps): bump some-lib from 1 to 2
+- style: reformat files"""
+
+
+class TestHumanizeCommits(unittest.TestCase):
+    def test_internal_only_collapses_to_stability_bullet(self):
+        # A release with nothing user-facing must never leak "chore:"/"ci:" etc.
+        out = humanize_commits(_INTERNAL_ONLY)
+        self.assertEqual(out, "- Stability and performance improvements.")
+
+    def test_empty_input_is_stability_bullet(self):
+        self.assertEqual(humanize_commits(""), "- Stability and performance improvements.")
+        self.assertEqual(humanize_commits("   \n  \n"), "- Stability and performance improvements.")
+
+    def test_strips_conventional_prefix_and_pr_refs(self):
+        out = humanize_commits("- feat: add dark mode (#123)")
+        self.assertEqual(out, "- Add dark mode")
+
+    def test_strips_scoped_prefix(self):
+        out = humanize_commits("- fix(reader): stop losing your place when you rotate")
+        self.assertEqual(out, "- Stop losing your place when you rotate")
+
+    def test_keeps_user_facing_drops_internal(self):
+        commits = """- feat: share articles with friends (#301)
+- chore: bump deps
+- fix: correct the relevance score (#310)
+- ci: tweak the pipeline"""
+        out = humanize_commits(commits)
+        self.assertEqual(
+            out,
+            "- Share articles with friends\n- Correct the relevance score",
+        )
+
+    def test_accepts_lines_without_leading_dash(self):
+        out = humanize_commits("feat: brand new inbox")
+        self.assertEqual(out, "- Brand new inbox")
+
+    def test_capitalizes_first_letter(self):
+        out = humanize_commits("- feat: lowercase start stays readable")
+        self.assertTrue(out.startswith("- Lowercase"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #818

## Problem
The in-app "What's new" popup is meant to show AI-generated, customer-facing release notes, but the AI step **failed on every build**. `PI_EXTENSION` was a YAML `env:` literal `"$HOME/pi/…"` that is never expanded, so `pi` received a literal `.../news-dashboard/$HOME/pi/…` path and exited 1 — silently swallowed by `continue-on-error: true`. Every release then fell back to **raw commit subjects**, so users saw developer jargon (e.g. *"chore: make API docs exposure configurable"*, *"ci: generate SBOM…"*).

Confirmed in the latest CI run log: `Extension path does not exist: .../$HOME/pi/…`.

## Changes
- **Fix the `$HOME` expansion** in both `ci.yml` and `release.yml` by defining the extension path inside the `run:` step, so `pi` actually runs.
- **New `scripts/humanize_commits.py`** (stdlib, pytest-covered): turns raw commit subjects into user-facing bullets — drops `chore/ci/test/docs/refactor/build/style`, strips `type(scope):` prefixes and trailing PR refs, and collapses to `Stability and performance improvements.` when nothing user-facing remains. Wired as the fallback in both workflows, so even if AI is unavailable users never see jargon.
- **Polish `WhatsNewDialog`**: friendlier heading + intro, de-emphasized version, and a graceful message when a release has no user-facing items.

## Tests
- `scripts/test_humanize_commits.py` — filtering, prefix/PR-ref stripping, capitalization, stability fallback (TDD, red→green).
- `frontend/src/__tests__/whatsNew.test.tsx` — updated for new copy + new empty-state case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)