### PR TITLE
feat: AI Stats page (word cloud + embedding map) and true embedding-scatter Topic Map

### DIFF
--- a/backend/news_dashboard/ai_stats/__init__.py
+++ b/backend/news_dashboard/ai_stats/__init__.py
@@ -1,0 +1,1 @@
+"""AI statistics over the user's news corpus (word cloud, embedding map)."""

--- a/backend/news_dashboard/ai_stats/router.py
+++ b/backend/news_dashboard/ai_stats/router.py
@@ -1,0 +1,33 @@
+"""HTTP routes for AI statistics over the news corpus.
+
+The router carries no blanket auth dependency of its own; it is mounted on
+``main``'s authenticated ``api`` router, which applies ``require_auth``. Each
+handler still depends on ``require_auth`` to receive the current user.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+
+from news_dashboard.ai_stats import service
+from news_dashboard.auth import require_auth
+
+router = APIRouter()
+
+
+@router.get("/api/ai-stats/word-cloud")
+def word_cloud_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    days: Annotated[int, Query(ge=1, le=30)] = 7,
+) -> dict[str, Any]:
+    return service.word_cloud(user_id=current_user["id"], days=days)
+
+
+@router.get("/api/ai-stats/embedding-map")
+def embedding_map_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    days: Annotated[int, Query(ge=1, le=30)] = 7,
+) -> dict[str, Any]:
+    return service.embedding_map(user_id=current_user["id"], days=days)

--- a/backend/news_dashboard/ai_stats/service.py
+++ b/backend/news_dashboard/ai_stats/service.py
@@ -1,0 +1,540 @@
+"""AI-derived statistics over the user's visible news corpus.
+
+Pure aggregation over data the pipeline already produced (titles, summaries,
+stored embeddings) — no LLM calls happen here, so the endpoints are fast,
+free, and always available.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.embeddings import decode_embedding
+from news_dashboard.insights import (
+    greedy_cluster,
+    load_recent_embedded_articles,
+    normalize_vector,
+    pca_2d,
+)
+
+_MAX_ARTICLES = 300
+_CLUSTER_THRESHOLD = 0.72
+_LABEL_TERMS = 2
+
+# Common English stopwords plus newsfeed noise that would otherwise dominate
+# every word cloud without carrying any signal.
+_STOPWORDS = frozenset(
+    [
+        "a",
+        "about",
+        "above",
+        "across",
+        "after",
+        "again",
+        "against",
+        "all",
+        "along",
+        "already",
+        "also",
+        "am",
+        "amid",
+        "among",
+        "an",
+        "and",
+        "another",
+        "any",
+        "are",
+        "aren't",
+        "around",
+        "as",
+        "at",
+        "back",
+        "based",
+        "be",
+        "because",
+        "become",
+        "becomes",
+        "been",
+        "before",
+        "behind",
+        "being",
+        "below",
+        "best",
+        "better",
+        "between",
+        "big",
+        "biggest",
+        "both",
+        "but",
+        "by",
+        "can",
+        "can't",
+        "cannot",
+        "com",
+        "could",
+        "couldn't",
+        "day",
+        "days",
+        "despite",
+        "did",
+        "didn't",
+        "do",
+        "does",
+        "doesn't",
+        "doing",
+        "don't",
+        "down",
+        "during",
+        "each",
+        "early",
+        "even",
+        "ever",
+        "every",
+        "few",
+        "first",
+        "for",
+        "from",
+        "further",
+        "get",
+        "gets",
+        "getting",
+        "given",
+        "goes",
+        "going",
+        "good",
+        "got",
+        "great",
+        "had",
+        "hadn't",
+        "has",
+        "hasn't",
+        "have",
+        "haven't",
+        "having",
+        "he",
+        "he'd",
+        "he'll",
+        "he's",
+        "her",
+        "here",
+        "here's",
+        "hers",
+        "herself",
+        "high",
+        "him",
+        "himself",
+        "his",
+        "how",
+        "how's",
+        "however",
+        "http",
+        "https",
+        "i",
+        "i'd",
+        "i'll",
+        "i'm",
+        "i've",
+        "if",
+        "in",
+        "inside",
+        "instead",
+        "into",
+        "is",
+        "isn't",
+        "it",
+        "it's",
+        "its",
+        "itself",
+        "just",
+        "know",
+        "known",
+        "large",
+        "last",
+        "late",
+        "later",
+        "latest",
+        "least",
+        "less",
+        "let's",
+        "like",
+        "likely",
+        "little",
+        "long",
+        "look",
+        "looking",
+        "made",
+        "make",
+        "makes",
+        "making",
+        "many",
+        "may",
+        "maybe",
+        "me",
+        "might",
+        "million",
+        "minute",
+        "minutes",
+        "month",
+        "months",
+        "more",
+        "most",
+        "much",
+        "must",
+        "mustn't",
+        "my",
+        "myself",
+        "near",
+        "need",
+        "needs",
+        "never",
+        "new",
+        "news",
+        "next",
+        "no",
+        "nor",
+        "not",
+        "now",
+        "of",
+        "off",
+        "often",
+        "old",
+        "on",
+        "once",
+        "one",
+        "only",
+        "onto",
+        "or",
+        "other",
+        "others",
+        "ought",
+        "our",
+        "ours",
+        "ourselves",
+        "out",
+        "over",
+        "own",
+        "part",
+        "per",
+        "plan",
+        "plans",
+        "post",
+        "read",
+        "really",
+        "recent",
+        "report",
+        "reports",
+        "right",
+        "said",
+        "same",
+        "say",
+        "says",
+        "see",
+        "seen",
+        "set",
+        "several",
+        "shan't",
+        "she",
+        "she'd",
+        "she'll",
+        "she's",
+        "should",
+        "shouldn't",
+        "show",
+        "shows",
+        "since",
+        "site",
+        "small",
+        "so",
+        "some",
+        "state",
+        "still",
+        "such",
+        "take",
+        "takes",
+        "taking",
+        "tell",
+        "tells",
+        "than",
+        "that",
+        "that's",
+        "the",
+        "their",
+        "theirs",
+        "them",
+        "themselves",
+        "then",
+        "there",
+        "there's",
+        "these",
+        "they",
+        "they'd",
+        "they'll",
+        "they're",
+        "they've",
+        "third",
+        "this",
+        "those",
+        "three",
+        "through",
+        "time",
+        "times",
+        "to",
+        "today",
+        "told",
+        "too",
+        "top",
+        "toward",
+        "two",
+        "under",
+        "until",
+        "up",
+        "use",
+        "used",
+        "user",
+        "users",
+        "uses",
+        "using",
+        "very",
+        "via",
+        "want",
+        "wants",
+        "was",
+        "wasn't",
+        "way",
+        "ways",
+        "we",
+        "we'd",
+        "we'll",
+        "we're",
+        "we've",
+        "week",
+        "weeks",
+        "well",
+        "went",
+        "were",
+        "weren't",
+        "what",
+        "what's",
+        "when",
+        "when's",
+        "where",
+        "where's",
+        "which",
+        "while",
+        "who",
+        "who's",
+        "whom",
+        "why",
+        "why's",
+        "will",
+        "with",
+        "within",
+        "without",
+        "won't",
+        "work",
+        "working",
+        "works",
+        "would",
+        "wouldn't",
+        "year",
+        "years",
+        "yet",
+        "you",
+        "you'd",
+        "you'll",
+        "you're",
+        "you've",
+        "your",
+        "yours",
+        "yourself",
+        "yourselves",
+    ]
+)
+
+_TOKEN_RE = re.compile(r"[a-z][a-z0-9'\-]{2,}")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase, split into word-ish tokens of 3+ chars, drop stopwords."""
+    return [
+        token
+        for token in _TOKEN_RE.findall(text.lower())
+        if token not in _STOPWORDS and not token.endswith("-")
+    ]
+
+
+def _load_recent_articles(
+    user_id: int | None,
+    days: int,
+    limit: int,
+    database_url: str | None,
+) -> list[dict[str, Any]]:
+    """Recent visible articles regardless of embedding status.
+
+    Same visibility scoping as ``insights.load_recent_embedded_articles`` but
+    without the ``embedding IS NOT NULL`` filter, so callers can also report
+    how much of the corpus is embedded.
+    """
+    init_db(database_url=database_url)
+
+    with connect(database_url=database_url) as conn:
+        if user_id is None:
+            rows = conn.execute(
+                """
+                SELECT id, title, summary, category, (embedding IS NOT NULL) AS embedded
+                FROM articles
+                WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                ORDER BY discovered_at DESC
+                LIMIT %s
+                """,
+                (days, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT a.id, a.title, a.summary, a.category,
+                       (a.embedding IS NOT NULL) AS embedded
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us
+                  ON us.source_slug = src.slug AND us.user_id = %s
+                LEFT JOIN user_article_state uas
+                  ON uas.article_id = a.id AND uas.user_id = %s
+                WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                  AND COALESCE(uas.state, 'today') != 'archived'
+                  AND (
+                    (
+                      src.owner_user_id IS NULL
+                      AND COALESCE(us.enabled, TRUE) IS TRUE
+                    )
+                    OR (
+                      src.owner_user_id = %s
+                      AND src.enabled IS TRUE
+                    )
+                  )
+                ORDER BY a.discovered_at DESC
+                LIMIT %s
+                """,
+                (user_id, user_id, days, user_id, limit),
+            ).fetchall()
+
+    return [dict(row) for row in rows]
+
+
+def _tfidf_scores(docs: list[list[str]]) -> dict[str, tuple[int, float]]:
+    """Map term -> (total count, TF-IDF score) across the given token lists."""
+    tf: dict[str, int] = {}
+    df: dict[str, int] = {}
+    for tokens in docs:
+        for token in tokens:
+            tf[token] = tf.get(token, 0) + 1
+        for token in set(tokens):
+            df[token] = df.get(token, 0) + 1
+
+    n_docs = len(docs)
+    return {term: (count, count * math.log(1 + n_docs / df[term])) for term, count in tf.items()}
+
+
+def word_cloud(
+    user_id: int | None = None,
+    days: int = 7,
+    max_terms: int = 60,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """TF-IDF-weighted terms from recent visible articles' titles and summaries.
+
+    Returns ``{"terms": [{"term", "count", "weight"}], "article_count", "days"}``
+    with weights normalized to (0, 1] and terms sorted by weight descending.
+    """
+    articles = _load_recent_articles(user_id, days, _MAX_ARTICLES, database_url)
+
+    docs = [
+        _tokenize(f"{article['title'] or ''} {article['summary'] or ''}") for article in articles
+    ]
+    scored = _tfidf_scores([doc for doc in docs if doc])
+
+    ranked = sorted(scored.items(), key=lambda item: (-item[1][1], item[0]))[:max_terms]
+    max_score = ranked[0][1][1] if ranked else 1.0
+
+    return {
+        "terms": [
+            {"term": term, "count": count, "weight": score / max_score}
+            for term, (count, score) in ranked
+        ],
+        "article_count": len(articles),
+        "days": days,
+    }
+
+
+def _cluster_label(titles: list[str]) -> str:
+    """Deterministic cluster label: the top TF-IDF terms of member titles."""
+    docs = [_tokenize(title) for title in titles]
+    scored = _tfidf_scores([doc for doc in docs if doc])
+    top = sorted(scored.items(), key=lambda item: (-item[1][1], item[0]))[:_LABEL_TERMS]
+    return " · ".join(term for term, _ in top)
+
+
+def embedding_map(
+    user_id: int | None = None,
+    days: int = 7,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Per-article 2D PCA projection of stored embeddings with greedy clusters.
+
+    Returns ``{"points", "clusters", "embedded_count", "total_count", "days"}``;
+    ``total_count`` includes visible articles that have no embedding yet so the
+    UI can explain sparse maps.
+    """
+    all_articles = _load_recent_articles(user_id, days, _MAX_ARTICLES, database_url)
+    embedded = load_recent_embedded_articles(user_id=user_id, days=days, database_url=database_url)
+
+    if not embedded:
+        return {
+            "points": [],
+            "clusters": [],
+            "embedded_count": 0,
+            "total_count": len(all_articles),
+            "days": days,
+        }
+
+    norm_vecs = [
+        normalize_vector(decode_embedding(bytes(article["embedding"]))) for article in embedded
+    ]
+    coords = pca_2d(norm_vecs)
+    assignments = greedy_cluster(norm_vecs, _CLUSTER_THRESHOLD)
+
+    members: dict[int, list[int]] = {}
+    for idx, cid in enumerate(assignments):
+        members.setdefault(cid, []).append(idx)
+
+    clusters = [
+        {
+            "id": cid,
+            "label": _cluster_label([embedded[i]["title"] or "" for i in indices]),
+            "size": len(indices),
+        }
+        for cid, indices in sorted(members.items(), key=lambda item: -len(item[1]))
+    ]
+
+    points = [
+        {
+            "id": article["id"],
+            "title": article["title"],
+            "category": article["category"],
+            "x": x,
+            "y": y,
+            "cluster": cid,
+        }
+        for article, (x, y), cid in zip(embedded, coords, assignments, strict=True)
+    ]
+
+    return {
+        "points": points,
+        "clusters": clusters,
+        "embedded_count": len(embedded),
+        "total_count": len(all_articles),
+        "days": days,
+    }

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -311,6 +311,14 @@ def _greedy_cluster(normalized_vecs: list[list[float]], threshold: float) -> lis
     return assignments
 
 
+# Public aliases for reuse by other feature modules (e.g. ai_stats); the
+# underscore-prefixed names stay for existing imports and tests.
+pca_2d = _pca_2d
+greedy_cluster = _greedy_cluster
+normalize_vector = _normalize
+unpack_embedding = _unpack_embedding
+
+
 def _generate_cluster_label(
     articles: list[dict[str, Any]],
     user_id: int | None = None,
@@ -358,19 +366,15 @@ def _generate_cluster_label(
     return headline, trend_summary
 
 
-def cluster_recent_articles(
+def load_recent_embedded_articles(
     user_id: int | None = None,
+    days: int = 7,
+    limit: int = _MAX_ARTICLES,
     database_url: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Cluster articles from the last 7 days by embedding similarity.
+    """Load recent articles that have an embedding, scoped to the user's visible sources.
 
-    Returns a list of story cluster dicts:
-      - id: int
-      - headline: str
-      - trend_summary: str
-      - x, y: float (2D coordinates in [-1, 1])
-      - article_ids: list[int]
-      - articles: list[{id, title, url, summary}]
+    Returns dicts with keys: id, title, url, summary, category, embedding.
     """
     init_db(database_url=database_url)
 
@@ -380,12 +384,12 @@ def cluster_recent_articles(
                 """
                 SELECT id, title, url, summary, category, embedding
                 FROM articles
-                WHERE discovered_at::timestamptz >= NOW() - INTERVAL '7 days'
+                WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
                   AND embedding IS NOT NULL
                 ORDER BY discovered_at DESC
                 LIMIT %s
                 """,
-                (_MAX_ARTICLES,),
+                (days, limit),
             ).fetchall()
         else:
             rows = conn.execute(
@@ -397,7 +401,7 @@ def cluster_recent_articles(
                   ON us.source_slug = src.slug AND us.user_id = %s
                 LEFT JOIN user_article_state uas
                   ON uas.article_id = a.id AND uas.user_id = %s
-                WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '7 days'
+                WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
                   AND a.embedding IS NOT NULL
                   AND COALESCE(uas.state, 'today') != 'archived'
                   AND (
@@ -413,8 +417,27 @@ def cluster_recent_articles(
                 ORDER BY a.discovered_at DESC
                 LIMIT %s
                 """,
-                (user_id, user_id, user_id, _MAX_ARTICLES),
+                (user_id, user_id, days, user_id, limit),
             ).fetchall()
+
+    return [dict(row) for row in rows]
+
+
+def cluster_recent_articles(
+    user_id: int | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Cluster articles from the last 7 days by embedding similarity.
+
+    Returns a list of story cluster dicts:
+      - id: int
+      - headline: str
+      - trend_summary: str
+      - x, y: float (2D coordinates in [-1, 1], mean of member positions)
+      - article_ids: list[int]
+      - articles: list[{id, title, url, summary, category, x, y}]
+    """
+    rows = load_recent_embedded_articles(user_id=user_id, database_url=database_url)
 
     if not rows:
         return []
@@ -448,16 +471,12 @@ def cluster_recent_articles(
     if not valid_clusters:
         return []
 
-    centroids = [
-        _normalize(_vec_mean([norm_vecs[i] for i in indices])) for _, indices in valid_clusters
-    ]
-    coords_2d = _pca_2d(centroids)
+    article_coords = _pca_2d(norm_vecs)
 
     result: list[dict[str, Any]] = []
-    for cluster_seq, ((cid, indices), (cx, cy)) in enumerate(
-        zip(valid_clusters, coords_2d, strict=False)
-    ):
+    for cluster_seq, (cid, indices) in enumerate(valid_clusters):
         cluster_articles = [article_data[i] for i in indices]
+        member_coords = [article_coords[i] for i in indices]
         try:
             headline, trend_summary = _generate_cluster_label(cluster_articles, user_id=user_id)
         except Exception:
@@ -470,8 +489,8 @@ def cluster_recent_articles(
                 "id": cluster_seq,
                 "headline": headline,
                 "trend_summary": trend_summary,
-                "x": cx,
-                "y": cy,
+                "x": sum(x for x, _ in member_coords) / len(member_coords),
+                "y": sum(y for _, y in member_coords) / len(member_coords),
                 "article_ids": [a["id"] for a in cluster_articles],
                 "articles": [
                     {
@@ -479,8 +498,11 @@ def cluster_recent_articles(
                         "title": a["title"],
                         "url": a["url"],
                         "summary": a["summary"],
+                        "category": a["category"],
+                        "x": ax,
+                        "y": ay,
                     }
-                    for a in cluster_articles
+                    for a, (ax, ay) in zip(cluster_articles, member_coords, strict=True)
                 ],
             }
         )

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2776,8 +2776,10 @@ def admin_delete_user(
 
 # Feature-module routers mount onto ``api`` so they inherit its ``require_auth``
 # gate. Add each new domain's router here as it is extracted from main.py.
+from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E402
 from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
 
+api.include_router(ai_stats_router)
 api.include_router(quizzes_router)
 
 app.include_router(api)

--- a/backend/tests/test_ai_stats.py
+++ b/backend/tests/test_ai_stats.py
@@ -1,0 +1,293 @@
+"""Tests for the ai_stats feature module's service layer.
+
+Covers the word-cloud TF-IDF aggregation and the per-article embedding map,
+including per-user visibility scoping (global vs private vs disabled sources).
+"""
+
+from __future__ import annotations
+
+import struct
+
+from news_dashboard.ai_stats.service import _tokenize, embedding_map, word_cloud
+from news_dashboard.db import connect
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _pack_vec(vec: list[float]) -> bytes:
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+def _seed_source(
+    pg_url: str,
+    slug: str,
+    *,
+    owner_user_id: int | None = None,
+) -> None:
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES (%s, %s, %s, 'tech', 'rss_feed', %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug, f"https://{slug}.example", owner_user_id),
+        )
+
+
+def _seed_article(
+    pg_url: str,
+    *,
+    slug: str = "ai-stats-src",
+    url_slug: str,
+    title: str,
+    summary: str = "",
+    category: str = "tech",
+    embedding: list[float] | None = None,
+) -> int:
+    _seed_source(pg_url, slug)
+    blob = _pack_vec(embedding) if embedding is not None else None
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, summary, embedding, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', %s, %s, NOW())
+            RETURNING id
+            """,
+            (
+                f"https://{slug}.example/{url_slug}",
+                f"https://{slug}.example/{url_slug}",
+                title,
+                slug,
+                slug,
+                category,
+                summary,
+                blob,
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_user(pg_url: str, username: str) -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, 'x') RETURNING id",
+            (username,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+# ── _tokenize ─────────────────────────────────────────────────────────────────
+
+
+def test_tokenize_filters_stopwords_and_short_tokens() -> None:
+    tokens = _tokenize("The new AI model and its uses in an open, modern world")
+    assert "the" not in tokens
+    assert "and" not in tokens
+    assert "its" not in tokens
+    assert "in" not in tokens
+    assert "an" not in tokens
+    assert "ai" not in tokens  # shorter than 3 chars
+    assert "model" in tokens
+    assert "modern" in tokens
+    assert "world" in tokens
+
+
+def test_tokenize_lowercases_and_keeps_hyphenated_terms() -> None:
+    tokens = _tokenize("Kubernetes-Native tooling beats VM-based flows")
+    assert "kubernetes-native" in tokens
+    assert "vm-based" in tokens
+    assert "tooling" in tokens
+
+
+# ── word_cloud ────────────────────────────────────────────────────────────────
+
+
+def test_word_cloud_empty_corpus_returns_no_terms(pg_clean: str) -> None:
+    result = word_cloud(database_url=pg_clean)
+    assert result["terms"] == []
+    assert result["article_count"] == 0
+    assert result["days"] == 7
+
+
+def test_word_cloud_ranks_distinctive_terms_above_ubiquitous(pg_clean: str) -> None:
+    # "kubernetes" appears once in every article (ubiquitous), while
+    # "quantum" appears three times but only in a single article.
+    for idx in range(4):
+        _seed_article(
+            pg_clean,
+            url_slug=f"ubiquitous-{idx}",
+            title=f"Kubernetes release note {idx}",
+            summary="Improvements landed.",
+        )
+    _seed_article(
+        pg_clean,
+        url_slug="distinctive",
+        title="Quantum breakthrough: quantum chips go mainstream",
+        summary="A quantum leap for kubernetes workloads.",
+    )
+
+    result = word_cloud(database_url=pg_clean)
+    terms = {t["term"]: t for t in result["terms"]}
+    assert "quantum" in terms
+    assert "kubernetes" in terms
+    ranked = [t["term"] for t in result["terms"]]
+    assert ranked.index("quantum") < ranked.index("kubernetes")
+    assert result["article_count"] == 5
+
+
+def test_word_cloud_weights_normalized_and_counts_reported(pg_clean: str) -> None:
+    _seed_article(
+        pg_clean,
+        url_slug="weights",
+        title="Rust rewrites accelerate compilers",
+        summary="Rust rust rust everywhere.",
+    )
+    result = word_cloud(database_url=pg_clean)
+    assert result["terms"], "expected at least one term"
+    weights = [t["weight"] for t in result["terms"]]
+    assert max(weights) == 1.0
+    assert all(0.0 < w <= 1.0 for w in weights)
+    top = result["terms"][0]
+    assert top["term"] == "rust"
+    assert top["count"] == 4
+
+
+def test_word_cloud_caps_terms(pg_clean: str) -> None:
+    _seed_article(
+        pg_clean,
+        url_slug="caps",
+        title="alpha bravo charlie delta echo foxtrot golf hotel india juliet",
+        summary="kilo lima mike november oscar papa quebec romeo sierra tango",
+    )
+    result = word_cloud(database_url=pg_clean, max_terms=5)
+    assert len(result["terms"]) == 5
+
+
+def test_word_cloud_scopes_to_user_visible_articles(pg_clean: str) -> None:
+    user_id = _seed_user(pg_clean, "wc-user")
+    other_id = _seed_user(pg_clean, "wc-other")
+
+    _seed_source(pg_clean, "wc-visible-global")
+    _seed_source(pg_clean, "wc-disabled-global")
+    _seed_source(pg_clean, "wc-own-private", owner_user_id=user_id)
+    _seed_source(pg_clean, "wc-other-private", owner_user_id=other_id)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled)"
+            " VALUES (%s, 'wc-disabled-global', FALSE)",
+            (user_id,),
+        )
+
+    _seed_article(pg_clean, slug="wc-visible-global", url_slug="v", title="Visibleterm everywhere")
+    _seed_article(pg_clean, slug="wc-own-private", url_slug="o", title="Ownprivateterm article")
+    _seed_article(pg_clean, slug="wc-disabled-global", url_slug="d", title="Disabledterm article")
+    _seed_article(pg_clean, slug="wc-other-private", url_slug="x", title="Foreignterm article")
+
+    result = word_cloud(user_id=user_id, database_url=pg_clean)
+    terms = {t["term"] for t in result["terms"]}
+    assert "visibleterm" in terms
+    assert "ownprivateterm" in terms
+    assert "disabledterm" not in terms
+    assert "foreignterm" not in terms
+    assert result["article_count"] == 2
+
+
+# ── embedding_map ─────────────────────────────────────────────────────────────
+
+
+def test_embedding_map_empty_corpus(pg_clean: str) -> None:
+    result = embedding_map(database_url=pg_clean)
+    assert result["points"] == []
+    assert result["clusters"] == []
+    assert result["embedded_count"] == 0
+    assert result["total_count"] == 0
+
+
+def test_embedding_map_returns_per_article_points_within_unit_range(pg_clean: str) -> None:
+    dim = 8
+    for idx in range(4):
+        vec = [0.0] * dim
+        vec[idx] = 1.0
+        _seed_article(
+            pg_clean,
+            url_slug=f"pt-{idx}",
+            title=f"Point article {idx}",
+            embedding=vec,
+        )
+
+    result = embedding_map(database_url=pg_clean)
+    assert len(result["points"]) == 4
+    for point in result["points"]:
+        assert set(point) >= {"id", "title", "category", "x", "y", "cluster"}
+        assert -1.01 <= point["x"] <= 1.01
+        assert -1.01 <= point["y"] <= 1.01
+        assert point["category"] == "tech"
+
+
+def test_embedding_map_groups_similar_vectors_into_same_cluster(pg_clean: str) -> None:
+    dim = 8
+    group_a = [[1.0, 0.01 * i] + [0.0] * (dim - 2) for i in range(3)]
+    group_b = [[0.0] * (dim - 2) + [0.01 * i, 1.0] for i in range(3)]
+    ids_a = [
+        _seed_article(pg_clean, url_slug=f"a-{i}", title=f"Alpha topic {i}", embedding=v)
+        for i, v in enumerate(group_a)
+    ]
+    ids_b = [
+        _seed_article(pg_clean, url_slug=f"b-{i}", title=f"Beta subject {i}", embedding=v)
+        for i, v in enumerate(group_b)
+    ]
+
+    result = embedding_map(database_url=pg_clean)
+    cluster_of = {p["id"]: p["cluster"] for p in result["points"]}
+    assert len({cluster_of[i] for i in ids_a}) == 1
+    assert len({cluster_of[i] for i in ids_b}) == 1
+    assert cluster_of[ids_a[0]] != cluster_of[ids_b[0]]
+
+    clusters = {c["id"]: c for c in result["clusters"]}
+    assert clusters[cluster_of[ids_a[0]]]["size"] == 3
+    assert clusters[cluster_of[ids_a[0]]]["label"]
+    assert "alpha" in clusters[cluster_of[ids_a[0]]]["label"].lower()
+
+
+def test_embedding_map_excludes_unembedded_but_counts_them(pg_clean: str) -> None:
+    for idx in range(3):
+        _seed_article(
+            pg_clean,
+            url_slug=f"emb-{idx}",
+            title=f"Embedded {idx}",
+            embedding=[1.0, 0.01 * idx, 0.0, 0.0],
+        )
+    for idx in range(2):
+        _seed_article(pg_clean, url_slug=f"raw-{idx}", title=f"Unembedded {idx}")
+
+    result = embedding_map(database_url=pg_clean)
+    assert len(result["points"]) == 3
+    assert result["embedded_count"] == 3
+    assert result["total_count"] == 5
+
+
+def test_embedding_map_scopes_to_user_visible_articles(pg_clean: str) -> None:
+    user_id = _seed_user(pg_clean, "em-user")
+    other_id = _seed_user(pg_clean, "em-other")
+    _seed_source(pg_clean, "em-global")
+    _seed_source(pg_clean, "em-other-private", owner_user_id=other_id)
+
+    vec = [1.0, 0.0, 0.0, 0.0]
+    visible_id = _seed_article(
+        pg_clean, slug="em-global", url_slug="v", title="Visible", embedding=vec
+    )
+    hidden_id = _seed_article(
+        pg_clean, slug="em-other-private", url_slug="h", title="Hidden", embedding=vec
+    )
+
+    result = embedding_map(user_id=user_id, database_url=pg_clean)
+    ids = {p["id"] for p in result["points"]}
+    assert visible_id in ids
+    assert hidden_id not in ids
+    assert result["total_count"] == 1

--- a/backend/tests/test_ai_stats_api.py
+++ b/backend/tests/test_ai_stats_api.py
@@ -1,0 +1,72 @@
+"""HTTP contract tests for the ai_stats feature-module router."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.main import app
+
+
+def _client() -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 42,
+        "username": "reader",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_ai_stats_routes_are_registered() -> None:
+    paths = app.openapi()["paths"]
+    assert "/api/ai-stats/word-cloud" in paths
+    assert "/api/ai-stats/embedding-map" in paths
+
+
+def test_word_cloud_endpoint_passes_user_and_days(monkeypatch: Any) -> None:
+    def fake_word_cloud(*, user_id: int, days: int) -> dict[str, Any]:
+        assert user_id == 42
+        assert days == 14
+        return {"terms": [], "article_count": 0, "days": days}
+
+    monkeypatch.setattr("news_dashboard.ai_stats.service.word_cloud", fake_word_cloud)
+
+    response = _client().get("/api/ai-stats/word-cloud?days=14")
+
+    assert response.status_code == 200
+    assert response.json() == {"terms": [], "article_count": 0, "days": 14}
+
+
+def test_embedding_map_endpoint_passes_user_and_days(monkeypatch: Any) -> None:
+    def fake_embedding_map(*, user_id: int, days: int) -> dict[str, Any]:
+        assert user_id == 42
+        assert days == 7
+        return {
+            "points": [],
+            "clusters": [],
+            "embedded_count": 0,
+            "total_count": 0,
+            "days": days,
+        }
+
+    monkeypatch.setattr("news_dashboard.ai_stats.service.embedding_map", fake_embedding_map)
+
+    response = _client().get("/api/ai-stats/embedding-map")
+
+    assert response.status_code == 200
+    assert response.json()["days"] == 7
+
+
+def test_word_cloud_days_out_of_range_is_422() -> None:
+    client = _client()
+    assert client.get("/api/ai-stats/word-cloud?days=0").status_code == 422
+    assert client.get("/api/ai-stats/word-cloud?days=31").status_code == 422
+
+
+def test_embedding_map_days_out_of_range_is_422() -> None:
+    client = _client()
+    assert client.get("/api/ai-stats/embedding-map?days=0").status_code == 422
+    assert client.get("/api/ai-stats/embedding-map?days=31").status_code == 422

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -28,6 +28,7 @@ from news_dashboard.insights import (
     cluster_recent_articles,
     generate_insights,
     get_or_generate_insights,
+    load_recent_embedded_articles,
 )
 
 # ── shared test data ──────────────────────────────────────────────────────────
@@ -820,3 +821,51 @@ def test_cluster_recent_articles_returns_empty_below_min_size(pg_clean: str) -> 
 
     result = cluster_recent_articles(database_url=pg_clean)
     assert result == []
+
+
+def test_cluster_recent_articles_returns_per_article_coordinates(pg_clean: str) -> None:
+    """Every clustered article carries its own 2D position and category."""
+    dim = 16
+    group_a = [
+        _normalize([1.0 if j == 0 else 0.01 * j for j in range(dim)]),
+        _normalize([1.0 if j == 0 else 0.011 * j for j in range(dim)]),
+        _normalize([1.0 if j == 0 else 0.012 * j for j in range(dim)]),
+    ]
+    group_b = [
+        _normalize([1.0 if j == dim - 1 else 0.01 * j for j in range(dim)]),
+        _normalize([1.0 if j == dim - 1 else 0.011 * j for j in range(dim)]),
+        _normalize([1.0 if j == dim - 1 else 0.012 * j for j in range(dim)]),
+    ]
+
+    _seed_articles_with_embeddings(pg_clean, [group_a, group_b])
+
+    with patch(
+        "news_dashboard.insights._generate_cluster_label",
+        return_value=("Cluster", "Summary."),
+    ):
+        clusters = cluster_recent_articles(database_url=pg_clean)
+
+    assert clusters
+    for cluster in clusters:
+        for article in cluster["articles"]:
+            assert -1.01 <= article["x"] <= 1.01
+            assert -1.01 <= article["y"] <= 1.01
+            assert article["category"] == "tech"
+        # The cluster position is the mean of its members' positions.
+        mean_x = sum(a["x"] for a in cluster["articles"]) / len(cluster["articles"])
+        mean_y = sum(a["y"] for a in cluster["articles"]) / len(cluster["articles"])
+        assert abs(cluster["x"] - mean_x) < 1e-6
+        assert abs(cluster["y"] - mean_y) < 1e-6
+
+
+def test_load_recent_embedded_articles_returns_only_embedded_rows(pg_clean: str) -> None:
+    vec = _normalize([1.0, 0.02, 0.03, 0.04])
+    _seed_articles_with_embeddings(pg_clean, [[vec, vec]])
+    _seed_article(pg_clean)  # no embedding
+
+    rows = load_recent_embedded_articles(user_id=None, database_url=pg_clean)
+
+    assert len(rows) == 2
+    for row in rows:
+        assert set(row) >= {"id", "title", "url", "summary", "category", "embedding"}
+        assert row["embedding"] is not None

--- a/backend/tests/test_topic_map_api.py
+++ b/backend/tests/test_topic_map_api.py
@@ -29,7 +29,16 @@ def test_topic_map_static_route_is_not_parsed_as_article_id(monkeypatch: Any) ->
                 "x": 0.0,
                 "y": 0.0,
                 "article_ids": [7],
-                "articles": [{"id": 7, "title": "Article 7", "source": "Example"}],
+                "articles": [
+                    {
+                        "id": 7,
+                        "title": "Article 7",
+                        "source": "Example",
+                        "x": 0.25,
+                        "y": -0.5,
+                        "category": "tech",
+                    }
+                ],
             }
         ]
 
@@ -41,7 +50,12 @@ def test_topic_map_static_route_is_not_parsed_as_article_id(monkeypatch: Any) ->
     response = _client().get("/api/articles/topic-map")
 
     assert response.status_code == 200
-    assert response.json()["clusters"][0]["headline"] == "Topic arc"
+    payload = response.json()
+    assert payload["clusters"][0]["headline"] == "Topic arc"
+    article = payload["clusters"][0]["articles"][0]
+    assert article["x"] == 0.25
+    assert article["y"] == -0.5
+    assert article["category"] == "tech"
 
 
 def test_numeric_article_detail_route_still_resolves(monkeypatch: Any) -> None:

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -57,6 +57,9 @@ const BriefingDetailPage = lazy(() =>
 const TopicMapPage = lazy(() =>
   import('./pages/TopicMapPage').then((m) => ({ default: m.TopicMapPage }))
 );
+const AiStatsPage = lazy(() =>
+  import('./pages/AiStatsPage').then((m) => ({ default: m.AiStatsPage }))
+);
 
 function PageLoader() {
   return (
@@ -155,6 +158,7 @@ export const routes: RouteObject[] = [
       { path: 'briefs', element: withSuspense(BriefingsHistoryPage) },
       { path: 'briefs/:id', element: withSuspense(BriefingDetailPage) },
       { path: 'topic-map', element: withSuspense(TopicMapPage) },
+      { path: 'ai-stats', element: withSuspense(AiStatsPage) },
       {
         path: 'stats',
         element: (

--- a/frontend/src/__tests__/aiStatsPage.test.tsx
+++ b/frontend/src/__tests__/aiStatsPage.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AiStatsPage } from '../pages/AiStatsPage';
+import * as api from '../api';
+import type { EmbeddingMapResponse, WordCloudResponse } from '../types';
+
+vi.mock('../api', () => ({
+  fetchAiWordCloud: vi.fn(),
+  fetchAiEmbeddingMap: vi.fn(),
+}));
+
+const mockedApi = vi.mocked(api, true);
+
+const WORD_CLOUD: WordCloudResponse = {
+  terms: [
+    { term: 'kubernetes', count: 12, weight: 1 },
+    { term: 'quantum', count: 5, weight: 0.6 },
+  ],
+  article_count: 40,
+  days: 7,
+};
+
+const EMBEDDING_MAP: EmbeddingMapResponse = {
+  points: [
+    { id: 1, title: 'Alpha article', category: 'tech', x: 0.5, y: -0.5, cluster: 0 },
+    { id: 2, title: 'Beta article', category: 'science', x: -0.4, y: 0.2, cluster: 1 },
+  ],
+  clusters: [
+    { id: 0, label: 'alpha · topic', size: 1 },
+    { id: 1, label: 'beta · subject', size: 1 },
+  ],
+  embedded_count: 2,
+  total_count: 10,
+  days: 7,
+};
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <AiStatsPage />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockedApi.fetchAiWordCloud.mockResolvedValue(WORD_CLOUD);
+  mockedApi.fetchAiEmbeddingMap.mockResolvedValue(EMBEDDING_MAP);
+});
+
+describe('AiStatsPage', () => {
+  it('renders word cloud terms as SVG text', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('kubernetes')).toBeInTheDocument();
+    });
+    expect(screen.getByText('quantum')).toBeInTheDocument();
+  });
+
+  it('renders one embedding-map point per article', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="embedding-point"]')).toHaveLength(2);
+    });
+  });
+
+  it('shows the embedding coverage note', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/2 of 10 articles/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error state with retry when the word cloud fails', async () => {
+    mockedApi.fetchAiWordCloud.mockRejectedValue(new Error('boom'));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load word cloud/i)).toBeInTheDocument();
+    });
+    expect(screen.getAllByRole('button', { name: /retry/i }).length).toBeGreaterThan(0);
+  });
+
+  it('refetches with the selected range when a days option is clicked', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(mockedApi.fetchAiWordCloud).toHaveBeenCalledWith(7);
+    });
+    screen.getByRole('button', { name: '30d' }).click();
+    await waitFor(() => {
+      expect(mockedApi.fetchAiWordCloud).toHaveBeenCalledWith(30);
+    });
+  });
+});

--- a/frontend/src/__tests__/convexHull.test.ts
+++ b/frontend/src/__tests__/convexHull.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { convexHull, padHull } from '../lib/convexHull';
+
+describe('convexHull', () => {
+  it('returns the input for fewer than 3 points', () => {
+    expect(convexHull([])).toEqual([]);
+    expect(convexHull([{ x: 1, y: 2 }])).toEqual([{ x: 1, y: 2 }]);
+  });
+
+  it('drops interior points of a square', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+      { x: 4, y: 4 },
+      { x: 0, y: 4 },
+      { x: 2, y: 2 }, // interior
+    ];
+    const hull = convexHull(square);
+    expect(hull).toHaveLength(4);
+    expect(hull).not.toContainEqual({ x: 2, y: 2 });
+  });
+
+  it('handles collinear and duplicate points', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 2 },
+    ];
+    const hull = convexHull(points);
+    expect(hull).toHaveLength(3);
+  });
+});
+
+describe('padHull', () => {
+  it('expands the hull outward from its centroid', () => {
+    const hull = [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 2 },
+      { x: 0, y: 2 },
+    ];
+    const padded = padHull(hull, 1);
+    // Centroid is (1,1); every padded vertex must be further from it.
+    for (let i = 0; i < hull.length; i++) {
+      const before = Math.hypot(hull[i].x - 1, hull[i].y - 1);
+      const after = Math.hypot(padded[i].x - 1, padded[i].y - 1);
+      expect(after).toBeGreaterThan(before);
+    }
+  });
+});

--- a/frontend/src/__tests__/navigation.test.ts
+++ b/frontend/src/__tests__/navigation.test.ts
@@ -62,3 +62,14 @@ describe('navigation metadata', () => {
     expect(isNavigationItemActive('/feeds', '/stats')).toBe(false);
   });
 });
+
+describe('AI Stats navigation', () => {
+  it('lists /ai-stats in the secondary navigation', () => {
+    const targets = secondaryNavigationItems.map((item) => item.to);
+    expect(targets).toContain('/ai-stats');
+  });
+
+  it('titles the AI Stats page', () => {
+    expect(getPageTitle('/ai-stats')).toBe('AI Stats');
+  });
+});

--- a/frontend/src/__tests__/topicMapPage.test.tsx
+++ b/frontend/src/__tests__/topicMapPage.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TopicMapPage } from '../pages/TopicMapPage';
+import * as api from '../api';
+import type { TopicMapResponse } from '../types';
+
+vi.mock('../api', () => ({
+  fetchTopicMap: vi.fn(),
+}));
+
+const mockedApi = vi.mocked(api, true);
+
+const TOPIC_MAP: TopicMapResponse = {
+  clusters: [
+    {
+      id: 0,
+      headline: 'AI chips heat up',
+      trend_summary: 'Several vendors announced accelerators.',
+      x: 0.1,
+      y: 0.1,
+      article_ids: [1, 2, 3],
+      articles: [
+        {
+          id: 1,
+          title: 'Vendor A ships chip',
+          url: 'https://example.com/1',
+          summary: 'S1',
+          category: 'tech',
+          x: 0.0,
+          y: 0.0,
+        },
+        {
+          id: 2,
+          title: 'Vendor B ships chip',
+          url: 'https://example.com/2',
+          summary: 'S2',
+          category: 'tech',
+          x: 0.2,
+          y: 0.1,
+        },
+        {
+          id: 3,
+          title: 'Vendor C ships chip',
+          url: 'https://example.com/3',
+          summary: 'S3',
+          category: 'business',
+          x: 0.1,
+          y: 0.2,
+        },
+      ],
+    },
+  ],
+};
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={['/topic-map']}>
+      <QueryClientProvider client={client}>
+        <Routes>
+          <Route path="/topic-map" element={<TopicMapPage />} />
+          <Route path="/a/:id" element={<div>article detail</div>} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockedApi.fetchTopicMap.mockResolvedValue(TOPIC_MAP);
+});
+
+describe('TopicMapPage embedding scatter', () => {
+  it('renders one point per article at its own position (no orbit rings)', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="article-point"]')).toHaveLength(3);
+    });
+    const points = [...container.querySelectorAll('[data-testid="article-point"]')];
+    const xs = new Set(points.map((p) => p.getAttribute('cx')));
+    // Distinct per-article coordinates, not a shared orbit radius.
+    expect(xs.size).toBeGreaterThan(1);
+  });
+
+  it('draws a convex hull path for the cluster', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="cluster-hull"]')).not.toBeNull();
+    });
+  });
+
+  it('shows the cluster headline label', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('AI chips heat up')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to the article when a point is clicked', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="article-point"]')).toHaveLength(3);
+    });
+    fireEvent.click(container.querySelectorAll('[data-testid="article-point"]')[0]);
+    await waitFor(() => {
+      expect(screen.getByText('article detail')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/wordCloudLayout.test.ts
+++ b/frontend/src/__tests__/wordCloudLayout.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { layoutWordCloud, type PlacedTerm } from '../lib/wordCloudLayout';
+
+const CANVAS = { width: 800, height: 480 };
+
+function boxesOverlap(a: PlacedTerm, b: PlacedTerm): boolean {
+  return (
+    Math.abs(a.x - b.x) * 2 < a.boxWidth + b.boxWidth &&
+    Math.abs(a.y - b.y) * 2 < a.boxHeight + b.boxHeight
+  );
+}
+
+describe('layoutWordCloud', () => {
+  it('returns an empty layout for no terms', () => {
+    expect(layoutWordCloud([], CANVAS.width, CANVAS.height)).toEqual([]);
+  });
+
+  it('is deterministic for the same input', () => {
+    const terms = [
+      { term: 'kubernetes', weight: 1 },
+      { term: 'quantum', weight: 0.6 },
+      { term: 'rust', weight: 0.3 },
+    ];
+    const a = layoutWordCloud(terms, CANVAS.width, CANVAS.height);
+    const b = layoutWordCloud(terms, CANVAS.width, CANVAS.height);
+    expect(a).toEqual(b);
+  });
+
+  it('gives higher-weighted terms a larger font size', () => {
+    const placed = layoutWordCloud(
+      [
+        { term: 'big', weight: 1 },
+        { term: 'small', weight: 0.1 },
+      ],
+      CANVAS.width,
+      CANVAS.height
+    );
+    const big = placed.find((p) => p.term === 'big')!;
+    const small = placed.find((p) => p.term === 'small')!;
+    expect(big.fontSize).toBeGreaterThan(small.fontSize);
+  });
+
+  it('places terms without overlapping boxes and inside the canvas', () => {
+    const terms = Array.from({ length: 30 }, (_, i) => ({
+      term: `term-${i}`,
+      weight: 1 - i / 30,
+    }));
+    const placed = layoutWordCloud(terms, CANVAS.width, CANVAS.height);
+    expect(placed.length).toBeGreaterThan(0);
+    for (let i = 0; i < placed.length; i++) {
+      expect(placed[i].x - placed[i].boxWidth / 2).toBeGreaterThanOrEqual(0);
+      expect(placed[i].x + placed[i].boxWidth / 2).toBeLessThanOrEqual(CANVAS.width);
+      expect(placed[i].y - placed[i].boxHeight / 2).toBeGreaterThanOrEqual(0);
+      expect(placed[i].y + placed[i].boxHeight / 2).toBeLessThanOrEqual(CANVAS.height);
+      for (let j = i + 1; j < placed.length; j++) {
+        expect(boxesOverlap(placed[i], placed[j])).toBe(false);
+      }
+    }
+  });
+
+  it('assigns a stable color index per term', () => {
+    const placed = layoutWordCloud(
+      [
+        { term: 'alpha', weight: 1 },
+        { term: 'beta', weight: 0.5 },
+      ],
+      CANVAS.width,
+      CANVAS.height
+    );
+    for (const p of placed) {
+      expect(p.colorIndex).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(p.colorIndex)).toBe(true);
+    }
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -43,6 +43,8 @@ import type {
   IngestRunPage,
   IngestRunSource,
   TopicMapResponse,
+  WordCloudResponse,
+  EmbeddingMapResponse,
   User,
 } from './types';
 
@@ -705,6 +707,14 @@ export async function postShareMessage(shareId: number, message: string): Promis
 
 export async function fetchTopicMap(): Promise<TopicMapResponse> {
   return requestJson<TopicMapResponse>('/api/articles/topic-map');
+}
+
+export async function fetchAiWordCloud(days = 7): Promise<WordCloudResponse> {
+  return requestJson<WordCloudResponse>(`/api/ai-stats/word-cloud?days=${days}`);
+}
+
+export async function fetchAiEmbeddingMap(days = 7): Promise<EmbeddingMapResponse> {
+  return requestJson<EmbeddingMapResponse>(`/api/ai-stats/embedding-map?days=${days}`);
 }
 
 export async function fetchOnboardingStatus(): Promise<OnboardingStatus> {

--- a/frontend/src/components/aiStats/EmbeddingMapChart.tsx
+++ b/frontend/src/components/aiStats/EmbeddingMapChart.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { EmbeddingMapCluster, EmbeddingMapPoint } from '@/types';
+import { categoryColorMap, colorForCategory } from '@/lib/categoryColor';
+import { convexHull, hullPath, padHull } from '@/lib/convexHull';
+
+const CANVAS_W = 800;
+const CANVAS_H = 560;
+const PADDING = 48;
+const POINT_R = 6;
+const HULL_PAD = 18;
+const MIN_HULL_SIZE = 3;
+
+function toCanvasX(v: number): number {
+  return PADDING + ((v + 1) / 2) * (CANVAS_W - PADDING * 2);
+}
+
+function toCanvasY(v: number): number {
+  return PADDING + ((v + 1) / 2) * (CANVAS_H - PADDING * 2);
+}
+
+interface TooltipState {
+  x: number;
+  y: number;
+  title: string;
+}
+
+interface EmbeddingMapChartProps {
+  points: EmbeddingMapPoint[];
+  clusters: EmbeddingMapCluster[];
+}
+
+export function EmbeddingMapChart({ points, clusters }: EmbeddingMapChartProps) {
+  const navigate = useNavigate();
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+  const colors = useMemo(() => categoryColorMap(points.map((p) => p.category)), [points]);
+
+  const hulls = useMemo(() => {
+    const byCluster = new Map<number, EmbeddingMapPoint[]>();
+    for (const p of points) {
+      const list = byCluster.get(p.cluster) ?? [];
+      list.push(p);
+      byCluster.set(p.cluster, list);
+    }
+    return clusters
+      .filter((c) => (byCluster.get(c.id)?.length ?? 0) >= MIN_HULL_SIZE)
+      .map((cluster) => {
+        const members = byCluster.get(cluster.id) ?? [];
+        const hull = padHull(
+          convexHull(members.map((p) => ({ x: toCanvasX(p.x), y: toCanvasY(p.y) }))),
+          HULL_PAD
+        );
+        const cx = members.reduce((s, p) => s + toCanvasX(p.x), 0) / members.length;
+        const topY = Math.min(...hull.map((h) => h.y));
+        return { cluster, path: hullPath(hull), cx, topY };
+      });
+  }, [points, clusters]);
+
+  const handleClick = useCallback((id: number) => void navigate(`/a/${id}`), [navigate]);
+
+  return (
+    <div className="relative">
+      <svg viewBox={`0 0 ${CANVAS_W} ${CANVAS_H}`} className="h-auto w-full" role="img">
+        <title>Embedding-space map of recent articles</title>
+        {hulls.map(({ cluster, path, cx, topY }) => (
+          <g key={`hull-${cluster.id}`} className="pointer-events-none">
+            <path d={path} className="fill-primary/5 stroke-primary/20 stroke-[1]" />
+            <text
+              x={cx}
+              y={topY - 6}
+              textAnchor="middle"
+              className="select-none fill-muted-foreground text-[11px] font-medium"
+            >
+              {cluster.label}
+            </text>
+          </g>
+        ))}
+        {points.map((p) => (
+          <circle
+            key={p.id}
+            data-testid="embedding-point"
+            cx={toCanvasX(p.x)}
+            cy={toCanvasY(p.y)}
+            r={POINT_R}
+            fill={colorForCategory(colors, p.category)}
+            fillOpacity={0.75}
+            className="cursor-pointer stroke-background stroke-[1.5] transition-all hover:fill-opacity-100"
+            onMouseEnter={(e) => setTooltip({ x: e.clientX, y: e.clientY, title: p.title })}
+            onMouseLeave={() => setTooltip(null)}
+            onClick={() => handleClick(p.id)}
+          />
+        ))}
+      </svg>
+
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+        {[...colors.entries()].map(([category, color]) => (
+          <span
+            key={category}
+            className="flex items-center gap-1.5 text-[11px] text-muted-foreground"
+          >
+            <span className="size-2.5 rounded-full" style={{ backgroundColor: color }} />
+            {category}
+          </span>
+        ))}
+      </div>
+
+      {tooltip && (
+        <div
+          className="pointer-events-none fixed z-50 max-w-xs rounded-lg border border-border bg-background/95 px-3 py-2 shadow-lg backdrop-blur-sm"
+          style={{ left: tooltip.x + 12, top: tooltip.y - 8 }}
+        >
+          <p className="text-xs font-semibold leading-snug">{tooltip.title}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/aiStats/WordCloudChart.tsx
+++ b/frontend/src/components/aiStats/WordCloudChart.tsx
@@ -1,0 +1,48 @@
+import { useMemo, useState } from 'react';
+import type { WordCloudTerm } from '@/types';
+import { layoutWordCloud } from '@/lib/wordCloudLayout';
+
+const CANVAS_W = 800;
+const CANVAS_H = 480;
+
+const TERM_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+  'var(--color-chart-5)',
+];
+
+interface WordCloudChartProps {
+  terms: WordCloudTerm[];
+}
+
+export function WordCloudChart({ terms }: WordCloudChartProps) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const placed = useMemo(() => layoutWordCloud(terms, CANVAS_W, CANVAS_H), [terms]);
+  const countByTerm = useMemo(() => new Map(terms.map((t) => [t.term, t.count])), [terms]);
+
+  return (
+    <svg viewBox={`0 0 ${CANVAS_W} ${CANVAS_H}`} className="h-auto w-full" role="img">
+      <title>Word cloud of recent article terms</title>
+      {placed.map((p) => (
+        <text
+          key={p.term}
+          x={p.x}
+          y={p.y}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={p.fontSize}
+          fill={TERM_COLORS[p.colorIndex % TERM_COLORS.length]}
+          className="cursor-default select-none font-semibold transition-opacity"
+          opacity={hovered === null || hovered === p.term ? 1 : 0.35}
+          onMouseEnter={() => setHovered(p.term)}
+          onMouseLeave={() => setHovered(null)}
+        >
+          {p.term}
+          <title>{`${p.term} — ${countByTerm.get(p.term) ?? 0} mentions`}</title>
+        </text>
+      ))}
+    </svg>
+  );
+}

--- a/frontend/src/lib/categoryColor.ts
+++ b/frontend/src/lib/categoryColor.ts
@@ -1,0 +1,23 @@
+const CHART_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+  'var(--color-chart-5)',
+] as const;
+
+/**
+ * Stable category → chart-color mapping: categories are sorted so the same
+ * corpus always yields the same assignment, independent of point order.
+ */
+export function categoryColorMap(categories: (string | null | undefined)[]): Map<string, string> {
+  const unique = [...new Set(categories.map((c) => c ?? 'other'))].sort();
+  return new Map(unique.map((category, i) => [category, CHART_COLORS[i % CHART_COLORS.length]]));
+}
+
+export function colorForCategory(
+  map: Map<string, string>,
+  category: string | null | undefined
+): string {
+  return map.get(category ?? 'other') ?? CHART_COLORS[0];
+}

--- a/frontend/src/lib/convexHull.ts
+++ b/frontend/src/lib/convexHull.ts
@@ -1,0 +1,61 @@
+export interface HullPoint {
+  x: number;
+  y: number;
+}
+
+function cross(o: HullPoint, a: HullPoint, b: HullPoint): number {
+  return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+}
+
+/**
+ * Convex hull via Andrew's monotone chain, counter-clockwise, without
+ * collinear or duplicate points. Inputs of fewer than 3 points are returned
+ * as-is.
+ */
+export function convexHull(points: HullPoint[]): HullPoint[] {
+  if (points.length < 3) return [...points];
+
+  const sorted = [...points].sort((a, b) => a.x - b.x || a.y - b.y);
+
+  const lower: HullPoint[] = [];
+  for (const p of sorted) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+
+  const upper: HullPoint[] = [];
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const p = sorted[i];
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+
+  lower.pop();
+  upper.pop();
+  return [...lower, ...upper];
+}
+
+/** Expand each hull vertex away from the hull centroid by `padding` units. */
+export function padHull(hull: HullPoint[], padding: number): HullPoint[] {
+  if (hull.length === 0) return [];
+  const cx = hull.reduce((sum, p) => sum + p.x, 0) / hull.length;
+  const cy = hull.reduce((sum, p) => sum + p.y, 0) / hull.length;
+  return hull.map((p) => {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    const dist = Math.hypot(dx, dy) || 1;
+    return { x: p.x + (dx / dist) * padding, y: p.y + (dy / dist) * padding };
+  });
+}
+
+/** Build an SVG path string from hull vertices. */
+export function hullPath(hull: HullPoint[]): string {
+  if (hull.length === 0) return '';
+  const [first, ...rest] = hull;
+  const segments = rest.map((p) => `L ${p.x} ${p.y}`).join(' ');
+  return `M ${first.x} ${first.y} ${segments} Z`;
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -2,6 +2,7 @@ import {
   Activity,
   Archive,
   BarChart3,
+  BrainCircuit,
   Clock,
   History,
   Inbox,
@@ -41,6 +42,7 @@ export const primaryNavigationItems: NavigationItem[] = [
 export const secondaryNavigationItems: NavigationItem[] = [
   { to: '/briefs', label: 'Briefing History', icon: History, shortcut: 'h' },
   { to: '/topic-map', label: 'Topic Map', icon: Network },
+  { to: '/ai-stats', label: 'AI Stats', icon: BrainCircuit },
   { to: '/feeds', label: 'Feeds', icon: Radio, shortcut: 'f' },
   { to: '/reading-dna', label: 'Reading DNA', icon: SlidersHorizontal },
   { to: '/archive', label: 'Archive', icon: Archive },
@@ -133,6 +135,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/search')) return 'Search';
   if (pathname.startsWith('/ask')) return 'Ask AI';
   if (pathname.startsWith('/topic-map')) return 'Topic Map';
+  if (pathname.startsWith('/ai-stats')) return 'AI Stats';
   if (pathname.startsWith('/briefs')) return 'Briefs';
   if (pathname.startsWith('/feeds')) return 'Feeds';
   if (pathname.startsWith('/stats')) return 'Stats';

--- a/frontend/src/lib/wordCloudLayout.ts
+++ b/frontend/src/lib/wordCloudLayout.ts
@@ -1,0 +1,77 @@
+export interface WordCloudInput {
+  term: string;
+  weight: number;
+}
+
+export interface PlacedTerm {
+  term: string;
+  x: number;
+  y: number;
+  fontSize: number;
+  boxWidth: number;
+  boxHeight: number;
+  colorIndex: number;
+}
+
+const MIN_FONT = 12;
+const FONT_RANGE = 30;
+// Rough glyph metrics for a sans-serif face; layout only needs an estimate.
+const CHAR_WIDTH_RATIO = 0.62;
+const LINE_HEIGHT_RATIO = 1.1;
+
+function overlaps(a: PlacedTerm, b: PlacedTerm): boolean {
+  return (
+    Math.abs(a.x - b.x) * 2 < a.boxWidth + b.boxWidth &&
+    Math.abs(a.y - b.y) * 2 < a.boxHeight + b.boxHeight
+  );
+}
+
+function insideCanvas(p: PlacedTerm, width: number, height: number): boolean {
+  return (
+    p.x - p.boxWidth / 2 >= 0 &&
+    p.x + p.boxWidth / 2 <= width &&
+    p.y - p.boxHeight / 2 >= 0 &&
+    p.y + p.boxHeight / 2 <= height
+  );
+}
+
+/**
+ * Deterministic word-cloud layout: terms are placed heaviest-first along an
+ * Archimedean spiral from the canvas center, rejecting positions that overlap
+ * already-placed boxes. Terms that cannot fit are dropped.
+ */
+export function layoutWordCloud(
+  terms: WordCloudInput[],
+  width: number,
+  height: number
+): PlacedTerm[] {
+  const placed: PlacedTerm[] = [];
+  const sorted = [...terms].sort((a, b) => b.weight - a.weight || a.term.localeCompare(b.term));
+
+  sorted.forEach((input, index) => {
+    const fontSize = MIN_FONT + input.weight * FONT_RANGE;
+    const candidate: PlacedTerm = {
+      term: input.term,
+      x: width / 2,
+      y: height / 2,
+      fontSize,
+      boxWidth: Math.max(CHAR_WIDTH_RATIO * fontSize * input.term.length, fontSize),
+      boxHeight: LINE_HEIGHT_RATIO * fontSize,
+      colorIndex: index % 5,
+    };
+
+    const step = 0.35;
+    const radiusPerTurn = 4.5;
+    for (let i = 0; i < 2000; i++) {
+      const angle = step * i;
+      candidate.x = width / 2 + ((radiusPerTurn * angle) / (2 * Math.PI)) * Math.cos(angle);
+      candidate.y = height / 2 + ((radiusPerTurn * angle) / (2 * Math.PI)) * Math.sin(angle) * 0.7;
+      if (insideCanvas(candidate, width, height) && placed.every((p) => !overlaps(p, candidate))) {
+        placed.push({ ...candidate });
+        return;
+      }
+    }
+  });
+
+  return placed;
+}

--- a/frontend/src/pages/AiStatsPage.tsx
+++ b/frontend/src/pages/AiStatsPage.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { AlertCircle, Loader2, ScatterChart, Type } from 'lucide-react';
+import { fetchAiEmbeddingMap, fetchAiWordCloud } from '@/api';
+import { WordCloudChart } from '@/components/aiStats/WordCloudChart';
+import { EmbeddingMapChart } from '@/components/aiStats/EmbeddingMapChart';
+import { cn } from '@/lib/utils';
+
+const RANGES = [7, 14, 30] as const;
+const STALE_TIME = 5 * 60 * 1000;
+
+interface SectionErrorProps {
+  message: string;
+  onRetry: () => void;
+}
+
+function SectionError({ message, onRetry }: SectionErrorProps) {
+  return (
+    <div className="flex min-h-[200px] flex-col items-center justify-center gap-3 text-muted-foreground">
+      <AlertCircle className="size-6" />
+      <p className="text-sm">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="rounded-md bg-surface-2 px-3 py-1.5 text-sm hover:bg-surface-3"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function SectionLoading() {
+  return (
+    <div className="flex min-h-[200px] items-center justify-center">
+      <Loader2 className="size-6 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+export function AiStatsPage() {
+  const [days, setDays] = useState<number>(7);
+
+  const wordCloud = useQuery({
+    queryKey: ['ai-word-cloud', days],
+    queryFn: () => fetchAiWordCloud(days),
+    staleTime: STALE_TIME,
+  });
+
+  const embeddingMap = useQuery({
+    queryKey: ['ai-embedding-map', days],
+    queryFn: () => fetchAiEmbeddingMap(days),
+    staleTime: STALE_TIME,
+  });
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold">AI Stats</h1>
+          <p className="text-xs text-muted-foreground">
+            AI-derived statistics about your news corpus
+          </p>
+        </div>
+        <div className="flex gap-1 rounded-md bg-surface-2 p-1">
+          {RANGES.map((range) => (
+            <button
+              key={range}
+              type="button"
+              onClick={() => setDays(range)}
+              className={cn(
+                'rounded px-2.5 py-1 text-xs transition-colors',
+                days === range
+                  ? 'bg-background font-medium shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {range}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <section className="rounded-xl border border-border bg-surface p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Type className="size-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Word Cloud</h2>
+          {wordCloud.data && (
+            <span className="text-[11px] text-muted-foreground">
+              {wordCloud.data.article_count} articles, last {wordCloud.data.days} days
+            </span>
+          )}
+        </div>
+        {wordCloud.isLoading && <SectionLoading />}
+        {wordCloud.isError && (
+          <SectionError
+            message="Failed to load word cloud."
+            onRetry={() => void wordCloud.refetch()}
+          />
+        )}
+        {wordCloud.data &&
+          (wordCloud.data.terms.length === 0 ? (
+            <p className="py-10 text-center text-sm text-muted-foreground">
+              No terms yet — the cloud fills in as articles are ingested.
+            </p>
+          ) : (
+            <WordCloudChart terms={wordCloud.data.terms} />
+          ))}
+      </section>
+
+      <section className="rounded-xl border border-border bg-surface p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <ScatterChart className="size-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Embedding Space</h2>
+          {embeddingMap.data && (
+            <span className="text-[11px] text-muted-foreground">
+              {embeddingMap.data.embedded_count} of {embeddingMap.data.total_count} articles
+              embedded
+            </span>
+          )}
+        </div>
+        {embeddingMap.isLoading && <SectionLoading />}
+        {embeddingMap.isError && (
+          <SectionError
+            message="Failed to load embedding map."
+            onRetry={() => void embeddingMap.refetch()}
+          />
+        )}
+        {embeddingMap.data &&
+          (embeddingMap.data.points.length === 0 ? (
+            <p className="py-10 text-center text-sm text-muted-foreground">
+              No embedded articles yet — embeddings are generated as you triage articles.
+            </p>
+          ) : (
+            <EmbeddingMapChart
+              points={embeddingMap.data.points}
+              clusters={embeddingMap.data.clusters}
+            />
+          ))}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/TopicMapPage.tsx
+++ b/frontend/src/pages/TopicMapPage.tsx
@@ -1,91 +1,21 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, AlertCircle, Network, RefreshCw } from 'lucide-react';
 import { fetchTopicMap } from '@/api';
-import type { TopicCluster, TopicMapArticle } from '@/types';
+import type { TopicMapArticle } from '@/types';
 import { cn } from '@/lib/utils';
+import { categoryColorMap, colorForCategory } from '@/lib/categoryColor';
+import { convexHull, hullPath, padHull } from '@/lib/convexHull';
 
 const CANVAS_W = 800;
 const CANVAS_H = 560;
-const CLUSTER_R = 32;
-const ARTICLE_R = 10;
-const ORBIT_R = 90;
+const ARTICLE_R = 7;
+const HULL_PAD = 20;
 
 function toCanvas(normalized: number, size: number): number {
-  const padding = 120;
+  const padding = 60;
   return padding + ((normalized + 1) / 2) * (size - padding * 2);
-}
-
-interface ArticleNodeProps {
-  article: TopicMapArticle;
-  cx: number;
-  cy: number;
-  onHover: (a: TopicMapArticle | null, x: number, y: number) => void;
-  onClick: (id: number) => void;
-}
-
-function ArticleNode({ article, cx, cy, onHover, onClick }: ArticleNodeProps) {
-  return (
-    <circle
-      cx={cx}
-      cy={cy}
-      r={ARTICLE_R}
-      className="cursor-pointer fill-primary/30 stroke-primary stroke-[1.5] transition-all hover:fill-primary/70"
-      onMouseEnter={(e) => onHover(article, e.clientX, e.clientY)}
-      onMouseLeave={() => onHover(null, 0, 0)}
-      onClick={() => onClick(article.id)}
-    />
-  );
-}
-
-interface ClusterNodeProps {
-  cluster: TopicCluster;
-  cx: number;
-  cy: number;
-  isSelected: boolean;
-  onHover: (c: TopicCluster | null, x: number, y: number) => void;
-  onClick: (id: number) => void;
-}
-
-function ClusterNode({ cluster, cx, cy, isSelected, onHover, onClick }: ClusterNodeProps) {
-  return (
-    <g>
-      <circle
-        cx={cx}
-        cy={cy}
-        r={CLUSTER_R + 8}
-        className={cn(
-          'transition-all',
-          isSelected
-            ? 'fill-primary/20 stroke-primary/60 stroke-[2]'
-            : 'fill-primary/5 stroke-primary/20 stroke-[1]'
-        )}
-      />
-      <circle
-        cx={cx}
-        cy={cy}
-        r={CLUSTER_R}
-        className={cn(
-          'cursor-pointer transition-all',
-          isSelected
-            ? 'fill-primary/40 stroke-primary stroke-[2.5]'
-            : 'fill-surface-2 stroke-primary/50 stroke-[1.5] hover:fill-primary/20 hover:stroke-primary'
-        )}
-        onMouseEnter={(e) => onHover(cluster, e.clientX, e.clientY)}
-        onMouseLeave={() => onHover(null, 0, 0)}
-        onClick={() => onClick(cluster.id)}
-      />
-      <text
-        x={cx}
-        y={cy + 4}
-        textAnchor="middle"
-        className="pointer-events-none select-none fill-foreground text-[11px] font-semibold"
-      >
-        {cluster.articles.length}
-      </text>
-    </g>
-  );
 }
 
 interface TooltipState {
@@ -113,6 +43,28 @@ export function TopicMapPage() {
     retry: 1,
   });
 
+  const clusters = useMemo(() => data?.clusters ?? [], [data]);
+
+  const colors = useMemo(
+    () => categoryColorMap(clusters.flatMap((c) => c.articles.map((a) => a.category))),
+    [clusters]
+  );
+
+  const hulls = useMemo(
+    () =>
+      clusters
+        .filter((c) => c.articles.length >= 3)
+        .map((cluster) => {
+          const canvasPoints = cluster.articles.map((a) => ({
+            x: toCanvas(a.x, CANVAS_W),
+            y: toCanvas(a.y, CANVAS_H),
+          }));
+          const hull = padHull(convexHull(canvasPoints), HULL_PAD);
+          return { cluster, path: hullPath(hull), topY: Math.min(...hull.map((h) => h.y)) };
+        }),
+    [clusters]
+  );
+
   const showTooltip = useCallback(
     (title: string, subtitle: string | undefined, x: number, y: number) => {
       setTooltip({ visible: true, x, y, content: { title, subtitle } });
@@ -123,14 +75,6 @@ export function TopicMapPage() {
   const hideTooltip = useCallback(() => {
     setTooltip((t) => ({ ...t, visible: false }));
   }, []);
-
-  const handleClusterHover = useCallback(
-    (cluster: TopicCluster | null, x: number, y: number) => {
-      if (cluster) showTooltip(cluster.headline, cluster.trend_summary, x, y);
-      else hideTooltip();
-    },
-    [showTooltip, hideTooltip]
-  );
 
   const handleArticleHover = useCallback(
     (article: TopicMapArticle | null, x: number, y: number) => {
@@ -173,8 +117,6 @@ export function TopicMapPage() {
     );
   }
 
-  const clusters = data?.clusters ?? [];
-
   if (clusters.length === 0) {
     return (
       <div className="flex min-h-[50vh] flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
@@ -188,28 +130,6 @@ export function TopicMapPage() {
     );
   }
 
-  const clusterPositions = clusters.map((c) => ({
-    cx: toCanvas(c.x, CANVAS_W),
-    cy: toCanvas(c.y, CANVAS_H),
-  }));
-
-  const articleNodes: { article: TopicMapArticle; cx: number; cy: number; clusterId: number }[] =
-    [];
-  for (let ci = 0; ci < clusters.length; ci++) {
-    const cluster = clusters[ci];
-    if (selectedClusterId !== null && selectedClusterId !== cluster.id) continue;
-    const { cx, cy } = clusterPositions[ci];
-    cluster.articles.forEach((article, ai) => {
-      const angle = (2 * Math.PI * ai) / cluster.articles.length - Math.PI / 2;
-      articleNodes.push({
-        article,
-        cx: cx + ORBIT_R * Math.cos(angle),
-        cy: cy + ORBIT_R * Math.sin(angle),
-        clusterId: cluster.id,
-      });
-    });
-  }
-
   const selectedCluster =
     selectedClusterId !== null ? clusters.find((c) => c.id === selectedClusterId) : null;
 
@@ -219,7 +139,8 @@ export function TopicMapPage() {
         <div>
           <h1 className="text-lg font-semibold">Topic Map</h1>
           <p className="text-xs text-muted-foreground">
-            {clusters.length} story cluster{clusters.length !== 1 ? 's' : ''} from the last 7 days
+            {clusters.length} story cluster{clusters.length !== 1 ? 's' : ''} from the last 7 days —
+            articles positioned by embedding similarity
           </p>
         </div>
         <button
@@ -240,71 +161,55 @@ export function TopicMapPage() {
           className="h-auto w-full"
           style={{ maxHeight: '560px' }}
         >
-          {articleNodes.map(({ article, cx, cy, clusterId }) => {
-            const ci = clusters.findIndex((c) => c.id === clusterId);
-            const { cx: pcx, cy: pcy } = clusterPositions[ci];
-            return (
-              <line
-                key={`edge-${article.id}`}
-                x1={pcx}
-                y1={pcy}
-                x2={cx}
-                y2={cy}
-                className="stroke-primary/20 stroke-[1]"
+          {hulls.map(({ cluster, path }) => (
+            <path
+              key={`hull-${cluster.id}`}
+              data-testid="cluster-hull"
+              d={path}
+              className={cn(
+                'cursor-pointer transition-all',
+                selectedClusterId === cluster.id
+                  ? 'fill-primary/15 stroke-primary/60 stroke-[2]'
+                  : 'fill-primary/5 stroke-primary/20 stroke-[1] hover:fill-primary/10'
+              )}
+              onClick={() => handleClusterClick(cluster.id)}
+            />
+          ))}
+
+          {clusters.map((cluster) =>
+            cluster.articles.map((article) => (
+              <circle
+                key={article.id}
+                data-testid="article-point"
+                cx={toCanvas(article.x, CANVAS_W)}
+                cy={toCanvas(article.y, CANVAS_H)}
+                r={ARTICLE_R}
+                fill={colorForCategory(colors, article.category)}
+                fillOpacity={
+                  selectedClusterId === null || selectedClusterId === cluster.id ? 0.8 : 0.25
+                }
+                className="cursor-pointer stroke-background stroke-[1.5] transition-all"
+                onMouseEnter={(e) => handleArticleHover(article, e.clientX, e.clientY)}
+                onMouseLeave={() => handleArticleHover(null, 0, 0)}
+                onClick={() => handleArticleClick(article.id)}
               />
-            );
-          })}
+            ))
+          )}
 
-          {clusters.map((cluster, ci) => (
-            <ClusterNode
-              key={cluster.id}
-              cluster={cluster}
-              cx={clusterPositions[ci].cx}
-              cy={clusterPositions[ci].cy}
-              isSelected={selectedClusterId === cluster.id}
-              onHover={handleClusterHover}
-              onClick={handleClusterClick}
-            />
-          ))}
-
-          {articleNodes.map(({ article, cx, cy }) => (
-            <ArticleNode
-              key={article.id}
-              article={article}
-              cx={cx}
-              cy={cy}
-              onHover={handleArticleHover}
-              onClick={handleArticleClick}
-            />
-          ))}
-
-          {clusters.map((cluster, ci) => {
-            const { cx, cy } = clusterPositions[ci];
-            const words = cluster.headline.split(' ');
-            const mid = Math.ceil(words.length / 2);
-            const line1 = words.slice(0, mid).join(' ');
-            const line2 = words.slice(mid).join(' ');
+          {hulls.map(({ cluster, topY }) => {
+            const cx =
+              cluster.articles.reduce((sum, a) => sum + toCanvas(a.x, CANVAS_W), 0) /
+              cluster.articles.length;
             return (
-              <g key={`label-${cluster.id}`} className="pointer-events-none">
-                <text
-                  x={cx}
-                  y={cy + CLUSTER_R + 16}
-                  textAnchor="middle"
-                  className="select-none fill-foreground text-[10px] font-medium"
-                >
-                  {line1}
-                </text>
-                {line2 && (
-                  <text
-                    x={cx}
-                    y={cy + CLUSTER_R + 28}
-                    textAnchor="middle"
-                    className="select-none fill-foreground text-[10px] font-medium"
-                  >
-                    {line2}
-                  </text>
-                )}
-              </g>
+              <text
+                key={`label-${cluster.id}`}
+                x={cx}
+                y={topY - 8}
+                textAnchor="middle"
+                className="pointer-events-none select-none fill-foreground text-[11px] font-semibold"
+              >
+                {cluster.headline}
+              </text>
             );
           })}
         </svg>
@@ -322,6 +227,18 @@ export function TopicMapPage() {
             )}
           </div>
         )}
+      </div>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {[...colors.entries()].map(([category, color]) => (
+          <span
+            key={category}
+            className="flex items-center gap-1.5 text-[11px] text-muted-foreground"
+          >
+            <span className="size-2.5 rounded-full" style={{ backgroundColor: color }} />
+            {category}
+          </span>
+        ))}
       </div>
 
       {selectedCluster && (
@@ -353,7 +270,7 @@ export function TopicMapPage() {
       )}
 
       <p className="text-center text-[11px] text-muted-foreground">
-        Click a cluster node to expand its articles · Click an article node to open it
+        Click a cluster outline to inspect its articles · Click a point to open the article
       </p>
     </div>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -463,6 +463,9 @@ export interface TopicMapArticle {
   title: string;
   url: string;
   summary: string;
+  category: string;
+  x: number;
+  y: number;
 }
 
 export interface TopicCluster {
@@ -477,6 +480,41 @@ export interface TopicCluster {
 
 export interface TopicMapResponse {
   clusters: TopicCluster[];
+}
+
+export interface WordCloudTerm {
+  term: string;
+  count: number;
+  weight: number;
+}
+
+export interface WordCloudResponse {
+  terms: WordCloudTerm[];
+  article_count: number;
+  days: number;
+}
+
+export interface EmbeddingMapPoint {
+  id: number;
+  title: string;
+  category: string;
+  x: number;
+  y: number;
+  cluster: number;
+}
+
+export interface EmbeddingMapCluster {
+  id: number;
+  label: string;
+  size: number;
+}
+
+export interface EmbeddingMapResponse {
+  points: EmbeddingMapPoint[];
+  clusters: EmbeddingMapCluster[];
+  embedded_count: number;
+  total_count: number;
+  days: number;
 }
 
 export interface OnboardingInterest {


### PR DESCRIPTION
Closes #868

## What

- **New `/ai-stats` page** (all signed-in users, secondary nav): word cloud + embedding-space map of the user's visible news corpus, with a 7/14/30-day selector.
- **`GET /api/ai-stats/word-cloud`** — TF-IDF-weighted terms over recent visible articles' titles+summaries, stopword-filtered, no LLM calls.
- **`GET /api/ai-stats/embedding-map`** — per-article 2D PCA projection of stored embeddings, greedy clusters with deterministic TF-IDF labels, plus embedded/total coverage counts.
- **Topic Map upgrade** — `/topic-map` now plots each article at its true PCA position (previously a decorative orbit around cluster centroids), colored by category, with padded convex-hull cluster outlines. Route path and response envelope unchanged; articles gain `x`/`y`/`category`.
- New `ai_stats` feature-module package (router/service per ADR 0003); `insights.py` gains public aliases and a shared `load_recent_embedded_articles()` visibility query.
- Frontend layouts are pure, deterministic functions in `lib/` (spiral word-cloud placement, Andrew monotone-chain convex hull, stable category colors) — no new dependencies.

## Tests

TDD: `backend/tests/test_ai_stats.py` (TF-IDF ranking, caps, visibility scoping, embedding map ranges/clusters/coverage), `test_ai_stats_api.py` (route registration, user/days passthrough, 422 bounds), per-article coordinate contracts in `test_insights.py`/`test_topic_map_api.py`; frontend `wordCloudLayout`, `convexHull`, `aiStatsPage`, `topicMapPage`, `navigation` tests. Full local gates green (ruff, mypy, ty, pyrefly, eslint, prettier, tsc, vitest 694 passed, build).

Note: ~42 unrelated backend tests error locally due to a pre-existing test-DB ownership issue on the dev machine (verified identical on a clean checkout); CI's service container is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)