### PR TITLE
feat: add Reading List for saving ad-hoc links with background metadata fetch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,8 @@ SMTP_PASSWORD=
 INGEST_INTERVAL_MINUTES=30
 # Interval for the background entity-extraction job feeding the knowledge graph. Default 30.
 ENTITY_EXTRACTION_INTERVAL_MINUTES=30
+# Interval for the reading-list metadata sweep retrying pending link previews. Default 5.
+READING_LIST_FETCH_INTERVAL_MINUTES=5
 DIGEST_CRON=0 8 * * *
 BRIEFING_CRON=0 9 * * *
 RECOMMENDATIONS_CRON=30 7 * * *

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -557,6 +557,35 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_weekly_recaps_user"
     " ON user_weekly_recaps(user_id, week_start DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS reading_list_items (
+      id             BIGSERIAL PRIMARY KEY,
+      user_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      url            TEXT NOT NULL,
+      normalized_url TEXT NOT NULL,
+      title          TEXT,
+      description    TEXT,
+      image_url      TEXT,
+      site_name      TEXT,
+      kind           TEXT NOT NULL DEFAULT 'link'
+        CHECK(kind IN ('article','video','channel','link')),
+      fetch_status   TEXT NOT NULL DEFAULT 'pending'
+        CHECK(fetch_status IN ('pending','ok','error')),
+      fetch_error    TEXT,
+      fetched_at     TIMESTAMPTZ,
+      status         TEXT NOT NULL DEFAULT 'unread'
+        CHECK(status IN ('unread','done','archived')),
+      priority       INTEGER NOT NULL DEFAULT 0,
+      note           TEXT,
+      created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      done_at        TIMESTAMPTZ,
+      UNIQUE (user_id, normalized_url)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_reading_list_items_user_status"
+    " ON reading_list_items(user_id, status, priority)",
+    "CREATE INDEX IF NOT EXISTS idx_reading_list_items_fetch_status"
+    " ON reading_list_items(fetch_status)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2970,11 +2970,13 @@ def admin_delete_user(
 # gate. Add each new domain's router here as it is extracted from main.py.
 from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E402
 from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
+from news_dashboard.reading_list.router import router as reading_list_router  # noqa: E402
 from news_dashboard.reading_progress.router import router as reading_progress_router  # noqa: E402
 from news_dashboard.recaps.router import router as recaps_router  # noqa: E402
 
 api.include_router(ai_stats_router)
 api.include_router(quizzes_router)
+api.include_router(reading_list_router)
 api.include_router(reading_progress_router)
 api.include_router(recaps_router)
 

--- a/backend/news_dashboard/reading_list/__init__.py
+++ b/backend/news_dashboard/reading_list/__init__.py
@@ -1,0 +1,1 @@
+"""Reading list: save ad-hoc links with background metadata enrichment."""

--- a/backend/news_dashboard/reading_list/metadata.py
+++ b/backend/news_dashboard/reading_list/metadata.py
@@ -1,0 +1,116 @@
+"""Fetch and parse metadata (OpenGraph / oEmbed) for reading list URLs."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urlencode, urlparse
+
+from news_dashboard.url_safety import open_server_fetch_url
+
+USER_AGENT = "news-dashboard/0.1 (personal RSS reader; contact@lihor.ro)"
+TIMEOUT_SECS = 15
+_MAX_BYTES = 1_000_000
+
+_YOUTUBE_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"}
+_YOUTUBE_CHANNEL_PREFIXES = ("/@", "/channel/", "/c/", "/user/")
+
+
+def detect_kind(url: str) -> str:
+    """Classify a URL as video, channel, or article."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host not in _YOUTUBE_HOSTS:
+        return "article"
+    if host == "youtu.be":
+        return "video"
+    if parsed.path.startswith(_YOUTUBE_CHANNEL_PREFIXES):
+        return "channel"
+    return "video"
+
+
+class _MetaParser(HTMLParser):
+    """Collect OpenGraph / Twitter-card meta tags and the <title> text."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.meta: dict[str, str] = {}
+        self.title_parts: list[str] = []
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "title":
+            self._in_title = True
+            return
+        if tag != "meta":
+            return
+        attr_map = {name: value for name, value in attrs if value is not None}
+        key = attr_map.get("property") or attr_map.get("name")
+        content = attr_map.get("content")
+        if key and content and key.lower() not in self.meta:
+            self.meta[key.lower()] = content
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title_parts.append(data)
+
+
+def parse_html_metadata(html: str) -> dict[str, Any]:
+    """Extract title/description/image/site name from an HTML document."""
+    parser = _MetaParser()
+    parser.feed(html)
+    meta = parser.meta
+    page_title = "".join(parser.title_parts).strip() or None
+    return {
+        "title": meta.get("og:title") or meta.get("twitter:title") or page_title,
+        "description": (
+            meta.get("og:description") or meta.get("twitter:description") or meta.get("description")
+        ),
+        "image_url": meta.get("og:image") or meta.get("twitter:image"),
+        "site_name": meta.get("og:site_name"),
+    }
+
+
+def _fetch_html(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})  # noqa: S310 - scheme validated by open_server_fetch_url
+    with open_server_fetch_url(req, timeout=TIMEOUT_SECS) as resp:
+        raw: bytes = resp.read(_MAX_BYTES)
+    return raw.decode("utf-8", errors="replace")
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})  # noqa: S310 - scheme validated by open_server_fetch_url
+    with open_server_fetch_url(req, timeout=TIMEOUT_SECS) as resp:
+        raw: bytes = resp.read(_MAX_BYTES)
+    payload = json.loads(raw.decode("utf-8", errors="replace"))
+    if not isinstance(payload, dict):
+        message = f"Unexpected oEmbed payload for {url!r}"
+        raise TypeError(message)
+    return payload
+
+
+def fetch_url_metadata(url: str) -> dict[str, Any]:
+    """Fetch preview metadata for a URL.
+
+    YouTube videos go through the keyless oEmbed endpoint; everything else is
+    fetched as HTML and parsed for OpenGraph/Twitter-card tags.
+    """
+    kind = detect_kind(url)
+    if kind == "video":
+        oembed_url = "https://www.youtube.com/oembed?" + urlencode({"url": url, "format": "json"})
+        payload = _fetch_json(oembed_url)
+        return {
+            "title": payload.get("title"),
+            "description": payload.get("author_name"),
+            "image_url": payload.get("thumbnail_url"),
+            "site_name": "YouTube",
+            "kind": kind,
+        }
+    parsed = parse_html_metadata(_fetch_html(url))
+    return {**parsed, "kind": kind}

--- a/backend/news_dashboard/reading_list/models.py
+++ b/backend/news_dashboard/reading_list/models.py
@@ -1,0 +1,21 @@
+"""Request models for the reading list API."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ReadingListAddRequest(BaseModel):
+    url: str
+    note: str | None = None
+
+
+class ReadingListUpdateRequest(BaseModel):
+    status: Literal["unread", "done", "archived"] | None = None
+    note: str | None = None
+
+
+class ReadingListReorderRequest(BaseModel):
+    ordered_ids: list[int]

