### PR TITLE
fix: make GHCR deploy token optional (#709)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,8 +576,9 @@ jobs:
   # ┌──────────────────────────────────────────────────────────────────────┐
   # │  SECRETS — add in: GitHub repo → Settings → Secrets → Actions       │
   # │                                                                      │
-  # │  GHCR_TOKEN       A GitHub Personal Access Token with the            │
-  # │                   *read:packages* scope (nothing else).               │
+  # │  GHCR_TOKEN       Optional when the GHCR package is public. Required │
+  # │                   for private packages: use a GitHub Personal Access │
+  # │                   Token with the *read:packages* scope (nothing else).│
   # │                   Create at: github.com/settings/tokens              │
   # │                   (Classic token, read:packages, 1-year expiry.)     │
   # │                   This lets the mini PC pull the image from GHCR.    │
@@ -600,11 +601,6 @@ jobs:
   # │  SENTRY_DSN_      Optional Sentry project DSN for frontend/UI error   │
   # │  FRONTEND         tracking. Stored as a secret and exposed publicly   │
   # │                   through GET /api/config as SENTRY_DSN_FRONTEND.     │
-  # │                                                                      │
-  # │                   SHORTCUT: if you make the GHCR package public      │
-  # │                   (repo Settings → Packages → Change visibility),    │
-  # │                   you can skip GHCR_TOKEN entirely and remove the    │
-  # │                   docker-login lines from the deploy step below.     │
   # └──────────────────────────────────────────────────────────────────────┘
   deploy:
     name: Deploy to mini PC
@@ -649,21 +645,26 @@ jobs:
             exit 1
           fi
 
-          # Authenticate to GHCR so the cluster node can pull the image.
-          # Remove these two lines if the GHCR package is public.
-          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
-
-          # Pull eagerly — surfaces auth failures before touching the cluster.
-          docker pull "${IMG}:${SHA}"
-
           kubectl create namespace news-dashboard --dry-run=client -o yaml | kubectl apply -f -
 
-          # Let Kubernetes pull the private GHCR image during rollout.
-          kubectl -n news-dashboard create secret docker-registry ghcr-pull-secret \
-            --docker-server=ghcr.io \
-            --docker-username="$GHCR_ACTOR" \
-            --docker-password="$GHCR_TOKEN" \
-            --dry-run=client -o yaml | kubectl apply -f -
+          if [ -n "$GHCR_TOKEN" ]; then
+            # Private GHCR packages need both local Docker auth and a cluster pull secret.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+
+            kubectl -n news-dashboard create secret docker-registry ghcr-pull-secret \
+              --docker-server=ghcr.io \
+              --docker-username="$GHCR_ACTOR" \
+              --docker-password="$GHCR_TOKEN" \
+              --dry-run=client -o yaml | kubectl apply -f -
+
+            pull_secret_helm_args=(--set-string image.pullSecretName=ghcr-pull-secret)
+          else
+            echo "GHCR_TOKEN is empty; treating ${IMG}:${SHA} as a public GHCR image."
+            pull_secret_helm_args=(--set-string image.pullSecretName=)
+          fi
+
+          # Pull eagerly — surfaces auth or visibility failures before touching the rollout.
+          docker pull "${IMG}:${SHA}"
 
           ai_secret_args=()
           if [ -n "$OPENAI_API_KEY" ]; then
@@ -746,7 +747,7 @@ jobs:
             --namespace news-dashboard --create-namespace
             --set "image.repository=${IMG}"
             --set "image.tag=${SHA}"
-            --set image.pullSecretName=ghcr-pull-secret
+            "${pull_secret_helm_args[@]}"
             --set service.type=NodePort
             --set service.nodePort=30088
             --set postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -3,6 +3,10 @@
 **Note**: The GHCR package must be made public (or accessible via pull secret) for this to work.
 > This is a one-time maintainer action: go to the repository's Packages settings,
 > select the `ghcr.io/lihor-hub/news-dashboard` package, and change its visibility to Public.
+> If the package stays private, configure the production `GHCR_TOKEN` Actions
+> secret with `read:packages` so CI can create the cluster pull secret. Public
+> packages do not need `GHCR_TOKEN`; the deploy workflow leaves
+> `image.pullSecretName` empty in that mode.
 
 This guide explains how to deploy News Dashboard for production use using the published Docker image from GitHub Container Registry (GHCR).
 

--- a/scripts/test_ci_deploy_namespace.py
+++ b/scripts/test_ci_deploy_namespace.py
@@ -21,3 +21,36 @@ def test_deploy_creates_namespace_before_secrets() -> None:
 
     assert namespace_index < pull_index  # noqa: S101
     assert namespace_index < ai_index  # noqa: S101
+
+
+def test_deploy_supports_public_ghcr_without_token() -> None:
+    workflow = WORKFLOW.read_text()
+    public_image_message = (
+        'echo "GHCR_TOKEN is empty; treating ${IMG}:${SHA} as a public GHCR image."'
+    )
+    empty_image_pull_arg = "pull_secret_helm_args=(--set-string image.pullSecretName=)"
+
+    assert 'if [ -n "$GHCR_TOKEN" ]; then' in workflow  # noqa: S101
+    assert public_image_message in workflow  # noqa: S101
+    assert empty_image_pull_arg in workflow  # noqa: S101
+    assert '"${pull_secret_helm_args[@]}"' in workflow  # noqa: S101
+
+
+def test_deploy_keeps_private_ghcr_pull_secret_when_token_is_set() -> None:
+    workflow = WORKFLOW.read_text()
+
+    token_branch_index = workflow.index('if [ -n "$GHCR_TOKEN" ]; then')
+    docker_login_index = workflow.index(
+        'echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin'
+    )
+    secret_index = workflow.index(
+        "kubectl -n news-dashboard create secret docker-registry ghcr-pull-secret"
+    )
+    helm_arg_index = workflow.index(
+        "pull_secret_helm_args=(--set-string image.pullSecretName=ghcr-pull-secret)"
+    )
+    no_token_index = workflow.index("else", token_branch_index)
+
+    assert token_branch_index < docker_login_index < no_token_index  # noqa: S101
+    assert token_branch_index < secret_index < no_token_index  # noqa: S101
+    assert token_branch_index < helm_arg_index < no_token_index  # noqa: S101


### PR DESCRIPTION
Closes #709

## Summary
- make the production deploy workflow branch on GHCR_TOKEN so private packages keep Docker login and ghcr-pull-secret creation
- skip GHCR auth and pass an empty image.pullSecretName Helm override for public GHCR packages
- document when GHCR_TOKEN is required and add regression tests for both deploy paths

## Tests
- pytest -q scripts/test_ci_deploy_namespace.py
- helm template news-dashboard ./helm/news-dashboard --set-string app.auth.sessionSecret=dummy-session-secret-for-render-only --set-string postgresql.password=dummy-postgres-password-for-render-only --set-string image.pullSecretName=, verified no imagePullSecrets or ghcr-pull-secret rendered
- make lint && make typecheck && source .env && make test

🤖 Generated with [Claude Code](https://claude.com/claude-code)