### PR TITLE
fix: block Keycloak local user mutations (#692)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2942,6 +2942,8 @@ def admin_get_user(user_id: int) -> dict[str, Any]:
 
 @admin.patch("/users/{user_id}/password")
 def admin_update_password(user_id: int, payload: UpdatePasswordRequest) -> dict[str, Any]:
+    if keycloak_config().enabled:
+        raise HTTPException(status_code=409, detail="Keycloak owns user passwords")
     if not update_password(user_id, payload.password):
         raise HTTPException(status_code=404, detail="user not found")
     return {"status": "updated"}
@@ -2952,6 +2954,11 @@ def admin_delete_user(
     user_id: int,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
+    if keycloak_config().enabled:
+        raise HTTPException(
+            status_code=409,
+            detail="Keycloak users must be deprovisioned outside the local app table",
+        )
     if user_id == current_user["id"]:
         raise HTTPException(status_code=400, detail="cannot delete your own account")
     if not delete_user(user_id):

--- a/backend/tests/test_auth_extra.py
+++ b/backend/tests/test_auth_extra.py
@@ -14,6 +14,7 @@ from news_dashboard import auth as auth_mod
 from news_dashboard.auth import (
     create_user,
     exchange_keycloak_code,
+    get_user_by_id,
     keycloak_authorization_url,
     keycloak_config,
     keycloak_logout_url,
@@ -226,6 +227,19 @@ def test_admin_update_password_found_and_missing(tmp_db: str) -> None:
         assert missing.status_code == 404
 
 
+def test_admin_update_password_rejects_keycloak_mode(
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_keycloak(monkeypatch)
+    created = create_user("keycloak-password", "pw123456")
+    with TestClient(app) as client:
+        resp = client.patch(
+            f"/api/admin/users/{created['id']}/password", json={"password": "newpass123"}
+        )
+    assert resp.status_code == 409
+    assert "Keycloak owns user passwords" in resp.json()["detail"]
+
+
 def test_admin_create_user_conflict_on_duplicate(tmp_db: str) -> None:
     with TestClient(app) as client:
         first = client.post("/api/admin/users", json={"username": "frank", "password": "pw123456"})
@@ -288,3 +302,15 @@ def test_admin_generate_user_uses_keycloak_when_enabled(
     assert body["temporary"] is True
     assert body["password"] == captured["password"]
     assert captured["username"] == "ivan"
+
+
+def test_admin_delete_user_rejects_keycloak_mode(
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_keycloak(monkeypatch)
+    target = create_user("keycloak-delete", "pw123456")
+    with TestClient(app) as client:
+        resp = client.delete(f"/api/admin/users/{target['id']}")
+    assert resp.status_code == 409
+    assert "Keycloak users must be deprovisioned" in resp.json()["detail"]
+    assert get_user_by_id(target["id"]) is not None


### PR DESCRIPTION
Closes #692

## Summary
- Reject local admin password updates with 409 Conflict when Keycloak auth is enabled.
- Reject local admin user deletion with 409 Conflict when Keycloak auth is enabled, preventing local app-table deletion/cascades for externally managed users.
- Added backend API regression tests for both Keycloak-mode rejections while preserving existing local-auth coverage and Keycloak generate-user coverage.

## Tests
- `source .env && pytest backend/tests/test_auth_extra.py -q` -> 23 passed
- `make lint` -> passed
- `make typecheck` -> passed
- `source .env && make test` -> 1502 passed, 1 skipped, 1 unrelated PostgreSQL connection-timeout error in `backend/tests/test_translation.py::test_fetch_and_cache_body_translates_non_english`
- `source .env && pytest backend/tests/test_translation.py::test_fetch_and_cache_body_translates_non_english -q` -> 1 passed
- `npm run test:frontend --silent` -> 68 files passed, 713 tests passed
- `npm run build --silent` -> passed, with existing Vite chunk-size warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)