--- a/backend/news_dashboard/reading_list/router.py
+++ b/backend/news_dashboard/reading_list/router.py
@@ -1,0 +1,80 @@
+"""HTTP routes for the reading list.
+
+The router carries no blanket auth dependency of its own; it is mounted on
+``main``'s authenticated ``api`` router, which applies ``require_auth``. Each
+handler still depends on ``require_auth`` to receive the current user.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response
+
+from news_dashboard.auth import require_auth
+from news_dashboard.reading_list import service
+from news_dashboard.reading_list.models import (
+    ReadingListAddRequest,
+    ReadingListReorderRequest,
+    ReadingListUpdateRequest,
+)
+
+router = APIRouter()
+
+
+@router.post("/api/reading-list", status_code=201)
+def add_reading_list_item_endpoint(
+    payload: ReadingListAddRequest,
+    background_tasks: BackgroundTasks,
+    response: Response,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        item = service.add_item(current_user["id"], payload.url, payload.note)
+    except service.InvalidReadingListUrlError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if item.pop("created", False):
+        background_tasks.add_task(service.fetch_metadata_for_item, item["id"])
+    else:
+        response.status_code = 200
+    return item
+
+
+@router.get("/api/reading-list")
+def list_reading_list_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    status: Annotated[str | None, Query(pattern="^(unread|done|archived)$")] = None,
+) -> dict[str, Any]:
+    return {"items": service.list_items(current_user["id"], status)}
+
+
+@router.post("/api/reading-list/reorder")
+def reorder_reading_list_endpoint(
+    payload: ReadingListReorderRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": service.reorder_items(current_user["id"], payload.ordered_ids)}
+
+
+@router.patch("/api/reading-list/{item_id}")
+def update_reading_list_item_endpoint(
+    item_id: int,
+    payload: ReadingListUpdateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    item = service.update_item(
+        current_user["id"], item_id, status=payload.status, note=payload.note
+    )
+    if item is None:
+        raise HTTPException(status_code=404, detail="Reading list item not found")
+    return item
+
+
+@router.delete("/api/reading-list/{item_id}")
+def delete_reading_list_item_endpoint(
+    item_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    if not service.delete_item(current_user["id"], item_id):
+        raise HTTPException(status_code=404, detail="Reading list item not found")
+    return {"deleted": True}

--- a/backend/news_dashboard/reading_list/service.py
+++ b/backend/news_dashboard/reading_list/service.py
@@ -1,0 +1,239 @@
+"""Reading list persistence and background metadata enrichment."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.reading_list.metadata import detect_kind, fetch_url_metadata
+
+logger = logging.getLogger(__name__)
+
+_TRACKING_PARAM_PREFIXES = ("utm_",)
+_TRACKING_PARAMS = {"fbclid", "gclid", "mc_cid", "mc_eid"}
+
+
+class InvalidReadingListUrlError(ValueError):
+    """Raised when a URL cannot be saved to the reading list."""
+
+
+def _require_http_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        message = f"Not a fetchable http(s) URL: {url!r}"
+        raise InvalidReadingListUrlError(message)
+
+
+def normalize_url(url: str) -> str:
+    """Canonicalize a URL for per-user deduplication.
+
+    Lowercases scheme/host, drops fragments and common tracking parameters,
+    and strips trailing slashes from the path.
+    """
+    parsed = urlparse(url.strip())
+    host = (parsed.hostname or "").lower()
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not key.lower().startswith(_TRACKING_PARAM_PREFIXES)
+        and key.lower() not in _TRACKING_PARAMS
+    ]
+    path = parsed.path.rstrip("/") or "/"
+    return urlunparse((parsed.scheme.lower(), host, path, "", urlencode(query), ""))
+
+
+def _serialize(row: Any) -> dict[str, Any]:
+    item = dict(row)
+    for key in ("created_at", "fetched_at", "done_at"):
+        value = item.get(key)
+        if value is not None:
+            item[key] = value.isoformat()
+    return item
+
+
+def add_item(
+    user_id: int,
+    url: str,
+    note: str | None = None,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Save a URL for the user; returns the existing item on duplicate.
+
+    The returned dict carries a ``created`` flag so callers can distinguish
+    a fresh insert (which needs a metadata fetch) from a dedupe hit.
+    """
+    cleaned = url.strip()
+    _require_http_url(cleaned)
+    normalized = normalize_url(cleaned)
+    kind = detect_kind(cleaned)
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO reading_list_items(user_id, url, normalized_url, kind, note, priority)
+            VALUES (
+              %s, %s, %s, %s, %s,
+              (SELECT COALESCE(MAX(priority), 0) + 1 FROM reading_list_items WHERE user_id = %s)
+            )
+            ON CONFLICT (user_id, normalized_url) DO NOTHING
+            RETURNING *
+            """,
+            (user_id, cleaned, normalized, kind, note, user_id),
+        ).fetchone()
+        if row is not None:
+            return _serialize(row) | {"created": True}
+        existing = conn.execute(
+            "SELECT * FROM reading_list_items WHERE user_id = %s AND normalized_url = %s",
+            (user_id, normalized),
+        ).fetchone()
+    return _serialize(existing) | {"created": False}
+
+
+def list_items(
+    user_id: int,
+    status: str | None = None,
+    *,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(database_url=database_url)
+    query = "SELECT * FROM reading_list_items WHERE user_id = %s"
+    params: list[Any] = [user_id]
+    if status is not None:
+        query += " AND status = %s"
+        params.append(status)
+    query += " ORDER BY priority ASC, created_at ASC, id ASC"
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(query, params).fetchall()
+    return [_serialize(row) for row in rows]
+
+
+def update_item(
+    user_id: int,
+    item_id: int,
+    *,
+    status: str | None = None,
+    note: str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE reading_list_items
+            SET status = COALESCE(%s, status),
+                note = COALESCE(%s, note),
+                done_at = CASE
+                  WHEN %s::text = 'done' THEN NOW()
+                  WHEN %s::text IS NOT NULL THEN NULL
+                  ELSE done_at
+                END
+            WHERE id = %s AND user_id = %s
+            RETURNING *
+            """,
+            (status, note, status, status, item_id, user_id),
+        ).fetchone()
+    return _serialize(row) if row is not None else None
+
+
+def reorder_items(
+    user_id: int,
+    ordered_ids: list[int],
+    *,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Persist an explicit priority order for the user's items."""
+    with connect(database_url=database_url) as conn:
+        for position, item_id in enumerate(ordered_ids, start=1):
+            conn.execute(
+                "UPDATE reading_list_items SET priority = %s WHERE id = %s AND user_id = %s",
+                (position, item_id, user_id),
+            )
+    return list_items(user_id, database_url=database_url)
+
+
+def delete_item(
+    user_id: int,
+    item_id: int,
+    *,
+    database_url: str | None = None,
+) -> bool:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "DELETE FROM reading_list_items WHERE id = %s AND user_id = %s RETURNING id",
+            (item_id, user_id),
+        ).fetchone()
+    return row is not None
+
+
+def fetch_metadata_for_item(item_id: int, *, database_url: str | None = None) -> None:
+    """Fetch and store preview metadata for one item.
+
+    Failures are recorded on the row (``fetch_status='error'``) instead of
+    raised, so background callers never crash the sweep.
+    """
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT url FROM reading_list_items WHERE id = %s",
+            (item_id,),
+        ).fetchone()
+    if row is None:
+        return
+    try:
+        meta = fetch_url_metadata(row["url"])
+    except Exception as exc:
+        logger.warning("Reading list metadata fetch failed for %s: %s", row["url"], exc)
+        with connect(database_url=database_url) as conn:
+            conn.execute(
+                """
+                UPDATE reading_list_items
+                SET fetch_status = 'error', fetch_error = %s, fetched_at = NOW()
+                WHERE id = %s
+                """,
+                (str(exc)[:500], item_id),
+            )
+        return
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            UPDATE reading_list_items
+            SET title = %s,
+                description = %s,
+                image_url = %s,
+                site_name = %s,
+                kind = COALESCE(%s, kind),
+                fetch_status = 'ok',
+                fetch_error = NULL,
+                fetched_at = NOW()
+            WHERE id = %s
+            """,
+            (
+                meta.get("title"),
+                meta.get("description"),
+                meta.get("image_url"),
+                meta.get("site_name"),
+                meta.get("kind"),
+                item_id,
+            ),
+        )
+
+
+def process_pending_items(*, limit: int = 20, database_url: str | None = None) -> int:
+    """Fetch metadata for items still pending; returns the number processed."""
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id FROM reading_list_items
+            WHERE fetch_status = 'pending'
+            ORDER BY created_at ASC
+            LIMIT %s
+            """,
+            (limit,),
+        ).fetchall()
+    for row in rows:
+        fetch_metadata_for_item(row["id"], database_url=database_url)
+    return len(rows)

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -326,6 +326,22 @@ def _run_entity_extraction() -> tuple[str, str | None]:
     return "success", f"extracted {extracted} article(s)"
 
 
