### PR TITLE
fix: make source management failures visible and actionable (#703)

### DIFF
--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -6,33 +6,45 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, type ReactElement, type ReactNode } from 'react';
 import type { Source, User } from '../types';
 import { AuthProvider, useAuth } from '../contexts/auth';
+import { toast } from 'sonner';
 
 // ── Shared API mock ──────────────────────────────────────────────────────────
 // SourcesPage imports from '@/api', SchedulerPage from '../api'; both resolve to
 // the same module, so one mock factory covers both import specifiers.
-const apiMock = vi.hoisted(() => ({
-  fetchSources: vi.fn(),
-  fetchSourceCleanupSuggestions: vi.fn(),
-  updateSourceEnabled: vi.fn(),
-  applySourceCleanup: vi.fn(),
-  createSource: vi.fn(),
-  deleteSource: vi.fn(),
-  fetchSchedulerStatus: vi.fn(),
-  setSchedulerInterval: vi.fn(),
-  pauseScheduler: vi.fn(),
-  resumeScheduler: vi.fn(),
-  ingestNow: vi.fn(),
-  fetchOnboardingInterests: vi.fn().mockResolvedValue([]),
-  fetchOnboardingSourceRecommendations: vi.fn().mockResolvedValue([]),
-  fetchOnboardingStatus: vi.fn().mockResolvedValue({ completed: true }),
-  saveOnboardingInterests: vi.fn().mockResolvedValue(undefined),
-  exportOpml: vi.fn().mockResolvedValue(undefined),
-  importOpml: vi.fn().mockResolvedValue({
-    added: [],
-    skipped: [],
-    failed: [],
-  }),
-}));
+const apiMock = vi.hoisted(() => {
+  class HttpError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = 'HttpError';
+    }
+  }
+  return {
+    HttpError,
+    fetchSources: vi.fn(),
+    fetchSourceCleanupSuggestions: vi.fn(),
+    updateSourceEnabled: vi.fn(),
+    applySourceCleanup: vi.fn(),
+    createSource: vi.fn(),
+    deleteSource: vi.fn(),
+    fetchSchedulerStatus: vi.fn(),
+    setSchedulerInterval: vi.fn(),
+    pauseScheduler: vi.fn(),
+    resumeScheduler: vi.fn(),
+    ingestNow: vi.fn(),
+    fetchOnboardingInterests: vi.fn().mockResolvedValue([]),
+    fetchOnboardingSourceRecommendations: vi.fn().mockResolvedValue([]),
+    fetchOnboardingStatus: vi.fn().mockResolvedValue({ completed: true }),
+    saveOnboardingInterests: vi.fn().mockResolvedValue(undefined),
+    exportOpml: vi.fn().mockResolvedValue(undefined),
+    importOpml: vi.fn().mockResolvedValue({
+      added: [],
+      skipped: [],
+      failed: [],
+    }),
+  };
+});
 vi.mock('@/api', () => apiMock);
 vi.mock('../api', () => apiMock);
 vi.mock('sonner', () => ({
@@ -188,6 +200,21 @@ describe('SourcesPage', () => {
     await waitFor(() => expect(apiMock.updateSourceEnabled).toHaveBeenCalledWith('acme', false));
   });
 
+  it('notifies and reverts the switch when a toggle fails', async () => {
+    apiMock.fetchSources.mockResolvedValue([source({ enabled: 1 })]);
+    apiMock.updateSourceEnabled.mockRejectedValue(new Error('network down'));
+    withProviders(<SourcesPage />);
+    const [toggle] = await screen.findAllByRole('switch');
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'Could not update the source — it has been reverted to its previous state.'
+      )
+    );
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
+  });
+
   it('opens the Add source dialog when "Add source" is clicked', async () => {
     apiMock.fetchSources.mockResolvedValue([source()]);
     withProviders(<SourcesPage />, '/', regularUser);
@@ -235,9 +262,9 @@ describe('SourcesPage', () => {
     );
   });
 
-  it('shows error message when createSource fails', async () => {
+  it('shows a friendly conflict message when createSource fails with a duplicate slug', async () => {
     apiMock.fetchSources.mockResolvedValue([source()]);
-    apiMock.createSource.mockRejectedValue(new Error('slug already exists'));
+    apiMock.createSource.mockRejectedValue(new apiMock.HttpError(409, 'slug already exists'));
     withProviders(<SourcesPage />, '/', regularUser);
     await screen.findAllByText('Acme News');
 
@@ -250,7 +277,31 @@ describe('SourcesPage', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /^add source$/i }));
 
-    await waitFor(() => expect(screen.getByText('slug already exists')).toBeTruthy());
+    expect(
+      await screen.findByText('That slug is already in use — choose a different slug or source.')
+    ).toBeTruthy();
+    expect(screen.queryByText('slug already exists')).toBeNull();
+  });
+
+  it('shows friendly copy rather than a raw server string for generic createSource failures', async () => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.createSource.mockRejectedValue(new Error('500 Internal Server Error'));
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    await screen.findByRole('dialog');
+
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'My Blog' } });
+    fireEvent.change(screen.getByLabelText(/feed url/i), {
+      target: { value: 'https://myblog.com/feed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^add source$/i }));
+
+    expect(
+      await screen.findByText('Could not add source. Check the feed URL and try again.')
+    ).toBeTruthy();
+    expect(screen.queryByText('500 Internal Server Error')).toBeNull();
   });
 
   it('shows delete button for sources owned by current user', async () => {
@@ -316,6 +367,55 @@ describe('SourcesPage', () => {
     fireEvent.click(deleteBtn);
 
     await waitFor(() => expect(apiMock.deleteSource).toHaveBeenCalledWith('mine'));
+  });
+
+  it('notifies and restores the source row when delete fails', async () => {
+    apiMock.fetchSources.mockResolvedValue([
+      source({ slug: 'mine', name: 'My Blog', owner_user_id: regularUser.id }),
+    ]);
+    apiMock.deleteSource.mockRejectedValue(new Error('network down'));
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('My Blog');
+
+    const [deleteBtn] = screen.getAllByRole('button', { name: /delete my blog/i });
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Couldn't delete the source — it has been restored.")
+    );
+    expect(await screen.findAllByText('My Blog')).toHaveLength(2); // desktop + mobile
+  });
+
+  it('notifies and restores the source list when cleanup fails', async () => {
+    const suggestion = {
+      source_slug: 'acme',
+      source_name: 'Acme News',
+      action: 'unsubscribe' as const,
+      reason: 'stale' as const,
+      message: 'No articles from Acme News in 30 days',
+      articles_last_30_days: 0,
+      skip_rate: 0,
+      skipped_count: 0,
+      done_count: 0,
+      starred_count: 0,
+      archived_count: 0,
+      engagement_score: 0,
+    };
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.fetchSourceCleanupSuggestions.mockResolvedValue([suggestion]);
+    apiMock.applySourceCleanup.mockRejectedValue(new Error('network down'));
+    withProviders(<SourcesPage />);
+    await screen.findAllByText('Acme News');
+
+    const applyBtn = await screen.findByRole('button', { name: /apply cleanup/i });
+    fireEvent.click(applyBtn);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Cleanup couldn't be applied — the source list has been restored."
+      )
+    );
+    expect(await screen.findByRole('button', { name: /apply cleanup/i })).toBeTruthy();
   });
 
   it('calls exportOpml when "Export OPML" button is clicked', async () => {

--- a/frontend/src/lib/errorPresentation.ts
+++ b/frontend/src/lib/errorPresentation.ts
@@ -41,3 +41,22 @@ export function presentFailedBriefing(error?: string | null): FriendlyError {
     detail: error ?? undefined,
   };
 }
+
+export type SourceActionKind = 'add' | 'toggle' | 'cleanup' | 'delete';
+
+/** Friendly copy for source management failures, without leaking raw backend/server strings as the primary message. */
+export function sourceActionErrorMessage(err: unknown, action: SourceActionKind): string {
+  if (err instanceof HttpError && err.status === 409) {
+    return 'That slug is already in use — choose a different slug or source.';
+  }
+  switch (action) {
+    case 'add':
+      return 'Could not add source. Check the feed URL and try again.';
+    case 'toggle':
+      return 'Could not update the source — it has been reverted to its previous state.';
+    case 'cleanup':
+      return "Cleanup couldn't be applied — the source list has been restored.";
+    case 'delete':
+      return "Couldn't delete the source — it has been restored.";
+  }
+}

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import {
   CheckCircle2,
   AlertTriangle,
@@ -27,6 +28,7 @@ import {
   updateSourceEnabled,
 } from '@/api';
 import { relativeTime } from '@/lib/format';
+import { sourceActionErrorMessage } from '@/lib/errorPresentation';
 import type { Source, SourceCleanupSuggestion, OpmlImportResult } from '@/types';
 import { OnboardingWizard } from '@/components/OnboardingWizard';
 import { useAuth } from '@/contexts/auth';
@@ -133,7 +135,7 @@ function AddSourceDialog({
       onClose();
     },
     onError: (err: Error) => {
-      setError(err.message);
+      setError(sourceActionErrorMessage(err, 'add'));
     },
   });
 
@@ -270,8 +272,9 @@ export function SourcesPage() {
       );
       return { prev };
     },
