### PR TITLE
security: scope GitHub Actions token permissions per job (#691)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,13 @@ env:
   # Full image name. GITHUB_REPOSITORY is "owner/repo" (lower-cased by GHCR).
   IMAGE: ghcr.io/${{ github.repository }}
 
-# Minimum permissions. packages:write is only exercised by the publish job;
-# GitHub scopes GITHUB_TOKEN to the individual job automatically.
-# models:read lets the publish job summarize the changelog via GitHub Models.
+# Minimum permissions at the workflow root. Jobs that need more (packages:write
+# and models:read for publish, security-events:write for trivy, pull-requests:write
+# for coverage-upload) declare their own narrower `permissions:` block below —
+# see .github/workflows/trivy-scan.yml, dependency-review.yml, release.yml, and
+# pr-metrics.yml for the same per-job pattern.
 permissions:
   contents: read
-  packages: write
-  models: read
 
 jobs:
   # ── 0. DETECT CHANGES ──────────────────────────────────────────────────────
@@ -403,6 +403,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      models: read # GitHub Models inference for the changelog entry
       id-token: write
       attestations: write
     outputs:


### PR DESCRIPTION
## Summary
- Moves `packages: write` and `models: read` out of the workflow-root `permissions:` block in `.github/workflows/ci.yml` down to the `publish` job, which is the only job that uses them.
- Workflow root now grants `contents: read` only; jobs without an explicit `permissions:` block (lint, smoke, test-backend, test-frontend, test-a11y, test, helm-validate) inherit that minimal scope.
- `trivy` (packages:read, security-events:write) and `coverage-upload` (contents:read, pull-requests:write) already declared their own job-level `permissions:` and are unchanged.
- `publish` keeps `contents: read`, `packages: write`, `id-token: write`, `attestations: write`, and now also explicitly declares `models: read` (previously inherited from root) for the changelog-generation step.
- Updated the workflow comment to describe the new per-job permission model and point at the existing per-job pattern in `trivy-scan.yml`, `dependency-review.yml`, `release.yml`, and `pr-metrics.yml`.

Closes #691

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly
- [x] Manual review: every job that calls a privileged API (GHCR push, GitHub Models, SARIF upload, PR comments) still has the permission it needs at job level
- [ ] CI run on this PR — lint/smoke/test/helm-validate jobs run with read-only token permissions (verified by the PR's own CI run since this is a workflow-only change with no runtime app changes)