### PR TITLE
fix: scan GHCR image in weekly Trivy workflow (#707)

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -8,6 +8,10 @@ on:
     - cron: '0 2 * * 0'  # Every Sunday at 02:00 UTC
   workflow_dispatch:  # Allow manual triggering
 
+env:
+  # Full image name. GITHUB_REPOSITORY is "owner/repo" (lower-cased by GHCR).
+  IMAGE: ghcr.io/${{ github.repository }}
+
 permissions:
   contents: read
   packages: read
@@ -37,7 +41,7 @@ jobs:
       - name: Run Trivy vulnerability scanner on latest image
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ github.repository }}:latest
+          image-ref: ${{ env.IMAGE }}:latest
           format: sarif
           output: trivy-results.sarif
           exit-code: '1'  # Fail on any vulnerabilities


### PR DESCRIPTION
## Summary
- Fixes #707
- The weekly Trivy rescan workflow (`.github/workflows/trivy-scan.yml`) scanned `${{ github.repository }}:latest`, a Docker Hub-style reference, instead of the GHCR image actually published by `ci.yml`.
- Added `env.IMAGE: ghcr.io/${{ github.repository }}`, mirroring the convention already used in `ci.yml`, and updated the Trivy scan step to use `${{ env.IMAGE }}:latest`.
- GHCR login step, SARIF upload category (`trivy-weekly`), and `workflow_dispatch` trigger are unchanged.

## Test plan
- [x] Manually reviewed the updated YAML for correctness (no `actionlint` available locally).
- [x] `pre-commit` hooks (yaml check, trailing whitespace, etc.) passed on commit.
- [ ] Manually dispatch the weekly Trivy workflow after merge to confirm it scans the `ghcr.io/...` image (cannot be done from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)