### PR TITLE
feat: self-serve account deletion + data export UI (#656)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -66,6 +66,18 @@ in-app stats/analytics views. This data:
 - Is pruned automatically by a daily cleanup job after
   `ANALYTICS_RETENTION_DAYS` days (default `180`).
 
+## Your data: export and deletion
+
+- **Download your data**: Settings → Data Export → "Download archive" (or
+  `GET /api/users/me/export`) returns a JSON file with your reading
+  history, starred articles, highlights, shares, and daily briefings.
+- **Delete your account**: Settings → Danger Zone → "Delete my account"
+  (or `DELETE /api/users/me`) permanently removes your user row and all
+  associated per-user data (articles state, highlights, shares, push
+  subscriptions, OTPs, tags, goals, quizzes, etc.) via cascading deletes.
+  You must type your username to confirm. Deleting the last remaining
+  admin account is blocked — promote another user to admin first.
+
 ## See also
 
 - [Configuration](README.md#configuration) — full environment variable

--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -253,6 +253,12 @@ def delete_user(user_id: int) -> bool:
         return bool(cursor.rowcount > 0)
 
 
+def count_admins() -> int:
+    with connect() as conn:
+        row = conn.execute("SELECT COUNT(*) AS n FROM users WHERE is_admin").fetchone()
+        return user_count_from_row(row)
+
+
 def _touch_last_login(user_id: int) -> None:
     with connect() as conn:
         conn.execute("UPDATE users SET last_login_at=CURRENT_TIMESTAMP WHERE id=%s", (user_id,))

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -44,6 +44,7 @@ from news_dashboard.auth import (
     _session_days,
     authenticate,
     consume_otp,
+    count_admins,
     create_otp_for_user,
     create_session_token,
     create_user,
@@ -2345,6 +2346,29 @@ def export_user_data(
     from news_dashboard.export import assemble_user_export
 
     return assemble_user_export(current_user["id"])
+
+
+class DeleteAccountRequest(BaseModel):
+    confirmation: str
+
+
+@api.delete("/api/users/me")
+def delete_own_account(
+    payload: DeleteAccountRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    response: Response,
+) -> dict[str, str]:
+    if payload.confirmation != current_user["username"]:
+        raise HTTPException(
+            status_code=400, detail="Confirmation text does not match your username"
+        )
+    if current_user.get("is_admin") and count_admins() <= 1:
+        raise HTTPException(
+            status_code=400, detail="Cannot delete the last remaining admin account"
+        )
+    delete_user(current_user["id"])
+    response.delete_cookie(key=_SESSION_COOKIE, path="/")
+    return {"status": "deleted"}
 
 
 @api.get("/api/users/me/recommendation-preferences")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -422,6 +422,58 @@ def test_admin_cannot_delete_self(tmp_db: str) -> None:
     assert resp.status_code == 400
 
 
+# ── Self-serve account deletion ───────────────────────────────────────────────
+
+
+def test_delete_own_account(tmp_db: str) -> None:
+    create_user("someadmin", "pw", is_admin=True)  # keep an admin around
+    user = create_user("regular", "pw2", is_admin=False)
+    token = create_session_token(user["id"], is_admin=False)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.request("DELETE", "/api/users/me", json={"confirmation": "regular"})
+    assert resp.status_code == 200
+    assert get_user_by_id(user["id"]) is None
+    assert resp.cookies.get("nd_session") is None
+
+
+def test_delete_own_account_wrong_confirmation(tmp_db: str) -> None:
+    user = create_user("regular2", "pw", is_admin=False)
+    token = create_session_token(user["id"], is_admin=False)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.request("DELETE", "/api/users/me", json={"confirmation": "not-my-username"})
+    assert resp.status_code == 400
+    assert get_user_by_id(user["id"]) is not None
+
+
+def test_delete_own_account_blocks_last_admin(tmp_db: str) -> None:
+    admin = create_user("lastadmin", "pw", is_admin=True)
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.request("DELETE", "/api/users/me", json={"confirmation": "lastadmin"})
+    assert resp.status_code == 400
+    assert get_user_by_id(admin["id"]) is not None
+
+
+def test_delete_own_account_allows_admin_when_others_remain(tmp_db: str) -> None:
+    admin = create_user("admin-one", "pw", is_admin=True)
+    create_user("admin-two", "pw2", is_admin=True)
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.request("DELETE", "/api/users/me", json={"confirmation": "admin-one"})
+    assert resp.status_code == 200
+    assert get_user_by_id(admin["id"]) is None
+
+
+def test_delete_own_account_requires_auth(tmp_db: str) -> None:
+    client = _fresh_client()
+    resp = client.request("DELETE", "/api/users/me", json={"confirmation": "whoever"})
+    assert resp.status_code == 401
+
+
 # ── Health endpoint is public ─────────────────────────────────────────────────
 
 

--- a/frontend/src/__tests__/dailyBriefSettings.test.tsx
+++ b/frontend/src/__tests__/dailyBriefSettings.test.tsx
@@ -2,7 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/contexts/auth';
 
 const {
   mockFetchSettings,
@@ -32,9 +34,13 @@ import type { PushSubscribeRequest } from '../types';
 function renderSettings() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={queryClient}>
-      <SettingsPage />
-    </QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <SettingsPage />
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
   );
 }
 

--- a/frontend/src/__tests__/settingsPlatforms.test.tsx
+++ b/frontend/src/__tests__/settingsPlatforms.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/contexts/auth';
 
 vi.mock('@/api', () => ({
   recalculateMyRecommendations: vi.fn(),
@@ -22,9 +24,13 @@ import { SettingsPage } from '../pages/SettingsPage';
 function renderSettings() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={queryClient}>
-      <SettingsPage />
-    </QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <SettingsPage />
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
   );
 }
 

--- a/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
+++ b/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ── Shared API mock ──────────────────────────────────────────────────────────
@@ -16,9 +17,18 @@ const apiMock = vi.hoisted(() => ({
   fetchIngestRunSources: vi.fn(),
   recalculateMyRecommendations: vi.fn(),
   downloadUserExport: vi.fn(),
+  deleteOwnAccount: vi.fn(),
 }));
 vi.mock('../api', () => apiMock);
 vi.mock('@/api', () => apiMock);
+
+const authMock = vi.hoisted(() => ({
+  user: { id: 1, username: 'testuser', is_admin: false },
+  setUser: vi.fn(),
+}));
+vi.mock('@/contexts/auth', () => ({
+  useAuth: () => authMock,
+}));
 
 // recharts renders nothing measurable under happy-dom; stub it to plain divs so
 // StatsPage's data rows/tables still mount and assert cleanly.
@@ -62,7 +72,11 @@ afterEach(() => {
 
 function renderPage(ui: ReactElement) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  );
 }
 
 // ── StatsPage ────────────────────────────────────────────────────────────────
@@ -167,9 +181,11 @@ describe('SettingsPage', () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
     render(
-      <QueryClientProvider client={queryClient}>
-        <SettingsPage />
-      </QueryClientProvider>
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <SettingsPage />
+        </QueryClientProvider>
+      </MemoryRouter>
     );
     fireEvent.click(screen.getByText('Refresh recommendations'));
     await waitFor(() => expect(screen.getByText(/Personalized 2 articles/)).toBeTruthy());
@@ -214,6 +230,47 @@ describe('SettingsPage', () => {
     renderPage(<SettingsPage />);
     fireEvent.click(screen.getByText('Download archive'));
     await waitFor(() => expect(screen.getByText('network error')).toBeTruthy());
+  });
+
+  it('requires typing the exact username before deletion is enabled', () => {
+    renderPage(<SettingsPage />);
+    fireEvent.click(screen.getByText('Delete my account'));
+    const button = screen.getByRole<HTMLButtonElement>('button', {
+      name: /Permanently delete account/,
+    });
+    expect(button.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText(/Type/), { target: { value: 'wrong' } });
+    expect(button.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText(/Type/), { target: { value: 'testuser' } });
+    expect(button.disabled).toBe(false);
+  });
+
+  it('deletes the account and clears the session on confirmation', async () => {
+    apiMock.deleteOwnAccount.mockResolvedValue(undefined);
+    renderPage(<SettingsPage />);
+    fireEvent.click(screen.getByText('Delete my account'));
+    fireEvent.change(screen.getByLabelText(/Type/), { target: { value: 'testuser' } });
+    fireEvent.click(screen.getByText('Permanently delete account'));
+    await waitFor(() => expect(apiMock.deleteOwnAccount).toHaveBeenCalledWith('testuser'));
+    expect(authMock.setUser).toHaveBeenCalledWith(null);
+  });
+
+  it('shows an error message when account deletion fails', async () => {
+    apiMock.deleteOwnAccount.mockRejectedValue(new Error('cannot delete last admin'));
+    renderPage(<SettingsPage />);
+    fireEvent.click(screen.getByText('Delete my account'));
+    fireEvent.change(screen.getByLabelText(/Type/), { target: { value: 'testuser' } });
+    fireEvent.click(screen.getByText('Permanently delete account'));
+    await waitFor(() => expect(screen.getByText('cannot delete last admin')).toBeTruthy());
+  });
+
+  it('cancels the delete confirmation flow', () => {
+    renderPage(<SettingsPage />);
+    fireEvent.click(screen.getByText('Delete my account'));
+    fireEvent.change(screen.getByLabelText(/Type/), { target: { value: 'testuser' } });
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByLabelText(/Type/)).toBeNull();
+    expect(screen.getByText('Delete my account')).toBeTruthy();
   });
 });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -766,6 +766,13 @@ export async function downloadUserExport(): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
+export async function deleteOwnAccount(confirmation: string): Promise<void> {
+  await requestJson<{ status: string }>('/api/users/me', {
+    method: 'DELETE',
+    body: JSON.stringify({ confirmation }),
+  });
+}
+
 // ── OPML import / export ──────────────────────────────────────────────────────
 
 export async function exportOpml(): Promise<void> {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Sun,
   Moon,
@@ -10,13 +11,16 @@ import {
   Sparkles,
   Bell,
   BellOff,
+  Trash2,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTheme } from '@/hooks/useTheme';
 import { cn } from '@/lib/utils';
 import type { Theme } from '@/lib/theme';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
+import { useAuth } from '@/contexts/auth';
 import {
+  deleteOwnAccount,
   downloadUserExport,
   fetchNotificationSettings,
   recalculateMyRecommendations,
@@ -729,6 +733,108 @@ function DataExportSection() {
   );
 }
 
+type DeleteAccountState = 'idle' | 'confirming' | 'deleting' | 'error';
+
+function DeleteAccountSection() {
+  const { user, setUser } = useAuth();
+  const navigate = useNavigate();
+  const [state, setState] = useState<DeleteAccountState>('idle');
+  const [confirmation, setConfirmation] = useState('');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  if (!user) return null;
+
+  const canDelete = confirmation === user.username;
+
+  const handleDelete = async () => {
+    if (!canDelete) return;
+    setState('deleting');
+    setErrorMsg(null);
+    try {
+      await deleteOwnAccount(confirmation);
+      setUser(null);
+      void navigate('/login', { replace: true });
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Could not delete account.');
+      setState('error');
+    }
+  };
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        Danger Zone
+      </div>
+      <div className="rounded-lg border border-destructive/40 bg-card p-4 space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Permanently delete your account and all associated data — reading history, starred
+          articles, highlights, shares, and preferences. This cannot be undone.
+        </p>
+
+        {state === 'idle' && (
+          <button
+            onClick={() => setState('confirming')}
+            className="flex items-center gap-1.5 rounded-md border border-destructive px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 transition-colors"
+          >
+            <Trash2 className="size-3" />
+            Delete my account
+          </button>
+        )}
+
+        {(state === 'confirming' || state === 'deleting' || state === 'error') && (
+          <div className="space-y-2">
+            <label
+              className="text-xs font-medium text-foreground"
+              htmlFor="delete-account-confirmation"
+            >
+              Type <span className="font-mono">{user.username}</span> to confirm
+            </label>
+            <input
+              id="delete-account-confirmation"
+              type="text"
+              value={confirmation}
+              onChange={(e) => setConfirmation(e.target.value)}
+              disabled={state === 'deleting'}
+              className="w-full rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              autoComplete="off"
+            />
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => void handleDelete()}
+                disabled={!canDelete || state === 'deleting'}
+                className="flex items-center gap-1.5 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors disabled:opacity-60"
+              >
+                {state === 'deleting' ? (
+                  <RefreshCw className="size-3 animate-spin" />
+                ) : (
+                  <Trash2 className="size-3" />
+                )}
+                {state === 'deleting' ? 'Deleting…' : 'Permanently delete account'}
+              </button>
+              <button
+                onClick={() => {
+                  setState('idle');
+                  setConfirmation('');
+                  setErrorMsg(null);
+                }}
+                disabled={state === 'deleting'}
+                className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-60"
+              >
+                Cancel
+              </button>
+            </div>
+            {state === 'error' && (
+              <p className="text-xs text-destructive" role="alert">
+                {errorMsg ?? 'Could not delete account. Please try again.'}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
 export function SettingsPage() {
   const { theme, setTheme } = useTheme();
 
@@ -771,6 +877,8 @@ export function SettingsPage() {
       <DailyBriefSection />
 
       <UpdatesSection />
+
+      <DeleteAccountSection />
 
       <section className="text-xs text-muted-foreground space-y-2">
         <div className="text-[10px] uppercase tracking-wider text-subtle font-medium">About</div>


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/users/me` (auth-required) so a logged-in user can permanently delete their own account, guarded by a typed-username confirmation.
- Blocks deleting the last remaining admin account (`count_admins()` lockout guard in `auth.py`) — mirrors the existing "can't delete yourself" guard on the admin route.
- Per-user data cleanup (articles state, highlights, shares, push subs, OTPs, tags, goals, quizzes, etc.) is already handled by the `ON DELETE CASCADE` foreign keys on the `users` table, so `delete_user()` (the same helper the admin route uses) cleans up everything with no orphaned rows.
- Adds a "Danger Zone" section to `SettingsPage.tsx` with a type-to-confirm delete flow, next to the existing "Download my data" export button.
- Documents both flows in `PRIVACY.md`.

Closes #656.

## Test plan
- [x] Backend: `pytest backend/tests/test_auth.py backend/tests/test_export.py` — 72 passed, including new tests: self-delete removes the user, wrong confirmation is rejected, last-admin deletion is blocked, deletion succeeds when other admins remain, and unauthenticated requests get 401.
- [x] Frontend: `vitest run frontend/src/__tests__/statsSettingsRunsPages.test.tsx` — 19 passed, including new tests for the confirm-to-delete UI flow (disabled until username matches, success clears session, error surfaces message, cancel resets state).
- [x] `ruff check`/`ruff format`, `mypy`, `ty`, `pyrefly` clean on backend.
- [x] `eslint`, `prettier`, `tsc --noEmit` clean on frontend.
- [x] Local pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)