### PR TITLE
feat: knowledge graph of entities across recent news

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ OPENAI_BRIEFING_MODEL=gpt-4o-mini
 OPENAI_ANSWER_MODEL=
 OPENAI_EMBEDDING_MODEL=
 OPENAI_INSIGHTS_MODEL=
+OPENAI_ENTITIES_MODEL=
 OPENAI_OPTIMIZER_MODEL=
 OPENAI_PERSPECTIVES_MODEL=
 OPENAI_QUIZ_MODEL=
@@ -94,6 +95,8 @@ SMTP_PASSWORD=
 
 # --- Scheduler / ingestion -----------------------------------------------------
 INGEST_INTERVAL_MINUTES=30
+# Interval for the background entity-extraction job feeding the knowledge graph. Default 30.
+ENTITY_EXTRACTION_INTERVAL_MINUTES=30
 DIGEST_CRON=0 8 * * *
 BRIEFING_CRON=0 9 * * *
 RECOMMENDATIONS_CRON=30 7 * * *

--- a/backend/news_dashboard/ai_stats/router.py
+++ b/backend/news_dashboard/ai_stats/router.py
@@ -31,3 +31,13 @@ def embedding_map_endpoint(
     days: Annotated[int, Query(ge=1, le=30)] = 7,
 ) -> dict[str, Any]:
     return service.embedding_map(user_id=current_user["id"], days=days)
