### PR TITLE
feat: add shared error presentation helper (#702)

### DIFF
--- a/frontend/src/__tests__/errorPresentation.test.ts
+++ b/frontend/src/__tests__/errorPresentation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { HttpError } from '../api';
+import { presentError } from '../lib/errorPresentation';
+
+describe('presentError', () => {
+  it.each([
+    [
+      new HttpError(401, 'token expired'),
+      {
+        title: 'Sign in required',
+        message: 'Sign in again to continue.',
+        detail: 'token expired',
+      },
+    ],
+    [
+      new HttpError(403, 'admin role required'),
+      {
+        title: 'Permission needed',
+        message: 'You do not have permission to do that.',
+        detail: 'admin role required',
+      },
+    ],
+    [
+      new HttpError(404, 'source not found'),
+      {
+        title: 'Not found',
+        message: 'That item could not be found. It may have been removed.',
+        detail: 'source not found',
+      },
+    ],
+    [
+      new HttpError(409, 'slug already exists'),
+      {
+        title: 'Already exists',
+        message: 'This conflicts with something that already exists.',
+        detail: 'slug already exists',
+      },
+    ],
+    [
+      new HttpError(422, 'field required'),
+      {
+        title: 'Check the details',
+        message: 'Some information is missing or invalid.',
+        detail: 'field required',
+      },
+    ],
+    [
+      new HttpError(429, 'rate limit exceeded'),
+      {
+        title: 'Too many requests',
+        message: 'Wait a moment, then try again.',
+        detail: 'rate limit exceeded',
+      },
+    ],
+    [
+      new HttpError(500, 'Internal Server Error'),
+      {
+        title: 'Server problem',
+        message: 'The server hit a problem. Try again shortly.',
+        detail: 'Internal Server Error',
+      },
+    ],
+  ])('maps known HTTP errors to friendly copy while preserving detail', (error, expected) => {
+    expect(presentError(error)).toMatchObject(expected);
+  });
+
+  it('maps network failures to offline-friendly copy', () => {
+    expect(presentError(new TypeError('Failed to fetch'))).toMatchObject({
+      title: 'Connection problem',
+      message: 'Check your connection, then try again.',
+      detail: 'Failed to fetch',
+    });
+  });
+
+  it('maps AI provider configuration errors without exposing raw configuration text as primary copy', () => {
+    expect(presentError(new Error('OPENAI_API_KEY is not configured'))).toMatchObject({
+      title: 'AI not configured',
+      message:
+        'Your administrator needs to configure an AI provider for this app before AI features can run.',
+      detail: 'OPENAI_API_KEY is not configured',
+    });
+  });
+
+  it('falls back to generic copy for unknown errors and keeps technical detail', () => {
+    expect(presentError(new Error('unexpected parser branch'))).toMatchObject({
+      title: 'Something went wrong',
+      message:
+        'Try again. If the problem continues, share the technical details with an administrator.',
+      detail: 'unexpected parser branch',
+    });
+  });
+});

--- a/frontend/src/lib/errorPresentation.ts
+++ b/frontend/src/lib/errorPresentation.ts
@@ -2,6 +2,13 @@ import { HttpError } from '@/api';
 
 export type GenerationErrorKind = 'no_ai' | 'failed';
 
+export interface ErrorPresentation {
+  title: string;
+  message: string;
+  detail?: string;
+  action?: string;
+}
+
 export interface FriendlyError {
   kind: GenerationErrorKind;
   title: string;
@@ -11,6 +18,135 @@ export interface FriendlyError {
 
 function detailOf(err: unknown): string | undefined {
   return err instanceof Error ? err.message : undefined;
+}
+
+function hasDetail(detail: string | undefined): detail is string {
+  return typeof detail === 'string' && detail.trim().length > 0;
+}
+
+function withDetail(
+  presentation: Omit<ErrorPresentation, 'detail'>,
+  detail: string | undefined
+): ErrorPresentation {
+  return hasDetail(detail) ? { ...presentation, detail } : presentation;
+}
+
+function isNetworkError(err: unknown): boolean {
+  return err instanceof TypeError && /fetch|network|load failed|connection/i.test(err.message);
+}
+
+function isAiProviderConfigurationError(detail: string | undefined): boolean {
+  return (
+    hasDetail(detail) &&
+    /\b(ai provider|openai|anthropic|api[_ -]?key|provider[_ -]?not[_ -]?configured|not configured)\b/i.test(
+      detail
+    )
+  );
+}
+
+function presentHttpError(error: HttpError): ErrorPresentation {
+  const detail = detailOf(error);
+  if (isAiProviderConfigurationError(detail)) {
+    return withDetail(
+      {
+        title: 'AI not configured',
+        message:
+          'Your administrator needs to configure an AI provider for this app before AI features can run.',
+        action: 'Ask an administrator to configure an AI provider.',
+      },
+      detail
+    );
+  }
+
+  if (error.status >= 500) {
+    return withDetail(
+      {
+        title: 'Server problem',
+        message: 'The server hit a problem. Try again shortly.',
+        action: 'Try again shortly.',
+      },
+      detail
+    );
+  }
+
+  const byStatus: Record<number, Omit<ErrorPresentation, 'detail'>> = {
+    401: {
+      title: 'Sign in required',
+      message: 'Sign in again to continue.',
+      action: 'Sign in again.',
+    },
+    403: {
+      title: 'Permission needed',
+      message: 'You do not have permission to do that.',
+      action: 'Ask an administrator for access.',
+    },
+    404: {
+      title: 'Not found',
+      message: 'That item could not be found. It may have been removed.',
+      action: 'Refresh and try again.',
+    },
+    409: {
+      title: 'Already exists',
+      message: 'This conflicts with something that already exists.',
+      action: 'Use different details and try again.',
+    },
+    422: {
+      title: 'Check the details',
+      message: 'Some information is missing or invalid.',
+      action: 'Review the highlighted fields and try again.',
+    },
+    429: {
+      title: 'Too many requests',
+      message: 'Wait a moment, then try again.',
+      action: 'Retry after a short pause.',
+    },
+  };
+
+  return withDetail(
+    byStatus[error.status] ?? {
+      title: 'Request failed',
+      message: 'The request could not be completed. Try again.',
+      action: 'Try again.',
+    },
+    detail
+  );
+}
+
+export function presentError(err: unknown): ErrorPresentation {
+  const detail = detailOf(err);
+  if (err instanceof HttpError) {
+    return presentHttpError(err);
+  }
+  if (isNetworkError(err)) {
+    return withDetail(
+      {
+        title: 'Connection problem',
+        message: 'Check your connection, then try again.',
+        action: 'Reconnect and retry.',
+      },
+      detail
+    );
+  }
+  if (isAiProviderConfigurationError(detail)) {
+    return withDetail(
+      {
+        title: 'AI not configured',
+        message:
+          'Your administrator needs to configure an AI provider for this app before AI features can run.',
+        action: 'Ask an administrator to configure an AI provider.',
+      },
+      detail
+    );
+  }
+  return withDetail(
+    {
+      title: 'Something went wrong',
+      message:
+        'Try again. If the problem continues, share the technical details with an administrator.',
+      action: 'Try again.',
+    },
+    detail
+  );
 }
 
 /** Classifies a briefing/podcast generation failure into user-facing copy, without leaking provider/env details. */


### PR DESCRIPTION
Closes #702

## Summary
- add a general `presentError` helper that maps `HttpError` and unknown errors to friendly title/message/action/detail presentation data
- preserve raw backend text as optional `detail` for known HTTP/network/AI configuration cases
- keep the existing generation-specific helper exports intact

## Tests
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test:frontend -- frontend/src/__tests__/errorPresentation.test.ts`
- `npm run test:frontend`
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)