+def _run_reading_list_fetch() -> tuple[str, str | None] | None:
+    from news_dashboard.reading_list import service
+
+    try:
+        processed = service.process_pending_items()
+    except Exception as exc:
+        logger.exception("Reading list metadata fetch failed")
+        return "failure", str(exc)[:500]
+    if processed == 0:
+        # Nothing pending most of the time; skip recording to keep
+        # scheduled_job_runs from filling with no-op entries.
+        return None
+    logger.info("Reading list metadata fetch done: %d item(s).", processed)
+    return "success", f"fetched {processed} item(s)"
+
+
 def _run_and_record(
     job_name: str,
     fn: Callable[[], tuple[str, str | None] | None],
@@ -386,6 +402,10 @@ def _job_entity_extraction() -> None:
 
 def _job_weekly_recaps() -> None:
     _run_and_record("weekly_recaps", _run_weekly_recaps)
+
+
+def _job_reading_list_fetch() -> None:
+    _run_and_record("reading_list_fetch", _run_reading_list_fetch)
 
 
 def _parse_cron_hm(cron: str, default_minute: str, default_hour: str) -> tuple[str, str]:
@@ -512,6 +532,14 @@ def start_scheduler() -> None:
         trigger="interval",
         minutes=1,
         id="weekly_recaps",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _job_reading_list_fetch,
+        trigger="interval",
+        minutes=int(os.getenv("READING_LIST_FETCH_INTERVAL_MINUTES", "5")),
+        id="reading_list_fetch",
         replace_existing=True,
     )
 