+
+
+@router.get("/api/ai-stats/knowledge-graph")
+def knowledge_graph_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    days: Annotated[int, Query(ge=1, le=30)] = 7,
+) -> dict[str, Any]:
+    from news_dashboard import entities
+
+    return entities.knowledge_graph(user_id=current_user["id"], days=days)

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -146,6 +146,7 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body_status TEXT NOT NULL DEFAULT 'missing'",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS insights TEXT",
+    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS entities TEXT",
     """
     ALTER TABLE articles ADD COLUMN IF NOT EXISTS search_vector tsvector
       GENERATED ALWAYS AS (

--- a/backend/news_dashboard/entities.py
+++ b/backend/news_dashboard/entities.py
@@ -1,0 +1,373 @@
+"""LLM-backed named-entity extraction and the news knowledge graph.
+
+Entities (people, orgs, products, places) are extracted once per article via
+the free-LLM gateway and cached in ``articles.entities`` as JSON
+``{"v": 1, "entities": [{"name", "type"}]}`` — mirroring how ``insights``
+caches its bullets. ``knowledge_graph()`` aggregates the cached entities only
+and never invokes the LLM, so the endpoint stays fast and free; a scheduler
+job (``entity_extraction``) fills the cache in the background.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENTITIES_MODEL = "gpt-4o-mini"
+ENTITIES_CACHE_VERSION = 1
+_ENTITY_TYPES = frozenset({"person", "org", "product", "place"})
+_MAX_TEXT_CHARS = 4_000
+_MAX_ENTITIES_PER_ARTICLE = 10
+_MAX_GRAPH_ARTICLES = 300
+_PROMPT = (
+    "Extract the named entities from the news article below. "
+    "Return ONLY a JSON array (no prose, no code fences) of at most "
+    f"{_MAX_ENTITIES_PER_ARTICLE} objects, each shaped "
+    '{"name": "<canonical short name>", "type": "<person|org|product|place>"}. '
+    "Use the most canonical short form of each name (e.g. 'OpenAI', not "
+    "'OpenAI, Inc.'). Only include entities that are clearly mentioned in the "
+    "article text; do not invent or infer entities from general knowledge."
+)
+
+
+class EntitiesNotConfiguredError(Exception):
+    """Raised when no AI key is configured for entity extraction."""
+
+
+def _entities_ai_config() -> tuple[str, str | None, str]:
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
+    if not api_key:
+        msg = "FREE_LLM_API_KEY (or OPENAI_API_KEY) is not configured"
+        raise EntitiesNotConfiguredError(msg)
+    model = os.getenv("OPENAI_ENTITIES_MODEL", DEFAULT_ENTITIES_MODEL)
+    return api_key, base_url, model
+
+
+def _build_text(article: dict[str, Any]) -> str:
+    parts = [
+        str(article.get("title") or ""),
+        str(article.get("summary") or ""),
+        str(article.get("body") or ""),
+    ]
+    return "\n\n".join(p for p in parts if p.strip())[:_MAX_TEXT_CHARS]
+
+
+def _parse_entities(response_text: str) -> list[dict[str, str]]:
+    """Parse the model response into a validated, deduplicated entity list."""
+    text = response_text.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        text = text.removeprefix("json").strip()
+
+    try:
+        raw = json.loads(text)
+    except ValueError:
+        return []
+    if not isinstance(raw, list):
+        return []
+
+    entities: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        entity_type = str(item.get("type") or "").strip().lower()
+        if not name or entity_type not in _ENTITY_TYPES:
+            continue
+        key = (name.lower(), entity_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        entities.append({"name": name, "type": entity_type})
+        if len(entities) >= _MAX_ENTITIES_PER_ARTICLE:
+            break
+    return entities
+
+
+def extract_entities(article: dict[str, Any], user_id: int | None = None) -> list[dict[str, str]]:
+    """Call the LLM and return the extracted entity list.
+
+    Raises EntitiesNotConfiguredError when no AI key is configured.
+    """
+    api_key, base_url, model = _entities_ai_config()
+
+    text = _build_text(article)
+    if not text.strip():
+        return []
+
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
+
+    client = get_chat_client(api_key=api_key, base_url=base_url)
+    prompt = get_prompt("entity-extraction", fallback=_PROMPT)
+    logger.info("Extracting entities for article %s", article.get("id"))
+    result = chat_create(
+        client,
+        name="entity-extraction",
+        tags=["entities"],
+        user_id=user_id,
+        prompt=prompt,
+        model=model,
+        messages=[{"role": "user", "content": f"{prompt.text}\n\n{text}"}],
+        max_tokens=512,
+    )
+    response_text = (result.choices[0].message.content or "").strip()
+    entities = _parse_entities(response_text)
+    logger.info("Entities extracted for article %s: %d entities", article.get("id"), len(entities))
+    return entities
+
+
+def _decode_cached(raw: str | None) -> list[dict[str, str]] | None:
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    entities = payload.get("entities")
+    if not isinstance(entities, list):
+        return None
+    return [e for e in entities if isinstance(e, dict)]
+
+
+def _store_entities(
+    article_id: int, entities: list[dict[str, str]], database_url: str | None
+) -> None:
+    payload = json.dumps({"v": ENTITIES_CACHE_VERSION, "entities": entities})
+    with connect(database_url=database_url) as conn:
+        conn.execute("UPDATE articles SET entities = %s WHERE id = %s", (payload, article_id))
+
+
+def get_or_extract_entities(
+    article_id: int,
+    user_id: int | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, str]]:
+    """Return cached entities or extract + cache them.
+
+    When user_id is provided the article must be visible to that user.
+    Returns [] for invisible or non-existent articles.
+    """
+    init_db(database_url=database_url)
+
+    with connect(database_url=database_url) as conn:
+        if user_id is not None:
+            row = conn.execute(
+                """
+                SELECT a.id, a.title, a.summary, a.body, a.entities
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us_src
+                  ON us_src.source_slug = a.source_slug AND us_src.user_id = %s
+                WHERE a.id = %s AND (
+                  (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
+                  OR src.owner_user_id = %s
+                )
+                """,
+                (user_id, article_id, user_id),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT id, title, summary, body, entities FROM articles WHERE id = %s",
+                (article_id,),
+            ).fetchone()
+
+    if row is None:
+        return []
+
+    cached = _decode_cached(row["entities"])
+    if cached is not None:
+        return cached
+
+    entities = extract_entities(dict(row), user_id=user_id)
+    _store_entities(article_id, entities, database_url)
+    return entities
+
+
+def extract_missing_entities(
+    limit: int = 25,
+    days: int = 7,
+    database_url: str | None = None,
+) -> int:
+    """Extract entities for up to ``limit`` recent articles lacking them.
+
+    Per-article failures are logged and skipped so one bad article does not
+    starve the batch. Returns the number of articles successfully extracted.
+    """
+    init_db(database_url=database_url)
+
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, title, summary, body
+            FROM articles
+            WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+              AND entities IS NULL
+            ORDER BY discovered_at DESC
+            LIMIT %s
+            """,
+            (days, limit),
+        ).fetchall()
+
+    extracted = 0
+    for row in rows:
+        try:
+            entities = extract_entities(dict(row))
+        except EntitiesNotConfiguredError:
+            raise
+        except Exception:
+            logger.exception("Entity extraction failed for article %s", row["id"])
+            continue
+        _store_entities(int(row["id"]), entities, database_url)
+        extracted += 1
+    return extracted
+
+
+def _entity_id(name: str, entity_type: str) -> str:
+    return f"{entity_type}:{name.lower().replace(' ', '-')}"
+
+
+def knowledge_graph(
+    user_id: int | None = None,
+    days: int = 7,
+    max_nodes: int = 40,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate cached entities over recent visible articles into a graph.
+
+    Reads the cache only — never calls the LLM. ``pending_count`` reports how
+    many visible recent articles still lack extracted entities so the UI can
+    explain a sparse graph.
+    """
+    init_db(database_url=database_url)
+
+    with connect(database_url=database_url) as conn:
+        if user_id is None:
+            rows = conn.execute(
+                """
+                SELECT id, title, entities
+                FROM articles
+                WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                ORDER BY discovered_at DESC
+                LIMIT %s
+                """,
+                (days, _MAX_GRAPH_ARTICLES),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT a.id, a.title, a.entities
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us
+                  ON us.source_slug = src.slug AND us.user_id = %s
+                LEFT JOIN user_article_state uas
+                  ON uas.article_id = a.id AND uas.user_id = %s
+                WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                  AND COALESCE(uas.state, 'today') != 'archived'
+                  AND (
+                    (
+                      src.owner_user_id IS NULL
+                      AND COALESCE(us.enabled, TRUE) IS TRUE
+                    )
+                    OR (
+                      src.owner_user_id = %s
+                      AND src.enabled IS TRUE
+                    )
+                  )
+                ORDER BY a.discovered_at DESC
+                LIMIT %s
+                """,
+                (user_id, user_id, days, user_id, _MAX_GRAPH_ARTICLES),
+            ).fetchall()
+
+    pending_count = 0
+    # node key -> {"id", "name", "type", "count", "article_ids"}
+    node_map: dict[tuple[str, str], dict[str, Any]] = {}
+    # article id -> list of node keys mentioned in it
+    mentions: dict[int, list[tuple[str, str]]] = {}
+    titles: dict[int, str] = {}
+
+    for row in rows:
+        entities = _decode_cached(row["entities"])
+        if entities is None:
+            pending_count += 1
+            continue
+        article_id = int(row["id"])
+        keys: list[tuple[str, str]] = []
+        for entity in entities:
+            name = str(entity.get("name") or "").strip()
+            entity_type = str(entity.get("type") or "").strip().lower()
+            if not name or entity_type not in _ENTITY_TYPES:
+                continue
+            key = (name.lower(), entity_type)
+            if key in keys:
+                continue
+            keys.append(key)
+            node = node_map.setdefault(
+                key,
+                {
+                    "id": _entity_id(name, entity_type),
+                    "name": name,
+                    "type": entity_type,
+                    "count": 0,
+                    "article_ids": [],
+                },
+            )
+            node["count"] += 1
+            node["article_ids"].append(article_id)
+        if keys:
+            mentions[article_id] = keys
+            titles[article_id] = str(row["title"] or "")
+
+    kept = sorted(node_map.values(), key=lambda n: (-n["count"], n["name"]))[:max_nodes]
+    kept_keys = {(n["name"].lower(), n["type"]) for n in kept}
+    node_id_by_key = {(n["name"].lower(), n["type"]): n["id"] for n in kept}
+
+    # edge (id_a, id_b) sorted -> {"weight", "article_ids"}
+    edge_map: dict[tuple[str, str], dict[str, Any]] = {}
+    referenced_articles: set[int] = set()
+    for article_id, keys in mentions.items():
+        visible = [k for k in keys if k in kept_keys]
+        for i in range(len(visible)):
+            for j in range(i + 1, len(visible)):
+                id_a = node_id_by_key[visible[i]]
+                id_b = node_id_by_key[visible[j]]
+                edge_key = (id_a, id_b) if id_a < id_b else (id_b, id_a)
+                edge = edge_map.setdefault(edge_key, {"weight": 0, "article_ids": []})
+                edge["weight"] += 1
+                edge["article_ids"].append(article_id)
+        if visible:
+            referenced_articles.add(article_id)
+
+    edges = [
+        {
+            "source": source,
+            "target": target,
+            "weight": data["weight"],
+            "article_ids": data["article_ids"],
+        }
+        for (source, target), data in sorted(edge_map.items(), key=lambda item: -item[1]["weight"])
+    ]
+
+    return {
+        "nodes": kept,
+        "edges": edges,
+        "articles": [
+            {"id": article_id, "title": titles[article_id]}
+            for article_id in sorted(referenced_articles)
+        ],
+        "article_count": len(rows),
+        "pending_count": pending_count,
+        "days": days,
+    }

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -230,6 +230,22 @@ def _run_digest() -> tuple[str, str | None]:
         return "failure", str(exc)[:500]
 
 
+def _run_entity_extraction() -> tuple[str, str | None]:
+    from news_dashboard.entities import EntitiesNotConfiguredError, extract_missing_entities
+
+    logger.info("Extracting entities for recent articles…")
+    try:
+        extracted = extract_missing_entities()
+    except EntitiesNotConfiguredError:
+        logger.info("Entity extraction skipped (no AI key configured).")
+        return "skipped", "no AI key configured"
+    except Exception as exc:
+        logger.exception("Entity extraction failed")
+        return "failure", str(exc)[:500]
+    logger.info("Entity extraction done: %d article(s).", extracted)
+    return "success", f"extracted {extracted} article(s)"
+
+
 def _run_and_record(
     job_name: str,
     fn: Callable[[], tuple[str, str | None] | None],
@@ -282,6 +298,10 @@ def _job_briefing() -> None:
 
 def _job_per_user_briefings() -> None:
     _run_and_record("per_user_briefings", _run_per_user_briefings)
+
+
+def _job_entity_extraction() -> None:
+    _run_and_record("entity_extraction", _run_entity_extraction)
 
 
 def _parse_cron_hm(cron: str, default_minute: str, default_hour: str) -> tuple[str, str]:
@@ -392,6 +412,14 @@ def start_scheduler() -> None:
         trigger="interval",
         minutes=1,
         id="per_user_briefings",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _job_entity_extraction,
+        trigger="interval",
+        minutes=int(os.getenv("ENTITY_EXTRACTION_INTERVAL_MINUTES", "30")),
+        id="entity_extraction",
         replace_existing=True,
     )
 

--- a/backend/tests/test_ai_stats_api.py
+++ b/backend/tests/test_ai_stats_api.py
@@ -70,3 +70,35 @@ def test_embedding_map_days_out_of_range_is_422() -> None:
     client = _client()
     assert client.get("/api/ai-stats/embedding-map?days=0").status_code == 422
     assert client.get("/api/ai-stats/embedding-map?days=31").status_code == 422
+
+
+def test_knowledge_graph_route_is_registered() -> None:
+    paths = app.openapi()["paths"]
+    assert "/api/ai-stats/knowledge-graph" in paths
+
+
+def test_knowledge_graph_endpoint_passes_user_and_days(monkeypatch: Any) -> None:
+    def fake_knowledge_graph(*, user_id: int, days: int) -> dict[str, Any]:
+        assert user_id == 42
+        assert days == 14
+        return {
+            "nodes": [],
+            "edges": [],
+            "articles": [],
+            "article_count": 0,
+            "pending_count": 0,
+            "days": days,
+        }
+
+    monkeypatch.setattr("news_dashboard.entities.knowledge_graph", fake_knowledge_graph)
+
+    response = _client().get("/api/ai-stats/knowledge-graph?days=14")
+
+    assert response.status_code == 200
+    assert response.json()["days"] == 14
+
+
+def test_knowledge_graph_days_out_of_range_is_422() -> None:
+    client = _client()
+    assert client.get("/api/ai-stats/knowledge-graph?days=0").status_code == 422
+    assert client.get("/api/ai-stats/knowledge-graph?days=31").status_code == 422

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -144,3 +144,13 @@ def test_init_db_postgres_caches_successful_schema_runs(tmp_path: Any) -> None:
         init_db(token)
 
     assert len(connect_calls) == len(fake_schema)
+
+
+def test_postgres_schema_adds_entities_column() -> None:
+    """The articles.entities cache column ships as an idempotent statement."""
+    from news_dashboard.db import POSTGRES_SCHEMA
+
+    assert any(
+        "ALTER TABLE articles ADD COLUMN IF NOT EXISTS entities TEXT" in stmt
+        for stmt in POSTGRES_SCHEMA
+    )

--- a/backend/tests/test_entities.py
+++ b/backend/tests/test_entities.py
@@ -1,0 +1,319 @@
+"""Tests for LLM-backed entity extraction and the knowledge graph."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.db import connect
+from news_dashboard.entities import (
+    EntitiesNotConfiguredError,
+    _parse_entities,
+    extract_entities,
+    extract_missing_entities,
+    get_or_extract_entities,
+    knowledge_graph,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _seed_source(pg_url: str, slug: str, *, owner_user_id: int | None = None) -> None:
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES (%s, %s, %s, 'tech', 'rss_feed', %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug, f"https://{slug}.example", owner_user_id),
+        )
+
+
+def _seed_article(
+    pg_url: str,
+    *,
+    slug: str = "ent-src",
+    url_slug: str,
+    title: str,
+    summary: str = "Summary.",
+    entities: str | None = None,
+) -> int:
+    _seed_source(pg_url, slug)
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, summary, entities, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', %s, %s, NOW())
+            RETURNING id
+            """,
+            (
+                f"https://{slug}.example/{url_slug}",
+                f"https://{slug}.example/{url_slug}",
+                title,
+                slug,
+                slug,
+                summary,
+                entities,
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_user(pg_url: str, username: str) -> int:
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, 'x') RETURNING id",
+            (username,),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _entities_json(*pairs: tuple[str, str]) -> str:
+    return json.dumps({"v": 1, "entities": [{"name": n, "type": t} for n, t in pairs]})
+
+
+def _mock_llm(content: str) -> MagicMock:
+    completion = MagicMock()
+    completion.choices[0].message.content = content
+    client = MagicMock()
+    client.chat.completions.create.return_value = completion
+    return client
+
+
+# ── _parse_entities ───────────────────────────────────────────────────────────
+
+
+def test_parse_entities_handles_fenced_json() -> None:
+    payload = '[{"name": "OpenAI", "type": "org"}, {"name": "Sam Altman", "type": "person"}]'
+    raw = f"```json\n{payload}\n```"
+    parsed = _parse_entities(raw)
+    assert parsed == [
+        {"name": "OpenAI", "type": "org"},
+        {"name": "Sam Altman", "type": "person"},
+    ]
+
+
+def test_parse_entities_drops_invalid_types_and_dedupes() -> None:
+    raw = json.dumps(
+        [
+            {"name": "OpenAI", "type": "org"},
+            {"name": "openai", "type": "org"},  # duplicate, case-insensitive
+            {"name": "Something", "type": "alien"},  # invalid type
+            {"name": "", "type": "org"},  # empty name
+            {"name": "Paris", "type": "place"},
+        ]
+    )
+    parsed = _parse_entities(raw)
+    assert parsed == [{"name": "OpenAI", "type": "org"}, {"name": "Paris", "type": "place"}]
+
+
+def test_parse_entities_returns_empty_for_garbage() -> None:
+    assert _parse_entities("not json at all") == []
+    assert _parse_entities(json.dumps({"name": "x"})) == []
+
+
+# ── extract_entities ──────────────────────────────────────────────────────────
+
+
+def test_extract_entities_raises_without_api_key() -> None:
+    import os
+
+    env = dict(os.environ.items())
+    for key in ("FREE_LLM_API_KEY", "FREE_LLM_BASE_URL", "OPENAI_API_KEY"):
+        env.pop(key, None)
+    with patch.dict("os.environ", env, clear=True), pytest.raises(EntitiesNotConfiguredError):
+        extract_entities({"id": 1, "title": "T", "summary": "S", "body": None})
+
+
+def test_extract_entities_calls_llm_and_returns_parsed_list() -> None:
+    client = _mock_llm('[{"name": "OpenAI", "type": "org"}, {"name": "OpenAI", "type": "org"}]')
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=client),
+    ):
+        result = extract_entities(
+            {"id": 1, "title": "OpenAI ships", "summary": "OpenAI news", "body": "text"}
+        )
+    assert result == [{"name": "OpenAI", "type": "org"}]
+    client.chat.completions.create.assert_called_once()
+
+
+# ── get_or_extract_entities ───────────────────────────────────────────────────
+
+
+def test_get_or_extract_entities_returns_cached_without_api_call(pg_clean: str) -> None:
+    cached = _entities_json(("OpenAI", "org"))
+    article_id = _seed_article(pg_clean, url_slug="cached", title="T", entities=cached)
+
+    client = _mock_llm("[]")
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=client),
+    ):
+        result = get_or_extract_entities(article_id, database_url=pg_clean)
+
+    assert result == [{"name": "OpenAI", "type": "org"}]
+    client.chat.completions.create.assert_not_called()
+
+
+def test_get_or_extract_entities_extracts_and_caches_when_missing(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean, url_slug="fresh", title="OpenAI ships a model")
+
+    client = _mock_llm('[{"name": "OpenAI", "type": "org"}]')
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=client),
+    ):
+        first = get_or_extract_entities(article_id, database_url=pg_clean)
+        second = get_or_extract_entities(article_id, database_url=pg_clean)
+
+    assert first == [{"name": "OpenAI", "type": "org"}]
+    assert second == first
+    client.chat.completions.create.assert_called_once()
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT entities FROM articles WHERE id = %s", (article_id,)).fetchone()
+    stored = json.loads(row["entities"])
+    assert stored["v"] == 1
+    assert stored["entities"] == [{"name": "OpenAI", "type": "org"}]
+
+
+def test_get_or_extract_entities_invisible_article_returns_empty(pg_clean: str) -> None:
+    owner_id = _seed_user(pg_clean, "ent-owner")
+    other_id = _seed_user(pg_clean, "ent-other")
+    _seed_source(pg_clean, "ent-private", owner_user_id=owner_id)
+    article_id = _seed_article(
+        pg_clean,
+        slug="ent-private",
+        url_slug="priv",
+        title="Private",
+        entities=_entities_json(("Secret Corp", "org")),
+    )
+
+    assert get_or_extract_entities(article_id, user_id=other_id, database_url=pg_clean) == []
+    assert get_or_extract_entities(article_id, user_id=owner_id, database_url=pg_clean) == [
+        {"name": "Secret Corp", "type": "org"}
+    ]
+
+
+# ── extract_missing_entities ──────────────────────────────────────────────────
+
+
+def test_extract_missing_entities_respects_limit_and_survives_failures(pg_clean: str) -> None:
+    for idx in range(4):
+        _seed_article(pg_clean, url_slug=f"m-{idx}", title=f"Article {idx}")
+
+    calls: list[int] = []
+
+    def fake_extract(article: dict[str, Any], user_id: int | None = None) -> list[dict[str, str]]:
+        calls.append(int(article["id"]))
+        if len(calls) == 1:
+            msg = "transient failure"
+            raise RuntimeError(msg)
+        return [{"name": "OpenAI", "type": "org"}]
+
+    with patch("news_dashboard.entities.extract_entities", side_effect=fake_extract):
+        extracted = extract_missing_entities(limit=3, database_url=pg_clean)
+
+    assert len(calls) == 3
+    assert extracted == 2
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM articles WHERE entities IS NOT NULL"
+        ).fetchone()
+    assert row["n"] == 2
+
+
+# ── knowledge_graph ───────────────────────────────────────────────────────────
+
+
+def test_knowledge_graph_empty_corpus(pg_clean: str) -> None:
+    result = knowledge_graph(database_url=pg_clean)
+    assert result["nodes"] == []
+    assert result["edges"] == []
+    assert result["pending_count"] == 0
+
+
+def test_knowledge_graph_builds_nodes_edges_and_article_refs(pg_clean: str) -> None:
+    a1 = _seed_article(
+        pg_clean,
+        url_slug="g1",
+        title="OpenAI and Altman",
+        entities=_entities_json(("OpenAI", "org"), ("Sam Altman", "person")),
+    )
+    a2 = _seed_article(
+        pg_clean,
+        url_slug="g2",
+        title="OpenAI and Altman again",
+        entities=_entities_json(("OpenAI", "org"), ("Sam Altman", "person")),
+    )
+    a3 = _seed_article(
+        pg_clean,
+        url_slug="g3",
+        title="OpenAI alone",
+        entities=_entities_json(("OpenAI", "org")),
+    )
+    _seed_article(pg_clean, url_slug="g4", title="Pending extraction")
+
+    result = knowledge_graph(database_url=pg_clean)
+
+    nodes = {n["name"]: n for n in result["nodes"]}
+    assert nodes["OpenAI"]["type"] == "org"
+    assert nodes["OpenAI"]["count"] == 3
+    assert nodes["Sam Altman"]["count"] == 2
+    assert set(nodes["OpenAI"]["article_ids"]) == {a1, a2, a3}
+
+    assert len(result["edges"]) == 1
+    edge = result["edges"][0]
+    assert edge["weight"] == 2
+    assert set(edge["article_ids"]) == {a1, a2}
+    assert {edge["source"], edge["target"]} == {nodes["OpenAI"]["id"], nodes["Sam Altman"]["id"]}
+
+    titles = {a["id"]: a["title"] for a in result["articles"]}
+    assert titles[a1] == "OpenAI and Altman"
+    assert result["pending_count"] == 1
+    assert result["article_count"] == 4
+
+
+def test_knowledge_graph_truncates_to_max_nodes(pg_clean: str) -> None:
+    pairs = [(f"Entity {i}", "org") for i in range(6)]
+    _seed_article(pg_clean, url_slug="t1", title="Many entities", entities=_entities_json(*pairs))
+    result = knowledge_graph(database_url=pg_clean, max_nodes=3)
+    assert len(result["nodes"]) == 3
+
+
+def test_knowledge_graph_scopes_to_user_visible_articles(pg_clean: str) -> None:
+    user_id = _seed_user(pg_clean, "kg-user")
+    other_id = _seed_user(pg_clean, "kg-other")
+    _seed_source(pg_clean, "kg-global")
+    _seed_source(pg_clean, "kg-other-private", owner_user_id=other_id)
+
+    _seed_article(
+        pg_clean,
+        slug="kg-global",
+        url_slug="vis",
+        title="Visible",
+        entities=_entities_json(("OpenAI", "org")),
+    )
+    _seed_article(
+        pg_clean,
+        slug="kg-other-private",
+        url_slug="hid",
+        title="Hidden",
+        entities=_entities_json(("Secret Corp", "org")),
+    )
+
+    result = knowledge_graph(user_id=user_id, database_url=pg_clean)
+    names = {n["name"] for n in result["nodes"]}
+    assert "OpenAI" in names
+    assert "Secret Corp" not in names

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -971,3 +971,62 @@ def test_per_user_briefings_null_timezone_falls_back_to_utc() -> None:
         _run_per_user_briefings()
 
     mock_generate.assert_called_once_with(user_id=5)
+
+
+# ── entity extraction job ─────────────────────────────────────────────────────
+
+
+def test_start_scheduler_registers_entity_extraction_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_sched = _start_with_env(monkeypatch)
+    jobs = {c.kwargs.get("id"): c.kwargs for c in mock_sched.add_job.call_args_list}
+    assert "entity_extraction" in jobs
+    assert jobs["entity_extraction"]["trigger"] == "interval"
+    assert jobs["entity_extraction"]["minutes"] == 30
+
+
+def test_start_scheduler_entity_extraction_interval_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENTITY_EXTRACTION_INTERVAL_MINUTES", "5")
+    mock_sched = _start_with_env(monkeypatch)
+    jobs = {c.kwargs.get("id"): c.kwargs for c in mock_sched.add_job.call_args_list}
+    assert jobs["entity_extraction"]["minutes"] == 5
+
+
+def test_run_entity_extraction_reports_count() -> None:
+    from news_dashboard.scheduler import _run_entity_extraction
+
+    with patch("news_dashboard.entities.extract_missing_entities", return_value=3) as mock_extract:
+        status, message = _run_entity_extraction()
+
+    mock_extract.assert_called_once()
+    assert status == "success"
+    assert "3" in (message or "")
+
+
+def test_run_entity_extraction_skips_when_not_configured() -> None:
+    from news_dashboard.entities import EntitiesNotConfiguredError
+    from news_dashboard.scheduler import _run_entity_extraction
+
+    with patch(
+        "news_dashboard.entities.extract_missing_entities",
+        side_effect=EntitiesNotConfiguredError("no key"),
+    ):
+        status, _message = _run_entity_extraction()
+
+    assert status == "skipped"
+
+
+def test_run_entity_extraction_reports_failure() -> None:
+    from news_dashboard.scheduler import _run_entity_extraction
+
+    with patch(
+        "news_dashboard.entities.extract_missing_entities",
+        side_effect=RuntimeError("boom"),
+    ):
+        status, message = _run_entity_extraction()
+
+    assert status == "failure"
+    assert "boom" in (message or "")

--- a/frontend/src/__tests__/aiStatsPage.test.tsx
+++ b/frontend/src/__tests__/aiStatsPage.test.tsx
@@ -10,6 +10,7 @@ import type { EmbeddingMapResponse, WordCloudResponse } from '../types';
 vi.mock('../api', () => ({
   fetchAiWordCloud: vi.fn(),
   fetchAiEmbeddingMap: vi.fn(),
+  fetchKnowledgeGraph: vi.fn(),
 }));
 
 const mockedApi = vi.mocked(api, true);
@@ -52,6 +53,14 @@ beforeEach(() => {
   vi.resetAllMocks();
   mockedApi.fetchAiWordCloud.mockResolvedValue(WORD_CLOUD);
   mockedApi.fetchAiEmbeddingMap.mockResolvedValue(EMBEDDING_MAP);
+  mockedApi.fetchKnowledgeGraph.mockResolvedValue({
+    nodes: [],
+    edges: [],
+    articles: [],
+    article_count: 0,
+    pending_count: 0,
+    days: 7,
+  });
 });
 
 describe('AiStatsPage', () => {

--- a/frontend/src/__tests__/forceLayout.test.ts
+++ b/frontend/src/__tests__/forceLayout.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { forceLayout } from '../lib/forceLayout';
+
+const W = 800;
+const H = 600;
+
+const NODES = Array.from({ length: 8 }, (_, i) => ({ id: `n${i}` }));
+const EDGES = [
+  { source: 'n0', target: 'n1', weight: 3 },
+  { source: 'n1', target: 'n2', weight: 1 },
+  { source: 'n3', target: 'n4', weight: 2 },
+];
+
+describe('forceLayout', () => {
+  it('returns an empty map for no nodes', () => {
+    expect(forceLayout([], [], W, H).size).toBe(0);
+  });
+
+  it('positions every node inside the viewport without NaN', () => {
+    const layout = forceLayout(NODES, EDGES, W, H);
+    expect(layout.size).toBe(NODES.length);
+    for (const { x, y } of layout.values()) {
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(W);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThanOrEqual(H);
+    }
+  });
+
+  it('is deterministic for the same input', () => {
+    const a = forceLayout(NODES, EDGES, W, H);
+    const b = forceLayout(NODES, EDGES, W, H);
+    expect([...a.entries()]).toEqual([...b.entries()]);
+  });
+
+  it('pulls connected nodes closer than the average unconnected pair', () => {
+    const layout = forceLayout(NODES, EDGES, W, H);
+    const dist = (a: string, b: string) => {
+      const pa = layout.get(a)!;
+      const pb = layout.get(b)!;
+      return Math.hypot(pa.x - pb.x, pa.y - pb.y);
+    };
+    const connected = EDGES.map((e) => dist(e.source, e.target));
+    const connectedSet = new Set(EDGES.map((e) => [e.source, e.target].sort().join('|')));
+    const unconnected: number[] = [];
+    for (let i = 0; i < NODES.length; i++) {
+      for (let j = i + 1; j < NODES.length; j++) {
+        const key = [NODES[i].id, NODES[j].id].sort().join('|');
+        if (!connectedSet.has(key)) unconnected.push(dist(NODES[i].id, NODES[j].id));
+      }
+    }
+    const mean = (xs: number[]) => xs.reduce((s, v) => s + v, 0) / xs.length;
+    expect(mean(connected)).toBeLessThan(mean(unconnected));
+  });
+
+  it('ignores edges that reference unknown nodes', () => {
+    const layout = forceLayout(
+      [{ id: 'a' }, { id: 'b' }],
+      [{ source: 'a', target: 'ghost', weight: 1 }],
+      W,
+      H
+    );
+    expect(layout.size).toBe(2);
+    for (const { x, y } of layout.values()) {
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+    }
+  });
+});

--- a/frontend/src/__tests__/knowledgeGraph.test.tsx
+++ b/frontend/src/__tests__/knowledgeGraph.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AiStatsPage } from '../pages/AiStatsPage';
+import * as api from '../api';
+import type { EmbeddingMapResponse, KnowledgeGraphResponse, WordCloudResponse } from '../types';
+
+vi.mock('../api', () => ({
+  fetchAiWordCloud: vi.fn(),
+  fetchAiEmbeddingMap: vi.fn(),
+  fetchKnowledgeGraph: vi.fn(),
+}));
+
+const mockedApi = vi.mocked(api, true);
+
+const WORD_CLOUD: WordCloudResponse = { terms: [], article_count: 0, days: 7 };
+const EMBEDDING_MAP: EmbeddingMapResponse = {
+  points: [],
+  clusters: [],
+  embedded_count: 0,
+  total_count: 0,
+  days: 7,
+};
+
+const GRAPH: KnowledgeGraphResponse = {
+  nodes: [
+    { id: 'org:openai', name: 'OpenAI', type: 'org', count: 3, article_ids: [1, 2, 3] },
+    { id: 'person:sam-altman', name: 'Sam Altman', type: 'person', count: 2, article_ids: [1, 2] },
+    { id: 'place:paris', name: 'Paris', type: 'place', count: 1, article_ids: [3] },
+  ],
+  edges: [{ source: 'org:openai', target: 'person:sam-altman', weight: 2, article_ids: [1, 2] }],
+  articles: [
+    { id: 1, title: 'OpenAI and Altman' },
+    { id: 2, title: 'Altman speaks' },
+    { id: 3, title: 'OpenAI in Paris' },
+  ],
+  article_count: 10,
+  pending_count: 0,
+  days: 7,
+};
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <AiStatsPage />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockedApi.fetchAiWordCloud.mockResolvedValue(WORD_CLOUD);
+  mockedApi.fetchAiEmbeddingMap.mockResolvedValue(EMBEDDING_MAP);
+  mockedApi.fetchKnowledgeGraph.mockResolvedValue(GRAPH);
+});
+
+describe('knowledge graph section', () => {
+  it('renders a node per entity and an edge per co-occurrence', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="kg-node"]')).toHaveLength(3);
+    });
+    expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(1);
+    expect(screen.getByText('OpenAI')).toBeInTheDocument();
+    expect(screen.getByText('Sam Altman')).toBeInTheDocument();
+  });
+
+  it('reveals the entity’s articles when a node is clicked', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="kg-node"]')).toHaveLength(3);
+    });
+    const openai = [...container.querySelectorAll('[data-testid="kg-node"]')].find(
+      (n) => n.getAttribute('data-entity') === 'org:openai'
+    )!;
+    fireEvent.click(openai);
+    await waitFor(() => {
+      expect(screen.getByText('OpenAI and Altman')).toBeInTheDocument();
+    });
+    expect(screen.getByText('OpenAI in Paris')).toBeInTheDocument();
+  });
+
+  it('explains pending extraction in the empty state', async () => {
+    mockedApi.fetchKnowledgeGraph.mockResolvedValue({
+      ...GRAPH,
+      nodes: [],
+      edges: [],
+      articles: [],
+      pending_count: 12,
+    });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/still running for 12 articles/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -45,6 +45,7 @@ import type {
   TopicMapResponse,
   WordCloudResponse,
   EmbeddingMapResponse,
+  KnowledgeGraphResponse,
   User,
 } from './types';
 
@@ -726,6 +727,10 @@ export async function fetchAiWordCloud(days = 7): Promise<WordCloudResponse> {
 
 export async function fetchAiEmbeddingMap(days = 7): Promise<EmbeddingMapResponse> {
   return requestJson<EmbeddingMapResponse>(`/api/ai-stats/embedding-map?days=${days}`);
+}
+
+export async function fetchKnowledgeGraph(days = 7): Promise<KnowledgeGraphResponse> {
+  return requestJson<KnowledgeGraphResponse>(`/api/ai-stats/knowledge-graph?days=${days}`);
 }
 
 export async function fetchOnboardingStatus(): Promise<OnboardingStatus> {

--- a/frontend/src/components/aiStats/KnowledgeGraph.tsx
+++ b/frontend/src/components/aiStats/KnowledgeGraph.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { EntityType, KnowledgeGraphEdge, KnowledgeGraphResponse } from '@/types';
+import { forceLayout } from '@/lib/forceLayout';
+import { cn } from '@/lib/utils';
+
+const CANVAS_W = 800;
+const CANVAS_H = 600;
+
+const TYPE_COLORS: Record<EntityType, string> = {
+  person: 'var(--color-chart-1)',
+  org: 'var(--color-chart-2)',
+  product: 'var(--color-chart-3)',
+  place: 'var(--color-chart-4)',
+};
+
+function nodeRadius(count: number): number {
+  return 6 + 3 * Math.sqrt(count);
+}
+
+function isIncident(edge: KnowledgeGraphEdge, nodeId: string): boolean {
+  return edge.source === nodeId || edge.target === nodeId;
+}
+
+interface KnowledgeGraphProps {
+  graph: KnowledgeGraphResponse;
+}
+
+export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const layout = useMemo(
+    () => forceLayout(graph.nodes, graph.edges, CANVAS_W, CANVAS_H),
+    [graph.nodes, graph.edges]
+  );
+
+  const selected = useMemo(
+    () => graph.nodes.find((n) => n.id === selectedId) ?? null,
+    [graph.nodes, selectedId]
+  );
+
+  const selectedArticles = useMemo(() => {
+    if (!selected) return [];
+    const wanted = new Set(selected.article_ids);
+    return graph.articles.filter((a) => wanted.has(a.id));
+  }, [graph.articles, selected]);
+
+  if (graph.nodes.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        {graph.pending_count > 0
+          ? `No entities yet — extraction is still running for ${graph.pending_count} article${
+              graph.pending_count !== 1 ? 's' : ''
+            }.`
+          : 'No entities yet — the graph fills in as articles are analyzed.'}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <svg viewBox={`0 0 ${CANVAS_W} ${CANVAS_H}`} className="h-auto w-full" role="img">
+        <title>Knowledge graph of entities in recent news</title>
+        {graph.edges.map((edge) => {
+          const a = layout.get(edge.source);
+          const b = layout.get(edge.target);
+          if (!a || !b) return null;
+          const dimmed = selectedId !== null && !isIncident(edge, selectedId);
+          return (
+            <line
+              key={`${edge.source}--${edge.target}`}
+              data-testid="kg-edge"
+              x1={a.x}
+              y1={a.y}
+              x2={b.x}
+              y2={b.y}
+              strokeWidth={Math.min(1 + edge.weight, 6)}
+              className={cn('stroke-primary/30', dimmed && 'stroke-primary/10')}
+            />
+          );
+        })}
+        {graph.nodes.map((node) => {
+          const p = layout.get(node.id);
+          if (!p) return null;
+          const dimmed = selectedId !== null && selectedId !== node.id;
+          return (
+            <g key={node.id}>
+              <circle
+                data-testid="kg-node"
+                data-entity={node.id}
+                cx={p.x}
+                cy={p.y}
+                r={nodeRadius(node.count)}
+                fill={TYPE_COLORS[node.type]}
+                fillOpacity={dimmed ? 0.3 : 0.85}
+                className="cursor-pointer stroke-background stroke-[1.5] transition-all"
+                onClick={() => setSelectedId((prev) => (prev === node.id ? null : node.id))}
+              >
+                <title>{`${node.name} — ${node.count} article${node.count !== 1 ? 's' : ''}`}</title>
+              </circle>
+              <text
+                x={p.x}
+                y={p.y - nodeRadius(node.count) - 4}
+                textAnchor="middle"
+                className={cn(
+                  'pointer-events-none select-none fill-foreground text-[11px] font-medium',
+                  dimmed && 'opacity-30'
+                )}
+              >
+                {node.name}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {(Object.keys(TYPE_COLORS) as EntityType[]).map((type) => (
+          <span key={type} className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+            <span
+              className="size-2.5 rounded-full"
+              style={{ backgroundColor: TYPE_COLORS[type] }}
+            />
+            {type}
+          </span>
+        ))}
+      </div>
+
+      {selected && (
+        <div className="rounded-xl border border-border bg-surface-2 p-4">
+          <h3 className="text-sm font-semibold">
+            {selected.name}{' '}
+            <span className="font-normal text-muted-foreground">
+              · {selected.type} · {selected.count} article{selected.count !== 1 ? 's' : ''}
+            </span>
+          </h3>
+          <ul className="mt-2 grid gap-1.5">
+            {selectedArticles.map((article) => (
+              <li key={article.id}>
+                <Link
+                  to={`/a/${article.id}`}
+                  className="text-xs text-foreground hover:text-primary hover:underline"
+                >
+                  {article.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/forceLayout.ts
+++ b/frontend/src/lib/forceLayout.ts
@@ -1,0 +1,115 @@
+export interface ForceNode {
+  id: string;
+}
+
+export interface ForceEdge {
+  source: string;
+  target: string;
+  weight: number;
+}
+
+export interface ForcePoint {
+  x: number;
+  y: number;
+}
+
+const ITERATIONS = 300;
+const REPULSION = 0.08; // fraction of area per node pair
+const SPRING = 0.02;
+const CENTERING = 0.01;
+const COOLING = 0.98;
+
+/**
+ * Deterministic force-directed layout: nodes start evenly spaced on a circle
+ * (so the result is reproducible without randomness), then iterate pairwise
+ * repulsion, weighted spring attraction along edges, and a centering pull,
+ * with a cooling step cap. Positions are clamped to the viewport.
+ */
+export function forceLayout(
+  nodes: ForceNode[],
+  edges: ForceEdge[],
+  width: number,
+  height: number
+): Map<string, ForcePoint> {
+  const layout = new Map<string, ForcePoint>();
+  if (nodes.length === 0) return layout;
+
+  const cx = width / 2;
+  const cy = height / 2;
+  const startRadius = Math.min(width, height) * 0.35;
+  nodes.forEach((node, i) => {
+    const angle = (2 * Math.PI * i) / nodes.length;
+    layout.set(node.id, {
+      x: cx + startRadius * Math.cos(angle),
+      y: cy + startRadius * Math.sin(angle),
+    });
+  });
+  if (nodes.length === 1) {
+    layout.set(nodes[0].id, { x: cx, y: cy });
+    return layout;
+  }
+
+  const ids = nodes.map((n) => n.id);
+  const validEdges = edges.filter((e) => layout.has(e.source) && layout.has(e.target));
+  const repulsionK = REPULSION * ((width * height) / nodes.length);
+  let maxStep = Math.min(width, height) / 10;
+
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    const force = new Map<string, ForcePoint>(ids.map((id) => [id, { x: 0, y: 0 }]));
+
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const a = layout.get(ids[i])!;
+        const b = layout.get(ids[j])!;
+        let dx = a.x - b.x;
+        let dy = a.y - b.y;
+        let distSq = dx * dx + dy * dy;
+        if (distSq < 1) {
+          // Deterministic nudge for coincident points.
+          dx = 0.5 * (i - j);
+          dy = 0.5;
+          distSq = dx * dx + dy * dy;
+        }
+        const push = repulsionK / distSq;
+        const fa = force.get(ids[i])!;
+        const fb = force.get(ids[j])!;
+        fa.x += dx * push;
+        fa.y += dy * push;
+        fb.x -= dx * push;
+        fb.y -= dy * push;
+      }
+    }
+
+    for (const edge of validEdges) {
+      const a = layout.get(edge.source)!;
+      const b = layout.get(edge.target)!;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const pull = SPRING * Math.min(edge.weight, 5);
+      const fa = force.get(edge.source)!;
+      const fb = force.get(edge.target)!;
+      fa.x += dx * pull;
+      fa.y += dy * pull;
+      fb.x -= dx * pull;
+      fb.y -= dy * pull;
+    }
+
+    for (const id of ids) {
+      const p = layout.get(id)!;
+      const f = force.get(id)!;
+      f.x += (cx - p.x) * CENTERING;
+      f.y += (cy - p.y) * CENTERING;
+
+      const magnitude = Math.hypot(f.x, f.y) || 1;
+      const step = Math.min(magnitude, maxStep);
+      layout.set(id, {
+        x: Math.min(width, Math.max(0, p.x + (f.x / magnitude) * step)),
+        y: Math.min(height, Math.max(0, p.y + (f.y / magnitude) * step)),
+      });
+    }
+
+    maxStep *= COOLING;
+  }
+
+  return layout;
+}

--- a/frontend/src/pages/AiStatsPage.tsx
+++ b/frontend/src/pages/AiStatsPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { AlertCircle, Loader2, ScatterChart, Type } from 'lucide-react';
-import { fetchAiEmbeddingMap, fetchAiWordCloud } from '@/api';
+import { AlertCircle, Loader2, Network, ScatterChart, Type } from 'lucide-react';
+import { fetchAiEmbeddingMap, fetchAiWordCloud, fetchKnowledgeGraph } from '@/api';
 import { WordCloudChart } from '@/components/aiStats/WordCloudChart';
 import { EmbeddingMapChart } from '@/components/aiStats/EmbeddingMapChart';
+import { KnowledgeGraph } from '@/components/aiStats/KnowledgeGraph';
 import { cn } from '@/lib/utils';
 
 const RANGES = [7, 14, 30] as const;
@@ -50,6 +51,12 @@ export function AiStatsPage() {
   const embeddingMap = useQuery({
     queryKey: ['ai-embedding-map', days],
     queryFn: () => fetchAiEmbeddingMap(days),
+    staleTime: STALE_TIME,
+  });
+
+  const knowledgeGraph = useQuery({
+    queryKey: ['ai-knowledge-graph', days],
+    queryFn: () => fetchKnowledgeGraph(days),
     staleTime: STALE_TIME,
   });
 
@@ -137,6 +144,27 @@ export function AiStatsPage() {
               clusters={embeddingMap.data.clusters}
             />
           ))}
+      </section>
+
+      <section className="rounded-xl border border-border bg-surface p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Network className="size-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Knowledge Graph</h2>
+          {knowledgeGraph.data && knowledgeGraph.data.pending_count > 0 && (
+            <span className="text-[11px] text-muted-foreground">
+              extraction pending for {knowledgeGraph.data.pending_count} article
+              {knowledgeGraph.data.pending_count !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+        {knowledgeGraph.isLoading && <SectionLoading />}
+        {knowledgeGraph.isError && (
+          <SectionError
+            message="Failed to load knowledge graph."
+            onRetry={() => void knowledgeGraph.refetch()}
+          />
+        )}
+        {knowledgeGraph.data && <KnowledgeGraph graph={knowledgeGraph.data} />}
       </section>
     </div>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -517,6 +517,37 @@ export interface EmbeddingMapResponse {
   days: number;
 }
 
+export type EntityType = 'person' | 'org' | 'product' | 'place';
+
+export interface KnowledgeGraphNode {
+  id: string;
+  name: string;
+  type: EntityType;
+  count: number;
+  article_ids: number[];
+}
+
+export interface KnowledgeGraphEdge {
+  source: string;
+  target: string;
+  weight: number;
+  article_ids: number[];
+}
+
+export interface KnowledgeGraphArticle {
+  id: number;
+  title: string;
+}
+
+export interface KnowledgeGraphResponse {
+  nodes: KnowledgeGraphNode[];
+  edges: KnowledgeGraphEdge[];
+  articles: KnowledgeGraphArticle[];
+  article_count: number;
+  pending_count: number;
+  days: number;
+}
+
 export interface OnboardingInterest {
   id: string;
   label: string;


### PR DESCRIPTION
Closes #872

## What

Part 2 of the AI Stats initiative (part 1: #871).

- **`articles.entities` cache column** (idempotent `ADD COLUMN IF NOT EXISTS` migration): LLM-extracted named entities per article as `{"v": 1, "entities": [{"name", "type"}]}`, type ∈ {person, org, product, place}.
- **`entities.py`** (insights.py pattern): extraction via the free-LLM gateway (`chat_create`, Langfuse-traced as `entity-extraction`), tolerant JSON parsing with type validation and case-insensitive dedupe, per-article caching, and a bounded `extract_missing_entities(limit=25)` backfill that survives per-article failures.
- **`entity_extraction` scheduler job** — interval (env `ENTITY_EXTRACTION_INTERVAL_MINUTES`, default 30), recorded in `scheduled_job_runs`, cleanly skipped when no AI key is configured.
- **`GET /api/ai-stats/knowledge-graph`** — aggregates cached entities only (never calls the LLM): typed nodes sized by mention count (top 40), co-occurrence edges with weights and article references, plus `pending_count` so the UI can explain a sparse graph. Scoped to the requesting user's visible articles.
- **Knowledge Graph section on `/ai-stats`** — hand-rolled deterministic force layout (`lib/forceLayout.ts`, ~100 lines, no d3 dependency), nodes colored by entity type and sized by mentions, weighted edges, node click highlights incident edges and lists that entity's articles with links.

## Tests

TDD: `backend/tests/test_entities.py` (parsing, extraction, caching, visibility, batch limits/resilience, graph nodes/edges/article refs/truncation/scoping), `test_db_init.py` (+entities column), `test_scheduler.py` (+job registration, env override, success/skip/failure outcomes), `test_ai_stats_api.py` (+route, user/days passthrough, 422 bounds); frontend `forceLayout.test.ts` (deterministic, bounded, no NaN, connected pairs closer) and `knowledgeGraph.test.tsx` (nodes/edges render, click reveals articles, pending empty state). All gates green: ruff, mypy, ty, pyrefly, eslint, prettier, tsc, vitest (706), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)