### PR TITLE
feat: weekly reading recap (#659)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -542,6 +542,21 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_article_tags_user_tag ON article_tags(user_id, tag_id)",
     "CREATE INDEX IF NOT EXISTS idx_article_tags_article ON article_tags(article_id)",
+    "ALTER TABLE users ADD COLUMN IF NOT EXISTS recap_enabled BOOLEAN NOT NULL DEFAULT TRUE",
+    "ALTER TABLE users ADD COLUMN IF NOT EXISTS recap_day TEXT NOT NULL DEFAULT 'mon'",
+    """
+    CREATE TABLE IF NOT EXISTS user_weekly_recaps (
+      id          SERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      week_start  DATE NOT NULL,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      data        JSONB NOT NULL DEFAULT '{}'::jsonb,
+      narrative   TEXT,
+      UNIQUE (user_id, week_start)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_weekly_recaps_user"
+    " ON user_weekly_recaps(user_id, week_start DESC)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2392,13 +2392,18 @@ def briefings_chat(
 # ── Notification settings & push subscriptions ───────────────────────────────
 
 _BRIEFING_TIME_RE = __import__("re").compile(r"^([01]\d|2[0-3]):[0-5]\d$")
-_NOTIFICATION_COLS = "briefing_time, briefing_push_enabled, briefing_timezone"
+_NOTIFICATION_COLS = (
+    "briefing_time, briefing_push_enabled, briefing_timezone, recap_enabled, recap_day"
+)
+_RECAP_DAYS = frozenset({"mon", "tue", "wed", "thu", "fri", "sat", "sun"})
 
 
 class NotificationSettingsUpdate(BaseModel):
     briefing_time: str | None = None
     push_enabled: bool | None = None
     briefing_timezone: str | None = None
+    recap_enabled: bool | None = None
+    recap_day: str | None = None
 
 
 class PushSubscribeRequest(BaseModel):
@@ -2509,6 +2514,8 @@ def get_notification_settings(
         "briefing_time": row["briefing_time"] or "09:00",
         "briefing_timezone": row["briefing_timezone"] or "UTC",
         "push_enabled": bool(row["briefing_push_enabled"]),
+        "recap_enabled": bool(row["recap_enabled"]),
+        "recap_day": row["recap_day"] or "mon",
         "vapid_public_key": get_vapid_public_key(),
     }
 
@@ -2534,6 +2541,13 @@ def update_notification_settings(
         except (ZoneInfoNotFoundError, KeyError):
             raise HTTPException(status_code=422, detail="unknown timezone") from None
         updates["briefing_timezone"] = payload.briefing_timezone
+    if payload.recap_enabled is not None:
+        updates["recap_enabled"] = payload.recap_enabled
+    if payload.recap_day is not None:
+        if payload.recap_day not in _RECAP_DAYS:
+            detail = "recap_day must be one of: " + ", ".join(sorted(_RECAP_DAYS))
+            raise HTTPException(status_code=422, detail=detail)
+        updates["recap_day"] = payload.recap_day
     if updates:
         set_clauses = ", ".join(f"{k} = %s" for k in updates)
         with connect() as conn:
@@ -2552,6 +2566,8 @@ def update_notification_settings(
         "briefing_time": row["briefing_time"] or "09:00",
         "briefing_timezone": row["briefing_timezone"] or "UTC",
         "push_enabled": bool(row["briefing_push_enabled"]),
+        "recap_enabled": bool(row["recap_enabled"]),
+        "recap_day": row["recap_day"] or "mon",
     }
 
 
@@ -2895,10 +2911,12 @@ def admin_delete_user(
 from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E402
 from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
 from news_dashboard.reading_progress.router import router as reading_progress_router  # noqa: E402
+from news_dashboard.recaps.router import router as recaps_router  # noqa: E402
 
 api.include_router(ai_stats_router)
 api.include_router(quizzes_router)
 api.include_router(reading_progress_router)
+api.include_router(recaps_router)
 
 app.include_router(api)
 app.include_router(admin)

--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -128,6 +128,62 @@ def generate_push_hook(briefing: dict[str, Any]) -> str:
     return fallback
 
 
+_DEFAULT_RECAP_TITLE = "Your weekly reading recap is ready"
+
+
+def generate_recap_push_hook(recap: dict[str, Any]) -> str:
+    """Generate an AI narrative hook for a weekly recap push notification.
+
+    Takes the recap dict from ``recaps.service.assemble_weekly_recap()``
+    (keys: ``articles_read``, ``categories``, ``sources``, ``minutes_read``,
+    ``current_streak_days``). Falls back to a plain summary sentence if the
+    LLM is not configured or the call fails, matching ``generate_push_hook``.
+    """
+    articles_read = int(recap.get("articles_read") or 0)
+    categories: list[dict[str, Any]] = recap.get("categories") or []
+    top_category = categories[0].get("category") if categories else None
+
+    if articles_read <= 0:
+        fallback = _DEFAULT_RECAP_TITLE
+    elif top_category:
+        fallback = f"You read {articles_read} articles this week, mostly on {top_category}."
+    else:
+        fallback = f"You read {articles_read} articles this week."
+
+    try:
+        from news_dashboard.ai_client import free_llm_config, get_chat_client
+
+        api_key, base_url = free_llm_config()
+        if not api_key:
+            return fallback
+
+        client = get_chat_client(api_key=api_key, base_url=base_url)
+        model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
+
+        prompt = (
+            "Write a single encouraging mobile push notification hook (max 20 words) "
+            "summarizing this user's weekly reading recap. "
+            f"Articles read: {articles_read}. "
+            f"Top category: {top_category or 'n/a'}. "
+            f"Current streak: {recap.get('current_streak_days', 0)} day(s).\n\n"
+            "Reply with only the hook text, no quotes or punctuation at the end."
+        )
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=40,
+            temperature=0.7,
+        )
+        hook = (response.choices[0].message.content or "").strip()
+        if hook:
+            return hook
+    except Exception:
+        logger.warning("Recap push hook LLM generation failed; using default message")
+
+    return fallback
+
+
 PushDeliveryResult = Literal["sent", "skipped_not_configured", "temporary_failure", "gone"]
 
 

--- a/backend/news_dashboard/recaps/__init__.py
+++ b/backend/news_dashboard/recaps/__init__.py
@@ -1,0 +1,1 @@
+"""Weekly reading recap: per-user summary of the trailing week's activity."""

--- a/backend/news_dashboard/recaps/router.py
+++ b/backend/news_dashboard/recaps/router.py
@@ -1,0 +1,35 @@
+"""HTTP routes for weekly reading recaps.
+
+Mounted on ``main``'s authenticated ``api`` router, which applies
+``require_auth``; handlers still depend on it to receive the current user.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from news_dashboard.auth import require_auth
+from news_dashboard.recaps import service
+
+router = APIRouter()
+
+
+@router.get("/api/recaps")
+def list_recaps_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    limit: Annotated[int, Query(ge=1, le=52)] = 12,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    return {"items": service.list_recaps(current_user["id"], limit=limit, offset=offset)}
+
+
+@router.get("/api/recaps/latest")
+def get_latest_recap_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    recap = service.get_latest_recap(current_user["id"])
+    if not recap:
+        raise HTTPException(status_code=404, detail="no recap available")
+    return recap

--- a/backend/news_dashboard/recaps/service.py
+++ b/backend/news_dashboard/recaps/service.py
@@ -1,0 +1,151 @@
+"""Weekly reading recap assembly and persistence.
+
+A recap summarizes one user's trailing 7-day reading activity: volume, top
+categories/sources, and a simple consecutive-day streak. Aggregation mirrors
+``news_dashboard.analytics.reading_dna`` but scoped to a fixed 7-day window
+and persisted so history can be listed via ``GET /api/recaps``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.reading_progress.service import get_streak
+
+logger = logging.getLogger(__name__)
+
+RECAP_WINDOW_DAYS = 7
+
+
+def assemble_weekly_recap(
+    user_id: int,
+    now: datetime | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate the trailing 7 days of activity for ``user_id``."""
+    init_db(db_path, database_url=database_url)
+    now = now or datetime.now(timezone.utc)
+    start = now - timedelta(days=RECAP_WINDOW_DAYS)
+    streak = get_streak(user_id, now=now, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        return {
+            "week_start": start.date().isoformat(),
+            "week_end": now.date().isoformat(),
+            "generated_at": now.isoformat(),
+            "articles_read": _articles_read(conn, user_id, start),
+            "categories": _top_field(conn, user_id, start, "a.category", "category"),
+            "sources": _top_field(conn, user_id, start, "a.source_name", "source"),
+            "minutes_read": _minutes_read(conn, user_id, start),
+            "current_streak_days": streak["current_streak_days"],
+        }
+
+
+def save_weekly_recap(
+    user_id: int,
+    recap: dict[str, Any],
+    narrative: str | None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Persist a computed recap, upserting on (user_id, week_start)."""
+    init_db(db_path, database_url=database_url)
+    week_start = date.fromisoformat(recap["week_start"])
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_weekly_recaps (user_id, week_start, data, narrative)
+            VALUES (%s, %s, %s::jsonb, %s)
+            ON CONFLICT (user_id, week_start)
+            DO UPDATE SET data = EXCLUDED.data, narrative = EXCLUDED.narrative
+            RETURNING id, user_id, week_start, created_at, data, narrative
+            """,
+            (user_id, week_start, json.dumps(recap), narrative),
+        ).fetchone()
+    result = dict(row)
+    result["data"] = recap
+    return result
+
+
+def list_recaps(
+    user_id: int,
+    limit: int = 12,
+    offset: int = 0,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, user_id, week_start, created_at, data, narrative
+            FROM user_weekly_recaps
+            WHERE user_id = %s
+            ORDER BY week_start DESC
+            LIMIT %s OFFSET %s
+            """,
+            (user_id, limit, offset),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_latest_recap(
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    recaps = list_recaps(user_id, limit=1, db_path=db_path, database_url=database_url)
+    return recaps[0] if recaps else None
+
+
+def _articles_read(conn: Any, user_id: int, start: datetime) -> int:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS n
+        FROM user_article_state
+        WHERE user_id = %s AND state = 'done' AND done_at >= %s
+        """,
+        (user_id, start),
+    ).fetchone()
+    return int(row["n"]) if row and row["n"] is not None else 0
+
+
+def _top_field(
+    conn: Any,
+    user_id: int,
+    start: datetime,
+    field_sql: str,
+    alias: str,
+) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        f"""
+        SELECT {field_sql} AS {alias}, COUNT(*) AS count
+        FROM user_article_state s
+        JOIN articles a ON a.id = s.article_id
+        WHERE s.user_id = %s AND s.state = 'done' AND s.done_at >= %s
+        GROUP BY 1
+        ORDER BY count DESC, {alias}
+        LIMIT 5
+        """,
+        (user_id, start),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _minutes_read(conn: Any, user_id: int, start: datetime) -> float:
+    row = conn.execute(
+        """
+        SELECT ROUND(COALESCE(SUM(duration_ms), 0) / 60000.0, 1) AS minutes
+        FROM user_events
+        WHERE user_id = %s AND event_type = 'heartbeat' AND created_at >= %s
+        """,
+        (user_id, start),
+    ).fetchone()
+    if row is None or row["minutes"] is None:
+        return 0.0
+    return float(row["minutes"])

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -214,6 +214,86 @@ def _run_per_user_briefings() -> tuple[str, str | None] | None:
     return status, msg
 
 
+def _generate_recap_for_user(user_id: int, *, push_enabled: bool = True) -> bool:
+    """Assemble, persist, and (optionally) push a weekly recap for one user."""
+    from news_dashboard.push import generate_recap_push_hook, send_push_for_user
+    from news_dashboard.recaps.service import assemble_weekly_recap, save_weekly_recap
+
+    logger.info("Weekly recap: generating for user_id=%s", user_id)
+    try:
+        recap = assemble_weekly_recap(user_id)
+        narrative = generate_recap_push_hook(recap) if push_enabled else None
+        saved = save_weekly_recap(user_id, recap, narrative)
+        logger.info("Weekly recap: complete for user_id=%s id=%s", user_id, saved.get("id"))
+        if push_enabled:
+            try:
+                send_push_for_user(
+                    user_id,
+                    narrative or "Your weekly reading recap is ready.",
+                    "",
+                    target_url="/recap",
+                )
+            except Exception:
+                logger.exception("Weekly recap: push notification failed for user_id=%s", user_id)
+        return True
+    except Exception:
+        logger.exception("Weekly recap: unexpected error for user_id=%s", user_id)
+        return False
+
+
+def _run_weekly_recaps() -> tuple[str, str | None] | None:
+    """Generate weekly recaps for users whose local scheduled day/time matches now.
+
+    Returns None when no users are scheduled this minute so the run is not recorded.
+    """
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    from news_dashboard.db import connect, row_to_dict
+
+    now = datetime.now(timezone.utc)
+
+    try:
+        with connect() as conn:
+            rows = conn.execute(
+                "SELECT id, recap_day, briefing_time, briefing_timezone, briefing_push_enabled"
+                " FROM users WHERE recap_enabled = TRUE",
+            ).fetchall()
+        user_rows = [row_to_dict(r) for r in rows]
+    except Exception as exc:
+        logger.exception("Weekly recap: failed to query users")
+        return "failure", str(exc)[:500]
+
+    scheduled_users: list[tuple[int, bool]] = []
+    for row in user_rows:
+        tz_name: str = row.get("briefing_timezone") or "UTC"
+        recap_time: str = row.get("briefing_time") or "09:00"
+        recap_day: str = row.get("recap_day") or "mon"
+        try:
+            tz = ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, KeyError):
+            tz = ZoneInfo("UTC")
+        local_now = now.astimezone(tz)
+        day_matches = local_now.strftime("%a").lower() == recap_day
+        time_matches = local_now.strftime("%H:%M") == recap_time
+        if day_matches and time_matches:
+            scheduled_users.append((int(row["id"]), bool(row.get("briefing_push_enabled"))))
+
+    if not scheduled_users:
+        return None  # nothing scheduled this minute — skip recording
+
+    results = [
+        _generate_recap_for_user(uid, push_enabled=push_enabled)
+        for uid, push_enabled in scheduled_users
+    ]
+    succeeded = sum(1 for ok in results if ok)
+    failed = len(results) - succeeded
+    total = len(scheduled_users)
+    noun = "user" if total == 1 else "users"
+    msg = f"{total} {noun} targeted, {succeeded} succeeded, {failed} failed"
+    status = "failure" if failed == total else "success"
+    return status, msg
+
+
 def _run_digest() -> tuple[str, str | None]:
     from news_dashboard.digest import send_digest
 
@@ -302,6 +382,10 @@ def _job_per_user_briefings() -> None:
 
 def _job_entity_extraction() -> None:
     _run_and_record("entity_extraction", _run_entity_extraction)
+
+
+def _job_weekly_recaps() -> None:
+    _run_and_record("weekly_recaps", _run_weekly_recaps)
 
 
 def _parse_cron_hm(cron: str, default_minute: str, default_hour: str) -> tuple[str, str]:
@@ -420,6 +504,14 @@ def start_scheduler() -> None:
         trigger="interval",
         minutes=int(os.getenv("ENTITY_EXTRACTION_INTERVAL_MINUTES", "30")),
         id="entity_extraction",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _job_weekly_recaps,
+        trigger="interval",
+        minutes=1,
+        id="weekly_recaps",
         replace_existing=True,
     )
 

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -351,6 +351,8 @@ def test_get_notification_settings_returns_defaults(
         "briefing_time": "09:00",
         "briefing_push_enabled": False,
         "briefing_timezone": "UTC",
+        "recap_enabled": True,
+        "recap_day": "mon",
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -364,6 +366,8 @@ def test_get_notification_settings_returns_defaults(
     assert data["briefing_time"] == "09:00"
     assert data["briefing_timezone"] == "UTC"
     assert data["push_enabled"] is False
+    assert data["recap_enabled"] is True
+    assert data["recap_day"] == "mon"
     assert data["vapid_public_key"] == "BExampleKey=="
 
 
@@ -377,6 +381,8 @@ def test_get_notification_settings_utc_fallback(
         "briefing_time": "09:00",
         "briefing_push_enabled": False,
         "briefing_timezone": None,
+        "recap_enabled": True,
+        "recap_day": "mon",
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -394,6 +400,8 @@ def test_put_notification_settings_valid_time(client: TestClient) -> None:
         "briefing_time": "08:30",
         "briefing_push_enabled": True,
         "briefing_timezone": "UTC",
+        "recap_enabled": True,
+        "recap_day": "mon",
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -416,6 +424,8 @@ def test_put_notification_settings_valid_timezone(client: TestClient) -> None:
         "briefing_time": "09:00",
         "briefing_push_enabled": False,
         "briefing_timezone": "Europe/Bucharest",
+        "recap_enabled": True,
+        "recap_day": "mon",
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:

--- a/backend/tests/test_recaps.py
+++ b/backend/tests/test_recaps.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+from news_dashboard.recaps.service import assemble_weekly_recap, list_recaps, save_weekly_recap
+
+pytestmark = pytest.mark.postgres
+
+
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    init_db(database_url=pg_url)
+    return pg_url
+
+
+def _make_user(db_path: str, username: str) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_article(db_path: str, slug: str, category: str) -> int:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, %s, 'rss_feed', 50, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml", category),
+        )
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, state, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/{slug}/article",
+                f"https://example.com/{slug}/article",
+                f"{category.title()} Article",
+                slug,
+                slug.title(),
+                category,
+                "2026-06-21T10:00:00+00:00",
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_assemble_weekly_recap_aggregates_trailing_week(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    article_id = _insert_article(db_path, "science-weekly", "science")
+    now = datetime.now(timezone.utc)
+    stale = now - timedelta(days=30)
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state, done_at)"
+            " VALUES (%s, %s, 'done', %s)",
+            (user_id, article_id, now),
+        )
+        conn.execute(
+            "INSERT INTO user_events(user_id, event_type, article_id, duration_ms, created_at)"
+            " VALUES (%s, 'heartbeat', NULL, 120000, %s)",
+            (user_id, now),
+        )
+        # A second article, done outside the 7-day window: must not be counted.
+        other_article_id = _insert_article(db_path, "old-news", "science")
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state, done_at)"
+            " VALUES (%s, %s, 'done', %s)",
+            (user_id, other_article_id, stale),
+        )
+
+    recap = assemble_weekly_recap(user_id, now=now, database_url=db_path)
+
+    assert recap["articles_read"] == 1
+    assert recap["categories"][0]["category"] == "science"
+    assert recap["categories"][0]["count"] == 1
+    assert recap["minutes_read"] == 2.0
+    assert recap["current_streak_days"] == 1
+
+
+def test_save_and_list_recaps_upserts_by_week(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    recap = {
+        "week_start": "2026-06-22",
+        "week_end": "2026-06-29",
+        "generated_at": "2026-06-29T00:00:00+00:00",
+        "articles_read": 3,
+        "categories": [],
+        "sources": [],
+        "minutes_read": 10.0,
+        "current_streak_days": 2,
+    }
+
+    saved = save_weekly_recap(user_id, recap, "Great week!", database_url=db_path)
+    assert saved["narrative"] == "Great week!"
+    assert saved["data"]["articles_read"] == 3
+
+    updated = dict(recap, articles_read=5)
+    save_weekly_recap(user_id, updated, "Even better!", database_url=db_path)
+
+    recaps = list_recaps(user_id, database_url=db_path)
+    assert len(recaps) == 1
+    assert recaps[0]["data"]["articles_read"] == 5
+    assert recaps[0]["narrative"] == "Even better!"
+
+
+def test_recaps_endpoint_returns_saved_history(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    recap = {
+        "week_start": "2026-06-22",
+        "week_end": "2026-06-29",
+        "generated_at": "2026-06-29T00:00:00+00:00",
+        "articles_read": 4,
+        "categories": [],
+        "sources": [],
+        "minutes_read": 15.0,
+        "current_streak_days": 3,
+    }
+    save_weekly_recap(user_id, recap, "Nice reading week", database_url=db_path)
+
+    try:
+        with _client_for(user_id) as client:
+            list_response = client.get("/api/recaps")
+            latest_response = client.get("/api/recaps/latest")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert list_response.status_code == 200
+    items = list_response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["data"]["articles_read"] == 4
+
+    assert latest_response.status_code == 200
+    assert latest_response.json()["narrative"] == "Nice reading week"
+
+
+def test_recaps_latest_endpoint_404_when_none(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.get("/api/recaps/latest")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 404

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from news_dashboard.briefings import BriefingAINotConfiguredError, BriefingGenerationError
-from news_dashboard.scheduler import _run_briefing, _run_per_user_briefings
+from news_dashboard.scheduler import _run_briefing, _run_per_user_briefings, _run_weekly_recaps
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -173,6 +173,105 @@ def test_run_per_user_briefings_generates_but_skips_push_when_disabled() -> None
     generate.assert_called_once_with(user_id=42)
     hook.assert_not_called()
     send_push.assert_not_called()
+
+
+# ── _run_weekly_recaps ────────────────────────────────────────────────────────
+
+
+def test_run_weekly_recaps_sends_push_when_enabled() -> None:
+    fake_conn = _FakeRowsConn(
+        [
+            {
+                "id": 42,
+                "recap_day": "mon",
+                "briefing_time": "09:00",
+                "briefing_timezone": "UTC",
+                "briefing_push_enabled": True,
+            }
+        ]
+    )
+    now = datetime(2026, 6, 29, 9, 0, 0, tzinfo=timezone.utc)
+    recap = {"articles_read": 5, "categories": [{"category": "science", "count": 3}]}
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch("news_dashboard.db.connect", return_value=fake_conn),
+        patch(
+            "news_dashboard.recaps.service.assemble_weekly_recap", return_value=recap
+        ) as assemble,
+        patch(
+            "news_dashboard.recaps.service.save_weekly_recap",
+            return_value={"id": 1, **recap},
+        ) as save,
+        patch("news_dashboard.push.generate_recap_push_hook", return_value="Nice week!") as hook,
+        patch("news_dashboard.push.send_push_for_user") as send_push,
+    ):
+        mock_dt.now.return_value = now
+        _run_weekly_recaps()
+
+    assert "recap_enabled" in fake_conn.sql
+    assemble.assert_called_once_with(42)
+    hook.assert_called_once_with(recap)
+    save.assert_called_once_with(42, recap, "Nice week!")
+    send_push.assert_called_once_with(42, "Nice week!", "", target_url="/recap")
+
+
+def test_run_weekly_recaps_generates_but_skips_push_when_disabled() -> None:
+    fake_conn = _FakeRowsConn(
+        [
+            {
+                "id": 42,
+                "recap_day": "mon",
+                "briefing_time": "09:00",
+                "briefing_timezone": "UTC",
+                "briefing_push_enabled": False,
+            }
+        ]
+    )
+    now = datetime(2026, 6, 29, 9, 0, 0, tzinfo=timezone.utc)
+    recap = {"articles_read": 5, "categories": []}
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch("news_dashboard.db.connect", return_value=fake_conn),
+        patch("news_dashboard.recaps.service.assemble_weekly_recap", return_value=recap),
+        patch(
+            "news_dashboard.recaps.service.save_weekly_recap",
+            return_value={"id": 1, **recap},
+        ) as save,
+        patch("news_dashboard.push.generate_recap_push_hook") as hook,
+        patch("news_dashboard.push.send_push_for_user") as send_push,
+    ):
+        mock_dt.now.return_value = now
+        _run_weekly_recaps()
+
+    save.assert_called_once_with(42, recap, None)
+    hook.assert_not_called()
+    send_push.assert_not_called()
+
+
+def test_run_weekly_recaps_returns_none_when_no_users_scheduled() -> None:
+    fake_conn = _FakeRowsConn(
+        [
+            {
+                "id": 42,
+                "recap_day": "tue",
+                "briefing_time": "09:00",
+                "briefing_timezone": "UTC",
+                "briefing_push_enabled": True,
+            }
+        ]
+    )
+    now = datetime(2026, 6, 29, 9, 0, 0, tzinfo=timezone.utc)  # a Monday
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch("news_dashboard.db.connect", return_value=fake_conn),
+    ):
+        mock_dt.now.return_value = now
+        result = _run_weekly_recaps()
+
+    assert result is None
 
 
 # ── start_scheduler — BRIEFING_CRON wiring ───────────────────────────────────

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -39,6 +39,9 @@ const StatsPage = lazy(() => import('./pages/StatsPage').then((m) => ({ default:
 const ReadingDnaPage = lazy(() =>
   import('./pages/ReadingDnaPage').then((m) => ({ default: m.ReadingDnaPage }))
 );
+const WeeklyRecapPage = lazy(() =>
+  import('./pages/WeeklyRecapPage').then((m) => ({ default: m.WeeklyRecapPage }))
+);
 const SettingsPage = lazy(() =>
   import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage }))
 );
@@ -171,6 +174,7 @@ export const routes: RouteObject[] = [
         ),
       },
       { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
+      { path: 'recap', element: withSuspense(WeeklyRecapPage) },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'collections', element: <CollectionsPage /> },
       { path: 'collections/:tagId', element: <CollectionDetailPage /> },

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,6 +49,7 @@ import type {
   EmbeddingMapResponse,
   KnowledgeGraphResponse,
   User,
+  WeeklyRecap,
 } from './types';
 
 async function readErrorMessage(response: Response): Promise<string> {
@@ -254,6 +255,20 @@ export async function fetchReadingStreak(): Promise<ReadingStreak> {
 export async function fetchAchievements(): Promise<Achievement[]> {
   const data = await requestJson<{ items: Achievement[] }>('/api/users/me/achievements');
   return data.items;
+}
+
+export async function fetchRecaps(): Promise<WeeklyRecap[]> {
+  const data = await requestJson<{ items: WeeklyRecap[] }>('/api/recaps');
+  return data.items;
+}
+
+export async function fetchLatestRecap(): Promise<WeeklyRecap | null> {
+  try {
+    return await requestJson<WeeklyRecap>('/api/recaps/latest');
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) return null;
+    throw err;
+  }
 }
 
 export async function fetchRecommendationPreferences(): Promise<RecommendationPreferences> {

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -4,6 +4,7 @@ import {
   BarChart3,
   BrainCircuit,
   Clock,
+  Flame,
   History,
   Inbox,
   Network,
@@ -45,6 +46,7 @@ export const secondaryNavigationItems: NavigationItem[] = [
   { to: '/ai-stats', label: 'AI Stats', icon: BrainCircuit },
   { to: '/feeds', label: 'Feeds', icon: Radio, shortcut: 'f' },
   { to: '/reading-dna', label: 'Reading DNA', icon: SlidersHorizontal },
+  { to: '/recap', label: 'Weekly Recap', icon: Flame },
   { to: '/archive', label: 'Archive', icon: Archive },
   { to: '/collections', label: 'Collections', icon: Tag },
   { to: '/settings', label: 'Settings', icon: Settings },
@@ -140,6 +142,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/feeds')) return 'Feeds';
   if (pathname.startsWith('/stats')) return 'Stats';
   if (pathname.startsWith('/reading-dna')) return 'Reading DNA';
+  if (pathname.startsWith('/recap')) return 'Weekly Recap';
   if (pathname.startsWith('/archive')) return 'Archive';
   if (pathname.startsWith('/collections')) return 'Collections';
   if (pathname.startsWith('/settings')) return 'Settings';

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useTheme } from '@/hooks/useTheme';
 import { cn } from '@/lib/utils';
+import { Switch } from '@/components/ui/switch';
 import type { Theme } from '@/lib/theme';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
 import { useAuth } from '@/contexts/auth';
@@ -679,6 +680,118 @@ function DailyBriefSection() {
   );
 }
 
+const RECAP_DAYS: { value: string; label: string }[] = [
+  { value: 'mon', label: 'Monday' },
+  { value: 'tue', label: 'Tuesday' },
+  { value: 'wed', label: 'Wednesday' },
+  { value: 'thu', label: 'Thursday' },
+  { value: 'fri', label: 'Friday' },
+  { value: 'sat', label: 'Saturday' },
+  { value: 'sun', label: 'Sunday' },
+];
+
+function WeeklyRecapSection() {
+  const [recapEnabled, setRecapEnabled] = useState(true);
+  const [recapDay, setRecapDay] = useState('mon');
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const s = await fetchNotificationSettings();
+        if (!cancelled) {
+          setRecapEnabled(s.recap_enabled);
+          setRecapDay(s.recap_day);
+        }
+      } catch {
+        // keep defaults if settings fail to load
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggleEnabled = async () => {
+    const next = !recapEnabled;
+    setRecapEnabled(next);
+    setSaving(true);
+    try {
+      await updateNotificationSettings({ recap_enabled: next });
+    } catch {
+      setRecapEnabled(!next);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDayChange = async (day: string) => {
+    setRecapDay(day);
+    setSaving(true);
+    try {
+      await updateNotificationSettings({ recap_day: day });
+    } catch {
+      // non-critical — cadence preference will resync on next load
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!loaded) return null;
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        Weekly Recap
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <div className="text-xs font-medium text-foreground">Send weekly recap</div>
+            <p className="text-[11px] text-muted-foreground">
+              A summary of your reading week, delivered via push.
+            </p>
+          </div>
+          <Switch
+            checked={recapEnabled}
+            onCheckedChange={() => void toggleEnabled()}
+            disabled={saving}
+            aria-label="Send weekly recap"
+          />
+        </div>
+
+        {recapEnabled && (
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground" htmlFor="recap-day">
+              Delivery day
+            </label>
+            <select
+              id="recap-day"
+              value={recapDay}
+              onChange={(e) => void handleDayChange(e.target.value)}
+              className="rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              {RECAP_DAYS.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <p className="text-[11px] text-muted-foreground">
+              Delivered at your daily brief time, in your briefing timezone.
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
 type ExportState = 'idle' | 'running' | 'done' | 'error';
 
 function DataExportSection() {
@@ -875,6 +988,8 @@ export function SettingsPage() {
       <DataExportSection />
 
       <DailyBriefSection />
+
+      <WeeklyRecapSection />
 
       <UpdatesSection />
 

--- a/frontend/src/pages/WeeklyRecapPage.tsx
+++ b/frontend/src/pages/WeeklyRecapPage.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Flame, Loader2 } from 'lucide-react';
+import { fetchRecaps } from '../api';
+import type { WeeklyRecap, WeeklyRecapField } from '../types';
+
+interface PageState {
+  recaps: WeeklyRecap[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function WeeklyRecapPage() {
+  const [state, setState] = useState<PageState>({ recaps: [], loading: true, error: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRecaps()
+      .then((recaps) => {
+        if (!cancelled) setState({ recaps, loading: false, error: null });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setState((s) => ({
+            ...s,
+            loading: false,
+            error: err instanceof Error ? err.message : 'Failed to load weekly recaps',
+          }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const { recaps, loading, error } = state;
+  const [latest, ...history] = recaps;
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center p-8">
+        <Loader2 className="text-muted-foreground size-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl space-y-5 p-4 md:p-5">
+      <section>
+        <h2 className="text-[22px] font-semibold tracking-tight">Weekly Recap</h2>
+        <p className="mt-0.5 text-xs text-muted-foreground">A summary of what you read this week</p>
+      </section>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {!latest ? (
+        <Panel title="This week">
+          <EmptyLine />
+        </Panel>
+      ) : (
+        <>
+          <section className="grid grid-cols-2 gap-2 md:grid-cols-4">
+            <Metric label="Articles read" value={String(latest.data.articles_read)} />
+            <Metric label="Minutes read" value={`${latest.data.minutes_read}m`} />
+            <Metric label="Streak" value={`${latest.data.current_streak_days}d`} />
+            <Metric
+              label="Week"
+              value={`${formatDate(latest.data.week_start)} – ${formatDate(latest.data.week_end)}`}
+            />
+          </section>
+
+          {latest.narrative && (
+            <Panel title="Your week in review">
+              <div className="flex items-start gap-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
+                  <Flame className="size-5" />
+                </div>
+                <p className="text-sm">{latest.narrative}</p>
+              </div>
+            </Panel>
+          )}
+
+          <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <Panel title="Top categories">
+              <FieldBars items={latest.data.categories} labelKey="category" />
+            </Panel>
+            <Panel title="Top sources">
+              <FieldBars items={latest.data.sources} labelKey="source" />
+            </Panel>
+          </section>
+        </>
+      )}
+
+      {history.length > 0 && (
+        <Panel title="Past recaps">
+          <ul className="divide-y divide-border">
+            {history.map((recap) => (
+              <li key={recap.id} className="flex items-center justify-between py-2 text-sm">
+                <span className="text-muted-foreground">
+                  {formatDate(recap.data.week_start)} – {formatDate(recap.data.week_end)}
+                </span>
+                <span className="tabular-nums">{recap.data.articles_read} articles</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      )}
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-surface px-3 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="mt-1 text-xl font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-md border border-border bg-surface p-3">
+      <h3 className="text-sm font-medium">{title}</h3>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function FieldBars({
+  items,
+  labelKey,
+}: {
+  items: WeeklyRecapField[];
+  labelKey: 'category' | 'source';
+}) {
+  if (items.length === 0) return <EmptyLine />;
+  const max = Math.max(...items.map((item) => item.count), 1);
+  return (
+    <div className="space-y-3">
+      {items.map((item) => {
+        const label = item[labelKey] ?? 'unknown';
+        return (
+          <div key={label} className="space-y-1">
+            <div className="flex items-center justify-between gap-3 text-xs">
+              <span className="truncate font-medium capitalize">{label}</span>
+              <span className="text-muted-foreground tabular-nums">{item.count}</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded bg-muted">
+              <div
+                className="h-full bg-chart-1"
+                style={{ width: `${(item.count / max) * 100}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function EmptyLine() {
+  return (
+    <div className="py-8 text-center text-sm text-muted-foreground">
+      No recap yet — check back after your first scheduled week.
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -301,6 +301,8 @@ export interface NotificationSettings {
   briefing_time: string;
   briefing_timezone: string;
   push_enabled: boolean;
+  recap_enabled: boolean;
+  recap_day: string;
   vapid_public_key: string | null;
 }
 
@@ -308,6 +310,8 @@ export interface NotificationSettingsUpdate {
   briefing_time?: string;
   briefing_timezone?: string;
   push_enabled?: boolean;
+  recap_enabled?: boolean;
+  recap_day?: string;
 }
 
 export interface PushSubscribeRequest {
@@ -345,6 +349,32 @@ export interface ReadingStreak {
   last_active_date: string | null;
   active_days: string[];
   qualifying_activity: string;
+}
+
+export interface WeeklyRecapField {
+  category?: string;
+  source?: string;
+  count: number;
+}
+
+export interface WeeklyRecapData {
+  week_start: string;
+  week_end: string;
+  generated_at: string;
+  articles_read: number;
+  categories: WeeklyRecapField[];
+  sources: WeeklyRecapField[];
+  minutes_read: number;
+  current_streak_days: number;
+}
+
+export interface WeeklyRecap {
+  id: number;
+  user_id: number;
+  week_start: string;
+  created_at: string;
+  data: WeeklyRecapData;
+  narrative: string | null;
 }
 
 export interface Achievement {


### PR DESCRIPTION
## Summary

Closes #659.

- New `news_dashboard.recaps` package assembles a per-user weekly recap (articles read, top categories/sources, minutes read, current streak — reusing `reading_progress.get_streak`) over the trailing 7 days, persists it in a new `user_weekly_recaps` table, and exposes `GET /api/recaps` + `GET /api/recaps/latest`.
- Scheduler gains a `weekly_recaps` job (mirrors the existing `per_user_briefings` per-minute poll pattern): fires when a user's local time matches their `briefing_time` on their chosen `recap_day`, then delivers an optional AI narrative (`push.generate_recap_push_hook`, gated/fallback like `generate_push_hook`) via the existing push channel.
- Cadence/opt-out are configurable through `/api/settings/notifications` (new `recap_enabled` / `recap_day` fields, following the existing `briefing_*` column pattern on `users`).
- Frontend: new `WeeklyRecapPage`, a "Weekly Recap" nav entry, and a settings section (`WeeklyRecapSection`) to toggle/schedule delivery.

## Test plan

- [x] `uv run pytest` (backend) — 1411 passed, 1 skipped, 1 pre-existing unrelated failure (`test_ingested_vs_handled_counts_user_article_state_done`, fails identically on `main` before this change — a timezone bug in `stats.py` unrelated to this PR)
- [x] `uv run ruff check .` / `ruff format --check .` — clean
- [x] `uv run mypy` on touched backend modules — clean
- [x] `npx vitest run` (frontend) — 713 passed
- [x] `npx tsc -b --noEmit` / `npx eslint . --max-warnings 0` — clean
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, eslint, prettier, tsc) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)