### PR TITLE
docs: add README security and supply-chain badges (#713)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://github.com/lihor-hub/news-dashboard/actions/workflows/release.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/release.yml)
 [![Coverage Status](https://codecov.io/gh/lihor-hub/news-dashboard/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lihor-hub/news-dashboard)
 [![CodeQL](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/codeql.yml)
+[![Trivy](https://github.com/lihor-hub/news-dashboard/actions/workflows/trivy-scan.yml/badge.svg)](https://github.com/lihor-hub/news-dashboard/actions/workflows/trivy-scan.yml)
 [![Version](https://img.shields.io/github/v/tag/lihor-hub/news-dashboard?filter=v*&sort=semver&label=version&color=blue)](https://github.com/lihor-hub/news-dashboard/releases/latest)
 [![License: MIT](https://img.shields.io/github/license/lihor-hub/news-dashboard)](LICENSE)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/lihor-hub/news-dashboard)


### PR DESCRIPTION
## Summary
- Add a linked Trivy badge (`trivy-scan.yml`) next to the existing CodeQL badge in the README badge row.
- Intentionally skip the Dependency Review badge: that workflow only triggers on pull requests to `main` (`dependency-review.yml:3`), so GitHub renders a stale/inapplicable status badge for it on the default branch. The Trivy workflow runs on a schedule/manual dispatch (`trivy-scan.yml:6`) and produces a meaningful default-branch status.
- CodeQL badge remains unchanged, still linked to `actions/workflows/codeql.yml`.

Closes #713

## Test plan
- [x] Documentation-only change; no runtime tests required.
- [x] Verified README markdown renders correctly (badge syntax matches existing badges in the row).