### PR TITLE
docs: add README CI and release badges (#712)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # News Dashboard
 
-[![CI](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml)
+[![CI / CD](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/ci.yml)
+[![Release](https://github.com/lihor-hub/news-dashboard/actions/workflows/release.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/release.yml)
 [![Coverage Status](https://codecov.io/gh/lihor-hub/news-dashboard/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lihor-hub/news-dashboard)
 [![CodeQL](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml)
 [![Version](https://img.shields.io/github/v/tag/lihor-hub/news-dashboard?filter=v*&sort=semver&label=version&color=blue)](https://github.com/lihor-hub/news-dashboard/releases/latest)


### PR DESCRIPTION
## Summary
- Adds a `Release` workflow status badge linked to `.github/workflows/release.yml`
- Renames the existing CI badge label from `CI` to `CI / CD` to match the workflow's actual `name:` so the badge row accurately reflects both pipelines readers care about before deploying

## Test plan
- [x] Documentation-only change; no runtime tests required per issue
- [x] Verified `.github/workflows/release.yml` workflow name is `Release` and `.github/workflows/ci.yml` workflow name is `CI / CD`
- [x] `npx prettier --check README.md` shows the same pre-existing warning as on `main` (unrelated to this change, not introduced by it)

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)