### PR TITLE
feat: reading streaks and achievements (#658)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -486,6 +486,16 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "ALTER TABLE user_quizzes ADD COLUMN IF NOT EXISTS submitted_answers JSONB",
     "ALTER TABLE user_quizzes ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ",
     """
+    CREATE TABLE IF NOT EXISTS user_achievements (
+      id               BIGSERIAL PRIMARY KEY,
+      user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      achievement_key  TEXT NOT NULL,
+      unlocked_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      metadata         JSONB NOT NULL DEFAULT '{}'::jsonb,
+      UNIQUE(user_id, achievement_key)
+    )
+    """,
+    """
     CREATE TABLE IF NOT EXISTS scheduled_job_runs (
       id           SERIAL PRIMARY KEY,
       job_name     TEXT NOT NULL,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2894,9 +2894,11 @@ def admin_delete_user(
 # gate. Add each new domain's router here as it is extracted from main.py.
 from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E402
 from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
+from news_dashboard.reading_progress.router import router as reading_progress_router  # noqa: E402
 
 api.include_router(ai_stats_router)
 api.include_router(quizzes_router)
+api.include_router(reading_progress_router)
 
 app.include_router(api)
 app.include_router(admin)

--- a/backend/news_dashboard/reading_progress/__init__.py
+++ b/backend/news_dashboard/reading_progress/__init__.py
@@ -1,0 +1,1 @@
+"""Reading streaks and achievements feature module."""

--- a/backend/news_dashboard/reading_progress/models.py
+++ b/backend/news_dashboard/reading_progress/models.py
@@ -1,0 +1,27 @@
+"""Response models for reading streaks and achievements."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ReadingStreakResponse(BaseModel):
+    current_streak_days: int
+    longest_streak_days: int
+    last_active_date: str | None
+    active_days: list[str]
+    qualifying_activity: str
+
+
+class AchievementResponse(BaseModel):
+    key: str
+    title: str
+    description: str
+    unlocked: bool
+    unlocked_at: str | None = None
+    progress: int
+    target: int
+
+
+class AchievementsResponse(BaseModel):
+    items: list[AchievementResponse]

--- a/backend/news_dashboard/reading_progress/router.py
+++ b/backend/news_dashboard/reading_progress/router.py
@@ -1,0 +1,27 @@
+"""HTTP routes for reading streaks and achievements."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+
+from news_dashboard.auth import require_auth
+from news_dashboard.reading_progress import service
+from news_dashboard.reading_progress.models import AchievementsResponse, ReadingStreakResponse
+
+router = APIRouter()
+
+
+@router.get("/api/users/me/streak", response_model=ReadingStreakResponse)
+def get_streak_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return service.get_streak(current_user["id"])
+
+
+@router.get("/api/users/me/achievements", response_model=AchievementsResponse)
+def list_achievements_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": service.list_achievements(current_user["id"])}

--- a/backend/news_dashboard/reading_progress/service.py
+++ b/backend/news_dashboard/reading_progress/service.py
@@ -1,0 +1,233 @@
+"""Derive reading streaks and award local achievements."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from psycopg.types.json import Jsonb
+
+from news_dashboard.db import connect, init_db
+
+QUALIFYING_ACTIVITY = "days with a finished article or article dwell event"
+
+
+@dataclass(frozen=True)
+class AchievementDefinition:
+    key: str
+    title: str
+    description: str
+    target: int
+    progress: Callable[[dict[str, int]], int]
+
+
+ACHIEVEMENTS: tuple[AchievementDefinition, ...] = (
+    AchievementDefinition(
+        key="seven_day_streak",
+        title="7-day streak",
+        description="Read on seven consecutive active days.",
+        target=7,
+        progress=lambda stats: stats["current_streak_days"],
+    ),
+    AchievementDefinition(
+        key="hundred_articles_read",
+        title="100 articles read",
+        description="Mark 100 articles as done.",
+        target=100,
+        progress=lambda stats: stats["articles_read"],
+    ),
+    AchievementDefinition(
+        key="first_quiz_passed",
+        title="First quiz passed",
+        description="Submit a quiz with at least one correct answer.",
+        target=1,
+        progress=lambda stats: stats["passed_quizzes"],
+    ),
+    AchievementDefinition(
+        key="inbox_zero",
+        title="Inbox zero",
+        description="Clear every current article from Today.",
+        target=1,
+        progress=lambda stats: 1 if stats["today_articles"] == 0 else 0,
+    ),
+)
+
+
+def _utc_today(now: datetime | None = None) -> date:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    return current.astimezone(timezone.utc).date()
+
+
+def _consecutive_run(active_days: set[date], start: date) -> int:
+    count = 0
+    day = start
+    while day in active_days:
+        count += 1
+        day -= timedelta(days=1)
+    return count
+
+
+def _longest_run(active_days: set[date]) -> int:
+    longest = 0
+    for day in active_days:
+        if day - timedelta(days=1) not in active_days:
+            run = 0
+            cursor = day
+            while cursor in active_days:
+                run += 1
+                cursor += timedelta(days=1)
+            longest = max(longest, run)
+    return longest
+
+
+def active_reading_days(
+    user_id: int,
+    *,
+    database_url: str | None = None,
+) -> set[date]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT activity_day
+            FROM (
+              SELECT (created_at AT TIME ZONE 'UTC')::date AS activity_day
+              FROM user_events
+              WHERE user_id = %s
+                AND event_type IN ('article_open', 'article_close')
+                AND article_id IS NOT NULL
+              UNION
+              SELECT (done_at AT TIME ZONE 'UTC')::date AS activity_day
+              FROM user_article_state
+              WHERE user_id = %s
+                AND state = 'done'
+                AND done_at IS NOT NULL
+            ) days
+            ORDER BY activity_day
+            """,
+            (user_id, user_id),
+        ).fetchall()
+    return {row["activity_day"] for row in rows}
+
+
+def get_streak(
+    user_id: int,
+    *,
+    now: datetime | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    days = active_reading_days(user_id, database_url=database_url)
+    today = _utc_today(now)
+    if not days:
+        return {
+            "current_streak_days": 0,
+            "longest_streak_days": 0,
+            "last_active_date": None,
+            "active_days": [],
+            "qualifying_activity": QUALIFYING_ACTIVITY,
+        }
+
+    last_active = max(days)
+    if last_active == today:
+        current = _consecutive_run(days, today)
+    elif last_active == today - timedelta(days=1):
+        current = _consecutive_run(days, last_active)
+    else:
+        current = 0
+
+    return {
+        "current_streak_days": current,
+        "longest_streak_days": _longest_run(days),
+        "last_active_date": last_active.isoformat(),
+        "active_days": [day.isoformat() for day in sorted(days, reverse=True)[:30]],
+        "qualifying_activity": QUALIFYING_ACTIVITY,
+    }
+
+
+def _achievement_stats(
+    user_id: int,
+    *,
+    now: datetime | None = None,
+    database_url: str | None = None,
+) -> dict[str, int]:
+    streak = get_streak(user_id, now=now, database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            SELECT
+              (
+                SELECT COUNT(*)
+                FROM user_article_state
+                WHERE user_id = %s AND state = 'done'
+              ) AS articles_read,
+              (
+                SELECT COUNT(*)
+                FROM user_quizzes
+                WHERE user_id = %s AND submitted_at IS NOT NULL AND COALESCE(score, 0) > 0
+              ) AS passed_quizzes,
+              (
+                SELECT COUNT(*)
+                FROM articles
+                WHERE state = 'today'
+              ) AS today_articles
+            """,
+            (user_id, user_id),
+        ).fetchone()
+    return {
+        "current_streak_days": int(streak["current_streak_days"]),
+        "articles_read": int(row["articles_read"]),
+        "passed_quizzes": int(row["passed_quizzes"]),
+        "today_articles": int(row["today_articles"]),
+    }
+
+
+def list_achievements(
+    user_id: int,
+    *,
+    now: datetime | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(database_url=database_url)
+    stats = _achievement_stats(user_id, now=now, database_url=database_url)
+    unlocked_now = [
+        definition for definition in ACHIEVEMENTS if definition.progress(stats) >= definition.target
+    ]
+
+    with connect(database_url=database_url) as conn:
+        for definition in unlocked_now:
+            conn.execute(
+                """
+                INSERT INTO user_achievements(user_id, achievement_key, metadata)
+                VALUES (%s, %s, %s)
+                ON CONFLICT(user_id, achievement_key) DO NOTHING
+                """,
+                (user_id, definition.key, Jsonb({"progress": definition.progress(stats)})),
+            )
+        rows = conn.execute(
+            """
+            SELECT achievement_key, unlocked_at
+            FROM user_achievements
+            WHERE user_id = %s
+            """,
+            (user_id,),
+        ).fetchall()
+
+    unlocked = {row["achievement_key"]: row["unlocked_at"] for row in rows}
+    return [
+        {
+            "key": definition.key,
+            "title": definition.title,
+            "description": definition.description,
+            "unlocked": definition.key in unlocked,
+            "unlocked_at": unlocked[definition.key].isoformat()
+            if definition.key in unlocked
+            else None,
+            "progress": min(definition.progress(stats), definition.target),
+            "target": definition.target,
+        }
+        for definition in ACHIEVEMENTS
+    ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -175,12 +175,14 @@ def pg_clean(pg_url: str) -> str:
     """
     import psycopg
 
+    init_db(database_url=pg_url)
     with psycopg.connect(pg_url, autocommit=True) as conn:
         conn.execute(
             "TRUNCATE user_article_recommendations, user_article_state, user_sources,"
             " user_interest_profiles, user_settings, user_push_subscriptions,"
-            " article_highlights, article_shares, user_events, briefing_articles, briefings,"
-            " ingest_run_sources, ingest_runs, scheduled_job_runs, article_tags, user_tags,"
+            " article_highlights, article_shares, user_events, user_achievements,"
+            " briefing_articles, briefings, ingest_run_sources, ingest_runs,"
+            " scheduled_job_runs, article_tags, user_tags,"
             " articles, sources, users"
             " RESTART IDENTITY CASCADE"
         )

--- a/backend/tests/test_reading_progress.py
+++ b/backend/tests/test_reading_progress.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+from news_dashboard.reading_progress.service import get_streak, list_achievements
+
+pytestmark = pytest.mark.postgres
+
+
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    init_db(database_url=pg_url)
+    return pg_url
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_article(database_url: str, slug: str, state: str = "archived") -> int:
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, 'tech', 'rss_feed', 50, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml"),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/{slug}/article",
+                f"https://example.com/{slug}/article",
+                slug.title(),
+                slug,
+                slug.title(),
+                state,
+                "2026-06-21T10:00:00+00:00",
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_streak_counts_consecutive_reading_days_and_resets_after_gap(
+    monkeypatch: Any,
+    pg_clean: str,
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    first_article = _insert_article(database_url, "one")
+    second_article = _insert_article(database_url, "two")
+    third_article = _insert_article(database_url, "three")
+
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state, done_at)
+            VALUES
+              (%s, %s, 'done', '2026-06-28T12:00:00+00:00'),
+              (%s, %s, 'done', '2026-06-29T12:00:00+00:00'),
+              (%s, %s, 'done', '2026-07-01T12:00:00+00:00')
+            """,
+            (user_id, first_article, user_id, second_article, user_id, third_article),
+        )
+
+    streak = get_streak(
+        user_id,
+        now=datetime(2026, 7, 2, 9, tzinfo=timezone.utc),
+        database_url=database_url,
+    )
+    assert streak["current_streak_days"] == 1
+    assert streak["longest_streak_days"] == 2
+    assert streak["last_active_date"] == "2026-07-01"
+
+    stale = get_streak(
+        user_id,
+        now=datetime(2026, 7, 4, 9, tzinfo=timezone.utc),
+        database_url=database_url,
+    )
+    assert stale["current_streak_days"] == 0
+
+
+def test_achievements_unlock_once_and_endpoint_returns_progress(
+    monkeypatch: Any,
+    pg_clean: str,
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    articles = [_insert_article(database_url, f"article-{idx}") for idx in range(7)]
+
+    with connect(database_url=database_url) as conn:
+        for idx, article_id in enumerate(articles, start=1):
+            conn.execute(
+                """
+                INSERT INTO user_article_state(user_id, article_id, state, done_at)
+                VALUES (%s, %s, 'done', %s)
+                """,
+                (user_id, article_id, f"2026-06-{20 + idx:02d}T12:00:00+00:00"),
+            )
+        conn.execute(
+            """
+            INSERT INTO user_quizzes(user_id, questions, score, submitted_at)
+            VALUES (%s, '[]'::jsonb, 1, '2026-06-27T12:00:00+00:00')
+            """,
+            (user_id,),
+        )
+
+    first = list_achievements(
+        user_id,
+        now=datetime(2026, 6, 27, 18, tzinfo=timezone.utc),
+        database_url=database_url,
+    )
+    second = list_achievements(
+        user_id,
+        now=datetime(2026, 6, 27, 18, tzinfo=timezone.utc),
+        database_url=database_url,
+    )
+
+    unlocked = {item["key"]: item for item in first if item["unlocked"]}
+    assert {"seven_day_streak", "first_quiz_passed", "inbox_zero"} <= set(unlocked)
+    assert unlocked["seven_day_streak"]["progress"] == 7
+    assert second == first
+    with connect(database_url=database_url) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM user_achievements WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()["count"]
+    assert count == 3
+
+    try:
+        with _client_for(user_id) as client:
+            streak_response = client.get("/api/users/me/streak")
+            achievements_response = client.get("/api/users/me/achievements")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert streak_response.status_code == 200
+    assert achievements_response.status_code == 200
+    assert achievements_response.json()["items"][0]["key"] == "seven_day_streak"

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -470,6 +470,38 @@ describe('ingest runs & briefings', () => {
   });
 });
 