-    onError: (_err, _vars, ctx) => {
+    onError: (err, _vars, ctx) => {
       if (ctx?.prev) qc.setQueryData([SOURCES_KEY], ctx.prev);
+      toast.error(sourceActionErrorMessage(err, 'toggle'));
     },
     onSettled: () => {
       void qc.invalidateQueries({ queryKey: [SOURCES_KEY] });
@@ -294,9 +297,10 @@ export function SourcesPage() {
       );
       return { prevSources, prevSuggestions };
     },
-    onError: (_err, _vars, ctx) => {
+    onError: (err, _vars, ctx) => {
       if (ctx?.prevSources) qc.setQueryData([SOURCES_KEY], ctx.prevSources);
       if (ctx?.prevSuggestions) qc.setQueryData([SOURCE_CLEANUP_KEY], ctx.prevSuggestions);
+      toast.error(sourceActionErrorMessage(err, 'cleanup'));
     },
     onSettled: () => {
       void qc.invalidateQueries({ queryKey: [SOURCES_KEY] });
@@ -312,8 +316,9 @@ export function SourcesPage() {
       qc.setQueryData<Source[]>([SOURCES_KEY], (old = []) => old.filter((s) => s.slug !== slug));
       return { prev };
     },
-    onError: (_err, _vars, ctx) => {
+    onError: (err, _vars, ctx) => {
       if (ctx?.prev) qc.setQueryData([SOURCES_KEY], ctx.prev);
+      toast.error(sourceActionErrorMessage(err, 'delete'));
     },
     onSettled: () => {
       void qc.invalidateQueries({ queryKey: [SOURCES_KEY] });


### PR DESCRIPTION
## Summary
- Fixes #703
- Add-source failures now render friendly, actionable copy instead of raw backend strings, with a specific message for duplicate-slug/409 conflicts telling the user to choose a different slug or source.
- Toggle, cleanup, and delete mutations now show a toast notification after their optimistic rollback, instead of silently reverting with no feedback.
- Both the desktop table and mobile card source controls share the same mutations/handlers, so they receive identical failure behavior.
- Extended `frontend/src/lib/errorPresentation.ts` with a small `sourceActionErrorMessage` adapter (kept intentionally local/lightweight per the issue's scope note, easy to fold into the shared helper from issue #702 once that lands) rather than duplicating classification logic in `SourcesPage.tsx`.

## Test plan
- [x] `npx vitest run frontend/src/__tests__/feedsPages.test.tsx` — 32/32 passing, including new tests for duplicate-slug conflict copy, generic add-source failure copy, and toggle/cleanup/delete failure toasts with rollback.
- [x] `npx vitest run` — full frontend suite, 717/717 passing.
- [x] `npx tsc -b --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.
- [x] pre-commit hooks (eslint, prettier, tsc) — passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)