### PR TITLE
fix: mount writable DATA_DIR for generated audio (#675)

### DIFF
--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -87,6 +87,53 @@ def test_helm_template_default() -> None:
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_app_mounts_writable_data_dir() -> None:
+    output = _render_chart()
+    deployment = _manifest_for_kind(output, "Deployment")
+    deployment_env = _env_block(deployment)
+
+    assert _env_entry(deployment_env, "DATA_DIR") == '- name: DATA_DIR\n  value: "/data"'
+    assert "readOnlyRootFilesystem: true" in deployment
+    assert "name: app-data" in deployment
+    assert 'mountPath: "/data"' in deployment
+    assert "emptyDir: {}" in deployment
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_app_data_dir_can_use_persistent_volume_claim() -> None:
+    output = _render_chart(
+        "app.data.dir=/var/lib/news-dashboard",
+        "app.data.persistence.enabled=true",
+        "app.data.persistence.size=5Gi",
+        "app.data.persistence.storageClassName=fast-storage",
+    )
+    deployment = _manifest_for_kind(output, "Deployment")
+    pvc = _manifest_for_kind(output, "PersistentVolumeClaim")
+    deployment_env = _env_block(deployment)
+
+    assert _env_entry(deployment_env, "DATA_DIR") == (
+        '- name: DATA_DIR\n  value: "/var/lib/news-dashboard"'
+    )
+    assert 'mountPath: "/var/lib/news-dashboard"' in deployment
+    assert 'claimName: "news-dashboard-news-dashboard-data"' in deployment
+    assert "name: news-dashboard-news-dashboard-data" in pvc
+    assert "storage: 5Gi" in pvc
+    assert 'storageClassName: "fast-storage"' in pvc
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_app_data_dir_can_use_existing_claim() -> None:
+    output = _render_chart(
+        "app.data.persistence.enabled=true",
+        "app.data.persistence.existingClaim=audio-cache",
+    )
+    deployment = _manifest_for_kind(output, "Deployment")
+
+    assert 'claimName: "audio-cache"' in deployment
+    assert "name: news-dashboard-news-dashboard-data" not in output
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
 def test_helm_template_ingest_cronjob_operational_overrides() -> None:
     output = _render_chart(
         "ingestCronJob.concurrencyPolicy=Replace",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,9 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       FREE_LLM_API_KEY: ${FREE_LLM_API_KEY:-}
       FREE_LLM_BASE_URL: ${FREE_LLM_BASE_URL:-}
+      DATA_DIR: /data
+    volumes:
+      - news-dashboard-data:/data
     depends_on:
       postgres:
         condition: service_healthy
@@ -41,3 +44,4 @@ services:
 
 volumes:
   news-dashboard-postgres:
+  news-dashboard-data:

--- a/helm/news-dashboard/templates/data-pvc.yaml
+++ b/helm/news-dashboard/templates/data-pvc.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.app.data.persistence.enabled (not .Values.app.data.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "news-dashboard.fullname" . }}-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.app.data.persistence.size }}
+{{- if .Values.app.data.persistence.storageClassName }}
+  storageClassName: {{ .Values.app.data.persistence.storageClassName | quote }}
+{{- end }}
+{{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
           env:
             - name: INGEST_INTERVAL_SCHEDULER_ENABLED
               value: {{ ternary "false" "true" .Values.ingestCronJob.enabled | quote }}
+            - name: DATA_DIR
+              value: {{ .Values.app.data.dir | quote }}
 {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_HOST
               value: {{ printf "%s-postgres" (include "news-dashboard.fullname" .) | quote }}
@@ -159,6 +161,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: app-data
+              mountPath: {{ .Values.app.data.dir | quote }}
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: app-data
+{{- if .Values.app.data.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-data" (include "news-dashboard.fullname" .)) .Values.app.data.persistence.existingClaim | quote }}
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -47,6 +47,20 @@ app:
     # Alternatively, specify a pre-existing Secret containing a full DATABASE_URL.
     existingSecret: ""
     key: "DATABASE_URL"
+  data:
+    # Writable app data directory used for generated audio caches such as
+    # article TTS and briefing podcast MP3 files. The app container keeps a
+    # read-only root filesystem, so this path is always backed by a volume.
+    dir: /data
+    persistence:
+      # Default false uses an emptyDir cache that is regenerated after pod
+      # replacement. Set enabled=true to create or attach a PVC for durable audio.
+      enabled: false
+      # Optional pre-existing PVC name. When empty and enabled=true, the chart
+      # creates a ReadWriteOnce PVC named <release>-news-dashboard-data.
+      existingClaim: ""
+      size: 1Gi
+      storageClassName: ""
   auth:
     enabled: true
     publicBaseUrl: https://news.lihor.ro


### PR DESCRIPTION
Closes #675

## Summary
- Set `DATA_DIR` for the Helm app container and mount a writable app data volume at that path while preserving `readOnlyRootFilesystem: true`.
- Added chart values for default regenerated `emptyDir` storage plus PVC/existing-claim persistence options.
- Added a local Docker Compose `/data` named volume for generated audio cache parity.
- Covered the Helm env, volumeMount, emptyDir, PVC, and existing-claim render paths.

## Test results
- `pytest backend/tests/test_chart_render.py` passed: 12 passed.
- `pytest backend/tests/test_tts.py` passed: 20 passed.
- `make lint` passed.
- `make typecheck` passed.
- `helm lint ./helm/news-dashboard` passed.
- Helm template renders passed for default, production-like, and external database modes when supplied the required render-only secrets.
- `npm run test:frontend --silent` passed: 68 files / 713 tests passed. Vitest emitted existing localhost:3000 connection-refused logs but exited 0.
- `npm run build --silent` passed.
- `source .env && make test` did not complete green because of an unrelated pre-existing backend failure: `backend/tests/test_stats.py::test_ingested_vs_handled_counts_user_article_state_done` expected handled=1 but got 0.
- `make helm-validate` did not complete green because its first render omits the required `postgresql.password`; the password-complete render commands above passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
