### PR TITLE
ci: harden Codecov PR uploads (#706)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,11 +291,13 @@ jobs:
           fi
           echo "All test lanes passed (backend=$backend, frontend=$frontend, a11y=$a11y)"
   # ── 7. COVERAGE UPLOAD ─────────────────────────────────────────────────────
-  # Uploads coverage reports to Codecov for tracking test coverage trends.
+  # Uploads coverage reports to Codecov for PR comments, status checks, and
+  # coverage trends. Merge groups run the full test suite, so they also upload
+  # coverage to keep queued merges covered by the same Codecov flag wiring.
   coverage-upload:
     needs: [test-backend, test-frontend]
     runs-on: ubuntu-latest
-    if: always() && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+    if: always() && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       pull-requests: write
@@ -309,6 +311,15 @@ jobs:
           name: backend-coverage
           path: ./coverage-backend
 
+      - name: Check backend coverage report
+        id: backend-coverage
+        run: |
+          if compgen -G "./coverage-backend/*.xml" > /dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download frontend coverage
         if: needs.test-frontend.result == 'success' || needs.test-frontend.result == 'failure'
         uses: actions/download-artifact@v8
@@ -316,8 +327,18 @@ jobs:
           name: frontend-coverage
           path: ./coverage-frontend
 
+      - name: Check frontend coverage report
+        id: frontend-coverage
+        run: |
+          if [[ -f "./coverage-frontend/lcov.info" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload Backend to Codecov
-        uses: codecov/codecov-action@v4
+        if: steps.backend-coverage.outputs.exists == 'true'
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-backend/*.xml
@@ -327,7 +348,8 @@ jobs:
           verbose: true
 
       - name: Upload Frontend to Codecov
-        uses: codecov/codecov-action@v4
+        if: steps.frontend-coverage.outputs.exists == 'true'
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-frontend/lcov.info

--- a/backend/tests/test_ci_merge_queue.py
+++ b/backend/tests/test_ci_merge_queue.py
@@ -101,6 +101,56 @@ def test_codecov_upload_specifies_token_and_flags() -> None:
     assert found_codecov, "No codecov/codecov-action steps found in ci.yml"
 
 
+def test_coverage_upload_runs_for_prs_and_merge_groups() -> None:
+    """Coverage upload must run where PR authors and the queue need feedback."""
+    coverage_job = _load_ci().get("jobs", {}).get("coverage-upload")
+    assert coverage_job is not None, "coverage-upload job missing from ci.yml"
+
+    condition = str(coverage_job.get("if", ""))
+    for event_name in ("pull_request", "push", "merge_group"):
+        assert event_name in condition, (
+            f"coverage-upload job condition does not include {event_name!r}: {condition!r}"
+        )
+
+
+def test_codecov_upload_uses_current_action_major() -> None:
+    """Pin the reviewed Codecov action major so accidental downgrades fail tests."""
+    ci = _load_ci()
+    codecov_uses = [
+        step.get("uses", "")
+        for job_data in ci.get("jobs", {}).values()
+        for step in job_data.get("steps", [])
+        if "codecov/codecov-action" in step.get("uses", "")
+    ]
+    assert codecov_uses, "No codecov/codecov-action steps found in ci.yml"
+    assert all(uses == "codecov/codecov-action@v5" for uses in codecov_uses)
+
+
+def test_codecov_uploads_are_guarded_by_report_existence() -> None:
+    """Path-filtered PRs must not call Codecov when one report is absent."""
+    coverage_job = _load_ci().get("jobs", {}).get("coverage-upload")
+    assert coverage_job is not None, "coverage-upload job missing from ci.yml"
+
+    steps = coverage_job.get("steps", [])
+    check_steps = {
+        step.get("id"): step
+        for step in steps
+        if step.get("id") in {"backend-coverage", "frontend-coverage"}
+    }
+    assert set(check_steps) == {"backend-coverage", "frontend-coverage"}
+    assert "coverage-backend" in str(check_steps["backend-coverage"].get("run", ""))
+    assert "coverage-frontend" in str(check_steps["frontend-coverage"].get("run", ""))
+
+    upload_steps = {
+        step.get("with", {}).get("flags"): step
+        for step in steps
+        if "codecov/codecov-action" in step.get("uses", "")
+    }
+    assert set(upload_steps) == {"backend", "frontend"}
+    assert upload_steps["backend"].get("if") == "steps.backend-coverage.outputs.exists == 'true'"
+    assert upload_steps["frontend"].get("if") == "steps.frontend-coverage.outputs.exists == 'true'"
+
+
 def test_workflows_do_not_queue_pull_requests_for_auto_merge() -> None:
     """GitHub Actions must not enable auto-merge for pull requests."""
     forbidden_patterns = (


### PR DESCRIPTION
Closes #706

## Summary
- run coverage-upload for push, pull_request, workflow_dispatch, and merge_group events
- guard Codecov uploads behind backend/frontend report existence checks so skipped lanes do not upload missing files
- update Codecov uploads to codecov/codecov-action@v5 and add workflow tests for PR/merge-group behavior

## Tests
- pytest backend/tests/test_ci_merge_queue.py
- make lint
- make typecheck
- source .env && make test
