### PR TITLE
[codex] fix CSRF origin handling behind proxies

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -292,6 +292,37 @@ def _request_origin(request: Request) -> str | None:
     return None
 
 
+def _origin_from_url(value: str | None) -> str | None:
+    """Return scheme://host[:port] for an absolute URL config value."""
+    if not value:
+        return None
+    parts = urlsplit(value.strip())
+    if parts.scheme and parts.netloc:
+        return f"{parts.scheme}://{parts.netloc}"
+    return None
+
+
+def _request_base_origin(request: Request) -> str:
+    """Return the externally visible request origin when proxy headers exist."""
+    forwarded_host = request.headers.get("x-forwarded-host")
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    if forwarded_host and forwarded_proto:
+        host = forwarded_host.split(",", maxsplit=1)[0].strip()
+        proto = forwarded_proto.split(",", maxsplit=1)[0].strip()
+        if host and proto:
+            return f"{proto}://{host}"
+    return f"{request.url.scheme}://{request.url.netloc}"
+
+
+def _allowed_csrf_origins(request: Request) -> set[str]:
+    """Return origins allowed to perform cookie-authenticated mutations."""
+    origins = {*_cors_origins, _request_base_origin(request)}
+    public_base_origin = _origin_from_url(os.getenv("NEWS_DASHBOARD_BASE_URL"))
+    if public_base_origin is not None:
+        origins.add(public_base_origin)
+    return origins
+
+
 @app.middleware("http")
 async def enforce_csrf_origin(request: Request, call_next: Any) -> Any:
     """Reject cross-origin unsafe requests carrying the session cookie.
@@ -317,13 +348,11 @@ async def enforce_csrf_origin(request: Request, call_next: Any) -> Any:
         return await call_next(request)
 
     origin = _request_origin(request)
-    if origin is not None:
-        allowed_origins = {*_cors_origins, f"{request.url.scheme}://{request.url.netloc}"}
-        if origin not in allowed_origins:
-            return JSONResponse(
-                status_code=403,
-                content={"detail": "Cross-origin request rejected"},
-            )
+    if origin is not None and origin not in _allowed_csrf_origins(request):
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Cross-origin request rejected"},
+        )
 
     return await call_next(request)
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -829,6 +829,39 @@ def test_csrf_guard_allows_same_origin_mutation(tmp_db: str) -> None:
     assert resp.status_code == 200
 
 
+def test_csrf_guard_allows_public_base_url_origin(
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NEWS_DASHBOARD_BASE_URL", "https://news.example.test")
+    admin = create_user("csrf_public_base_origin", "pw", is_admin=True)
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.post(
+        "/api/admin/users",
+        json={"username": "csrf_public_base_origin_new", "password": "pw2", "is_admin": False},
+        headers={"origin": "https://news.example.test"},
+    )
+    assert resp.status_code == 200
+
+
+def test_csrf_guard_allows_forwarded_same_origin_mutation(tmp_db: str) -> None:
+    admin = create_user("csrf_forwarded_origin", "pw", is_admin=True)
+    token = create_session_token(admin["id"], is_admin=True)
+    client = _fresh_client()
+    client.cookies.set("nd_session", token)
+    resp = client.post(
+        "/api/admin/users",
+        json={"username": "csrf_forwarded_origin_new", "password": "pw2", "is_admin": False},
+        headers={
+            "origin": "https://news.example.test",
+            "x-forwarded-proto": "https",
+            "x-forwarded-host": "news.example.test",
+        },
+    )
+    assert resp.status_code == 200
+
+
 def test_csrf_guard_allows_configured_dev_origin(tmp_db: str) -> None:
     admin = create_user("csrf_dev_origin", "pw", is_admin=True)
     token = create_session_token(admin["id"], is_admin=True)


### PR DESCRIPTION
## Summary

- allow the CSRF/origin guard to trust the configured public app origin from `NEWS_DASHBOARD_BASE_URL`
- honor standard `X-Forwarded-Proto` and `X-Forwarded-Host` headers when computing same-origin requests behind a reverse proxy
- add regression tests for public-base-url and forwarded-host same-origin mutations

## Root Cause

Valid browser POSTs, including generating a new brief, could be rejected behind a proxy because the browser sent the public HTTPS origin while FastAPI compared it with the internal request URL seen by the app.

## Validation

- `pytest backend/tests/test_auth.py -k 'csrf_guard'` passed: 9 passed
- `make lint` passed
- `make typecheck` passed
- `source .env && make test` was attempted, but the local test database schemas were missing core tables such as `user_article_recommendations`, causing broad unrelated fixture setup failures.
