### PR TITLE
fix: cap feed response bytes during ingestion (#678)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -422,10 +422,16 @@ _NITTER_INSTANCES: tuple[str, ...] = (
 
 _FEED_AGENT = "news-dashboard/0.1 (personal; contact@lihor.ro)"
 FEED_FETCH_TIMEOUT_SECS = 15
+# RSS/Atom feeds are rarely more than a few hundred KB; 2 MiB leaves headroom
+# for verbose feeds while bounding memory use and parse time for bad actors.
+FEED_FETCH_MAX_BYTES = 2 * 1024 * 1024
 
 
 def _fetch_feed_content(url: str) -> bytes:
-    """Fetch raw feed bytes with an explicit timeout. Raises FeedFetchError on failure."""
+    """Fetch raw feed bytes with an explicit timeout and size cap.
+
+    Raises FeedFetchError on failure.
+    """
     try:
         validate_server_fetch_url(url)
     except UnsafeUrlError as exc:
@@ -433,13 +439,28 @@ def _fetch_feed_content(url: str) -> bytes:
     req = urllib.request.Request(url, headers={"User-Agent": _FEED_AGENT})  # noqa: S310
     try:
         with open_server_fetch_url(req, timeout=FEED_FETCH_TIMEOUT_SECS) as resp:
-            return resp.read()  # type: ignore[no-any-return]
+            content_length = resp.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    if int(content_length) > FEED_FETCH_MAX_BYTES:
+                        msg = (
+                            f"Feed response too large ({content_length} bytes, "
+                            f"max {FEED_FETCH_MAX_BYTES}): {url}"
+                        )
+                        raise FeedFetchError(msg)
+                except ValueError:
+                    pass
+            content: bytes = resp.read(FEED_FETCH_MAX_BYTES + 1)
     except TimeoutError as exc:
         msg = f"Feed fetch timed out after {FEED_FETCH_TIMEOUT_SECS}s: {url}"
         raise FeedFetchError(msg) from exc
     except urllib.error.URLError as exc:
         msg = f"Feed fetch network error: {exc.reason}"
         raise FeedFetchError(msg) from exc
+    if len(content) > FEED_FETCH_MAX_BYTES:
+        msg = f"Feed response exceeded {FEED_FETCH_MAX_BYTES} byte limit: {url}"
+        raise FeedFetchError(msg)
+    return content
 
 
 def _parse_feed_url(url: str) -> list[dict[str, Any]]:

--- a/backend/tests/test_nitter_feed.py
+++ b/backend/tests/test_nitter_feed.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import urllib.error
+from typing import ClassVar
 
 import pytest
 
 from news_dashboard.ingest import (
     _FEED_AGENT,
     _NITTER_INSTANCES,
+    FEED_FETCH_MAX_BYTES,
     FEED_FETCH_TIMEOUT_SECS,
     FeedFetchError,
     _fetch_feed_content,
@@ -96,7 +98,9 @@ def test_fetch_feed_content_sends_user_agent(monkeypatch: pytest.MonkeyPatch) ->
     captured: list[str | None] = []
 
     class _FakeResp:
-        def read(self) -> bytes:
+        headers: ClassVar[dict[str, str]] = {}
+
+        def read(self, _n: int = -1) -> bytes:
             return b"<rss/>"
 
         def __enter__(self) -> _FakeResp:
@@ -136,6 +140,74 @@ def test_fetch_feed_content_converts_url_error(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
     with pytest.raises(FeedFetchError, match="network error"):
         _fetch_feed_content("https://example.com/feed.xml")
+
+
+# ── size cap ──────────────────────────────────────────────────────────────────
+
+
+class _SizedFakeResp:
+    def __init__(self, body: bytes, *, content_length: str | None = None) -> None:
+        self._body = body
+        self.headers = {"Content-Length": content_length} if content_length else {}
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            return self._body
+        return self._body[:n]
+
+    def __enter__(self) -> _SizedFakeResp:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        pass
+
+
+def test_fetch_feed_content_under_limit_parses_normally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = b"<rss>" + b"x" * 100 + b"</rss>"
+    monkeypatch.setattr(
+        "news_dashboard.ingest.open_server_fetch_url",
+        lambda *_a, **_k: _SizedFakeResp(body),
+    )
+    assert _fetch_feed_content("https://example.com/feed.xml") == body
+
+
+def test_fetch_feed_content_rejects_oversized_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = b"x" * (FEED_FETCH_MAX_BYTES + 1)
+    monkeypatch.setattr(
+        "news_dashboard.ingest.open_server_fetch_url",
+        lambda *_a, **_k: _SizedFakeResp(body),
+    )
+    with pytest.raises(FeedFetchError, match="exceeded"):
+        _fetch_feed_content("https://example.com/feed.xml")
+
+
+def test_fetch_feed_content_rejects_oversized_content_length_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    class _NeverReadResp(_SizedFakeResp):
+        def read(self, n: int = -1) -> bytes:
+            nonlocal called
+            called = True
+            return super().read(n)
+
+    resp = _NeverReadResp(b"short body", content_length=str(FEED_FETCH_MAX_BYTES + 1))
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", lambda *_a, **_k: resp)
+    with pytest.raises(FeedFetchError, match="too large"):
+        _fetch_feed_content("https://example.com/feed.xml")
+    assert called is False
+
+
+def test_fetch_feed_content_ignores_invalid_content_length_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = b"<rss/>"
+    resp = _SizedFakeResp(body, content_length="not-a-number")
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", lambda *_a, **_k: resp)
+    assert _fetch_feed_content("https://example.com/feed.xml") == body
 
 
 # ── successful fetch ──────────────────────────────────────────────────────────

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -160,6 +160,56 @@ def test_source_error_tracked(tmp_path: Path) -> None:
         assert row["last_checked_at"] is not None, "last_checked_at should be set even on failure"
 
 
+def test_oversized_feed_tracked_as_source_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An oversized feed response should fail like any other feed error."""
+    from news_dashboard.ingest import FEED_FETCH_MAX_BYTES, _ingest_source
+
+    big = SourceDefinition("big-feed", "Big Feed", "https://example.com/big.xml", "python")
+    db = tmp_path / "big.db"
+    sync_sources(db)
+    with connect(db) as conn:
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind, priority, enabled) "
+            "VALUES (%s, %s, %s, %s, %s, 50, TRUE) ON CONFLICT(slug) DO NOTHING",
+            (big.slug, big.name, big.url, big.category, big.kind),
+        )
+
+    class _OversizedResp:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def read(self, n: int = -1) -> bytes:
+            body = b"<rss>" + b"x" * (FEED_FETCH_MAX_BYTES + 10) + b"</rss>"
+            return body if n < 0 else body[:n]
+
+        def __enter__(self) -> _OversizedResp:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "news_dashboard.ingest.open_server_fetch_url", lambda *_a, **_k: _OversizedResp()
+    )
+
+    outcome = _ingest_source(big, db)
+    assert outcome.error_message is not None
+    assert "exceeded" in outcome.error_message or "too large" in outcome.error_message
+
+    with connect(db) as conn:
+        row = conn.execute(
+            "SELECT last_error, last_checked_at, last_fetched_count, last_inserted_count"
+            " FROM sources WHERE slug=%s",
+            (big.slug,),
+        ).fetchone()
+        assert row["last_error"] is not None
+        assert row["last_checked_at"] is not None
+        assert row["last_fetched_count"] == 0
+        assert row["last_inserted_count"] == 0
+
+
 def test_source_health_error_streak_resets_after_success(tmp_path: Path) -> None:
     db = tmp_path / "streak.db"
     sync_sources(db)


### PR DESCRIPTION
Closes #678

## Summary
- Add a named `FEED_FETCH_MAX_BYTES` (2 MiB) cap enforced in `_fetch_feed_content()`.
- Reject an oversized `Content-Length` header before reading any body bytes.
- Read at most `FEED_FETCH_MAX_BYTES + 1` bytes and raise `FeedFetchError` with an actionable message if the response is still over the cap (covers servers that omit or lie about `Content-Length`).
- All feed kinds (`rss_feed`, `nitter_feed`, Reddit, Lobsters, Mastodon, etc.) share this cap automatically since they all route through `_parse_feed_url` → `_fetch_feed_content`.
- Existing timeout, user-agent, SSRF validation, and no-redirect behavior are unchanged.
- Oversized feeds are recorded in source health (`last_error`, `last_fetched_count=0`) and ingest run history exactly like any other feed failure, since the error still flows through `_ingest_source`'s existing exception handling.

## Test plan
- [x] `test_fetch_feed_content_under_limit_parses_normally` — feed under the cap parses unchanged
- [x] `test_fetch_feed_content_rejects_oversized_body` — body over the cap raises `FeedFetchError`
- [x] `test_fetch_feed_content_rejects_oversized_content_length_header` — oversized `Content-Length` is rejected without reading the body
- [x] `test_fetch_feed_content_ignores_invalid_content_length_header` — malformed header falls back to reading and enforcing the byte cap
- [x] `test_oversized_feed_tracked_as_source_error` (test_source_health.py) — an oversized feed is recorded as a source error with `last_fetched_count`/`last_inserted_count` of 0
- [x] `ruff check` clean on touched files
- [x] `mypy` clean on `ingest.py`
- [x] Full focused suite: `pytest tests/test_nitter_feed.py tests/test_source_health.py tests/test_ingest.py` — 50 passed