+describe('reading progress endpoints', () => {
+  it('fetchReadingStreak returns the result', async () => {
+    const payload = {
+      current_streak_days: 3,
+      longest_streak_days: 5,
+      last_active_date: '2026-07-01',
+      active_days: ['2026-07-01'],
+      qualifying_activity: 'days with reading',
+    };
+    const { calls } = stubFetch(() => jsonOk(payload));
+
+    expect(await api.fetchReadingStreak()).toEqual(payload);
+    expect(calls[0].url).toBe('/api/users/me/streak');
+  });
+
+  it('fetchAchievements unwraps items', async () => {
+    const item = {
+      key: 'seven_day_streak',
+      title: '7-day streak',
+      description: 'Read on seven consecutive active days.',
+      unlocked: true,
+      unlocked_at: '2026-07-01T10:00:00Z',
+      progress: 7,
+      target: 7,
+    };
+    const { calls } = stubFetch(() => jsonOk({ items: [item] }));
+
+    expect(await api.fetchAchievements()).toEqual([item]);
+    expect(calls[0].url).toBe('/api/users/me/achievements');
+  });
+});
+
 describe('auth endpoints', () => {
   it('fetchAuthConfig returns config', async () => {
     stubFetch(() => jsonOk({ provider: 'password' }));

--- a/frontend/src/__tests__/quizCandidates.test.tsx
+++ b/frontend/src/__tests__/quizCandidates.test.tsx
@@ -11,6 +11,8 @@ vi.mock('../api', () => ({
   fetchQuizCandidates: vi.fn(),
   fetchQuizHistory: vi.fn(),
   fetchReadingDna: vi.fn(),
+  fetchReadingStreak: vi.fn(),
+  fetchAchievements: vi.fn(),
   fetchRecommendationPreferences: vi.fn(),
   createGoal: vi.fn(),
   deleteGoal: vi.fn(),
@@ -51,6 +53,14 @@ beforeEach(() => {
     category_weights: {},
     novelty_weight: 0.5,
   });
+  mockedApi.fetchReadingStreak.mockResolvedValue({
+    current_streak_days: 0,
+    longest_streak_days: 0,
+    last_active_date: null,
+    active_days: [],
+    qualifying_activity: 'days with reading',
+  });
+  mockedApi.fetchAchievements.mockResolvedValue([]);
 });
 
 describe('quiz candidate preview', () => {

--- a/frontend/src/__tests__/readingProgress.test.tsx
+++ b/frontend/src/__tests__/readingProgress.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as api from '../api';
+import { ReadingDnaPage } from '../pages/ReadingDnaPage';
+import type { Achievement, ReadingDna, ReadingStreak } from '../types';
+
+const dna: ReadingDna = {
+  range_days: 30,
+  generated_at: '2026-06-21T10:00:00Z',
+  categories: [{ category: 'science', done: 12, skipped: 2, total: 14, percentage: 100 }],
+  sources: [],
+  monthly_time: [],
+  average_dwell_seconds: 42,
+};
+
+const streak: ReadingStreak = {
+  current_streak_days: 7,
+  longest_streak_days: 9,
+  last_active_date: '2026-07-01',
+  active_days: ['2026-07-01'],
+  qualifying_activity: 'days with a finished article or article dwell event',
+};
+
+const achievements: Achievement[] = [
+  {
+    key: 'seven_day_streak',
+    title: '7-day streak',
+    description: 'Read on seven consecutive active days.',
+    unlocked: true,
+    unlocked_at: '2026-07-01T10:00:00Z',
+    progress: 7,
+    target: 7,
+  },
+  {
+    key: 'hundred_articles_read',
+    title: '100 articles read',
+    description: 'Mark 100 articles as done.',
+    unlocked: false,
+    unlocked_at: null,
+    progress: 12,
+    target: 100,
+  },
+];
+
+describe('ReadingDnaPage reading progress', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(api, 'fetchReadingDna').mockResolvedValue(dna);
+    vi.spyOn(api, 'fetchRecommendationPreferences').mockResolvedValue({
+      category_weights: {},
+      novelty_weight: 1,
+    });
+    vi.spyOn(api, 'fetchReadingStreak').mockResolvedValue(streak);
+    vi.spyOn(api, 'fetchAchievements').mockResolvedValue(achievements);
+  });
+
+  it('renders streak and achievement progress on Reading DNA', async () => {
+    render(<ReadingDnaPage />);
+
+    await waitFor(() => expect(screen.getByText('Reading streak')).toBeTruthy());
+    expect(screen.getByText('Longest streak: 9 days')).toBeTruthy();
+    expect(screen.getByText('7-day streak')).toBeTruthy();
+    expect(screen.getByText('Unlocked')).toBeTruthy();
+    expect(screen.getByText('100 articles read')).toBeTruthy();
+    expect(screen.getByText('12/100 progress')).toBeTruthy();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -23,8 +23,10 @@ import type {
   QuizCandidate,
   QuizHistoryItem,
   QuizResult,
+  Achievement,
   ReadingDna,
   ReadingGoal,
+  ReadingStreak,
   RecommendationPreferences,
   ReceivedShare,
   ShareDetail,
@@ -243,6 +245,15 @@ export async function fetchSummary(): Promise<Summary> {
 
 export async function fetchReadingDna(): Promise<ReadingDna> {
   return requestJson<ReadingDna>('/api/users/me/reading-dna');
+}
+
+export async function fetchReadingStreak(): Promise<ReadingStreak> {
+  return requestJson<ReadingStreak>('/api/users/me/streak');
+}
+
+export async function fetchAchievements(): Promise<Achievement[]> {
+  const data = await requestJson<{ items: Achievement[] }>('/api/users/me/achievements');
+  return data.items;
 }
 
 export async function fetchRecommendationPreferences(): Promise<RecommendationPreferences> {

--- a/frontend/src/pages/ReadingDnaPage.tsx
+++ b/frontend/src/pages/ReadingDnaPage.tsx
@@ -1,14 +1,25 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { CheckCircle, Loader2, Plus, RefreshCw, Trash2, XCircle } from 'lucide-react';
+import {
+  CheckCircle,
+  Flame,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Trophy,
+  XCircle,
+} from 'lucide-react';
 import {
   createGoal,
   deleteGoal,
+  fetchAchievements,
   fetchGoals,
   fetchLatestQuiz,
   fetchQuizCandidates,
   fetchQuizHistory,
   fetchReadingDna,
+  fetchReadingStreak,
   fetchRecommendationPreferences,
   generateQuiz,
   saveRecommendationPreferences,
@@ -20,9 +31,11 @@ import type {
   QuizHistoryItem,
   QuizQuestion,
   QuizResult,
+  Achievement,
   ReadingDna,
   ReadingDnaBucket,
   ReadingGoal,
+  ReadingStreak,
   RecommendationPreferences,
 } from '../types';
 
@@ -32,6 +45,8 @@ type Tab = 'dna' | 'learning';
 
 interface PageState {
   dna: ReadingDna | null;
+  streak: ReadingStreak | null;
+  achievements: Achievement[];
   preferences: RecommendationPreferences | null;
   loading: boolean;
   saving: boolean;
@@ -42,6 +57,8 @@ export function ReadingDnaPage() {
   const [tab, setTab] = useState<Tab>('dna');
   const [state, setState] = useState<PageState>({
     dna: null,
+    streak: null,
+    achievements: [],
     preferences: null,
     loading: true,
     saving: false,
@@ -50,10 +67,23 @@ export function ReadingDnaPage() {
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([fetchReadingDna(), fetchRecommendationPreferences()])
-      .then(([dna, preferences]) => {
+    Promise.all([
+      fetchReadingDna(),
+      fetchRecommendationPreferences(),
+      fetchReadingStreak().catch(() => null),
+      fetchAchievements().catch(() => []),
+    ])
+      .then(([dna, preferences, streak, achievements]) => {
         if (!cancelled) {
-          setState({ dna, preferences, loading: false, saving: false, error: null });
+          setState({
+            dna,
+            preferences,
+            streak,
+            achievements,
+            loading: false,
+            saving: false,
+            error: null,
+          });
         }
       })
       .catch((err) => {
@@ -96,7 +126,7 @@ export function ReadingDnaPage() {
     }
   }
 
-  const { dna, preferences, loading, saving, error } = state;
+  const { dna, streak, achievements, preferences, loading, saving, error } = state;
 
   if (loading) {
     return (
@@ -132,9 +162,10 @@ export function ReadingDnaPage() {
 
       {tab === 'dna' && (
         <>
-          <section className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          <section className="grid grid-cols-2 gap-2 md:grid-cols-5">
             <Metric label="Window" value={`${dna?.range_days ?? 30}d`} />
             <Metric label="Avg dwell" value={`${dna?.average_dwell_seconds ?? 0}s`} />
+            <Metric label="Streak" value={`${streak?.current_streak_days ?? 0}d`} />
             <Metric
               label="Read"
               value={String(dna?.categories.reduce((sum, item) => sum + item.done, 0) ?? 0)}
@@ -143,6 +174,42 @@ export function ReadingDnaPage() {
               label="Skipped"
               value={String(dna?.categories.reduce((sum, item) => sum + item.skipped, 0) ?? 0)}
             />
+          </section>
+
+          <section className="grid grid-cols-1 gap-4 lg:grid-cols-[0.8fr_1.2fr]">
+            <Panel title="Reading streak">
+              <div className="flex items-start gap-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
+                  <Flame className="size-5" />
+                </div>
+                <div className="min-w-0 space-y-1">
+                  <div className="text-2xl font-semibold">
+                    {streak?.current_streak_days ?? 0}
+                    <span className="ml-1 text-sm font-normal text-muted-foreground">days</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Longest streak: {streak?.longest_streak_days ?? 0} days
+                  </p>
+                  {streak?.last_active_date && (
+                    <p className="text-xs text-muted-foreground">
+                      Last active {new Date(streak.last_active_date).toLocaleDateString()}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </Panel>
+
+            <Panel title="Achievements">
+              {achievements.length === 0 ? (
+                <EmptyLine />
+              ) : (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {achievements.map((achievement) => (
+                    <AchievementBadge key={achievement.key} achievement={achievement} />
+                  ))}
+                </div>
+              )}
+            </Panel>
           </section>
 
           <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -215,6 +282,29 @@ export function ReadingDnaPage() {
       )}
 
       {tab === 'learning' && <LearningCenter />}
+    </div>
+  );
+}
+
+function AchievementBadge({ achievement }: { achievement: Achievement }) {
+  return (
+    <div
+      className={`flex min-h-20 items-start gap-2 rounded border px-3 py-2 ${
+        achievement.unlocked
+          ? 'border-primary/30 bg-primary/5'
+          : 'border-border bg-muted/20 text-muted-foreground'
+      }`}
+    >
+      <Trophy className={`mt-0.5 size-4 shrink-0 ${achievement.unlocked ? 'text-primary' : ''}`} />
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-foreground">{achievement.title}</div>
+        <p className="mt-0.5 text-xs">{achievement.description}</p>
+        <div className="mt-1 text-[11px]">
+          {achievement.unlocked
+            ? 'Unlocked'
+            : `${achievement.progress}/${achievement.target} progress`}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -339,6 +339,24 @@ export interface ReadingDna {
   average_dwell_seconds: number;
 }
 
+export interface ReadingStreak {
+  current_streak_days: number;
+  longest_streak_days: number;
+  last_active_date: string | null;
+  active_days: string[];
+  qualifying_activity: string;
+}
+
+export interface Achievement {
+  key: string;
+  title: string;
+  description: string;
+  unlocked: boolean;
+  unlocked_at: string | null;
+  progress: number;
+  target: number;
+}
+
 export interface RecommendationPreferences {
   category_weights: Record<string, number>;
   novelty_weight: number;


### PR DESCRIPTION
Closes #658

## Summary
- add authenticated streak and achievement endpoints backed by local Postgres data
- persist achievement unlocks idempotently in `user_achievements`
- show streak and achievement progress on the Reading DNA page
- add backend/frontend tests and harden the Postgres cleanup fixture for the new table

## Tests
- `make lint`
- `make typecheck`
- `source .env && make test` (backend: 1448 passed; frontend: 705 passed)
- `npm run build`