--- a/backend/tests/test_reading_list.py
+++ b/backend/tests/test_reading_list.py
@@ -1,0 +1,370 @@
+"""Tests for the Reading List feature: save ad-hoc links, background
+metadata fetch, prioritization, and mark-as-done.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+from news_dashboard.reading_list import metadata, service
+
+# ── URL normalization ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "HTTPS://Example.com/Post/?utm_source=x&fbclid=y#frag",
+            "https://example.com/Post",
+        ),
+        (
+            "https://www.youtube.com/watch?v=abc123&utm_campaign=share",
+            "https://www.youtube.com/watch?v=abc123",
+        ),
+        ("https://example.com", "https://example.com/"),
+        ("  https://example.com/a  ", "https://example.com/a"),
+    ],
+)
+def test_normalize_url(raw: str, expected: str) -> None:
+    assert service.normalize_url(raw) == expected
+
+
+# ── Kind detection ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "video"),
+        ("https://youtu.be/dQw4w9WgXcQ", "video"),
+        ("https://www.youtube.com/shorts/abc", "video"),
+        ("https://www.youtube.com/@veritasium", "channel"),
+        ("https://www.youtube.com/channel/UCabc", "channel"),
+        ("https://example.com/blog/post", "article"),
+    ],
+)
+def test_detect_kind(url: str, expected: str) -> None:
+    assert metadata.detect_kind(url) == expected
+
+
+# ── HTML metadata parsing (no network) ───────────────────────────────────────
+
+
+def test_parse_html_metadata_extracts_opengraph() -> None:
+    html = """
+    <html><head>
+      <title>Fallback title</title>
+      <meta property="og:title" content="OG title" />
+      <meta property="og:description" content="OG description" />
+      <meta property="og:image" content="https://cdn.example.com/img.png" />
+      <meta property="og:site_name" content="Example Blog" />
+    </head><body></body></html>
+    """
+    parsed = metadata.parse_html_metadata(html)
+    assert parsed["title"] == "OG title"
+    assert parsed["description"] == "OG description"
+    assert parsed["image_url"] == "https://cdn.example.com/img.png"
+    assert parsed["site_name"] == "Example Blog"
+
+
+def test_parse_html_metadata_falls_back_to_title_and_meta_description() -> None:
+    html = """
+    <html><head>
+      <title>Plain page</title>
+      <meta name="description" content="Plain description">
+    </head><body></body></html>
+    """
+    parsed = metadata.parse_html_metadata(html)
+    assert parsed["title"] == "Plain page"
+    assert parsed["description"] == "Plain description"
+    assert parsed["image_url"] is None
+    assert parsed["site_name"] is None
+
+
+def test_fetch_url_metadata_parses_html_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = """
+    <html><head>
+      <meta property="og:title" content="A post" />
+      <meta property="og:site_name" content="Blog" />
+    </head></html>
+    """
+    monkeypatch.setattr(metadata, "_fetch_html", lambda _url: html)
+    result = metadata.fetch_url_metadata("https://example.com/a-post")
+    assert result["title"] == "A post"
+    assert result["site_name"] == "Blog"
+    assert result["kind"] == "article"
+
+
+def test_fetch_url_metadata_youtube_uses_oembed(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_fetch_json(url: str) -> dict[str, Any]:
+        captured["url"] = url
+        return {
+            "title": "Cool video",
+            "author_name": "Some Channel",
+            "thumbnail_url": "https://i.ytimg.com/vi/abc/hqdefault.jpg",
+        }
+
+    monkeypatch.setattr(metadata, "_fetch_json", fake_fetch_json)
+    result = metadata.fetch_url_metadata("https://www.youtube.com/watch?v=abc")
+    assert "youtube.com/oembed" in captured["url"]
+    assert result["title"] == "Cool video"
+    assert result["site_name"] == "YouTube"
+    assert result["image_url"] == "https://i.ytimg.com/vi/abc/hqdefault.jpg"
+    assert result["kind"] == "video"
+    assert result["description"] == "Some Channel"
+
+
+# ── API tests (Postgres) ─────────────────────────────────────────────────────
+
+
+def _setup_db(monkeypatch: pytest.MonkeyPatch, pg_url: str) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    init_db(database_url=pg_url)
+    return pg_url
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+def _no_network_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Background metadata fetches must never hit the network in tests."""
+    monkeypatch.setattr(
+        service,
+        "fetch_url_metadata",
+        lambda url: pytest.fail(f"unexpected network fetch for {url}"),
+    )
+
+
+def test_add_item_creates_pending_and_dedupes(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    monkeypatch.setattr(service, "fetch_metadata_for_item", lambda _item_id: None)
+
+    try:
+        with _client_for(user_id) as client:
+            first = client.post(
+                "/api/reading-list", json={"url": "https://example.com/post?utm_source=x"}
+            )
+            second = client.post("/api/reading-list", json={"url": "https://example.com/post"})
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert first.status_code == 201
+    item = first.json()
+    assert item["url"] == "https://example.com/post?utm_source=x"
+    assert item["fetch_status"] == "pending"
+    assert item["status"] == "unread"
+
+    assert second.status_code == 200
+    assert second.json()["id"] == item["id"]
+
+    with connect(database_url=database_url) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM reading_list_items WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()["count"]
+    assert count == 1
+
+
+def test_add_item_rejects_invalid_url(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post("/api/reading-list", json={"url": "ftp://example.com/file"})
+            garbage = client.post("/api/reading-list", json={"url": "not a url"})
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 400
+    assert garbage.status_code == 400
+
+
+def test_list_items_scoped_to_user_and_reorder(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    alice = _make_user(database_url, "alice")
+    bob = _make_user(database_url, "bob")
+    monkeypatch.setattr(service, "fetch_metadata_for_item", lambda _item_id: None)
+
+    try:
+        with _client_for(alice) as client:
+            first = client.post("/api/reading-list", json={"url": "https://example.com/1"}).json()
+            second = client.post("/api/reading-list", json={"url": "https://example.com/2"}).json()
+        with _client_for(bob) as client:
+            client.post("/api/reading-list", json={"url": "https://example.com/bob"})
+
+        with _client_for(alice) as client:
+            listed = client.get("/api/reading-list").json()["items"]
+            assert [entry["id"] for entry in listed] == [first["id"], second["id"]]
+
+            reorder = client.post(
+                "/api/reading-list/reorder",
+                json={"ordered_ids": [second["id"], first["id"]]},
+            )
+            assert reorder.status_code == 200
+            reordered = client.get("/api/reading-list").json()["items"]
+            assert [entry["id"] for entry in reordered] == [second["id"], first["id"]]
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def test_mark_done_sets_done_at_and_status_filter(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    monkeypatch.setattr(service, "fetch_metadata_for_item", lambda _item_id: None)
+
+    try:
+        with _client_for(user_id) as client:
+            item = client.post("/api/reading-list", json={"url": "https://example.com/1"}).json()
+            done = client.patch(f"/api/reading-list/{item['id']}", json={"status": "done"})
+            assert done.status_code == 200
+            assert done.json()["status"] == "done"
+            assert done.json()["done_at"] is not None
+
+            unread = client.get("/api/reading-list?status=unread").json()["items"]
+            assert unread == []
+            finished = client.get("/api/reading-list?status=done").json()["items"]
+            assert [entry["id"] for entry in finished] == [item["id"]]
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def test_delete_item_enforces_ownership(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    alice = _make_user(database_url, "alice")
+    bob = _make_user(database_url, "bob")
+    monkeypatch.setattr(service, "fetch_metadata_for_item", lambda _item_id: None)
+
+    try:
+        with _client_for(alice) as client:
+            item = client.post("/api/reading-list", json={"url": "https://example.com/1"}).json()
+        with _client_for(bob) as client:
+            forbidden = client.delete(f"/api/reading-list/{item['id']}")
+            assert forbidden.status_code == 404
+        with _client_for(alice) as client:
+            deleted = client.delete(f"/api/reading-list/{item['id']}")
+            assert deleted.status_code == 200
+            assert client.get("/api/reading-list").json()["items"] == []
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+# ── Background metadata fetch (Postgres) ─────────────────────────────────────
+
+
+def test_fetch_metadata_for_item_updates_row(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    item = service.add_item(user_id, "https://example.com/post", database_url=database_url)
+
+    monkeypatch.setattr(
+        service,
+        "fetch_url_metadata",
+        lambda _url: {
+            "title": "Fetched title",
+            "description": "Fetched description",
+            "image_url": "https://cdn.example.com/img.png",
+            "site_name": "Example",
+            "kind": "article",
+        },
+    )
+    service.fetch_metadata_for_item(item["id"], database_url=database_url)
+
+    items = service.list_items(user_id, database_url=database_url)
+    assert items[0]["fetch_status"] == "ok"
+    assert items[0]["title"] == "Fetched title"
+    assert items[0]["image_url"] == "https://cdn.example.com/img.png"
+    assert items[0]["fetched_at"] is not None
+
+
+def test_fetch_metadata_for_item_records_error(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    item = service.add_item(user_id, "https://example.com/broken", database_url=database_url)
+
+    def boom(url: str) -> dict[str, Any]:
+        message = "connection refused"
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(service, "fetch_url_metadata", boom)
+    service.fetch_metadata_for_item(item["id"], database_url=database_url)
+
+    items = service.list_items(user_id, database_url=database_url)
+    assert items[0]["fetch_status"] == "error"
+    assert "connection refused" in items[0]["fetch_error"]
+
+
+def test_process_pending_items_sweeps_pending(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    service.add_item(user_id, "https://example.com/1", database_url=database_url)
+    service.add_item(user_id, "https://example.com/2", database_url=database_url)
+
+    monkeypatch.setattr(
+        service,
+        "fetch_url_metadata",
+        lambda url: {
+            "title": f"Title for {url}",
+            "description": None,
+            "image_url": None,
+            "site_name": None,
+            "kind": "article",
+        },
+    )
+    processed = service.process_pending_items(database_url=database_url)
+    assert processed == 2
+    items = service.list_items(user_id, database_url=database_url)
+    assert {entry["fetch_status"] for entry in items} == {"ok"}
+    assert service.process_pending_items(database_url=database_url) == 0
+
+
+# ── Route registration ───────────────────────────────────────────────────────
+
+
+def test_reading_list_routes_registered() -> None:
+    paths = app.openapi()["paths"]
+    assert "post" in paths["/api/reading-list"]
+    assert "get" in paths["/api/reading-list"]
+    assert "post" in paths["/api/reading-list/reorder"]
+    assert "patch" in paths["/api/reading-list/{item_id}"]
+    assert "delete" in paths["/api/reading-list/{item_id}"]

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1129,3 +1129,27 @@ def test_run_entity_extraction_reports_failure() -> None:
 
     assert status == "failure"
     assert "boom" in (message or "")
+
+
+def test_start_scheduler_registers_reading_list_fetch_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_sched = _start_with_env(monkeypatch)
+    jobs = {c.kwargs.get("id"): c.kwargs for c in mock_sched.add_job.call_args_list}
+    assert "reading_list_fetch" in jobs
+    assert jobs["reading_list_fetch"]["trigger"] == "interval"
+
+
+def test_run_reading_list_fetch_reports_count() -> None:
+    from news_dashboard.scheduler import _run_reading_list_fetch
+
+    with patch(
+        "news_dashboard.reading_list.service.process_pending_items", return_value=2
+    ) as mock_process:
+        result = _run_reading_list_fetch()
+
+    mock_process.assert_called_once()
+    assert result is not None
+    status, message = result
+    assert status == "success"
+    assert "2" in (message or "")

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -39,6 +39,9 @@ const StatsPage = lazy(() => import('./pages/StatsPage').then((m) => ({ default:
 const ReadingDnaPage = lazy(() =>
   import('./pages/ReadingDnaPage').then((m) => ({ default: m.ReadingDnaPage }))
 );
+const ReadingListPage = lazy(() =>
+  import('./pages/ReadingListPage').then((m) => ({ default: m.ReadingListPage }))
+);
 const WeeklyRecapPage = lazy(() =>
   import('./pages/WeeklyRecapPage').then((m) => ({ default: m.WeeklyRecapPage }))
 );
@@ -174,6 +177,7 @@ export const routes: RouteObject[] = [
         ),
       },
       { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
+      { path: 'reading-list', element: withSuspense(ReadingListPage) },
       { path: 'recap', element: withSuspense(WeeklyRecapPage) },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'collections', element: <CollectionsPage /> },

--- a/frontend/src/__tests__/readingList.test.tsx
+++ b/frontend/src/__tests__/readingList.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReadingListPage } from '../pages/ReadingListPage';
+import * as readingListApi from '../api/readingListApi';
+import type { ReadingListItem } from '../api/readingListApi';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+function makeItem(overrides: Partial<ReadingListItem> = {}): ReadingListItem {
+  return {
+    id: 1,
+    user_id: 1,
+    url: 'https://example.com/post',
+    normalized_url: 'https://example.com/post',
+    title: 'Great post',
+    description: 'A very insightful post.',
+    image_url: null,
+    site_name: 'Example Blog',
+    kind: 'article',
+    fetch_status: 'ok',
+    fetch_error: null,
+    fetched_at: '2026-07-03T10:00:00Z',
+    status: 'unread',
+    priority: 1,
+    note: null,
+    created_at: '2026-07-03T09:00:00Z',
+    done_at: null,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ReadingListPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ReadingListPage', () => {
+  it('renders fetched items with their metadata', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([makeItem()]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Great post')).toBeTruthy();
+    });
+    expect(screen.getByText('Example Blog')).toBeTruthy();
+    expect(screen.getByText('A very insightful post.')).toBeTruthy();
+  });
+
+  it('shows a pending placeholder while metadata is being fetched', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([
+      makeItem({ title: null, description: null, site_name: null, fetch_status: 'pending' }),
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('https://example.com/post')).toBeTruthy();
+    });
+    expect(screen.getByText(/fetching preview/i)).toBeTruthy();
+  });
+
+  it('adds a pasted link', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([]);
+    const addSpy = vi
+      .spyOn(readingListApi, 'addReadingListItem')
+      .mockResolvedValue(makeItem({ fetch_status: 'pending' }));
+
+    renderPage();
+    const input = await screen.findByPlaceholderText(/paste a link/i);
+    await userEvent.type(input, 'https://example.com/post');
+    await userEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(addSpy).toHaveBeenCalledWith('https://example.com/post');
+    });
+  });
+
+  it('marks an item as done', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([makeItem()]);
+    const updateSpy = vi
+      .spyOn(readingListApi, 'updateReadingListItem')
+      .mockResolvedValue(makeItem({ status: 'done' }));
+
+    renderPage();
+    await screen.findByText('Great post');
+    await userEvent.click(screen.getByRole('button', { name: 'Mark as done' }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(1, { status: 'done' });
+    });
+  });
+
+  it('reorders items with the move-down control', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([
+      makeItem({ id: 1, title: 'First' }),
+      makeItem({ id: 2, title: 'Second', priority: 2 }),
+    ]);
+    const reorderSpy = vi.spyOn(readingListApi, 'reorderReadingList').mockResolvedValue([]);
+
+    renderPage();
+    await screen.findByText('First');
+    const [moveFirstDown] = screen.getAllByRole('button', { name: 'Move down' });
+    await userEvent.click(moveFirstDown);
+
+    await waitFor(() => {
+      expect(reorderSpy).toHaveBeenCalledWith([2, 1]);
+    });
+  });
+
+  it('deletes an item', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([makeItem()]);
+    const deleteSpy = vi.spyOn(readingListApi, 'deleteReadingListItem').mockResolvedValue();
+
+    renderPage();
+    await screen.findByText('Great post');
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(deleteSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/frontend/src/api/readingListApi.ts
+++ b/frontend/src/api/readingListApi.ts
@@ -1,0 +1,66 @@
+/** API layer for the reading list (#893). */
+
+import { requestJson } from '../api';
+
+export type ReadingListStatus = 'unread' | 'done' | 'archived';
+export type ReadingListKind = 'article' | 'video' | 'channel' | 'link';
+export type ReadingListFetchStatus = 'pending' | 'ok' | 'error';
+
+export interface ReadingListItem {
+  id: number;
+  user_id: number;
+  url: string;
+  normalized_url: string;
+  title: string | null;
+  description: string | null;
+  image_url: string | null;
+  site_name: string | null;
+  kind: ReadingListKind;
+  fetch_status: ReadingListFetchStatus;
+  fetch_error: string | null;
+  fetched_at: string | null;
+  status: ReadingListStatus;
+  priority: number;
+  note: string | null;
+  created_at: string;
+  done_at: string | null;
+}
+
+interface ReadingListResponse {
+  items: ReadingListItem[];
+}
+
+export async function fetchReadingList(status?: ReadingListStatus): Promise<ReadingListItem[]> {
+  const suffix = status ? `?status=${status}` : '';
+  const data = await requestJson<ReadingListResponse>(`/api/reading-list${suffix}`);
+  return data.items;
+}
+
+export async function addReadingListItem(url: string, note?: string): Promise<ReadingListItem> {
+  return requestJson<ReadingListItem>('/api/reading-list', {
+    method: 'POST',
+    body: JSON.stringify(note === undefined ? { url } : { url, note }),
+  });
+}
+
+export async function updateReadingListItem(
+  id: number,
+  changes: { status?: ReadingListStatus; note?: string }
+): Promise<ReadingListItem> {
+  return requestJson<ReadingListItem>(`/api/reading-list/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(changes),
+  });
+}
+
+export async function reorderReadingList(orderedIds: number[]): Promise<ReadingListItem[]> {
+  const data = await requestJson<ReadingListResponse>('/api/reading-list/reorder', {
+    method: 'POST',
+    body: JSON.stringify({ ordered_ids: orderedIds }),
+  });
+  return data.items;
+}
+
+export async function deleteReadingListItem(id: number): Promise<void> {
+  await requestJson(`/api/reading-list/${id}`, { method: 'DELETE' });
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -2,6 +2,7 @@ import {
   Activity,
   Archive,
   BarChart3,
+  Bookmark,
   BrainCircuit,
   Clock,
   Flame,
@@ -41,6 +42,7 @@ export const primaryNavigationItems: NavigationItem[] = [
 ];
 
 export const secondaryNavigationItems: NavigationItem[] = [
+  { to: '/reading-list', label: 'Reading List', icon: Bookmark, shortcut: 'r' },
   { to: '/briefs', label: 'Briefing History', icon: History, shortcut: 'h' },
   { to: '/topic-map', label: 'Topic Map', icon: Network },
   { to: '/ai-stats', label: 'AI Stats', icon: BrainCircuit },
@@ -142,6 +144,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/feeds')) return 'Feeds';
   if (pathname.startsWith('/stats')) return 'Stats';
   if (pathname.startsWith('/reading-dna')) return 'Reading DNA';
+  if (pathname.startsWith('/reading-list')) return 'Reading List';
   if (pathname.startsWith('/recap')) return 'Weekly Recap';
   if (pathname.startsWith('/archive')) return 'Archive';
   if (pathname.startsWith('/collections')) return 'Collections';

--- a/frontend/src/pages/ReadingListPage.tsx
+++ b/frontend/src/pages/ReadingListPage.tsx
@@ -1,0 +1,289 @@
+import { useState } from 'react';
+import {
+  ArrowDown,
+  ArrowUp,
+  BookmarkPlus,
+  Check,
+  ExternalLink,
+  Loader2,
+  MonitorPlay,
+  Newspaper,
+  RotateCcw,
+  Trash2,
+  TriangleAlert,
+  Users,
+} from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  addReadingListItem,
+  deleteReadingListItem,
+  fetchReadingList,
+  reorderReadingList,
+  updateReadingListItem,
+  type ReadingListItem,
+  type ReadingListKind,
+  type ReadingListStatus,
+} from '@/api/readingListApi';
+import { EmptyState } from '@/components/EmptyState';
+
+const KIND_META: Record<ReadingListKind, { label: string; Icon: typeof Newspaper }> = {
+  article: { label: 'Article', Icon: Newspaper },
+  video: { label: 'Video', Icon: MonitorPlay },
+  channel: { label: 'Channel', Icon: Users },
+  link: { label: 'Link', Icon: ExternalLink },
+};
+
+function ItemCard({
+  item,
+  isFirst,
+  isLast,
+  onMove,
+  onToggleDone,
+  onDelete,
+}: {
+  item: ReadingListItem;
+  isFirst: boolean;
+  isLast: boolean;
+  onMove: (id: number, direction: -1 | 1) => void;
+  onToggleDone: (item: ReadingListItem) => void;
+  onDelete: (id: number) => void;
+}) {
+  const pending = item.fetch_status === 'pending';
+  const { label: kindLabel, Icon: KindIcon } = KIND_META[item.kind];
+
+  return (
+    <div className="flex items-start gap-3 px-4 md:px-5 py-3 hover:bg-surface">
+      {item.image_url ? (
+        <img
+          src={item.image_url}
+          alt=""
+          className="h-16 w-24 shrink-0 rounded-md object-cover border border-border"
+          loading="lazy"
+        />
+      ) : (
+        <div className="flex h-16 w-24 shrink-0 items-center justify-center rounded-md border border-border bg-surface">
+          <KindIcon className="size-5 text-muted-foreground" strokeWidth={1.5} />
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1 rounded-sm border border-border px-1.5 py-0.5">
+            <KindIcon className="size-3" strokeWidth={1.75} />
+            {kindLabel}
+          </span>
+          {item.site_name ? <span className="truncate">{item.site_name}</span> : null}
+          {pending ? (
+            <span className="inline-flex items-center gap-1">
+              <Loader2 className="size-3 animate-spin" />
+              Fetching preview…
+            </span>
+          ) : null}
+          {item.fetch_status === 'error' ? (
+            <span
+              className="inline-flex items-center gap-1 text-muted-foreground"
+              title={item.fetch_error ?? undefined}
+            >
+              <TriangleAlert className="size-3" />
+              Preview unavailable
+            </span>
+          ) : null}
+        </div>
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noreferrer"
+          className={`mt-0.5 block truncate text-sm font-medium hover:underline ${
+            item.status === 'done' ? 'text-muted-foreground line-through' : ''
+          }`}
+        >
+          {item.title ?? item.url}
+        </a>
+        {item.description ? (
+          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{item.description}</p>
+        ) : null}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1 text-muted-foreground">
+        <button
+          type="button"
+          aria-label="Move up"
+          disabled={isFirst}
+          onClick={() => onMove(item.id, -1)}
+          className="rounded-sm p-1 hover:text-foreground disabled:opacity-30"
+        >
+          <ArrowUp className="size-4" strokeWidth={1.75} />
+        </button>
+        <button
+          type="button"
+          aria-label="Move down"
+          disabled={isLast}
+          onClick={() => onMove(item.id, 1)}
+          className="rounded-sm p-1 hover:text-foreground disabled:opacity-30"
+        >
+          <ArrowDown className="size-4" strokeWidth={1.75} />
+        </button>
+        <button
+          type="button"
+          aria-label={item.status === 'done' ? 'Mark as unread' : 'Mark as done'}
+          onClick={() => onToggleDone(item)}
+          className="rounded-sm p-1 hover:text-foreground"
+        >
+          {item.status === 'done' ? (
+            <RotateCcw className="size-4" strokeWidth={1.75} />
+          ) : (
+            <Check className="size-4" strokeWidth={1.75} />
+          )}
+        </button>
+        <button
+          type="button"
+          aria-label="Delete"
+          onClick={() => onDelete(item.id)}
+          className="rounded-sm p-1 hover:text-destructive"
+        >
+          <Trash2 className="size-4" strokeWidth={1.75} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ReadingListPage() {
+  const queryClient = useQueryClient();
+  const [newUrl, setNewUrl] = useState('');
+  const [filter, setFilter] = useState<ReadingListStatus>('unread');
+
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: ['reading-list', filter],
+    queryFn: () => fetchReadingList(filter),
+    refetchInterval: (query) =>
+      query.state.data?.some((item) => item.fetch_status === 'pending') ? 2000 : false,
+  });
+
+  const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['reading-list'] });
+
+  const addMutation = useMutation({
+    mutationFn: (url: string) => addReadingListItem(url),
+    onSuccess: () => {
+      invalidate();
+      setNewUrl('');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, status }: { id: number; status: ReadingListStatus }) =>
+      updateReadingListItem(id, { status }),
+    onSuccess: invalidate,
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: (orderedIds: number[]) => reorderReadingList(orderedIds),
+    onSuccess: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteReadingListItem(id),
+    onSuccess: invalidate,
+  });
+
+  function handleAdd() {
+    const url = newUrl.trim();
+    if (!url) return;
+    addMutation.mutate(url);
+  }
+
+  function handleMove(id: number, direction: -1 | 1) {
+    const ids = items.map((item) => item.id);
+    const index = ids.indexOf(id);
+    const target = index + direction;
+    if (index < 0 || target < 0 || target >= ids.length) return;
+    [ids[index], ids[target]] = [ids[target], ids[index]];
+    reorderMutation.mutate(ids);
+  }
+
+  function handleToggleDone(item: ReadingListItem) {
+    updateMutation.mutate({
+      id: item.id,
+      status: item.status === 'done' ? 'unread' : 'done',
+    });
+  }
+
+  return (
+    <div>
+      <div className="px-4 md:px-5 pt-4 pb-3">
+        <h2 className="text-[22px] font-semibold tracking-tight">Reading List</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Save links from anywhere — videos, posts, channels — and work through them later.
+        </p>
+      </div>
+
+      <div className="px-4 md:px-5 pb-3 flex items-center gap-2">
+        <input
+          value={newUrl}
+          onChange={(e) => setNewUrl(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleAdd();
+          }}
+          placeholder="Paste a link to read later…"
+          className="h-9 flex-1 max-w-xl rounded-md border border-border bg-surface px-3 text-sm outline-none focus:border-border-strong"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={!newUrl.trim() || addMutation.isPending}
+          className="h-9 px-3 rounded-md bg-foreground text-background text-sm font-medium disabled:opacity-50"
+        >
+          Add
+        </button>
+      </div>
+      {addMutation.isError ? (
+        <p className="px-4 md:px-5 pb-2 text-xs text-destructive">
+          Could not save that link — check that it is a valid http(s) URL.
+        </p>
+      ) : null}
+
+      <div className="px-4 md:px-5 pb-3 flex items-center gap-1">
+        {(['unread', 'done'] as const).map((status) => (
+          <button
+            key={status}
+            type="button"
+            onClick={() => setFilter(status)}
+            className={`h-8 rounded-md px-3 text-sm capitalize ${
+              filter === status
+                ? 'bg-foreground text-background font-medium'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {status}
+          </button>
+        ))}
+      </div>
+
+      {isLoading ? null : items.length === 0 ? (
+        <EmptyState
+          icon={BookmarkPlus}
+          title={filter === 'done' ? 'Nothing finished yet' : 'Your reading list is empty'}
+          subtitle={
+            filter === 'done'
+              ? 'Items you mark as done will show up here.'
+              : 'Paste a link above to save it for later.'
+          }
+        />
+      ) : (
+        <div className="divide-y divide-border border-t border-border">
+          {items.map((item, index) => (
+            <ItemCard
+              key={item.id}
+              item={item}
+              isFirst={index === 0}
+              isLast={index === items.length - 1}
+              onMove={handleMove}
+              onToggleDone={handleToggleDone}
+              onDelete={(id) => deleteMutation.mutate(id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #893

## Summary

Adds a per-user **Reading List**: paste any http(s) link (YouTube video, blog post, channel), and a background task fetches preview metadata while the UI shows the item immediately as pending. Items render as rich cards with thumbnail, site, kind badge, and description, and support priority reordering, mark-as-done, and delete.

**Backend** — new `reading_list` feature module (router/service/models/metadata per ADR 0003):
- `reading_list_items` table (per-user, `UNIQUE(user_id, normalized_url)` dedupe with tracking-param stripping)
- `POST/GET /api/reading-list`, `PATCH/DELETE /api/reading-list/{id}`, `POST /api/reading-list/reorder`, all auth-scoped
- Metadata via OpenGraph/Twitter-card parsing (stdlib HTML parser through `url_safety.open_server_fetch_url`); YouTube videos via keyless oEmbed; kind detection (article/video/channel)
- Fetch runs via FastAPI BackgroundTasks on add, plus an APScheduler sweep (`reading_list_fetch`, `READING_LIST_FETCH_INTERVAL_MINUTES`, default 5 min) retrying pending items; failures recorded as `fetch_status=error`

**Frontend** — `/reading-list` page (lazy route + nav entry, shortcut `r`): paste-to-add input, unread/done filter, preview cards with pending/error states, up/down reorder, done/undo, delete. React Query polls every 2s only while a fetch is pending.

## Tests

- `backend/tests/test_reading_list.py` (23 tests): URL normalization, kind detection, OG/oEmbed parsing (no network), API CRUD + dedupe + user scoping + reorder + done filter on Postgres, background fetch success/error, sweep
- `backend/tests/test_scheduler.py`: sweep job registration + run reporting
- `frontend/src/__tests__/readingList.test.tsx` (6 tests): render metadata, pending placeholder, add, done, reorder, delete
- Gates green locally: ruff, mypy/ty/pyrefly, full backend suite (1536 passed), eslint/prettier/tsc, vitest (733), vite build

🤖 Generated with [Claude Code](https://claude.com/claude-code)