### PR TITLE
feat: PWA share target and offline reading (#653)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -80,6 +80,7 @@ from news_dashboard.ingest import (
     get_user_summary,
     ingest_all,
     list_articles,
+    now_iso,
     search_articles_page,
     send_article_later,
     set_article_starred,
@@ -304,6 +305,29 @@ class StarUpdate(BaseModel):
 
 class LaterUpdate(BaseModel):
     days: int = 1
+
+
+class SaveSharedUrlRequest(BaseModel):
+    url: str = Field(min_length=1, max_length=2_000)
+    title: str | None = Field(default=None, max_length=500)
+    text: str | None = Field(default=None, max_length=4_000)
+
+    @field_validator("url")
+    @classmethod
+    def _url_not_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            message = "url must not be blank"
+            raise ValueError(message)
+        return stripped
+
+    @field_validator("title", "text")
+    @classmethod
+    def _blank_to_none(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
 
 
 class ShareArticleRequest(BaseModel):
@@ -853,6 +877,74 @@ def get_article_by_id(
     return article
 
 
+@api.post("/api/articles/save-url")
+def save_shared_url(
+    payload: SaveSharedUrlRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        validate_server_fetch_url(payload.url)
+    except UnsafeUrlError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    from urllib.parse import urlparse
+
+    init_db()
+    parsed = urlparse(payload.url)
+    source_name = parsed.netloc or "Shared link"
+    source_slug = "share-target"
+    title = payload.title or payload.text or payload.url
+    summary = payload.text if payload.text and payload.text != title else ""
+    ts = now_iso()
+    with connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, enabled, priority)
+            VALUES (%s, 'Shared Links', 'https://example.invalid/share-target', 'shared',
+                    'share_target', true, 50)
+            ON CONFLICT (slug) DO NOTHING
+            """,
+            (source_slug,),
+        )
+        row = conn.execute("SELECT * FROM articles WHERE url = %s", (payload.url,)).fetchone()
+        if row is None:
+            row = conn.execute(
+                """
+                INSERT INTO articles(
+                  url, canonical_url, title, source_slug, source_name, category, kind,
+                  published_at, summary, reason, importance_score, tags, discovered_at, updated_at
+                ) VALUES (
+                  %s, %s, %s, %s, %s, 'shared', 'share_target',
+                  %s, %s, 'Saved from the operating system share sheet', 50, '', %s, %s
+                )
+                RETURNING *
+                """,
+                (payload.url, payload.url, title, source_slug, source_name, ts, summary, ts, ts),
+            ).fetchone()
+        article = row_to_dict(row)
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state, updated_at)
+            VALUES (%s, %s, 'today', %s)
+            ON CONFLICT (user_id, article_id) DO UPDATE
+               SET state = CASE
+                     WHEN user_article_state.state IN ('archived', 'skipped') THEN 'today'
+                     ELSE user_article_state.state
+                   END,
+                   restored_at = CASE
+                     WHEN user_article_state.state IN ('archived', 'skipped')
+                     THEN EXCLUDED.updated_at
+                     ELSE user_article_state.restored_at
+                   END,
+                   updated_at = EXCLUDED.updated_at
+            """,
+            (current_user["id"], article["id"], ts),
+        )
+
+    return get_article(int(article["id"]), user_id=current_user["id"]) or article
+
+
+@api.get("/api/articles/{article_id}/body")
 @api.post("/api/articles/{article_id}/body")
 def fetch_article_body(
     article_id: int,

--- a/backend/tests/test_share_target_api.py
+++ b/backend/tests/test_share_target_api.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from news_dashboard.db import connect
+from news_dashboard.main import app
+
+
+def _seed_fake_user(database_url: str) -> None:
+    with connect(database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO users(id, username, password_hash, is_admin)
+            VALUES (1, 'testadmin', 'hash', true)
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+
+
+def test_save_shared_url_creates_article_for_current_user(pg_clean: str) -> None:
+    _seed_fake_user(pg_clean)
+    with TestClient(app, raise_server_exceptions=True) as client:
+        response = client.post(
+            "/api/articles/save-url",
+            json={
+                "url": "https://example.com/shared-post",
+                "title": "Shared Post",
+                "text": "A note from the share sheet",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["url"] == "https://example.com/shared-post"
+    assert data["title"] == "Shared Post"
+    assert data["state"] == "today"
+
+    with connect(pg_clean) as conn:
+        state = conn.execute(
+            "SELECT state FROM user_article_state WHERE user_id = %s AND article_id = %s",
+            (1, data["id"]),
+        ).fetchone()
+    assert state is not None
+    assert state["state"] == "today"
+
+
+def test_save_shared_url_rejects_unsafe_url(pg_clean: str) -> None:
+    _seed_fake_user(pg_clean)
+    with TestClient(app, raise_server_exceptions=True) as client:
+        response = client.post(
+            "/api/articles/save-url",
+            json={"url": "file:///etc/passwd", "title": "Nope"},
+        )
+
+    assert response.status_code == 422

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -18,6 +18,7 @@ import { SourcesPage } from './pages/SourcesPage';
 import { ArchivePage } from './pages/ArchivePage';
 import { CollectionsPage } from './pages/CollectionsPage';
 import { CollectionDetailPage } from './pages/CollectionDetailPage';
+import { ShareTargetPage } from './pages/ShareTargetPage';
 import { useAuth } from './contexts/auth';
 import { ShieldAlert } from 'lucide-react';
 
@@ -170,6 +171,7 @@ export const routes: RouteObject[] = [
       { path: 'collections', element: <CollectionsPage /> },
       { path: 'collections/:tagId', element: <CollectionDetailPage /> },
       { path: 'settings', element: withSuspense(SettingsPage) },
+      { path: 'share-target', element: <ShareTargetPage /> },
       { path: 'admin', element: withSuspense(AdminPage) },
       {
         path: 'analytics',

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -146,8 +146,28 @@ describe('article list endpoints', () => {
   it('fetchArticleBody POSTs', async () => {
     const { calls } = stubFetch(() => jsonOk({ id: 7 }));
     await api.fetchArticleBody(7);
-    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].init?.method).toBeUndefined();
     expect(calls[0].url).toBe('/api/articles/7/body');
+  });
+
+  it('saveSharedUrl posts the shared URL payload', async () => {
+    const { calls } = stubFetch(() => jsonOk({ id: 8 }));
+    const article = await api.saveSharedUrl({
+      url: 'https://example.com/post',
+      title: 'Shared title',
+      text: 'Shared note',
+    });
+
+    expect(article).toEqual({ id: 8 });
+    expect(calls[0].url).toBe('/api/articles/save-url');
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].init?.body).toBe(
+      JSON.stringify({
+        url: 'https://example.com/post',
+        title: 'Shared title',
+        text: 'Shared note',
+      })
+    );
   });
 
   it('creates and deletes article highlights through article-scoped paths', async () => {

--- a/frontend/src/__tests__/pwa.test.ts
+++ b/frontend/src/__tests__/pwa.test.ts
@@ -22,6 +22,11 @@ const MANIFEST = JSON.parse(
   background_color: string;
   theme_color: string;
   icons: { src: string; sizes: string; type: string; purpose: string }[];
+  share_target?: {
+    action: string;
+    method: string;
+    params: { title: string; text: string; url: string };
+  };
 };
 
 describe('PWA manifest — identity', () => {
@@ -93,5 +98,15 @@ describe('PWA manifest — branding', () => {
 
   it('background_color is light (warm off-white #faf8f5)', () => {
     expect(MANIFEST.background_color).toBe('#faf8f5');
+  });
+});
+
+describe('PWA manifest — share target', () => {
+  it('accepts shared URLs through the app route', () => {
+    expect(MANIFEST.share_target).toEqual({
+      action: '/share-target',
+      method: 'GET',
+      params: { title: 'title', text: 'text', url: 'url' },
+    });
   });
 });

--- a/frontend/src/__tests__/shareTarget.test.tsx
+++ b/frontend/src/__tests__/shareTarget.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as api from '../api';
+import { ShareTargetPage } from '../pages/ShareTargetPage';
+
+const testRoutes = [
+  { path: '/share-target', element: <ShareTargetPage /> },
+  { path: '/a/:id', element: <div>Reader</div> },
+];
+
+describe('ShareTargetPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('saves the shared URL and navigates to the article reader', async () => {
+    vi.spyOn(api, 'saveSharedUrl').mockResolvedValue({ id: 42 } as never);
+    const router = createMemoryRouter(testRoutes, {
+      initialEntries: ['/share-target?title=Post&text=Note&url=https%3A%2F%2Fexample.com%2Fpost'],
+    });
+    const client = new QueryClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() =>
+      expect(api.saveSharedUrl).toHaveBeenCalledWith({
+        url: 'https://example.com/post',
+        title: 'Post',
+        text: 'Note',
+      })
+    );
+    await waitFor(() => expect(router.state.location.pathname).toBe('/a/42'));
+  });
+
+  it('shows a graceful error when the share payload has no URL', async () => {
+    const saveSpy = vi.spyOn(api, 'saveSharedUrl');
+    const router = createMemoryRouter(testRoutes, {
+      initialEntries: ['/share-target?text=just+words'],
+    });
+    const client = new QueryClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText('Could not save link')).toBeTruthy();
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -115,7 +115,18 @@ export async function fetchArticle(id: number | string): Promise<Article> {
 }
 
 export async function fetchArticleBody(id: number | string): Promise<Article> {
-  return requestJson<Article>(`/api/articles/${id}/body`, { method: 'POST' });
+  return requestJson<Article>(`/api/articles/${id}/body`);
+}
+
+export async function saveSharedUrl(payload: {
+  url: string;
+  title?: string | null;
+  text?: string | null;
+}): Promise<Article> {
+  return requestJson<Article>('/api/articles/save-url', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
 }
 
 export async function fetchArticleHighlights(id: number | string): Promise<ArticleHighlight[]> {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate, Outlet, Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { LogOut, MoreHorizontal, Search } from 'lucide-react';
+import { LogOut, MoreHorizontal, Search, WifiOff } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { AppLogo } from './AppLogo';
 import { CommandPalette } from './CommandPalette';
@@ -44,6 +44,22 @@ function useNavCounts() {
     starred: data?.byStatus?.saved ?? null,
     shared: sharesUnread ?? null,
   };
+}
+
+function useOnlineStatus() {
+  const [online, setOnline] = useState(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine
+  );
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+  return online;
 }
 
 function DesktopRail({ pathname }: { pathname: string }) {
@@ -141,6 +157,7 @@ export function AppShell() {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const whatsNew = useWhatsNew();
   const onboarding = useOnboardingWizard();
+  const online = useOnlineStatus();
   useElectronBriefNotifier((path) => void navigate(path));
 
   async function handleLogout() {
@@ -218,6 +235,12 @@ export function AppShell() {
             <h1 className="text-[13px] font-semibold tracking-tight truncate">{title}</h1>
           </div>
           <div className="flex items-center gap-1">
+            {!online && (
+              <div className="inline-flex items-center gap-1 rounded-md border border-border bg-surface px-2 py-1 text-xs font-medium text-muted-foreground">
+                <WifiOff className="size-3.5" />
+                Offline
+              </div>
+            )}
             <button
               onClick={() => setPaletteOpen(true)}
               className="hidden md:inline-flex items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:border-border-strong transition-colors"

--- a/frontend/src/components/article/ArticleListView.tsx
+++ b/frontend/src/components/article/ArticleListView.tsx
@@ -34,6 +34,7 @@ interface ArticleListViewProps {
   showLaterUntil?: boolean;
   sortArticles?: (articles: WorkflowArticle[]) => WorkflowArticle[];
   banner?: React.ReactNode;
+  action?: (state: { articles: WorkflowArticle[] }) => React.ReactNode;
 }
 
 export function ArticleListView({
@@ -46,6 +47,7 @@ export function ArticleListView({
   showLaterUntil,
   sortArticles,
   banner,
+  action,
 }: ArticleListViewProps) {
   const navigate = useNavigate();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
@@ -96,14 +98,17 @@ export function ArticleListView({
           </p>
         </div>
         {list.length > 0 && (
-          <button
-            type="button"
-            onClick={() => startListenQueue(list)}
-            className="flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
-          >
-            <Headphones className="size-3.5" />
-            Listen
-          </button>
+          <div className="flex shrink-0 items-center gap-2">
+            {action?.({ articles: list })}
+            <button
+              type="button"
+              onClick={() => startListenQueue(list)}
+              className="flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
+            >
+              <Headphones className="size-3.5" />
+              Listen
+            </button>
+          </div>
         )}
       </div>
       {showCategoryFilter && <CategoryFilter />}

--- a/frontend/src/lib/offline.ts
+++ b/frontend/src/lib/offline.ts
@@ -1,0 +1,26 @@
+const OFFLINE_ARTICLE_CACHE = 'offline-articles-v1';
+
+export function isOfflineCacheSupported(): boolean {
+  return typeof window !== 'undefined' && 'caches' in window;
+}
+
+export async function cacheArticleBody(articleId: string | number): Promise<void> {
+  if (!isOfflineCacheSupported()) return;
+  const cache = await caches.open(OFFLINE_ARTICLE_CACHE);
+  await cache.add(`/api/articles/${articleId}/body`);
+}
+
+export async function cacheArticleBodies(articleIds: (string | number)[]): Promise<number> {
+  if (!isOfflineCacheSupported()) return 0;
+  const cache = await caches.open(OFFLINE_ARTICLE_CACHE);
+  let cached = 0;
+  for (const articleId of articleIds) {
+    try {
+      await cache.add(`/api/articles/${articleId}/body`);
+      cached += 1;
+    } catch {
+      // Keep caching the rest of the queue when one article body is unavailable.
+    }
+  }
+  return cached;
+}

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -21,6 +21,7 @@ import {
   Sparkles,
   Lightbulb,
   Scale,
+  Download,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -39,6 +40,7 @@ import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflo
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { formatDate, readingTime, signalLabel } from '@/lib/format';
 import { getReaderList } from '@/lib/readerList';
+import { cacheArticleBody, isOfflineCacheSupported } from '@/lib/offline';
 import { recommendationExplanation } from '@/lib/recommendation';
 import { trackArticleOpen, trackArticleClose } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
@@ -296,6 +298,16 @@ export function ArticlePage() {
     }
   }
 
+  async function saveCurrentArticleOffline() {
+    if (!article) return;
+    try {
+      await cacheArticleBody(article.id);
+      toast('Saved for offline');
+    } catch {
+      toast.error('Could not save offline');
+    }
+  }
+
   // TTS audio player
   type AudioState = 'idle' | 'loading' | 'playing' | 'paused';
   const [audioState, setAudioState] = useState<AudioState>('idle');
@@ -520,6 +532,15 @@ export function ArticlePage() {
               >
                 <ExternalLink className="size-4" />
               </a>
+              {isOfflineCacheSupported() && !shareId && (
+                <button
+                  onClick={() => void saveCurrentArticleOffline()}
+                  className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface"
+                  aria-label="Save for offline"
+                >
+                  <Download className="size-4" />
+                </button>
+              )}
             </div>
           </div>
         </header>

--- a/frontend/src/pages/LaterPage.tsx
+++ b/frontend/src/pages/LaterPage.tsx
@@ -1,8 +1,10 @@
-import { Clock } from 'lucide-react';
+import { useState } from 'react';
+import { Clock, Download } from 'lucide-react';
 import { ArticleListView } from '@/components/article/ArticleListView';
 import { fetchTriageArticles } from '@/api/workflowApi';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
+import { cacheArticleBodies, isOfflineCacheSupported } from '@/lib/offline';
 
 function sortByReturnDate(articles: WorkflowArticle[]) {
   return [...articles].sort(
@@ -11,6 +13,15 @@ function sortByReturnDate(articles: WorkflowArticle[]) {
 }
 
 export function LaterPage() {
+  const [saving, setSaving] = useState(false);
+  const [savedCount, setSavedCount] = useState<number | null>(null);
+
+  async function saveArticlesOffline(articles: WorkflowArticle[]): Promise<void> {
+    setSaving(true);
+    setSavedCount(await cacheArticleBodies(articles.map((article) => article.id)));
+    setSaving(false);
+  }
+
   return (
     <ArticleListView
       title="Later"
@@ -26,6 +37,19 @@ export function LaterPage() {
       }}
       showLaterUntil
       sortArticles={sortByReturnDate}
+      action={({ articles }) =>
+        isOfflineCacheSupported() && articles.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => void saveArticlesOffline(articles)}
+            disabled={saving}
+            className="flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Download className="size-3.5" />
+            {saving ? 'Saving...' : savedCount == null ? 'Save offline' : `${savedCount} saved`}
+          </button>
+        ) : null
+      }
     />
   );
 }

--- a/frontend/src/pages/ShareTargetPage.tsx
+++ b/frontend/src/pages/ShareTargetPage.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Loader2, TriangleAlert } from 'lucide-react';
+import { saveSharedUrl } from '@/api';
+
+function extractSharedUrl(params: URLSearchParams): string {
+  const directUrl = params.get('url')?.trim();
+  if (directUrl) return directUrl;
+  const text = params.get('text') ?? '';
+  return /https?:\/\/\S+/.exec(text)?.[0] ?? '';
+}
+
+export function ShareTargetPage() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const sharedUrl = useMemo(() => extractSharedUrl(params), [params]);
+
+  useEffect(() => {
+    if (!sharedUrl) {
+      setError('No link was shared.');
+      return;
+    }
+    let cancelled = false;
+    saveSharedUrl({
+      url: sharedUrl,
+      title: params.get('title'),
+      text: params.get('text'),
+    })
+      .then((article) => {
+        if (!cancelled) void navigate(`/a/${article.id}`, { replace: true });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Could not save link.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate, params, sharedUrl]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-4">
+        <div className="max-w-sm text-center">
+          <TriangleAlert className="mx-auto mb-3 size-8 text-destructive" />
+          <h1 className="text-lg font-semibold text-foreground">Could not save link</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center gap-2 text-sm text-muted-foreground">
+      <Loader2 className="size-4 animate-spin" />
+      Saving link...
+    </div>
+  );
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -7,6 +7,15 @@
   "background_color": "#faf8f5",
   "theme_color": "#221f1a",
   "lang": "en",
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  },
   "icons": [
     {
       "src": "/favicon.svg",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,33 @@ export default defineConfig({
               expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 30 },
             },
           },
+          {
+            // Article metadata/list JSON: prefer fresh network data, keep a bounded offline copy.
+            urlPattern: ({ url }) =>
+              url.origin === self.location.origin &&
+              url.pathname === '/api/articles' &&
+              !url.searchParams.has('include_archived'),
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'pwa-article-lists',
+              networkTimeoutSeconds: 3,
+              expiration: { maxEntries: 24, maxAgeSeconds: 60 * 60 * 24 * 7 },
+              cacheableResponse: { statuses: [200] },
+            },
+          },
+          {
+            // Article bodies are explicit GETs so Workbox can serve opened/offline-saved reads.
+            urlPattern: ({ url }) =>
+              url.origin === self.location.origin &&
+              /^\/api\/articles\/\d+\/body$/.test(url.pathname),
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'offline-articles-v1',
+              networkTimeoutSeconds: 3,
+              expiration: { maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 * 30 },
+              cacheableResponse: { statuses: [200] },
+            },
+          },
         ],
       },
     }),


### PR DESCRIPTION
Closes #653

## Summary
- add a Web Share Target manifest entry and authenticated `/share-target` intake route
- save shared links through `/api/articles/save-url` into a dedicated share-target source
- make article body fetches GET-cacheable and add bounded Workbox caches for article lists/bodies
- add offline indicator plus explicit Save offline actions in the reader and Later queue

## Tests
- `pytest backend/tests/test_share_target_api.py -q`
- `npm run test:frontend -- --run frontend/src/__tests__/api.test.ts frontend/src/__tests__/pwa.test.ts frontend/src/__tests__/shareTarget.test.tsx`
- `make lint`
- `make typecheck`
- `npm run build`
- `npm run test:frontend`

Note: local `source .env; make test` reached 1381 passed but failed 41 `backend/tests/test_briefings_api.py` setup cases because local Postgres returned `must be owner of table user_article_state` during schema init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)