### PR TITLE
fix: hide share recipient emails (#710)

### DIFF
--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -30,7 +30,7 @@ def shareable_users(current_user_id: int) -> list[dict[str, Any]]:
     """Return platform users the current user can share with (everyone else)."""
     with connect() as conn:
         rows = conn.execute(
-            "SELECT id, username, email FROM users WHERE id <> %s ORDER BY username",
+            "SELECT id, username FROM users WHERE id <> %s ORDER BY username",
             (current_user_id,),
         ).fetchall()
         return [row_to_dict(r) for r in rows]

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -38,8 +38,8 @@ def db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
     return pg_clean
 
 
-def _make_user(db_path: str, username: str) -> int:
-    return int(create_user(username, "password123", db_path=db_path)["id"])
+def _make_user(db_path: str, username: str, email: str | None = None) -> int:
+    return int(create_user(username, "password123", email=email, db_path=db_path)["id"])
 
 
 def _insert_article(db_path: str, suffix: str = "1") -> int:
@@ -123,10 +123,26 @@ def test_mark_read(db: str) -> None:
 
 
 def test_shareable_users_excludes_self(db: str) -> None:
-    alice = _make_user(db, "alice")
-    _make_user(db, "bob")
-    usernames = {u["username"] for u in shareable_users(alice)}
-    assert usernames == {"bob"}
+    alice = _make_user(db, "alice", email="alice@example.test")
+    bob = _make_user(db, "bob", email="bob@example.test")
+
+    users = shareable_users(alice)
+
+    assert users == [{"id": bob, "username": "bob"}]
+
+
+def test_shareable_users_endpoint_omits_other_users_email(db: str) -> None:
+    alice = _make_user(db, "alice", email="alice@example.test")
+    bob = _make_user(db, "bob", email="bob@example.test")
+    client = _authed_client(alice)
+
+    try:
+        response = client.get("/api/users")
+
+        assert response.status_code == 200
+        assert response.json() == {"items": [{"id": bob, "username": "bob"}]}
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
 
 
 def test_cannot_share_with_self(db: str) -> None:

--- a/frontend/src/__tests__/shareDialog.test.tsx
+++ b/frontend/src/__tests__/shareDialog.test.tsx
@@ -37,14 +37,15 @@ describe('ShareDialog', () => {
 
   it('lists users and shares to the chosen recipient', async () => {
     vi.spyOn(api, 'fetchShareableUsers').mockResolvedValue([
-      { id: 2, username: 'alice', email: 'alice@example.com' },
-      { id: 3, username: 'bob', email: null },
+      { id: 2, username: 'alice' },
+      { id: 3, username: 'bob' },
     ]);
     const shareSpy = vi.spyOn(api, 'shareArticle').mockResolvedValue({ id: 42 } as never);
     const { onOpenChange } = renderDialog();
 
     await userEvent.click(screen.getByText('Send inside the platform'));
     await waitFor(() => expect(screen.getByText('alice')).toBeTruthy());
+    expect(screen.queryByText('alice@example.com')).toBeNull();
 
     await userEvent.click(screen.getByText('alice'));
     await waitFor(() => expect(shareSpy).toHaveBeenCalledWith(7, 2, ''));
@@ -52,9 +53,7 @@ describe('ShareDialog', () => {
   });
 
   it('attaches selected passage as an annotation after creating the share', async () => {
-    vi.spyOn(api, 'fetchShareableUsers').mockResolvedValue([
-      { id: 2, username: 'alice', email: null },
-    ]);
+    vi.spyOn(api, 'fetchShareableUsers').mockResolvedValue([{ id: 2, username: 'alice' }]);
     vi.spyOn(api, 'shareArticle').mockResolvedValue({ id: 42 } as never);
     const annotationSpy = vi.spyOn(api, 'createShareAnnotation').mockResolvedValue({} as never);
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -203,11 +203,6 @@ export function ShareDialog({ article, open, onOpenChange, pendingHighlight }: S
                       >
                         <span className="flex min-w-0 flex-col">
                           <span className="truncate font-medium">{u.username}</span>
-                          {u.email ? (
-                            <span className="truncate text-xs text-muted-foreground">
-                              {u.email}
-                            </span>
-                          ) : null}
                         </span>
                         {sendingTo === u.id ? (
                           <Loader2 className="h-4 w-4 shrink-0 animate-spin" />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,7 +52,6 @@ export interface User {
 export interface ShareableUser {
   id: number;
   username: string;
-  email?: string | null;
 }
 
 export interface ReceivedShare {


### PR DESCRIPTION
Closes #710

## Summary
- remove email from the share recipient lookup query and `/api/users` response
- drop `ShareableUser.email` and username-list email rendering from the share dialog
- add backend and frontend regression coverage for username-only share recipients

## Test results
- `make lint`
- `make typecheck`
- `source .env && pytest backend/tests/test_article_shares.py`
- `npm run test:frontend -- frontend/src/__tests__/shareDialog.test.tsx`
- `source .env && make test` (backend: 1511 passed, 1 skipped; frontend: 727 passed; Vitest printed existing ECONNREFUSED :3000 diagnostics but exited 0)
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)