### PR TITLE
feat: PWA share-target and offline article reading (#653)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -74,7 +74,7 @@ from news_dashboard.briefings import (
     get_latest_briefing,
     list_briefings,
 )
-from news_dashboard.db import connect, describe_database, init_db, row_to_dict
+from news_dashboard.db import connect, describe_database, init_db, insert_article_sql, row_to_dict
 from news_dashboard.error_tracking import frontend_error_tracking_dsn, init_error_tracking
 from news_dashboard.ingest import (
     get_user_summary,
@@ -378,6 +378,11 @@ class CreateSourceRequest(BaseModel):
                 detail="slug must contain only lowercase letters, digits, and hyphens",
             )
         return slug
+
+
+class SaveSharedUrlRequest(BaseModel):
+    url: str
+    title: str | None = None
 
 
 class SourceCleanupRequest(BaseModel):
@@ -1579,6 +1584,84 @@ def create_source(
         )
         row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
     return row_to_dict(row)
+
+
+def _get_or_create_shared_links_source(conn: Any, user_id: int) -> str:
+    """Return the slug of the per-user 'Shared Links' source, creating it if needed."""
+    slug = f"shared-links-{user_id}"
+    conn.execute(
+        """
+        INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+        VALUES (%s, %s, %s, %s, %s, 0, TRUE, %s)
+        ON CONFLICT (slug) DO NOTHING
+        """,
+        (slug, "Shared Links", "about:blank", "shared", "manual", user_id),
+    )
+    return slug
+
+
+@api.post("/api/articles/from-url")
+def save_shared_url(
+    payload: SaveSharedUrlRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Save a URL (e.g. from the PWA share target) as a personal article in Later."""
+    url = payload.url.strip()
+    if not url:
+        raise HTTPException(status_code=400, detail="url must not be empty")
+    try:
+        validate_server_fetch_url(url)
+    except UnsafeUrlError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    uid = current_user["id"]
+    title = (payload.title or "").strip() or url
+
+    init_db()
+    with connect() as conn:
+        slug = _get_or_create_shared_links_source(conn, uid)
+        existing = conn.execute("SELECT id FROM articles WHERE url = %s", (url,)).fetchone()
+        if existing:
+            article_id = int(row_to_dict(existing)["id"])
+        else:
+            conn.execute(
+                insert_article_sql(),
+                (
+                    url,
+                    url,
+                    title,
+                    slug,
+                    "Shared Links",
+                    "shared",
+                    "manual",
+                    None,
+                    "",
+                    "saved via share target",
+                    50,
+                    "",
+                    None,
+                    None,
+                    "en",
+                ),
+            )
+            row = conn.execute("SELECT id FROM articles WHERE url = %s", (url,)).fetchone()
+            article_id = int(row_to_dict(row)["id"])
+
+    try:
+        article = transition_article_state(article_id, "later", user_id=uid)
+    except ValueError:
+        article = get_article(article_id, user_id=uid)
+    if not article:
+        raise HTTPException(status_code=404, detail="article not found")
+
+    try:
+        fetched = fetch_and_cache_body(article_id, user_id=uid)
+        if fetched:
+            article = fetched
+    except Exception:
+        logger.exception("failed to prefetch body for shared url %s", url)
+
+    return article
 
 
 @api.delete("/api/sources/{slug}")

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -114,7 +114,7 @@ export const SAMPLE_BRIEFING = {
   status: 'complete',
   title: 'AI Safety Takes Center Stage',
   summary:
-    'New safety frameworks and model releases dominated today\'s AI news, signaling a maturing field.',
+    "New safety frameworks and model releases dominated today's AI news, signaling a maturing field.",
   content: {
     sections: [
       {
@@ -232,6 +232,9 @@ export async function mockApi(page: Page) {
   await page.route('/api/articles/*/later', (r) =>
     r.fulfill(json({ ...SAMPLE_ARTICLE, state: 'later' }))
   );
+  await page.route('/api/articles/from-url', (r) =>
+    r.fulfill(json({ ...SAMPLE_ARTICLE, id: 1, state: 'later' }))
+  );
 
   // Search
   await page.route('/api/search**', (r) =>
@@ -302,7 +305,13 @@ export async function mockApi(page: Page) {
     r.fulfill(
       json({
         answer: 'Based on the articles, AI safety research is progressing rapidly [1].',
-        sources: [{ id: 1, title: 'AI Safety Researchers Publish New Framework', url: 'https://example.com/article-1' }],
+        sources: [
+          {
+            id: 1,
+            title: 'AI Safety Researchers Publish New Framework',
+            url: 'https://example.com/article-1',
+          },
+        ],
       })
     )
   );

--- a/e2e/pwa-share-offline.spec.ts
+++ b/e2e/pwa-share-offline.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * E2E tests for the PWA share-target flow and offline article reading.
+ *
+ * The dev server (used by playwright.config.ts) runs VitePWA with
+ * `devOptions.enabled: false`, so no real service worker/workbox cache is
+ * active here — that only exists in a production build. These tests instead
+ * verify the app-level behavior: the share-target route saves a shared link
+ * and redirects to it, and the app keeps rendering already-fetched data
+ * (via mocked routes, which Playwright still fulfills even once the browser
+ * context is offline) while surfacing an offline indicator.
+ */
+import { test, expect } from '@playwright/test';
+import { mockApi, SAMPLE_ARTICLE } from './fixtures';
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test.describe('Share target', () => {
+  test('saves a shared URL and redirects to the article', async ({ page }) => {
+    let requestBody: unknown;
+    await page.route('/api/articles/from-url', async (route) => {
+      requestBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...SAMPLE_ARTICLE, id: 1, state: 'later' }),
+      });
+    });
+
+    await page.goto(
+      '/share-target?url=' +
+        encodeURIComponent('https://example.com/shared-article') +
+        '&title=' +
+        encodeURIComponent('Shared Article')
+    );
+
+    await expect(page).toHaveURL('/a/1');
+    expect(requestBody).toMatchObject({
+      url: 'https://example.com/shared-article',
+      title: 'Shared Article',
+    });
+  });
+
+  test('shows an error when no link is present in the shared content', async ({ page }) => {
+    await page.goto('/share-target?title=' + encodeURIComponent('just a title, no link'));
+    await expect(page.getByText("Couldn't save link")).toBeVisible();
+  });
+});
+
+test.describe('Offline reading', () => {
+  test('shows the offline indicator when the network drops', async ({ page, context }) => {
+    await page.goto('/a/1');
+    await expect(page.getByText(SAMPLE_ARTICLE.title)).toBeVisible();
+
+    await context.setOffline(true);
+    await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+
+    await expect(page.getByText(/you're offline/i)).toBeVisible();
+
+    await context.setOffline(false);
+  });
+
+  test('a previously loaded article still renders after a client-side revisit while offline', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/today');
+    await page.getByText(SAMPLE_ARTICLE.title).click();
+    await expect(page).toHaveURL('/a/1');
+    await expect(page.getByText('Full article body text here.')).toBeVisible();
+
+    await page.goBack();
+    await expect(page).toHaveURL('/today');
+
+    // A full page navigation would fail offline (no service worker in dev
+    // mode), but revisiting the article is a client-side route change —
+    // only the mocked /api/* calls run, and Playwright still fulfills those
+    // while the browser context is offline.
+    await context.setOffline(true);
+    await page.getByText(SAMPLE_ARTICLE.title).click();
+    await expect(page).toHaveURL('/a/1');
+    await expect(page.getByText(SAMPLE_ARTICLE.title)).toBeVisible();
+
+    await context.setOffline(false);
+  });
+});

--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -118,6 +118,21 @@ const KNOWN_ROUTES = [
   '/archive',
 ];
 
+test.describe('PWA — share target', () => {
+  test('manifest declares a share_target pointing at /share-target', async ({ page }) => {
+    const response = await page.request.get('/manifest.webmanifest');
+    const manifest = await response.json();
+    expect(manifest.share_target).toBeTruthy();
+    expect(manifest.share_target.action).toBe('/share-target');
+    expect(manifest.share_target.method).toBe('GET');
+    expect(manifest.share_target.params).toMatchObject({
+      title: 'title',
+      text: 'text',
+      url: 'url',
+    });
+  });
+});
+
 test.describe('PWA — shortcuts', () => {
   test('manifest exposes a shortcuts array', async ({ page }) => {
     const response = await page.request.get('/manifest.webmanifest');

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -56,6 +56,9 @@ const BriefingDetailPage = lazy(() =>
 const TopicMapPage = lazy(() =>
   import('./pages/TopicMapPage').then((m) => ({ default: m.TopicMapPage }))
 );
+const ShareTargetPage = lazy(() =>
+  import('./pages/ShareTargetPage').then((m) => ({ default: m.ShareTargetPage }))
+);
 
 function PageLoader() {
   return (
@@ -124,6 +127,10 @@ export const routes: RouteObject[] = [
   {
     path: '/shared/:shareId/article',
     element: <RequireAuth>{withSuspense(ArticlePage)}</RequireAuth>,
+  },
+  {
+    path: '/share-target',
+    element: <RequireAuth>{withSuspense(ShareTargetPage)}</RequireAuth>,
   },
   {
     path: '/',

--- a/frontend/src/__tests__/shareTargetPage.test.tsx
+++ b/frontend/src/__tests__/shareTargetPage.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import * as api from '../api';
+import { ShareTargetPage } from '../pages/ShareTargetPage';
+import { extractSharedUrl } from '../lib/shareTarget';
+import type { Article } from '../types';
+
+vi.mock('../api', () => ({
+  saveSharedUrl: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: vi.fn(),
+}));
+
+const SAVED_ARTICLE = { id: 42 } as Article;
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/share-target" element={<ShareTargetPage />} />
+        <Route path="/a/:id" element={<div>article view</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('extractSharedUrl', () => {
+  it('extracts a URL from the url param', () => {
+    expect(extractSharedUrl('https://example.com/article', null)).toBe(
+      'https://example.com/article'
+    );
+  });
+
+  it('extracts a URL embedded in the text param when url is absent', () => {
+    expect(extractSharedUrl(null, 'Check this out: https://example.com/thing')).toBe(
+      'https://example.com/thing'
+    );
+  });
+
+  it('returns null when neither param contains a URL', () => {
+    expect(extractSharedUrl(null, 'just some text')).toBeNull();
+  });
+});
+
+describe('ShareTargetPage', () => {
+  beforeEach(() => {
+    vi.mocked(api.saveSharedUrl).mockReset();
+  });
+
+  it('saves the shared URL and navigates to the article', async () => {
+    vi.mocked(api.saveSharedUrl).mockResolvedValue(SAVED_ARTICLE);
+
+    renderAt('/share-target?url=https%3A%2F%2Fexample.com%2Fpost&title=Hello');
+
+    await waitFor(() => {
+      expect(api.saveSharedUrl).toHaveBeenCalledWith('https://example.com/post', 'Hello');
+    });
+    await screen.findByText('article view');
+  });
+
+  it('shows an error state when no URL can be found', async () => {
+    renderAt('/share-target?title=nothing%20useful');
+
+    await screen.findByText("Couldn't save link");
+    expect(api.saveSharedUrl).not.toHaveBeenCalled();
+  });
+
+  it('shows an error state when saving fails', async () => {
+    vi.mocked(api.saveSharedUrl).mockRejectedValue(new Error('boom'));
+
+    renderAt('/share-target?url=https%3A%2F%2Fexample.com%2Fpost');
+
+    await screen.findByText('Could not save this link. Please try again.');
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -118,6 +118,13 @@ export async function fetchArticleBody(id: number | string): Promise<Article> {
   return requestJson<Article>(`/api/articles/${id}/body`, { method: 'POST' });
 }
 
+export async function saveSharedUrl(url: string, title?: string): Promise<Article> {
+  return requestJson<Article>('/api/articles/from-url', {
+    method: 'POST',
+    body: JSON.stringify({ url, title }),
+  });
+}
+
 export async function fetchArticleHighlights(id: number | string): Promise<ArticleHighlight[]> {
   const data = await requestJson<{ items: ArticleHighlight[] }>(`/api/articles/${id}/highlights`);
   return data.items;

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { LogOut, MoreHorizontal, Search } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { AppLogo } from './AppLogo';
+import { OfflineIndicator } from './OfflineIndicator';
 import { CommandPalette } from './CommandPalette';
 import { ShortcutOverlay } from './ShortcutOverlay';
 import { WhatsNewDialog } from './WhatsNewDialog';
@@ -209,6 +210,7 @@ export function AppShell() {
 
   return (
     <div className="app-shell min-h-screen flex flex-col bg-background text-foreground">
+      <OfflineIndicator />
       {/* Header */}
       <header className="sticky top-0 z-30 border-b border-border bg-background/85 backdrop-blur">
         <div className="mx-auto max-w-6xl flex h-12 items-center justify-between px-4">

--- a/frontend/src/components/OfflineIndicator.tsx
+++ b/frontend/src/components/OfflineIndicator.tsx
@@ -1,0 +1,14 @@
+import { WifiOff } from 'lucide-react';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+
+export function OfflineIndicator() {
+  const isOnline = useOnlineStatus();
+  if (isOnline) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-2 bg-amber-500/90 px-4 py-1.5 text-xs font-medium text-white">
+      <WifiOff className="size-3.5" />
+      You're offline — showing previously loaded content
+    </div>
+  );
+}

--- a/frontend/src/hooks/useOnlineStatus.ts
+++ b/frontend/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/frontend/src/lib/shareTarget.ts
+++ b/frontend/src/lib/shareTarget.ts
@@ -1,0 +1,15 @@
+/** Extract the first http(s) URL from OS share-sheet `url`/`text` fields. */
+export function extractSharedUrl(url: string | null, text: string | null): string | null {
+  const candidates = [url, text].filter((v): v is string => Boolean(v?.trim()));
+  for (const candidate of candidates) {
+    const match = /https?:\/\/\S+/.exec(candidate);
+    if (match) return match[0];
+    try {
+      const parsed = new URL(candidate.trim());
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return parsed.toString();
+    } catch {
+      // not a bare URL, keep looking
+    }
+  }
+  return null;
+}

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -44,6 +44,7 @@ import { trackArticleOpen, trackArticleClose } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 import { ShareDialog } from '@/components/ShareDialog';
 import { ArticleTags } from '@/components/article/ArticleTags';
+import { OfflineIndicator } from '@/components/OfflineIndicator';
 
 const LANGUAGE_NAMES: Record<string, string> = {
   en: 'English',
@@ -455,6 +456,7 @@ export function ArticlePage() {
   if (isLoading || !article) {
     return (
       <div className="min-h-screen bg-background flex flex-col">
+        <OfflineIndicator />
         <header className="sticky top-0 z-20 border-b border-border bg-background/90 backdrop-blur">
           <div className="mx-auto max-w-2xl flex h-12 items-center px-3">
             <button
@@ -481,6 +483,7 @@ export function ArticlePage() {
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
+      <OfflineIndicator />
       {/* Header + scrollable content slide in together.  The action bar is a
           sibling outside this wrapper so its position:fixed always resolves
           against the viewport, even while the entry transform is active. */}

--- a/frontend/src/pages/ShareTargetPage.tsx
+++ b/frontend/src/pages/ShareTargetPage.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Loader2, AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+import { saveSharedUrl } from '@/api';
+import { extractSharedUrl } from '@/lib/shareTarget';
+
+export function ShareTargetPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    const sharedUrl = extractSharedUrl(searchParams.get('url'), searchParams.get('text'));
+    if (!sharedUrl) {
+      setError('No link was found in the shared content.');
+      return;
+    }
+
+    const title = searchParams.get('title') ?? undefined;
+    saveSharedUrl(sharedUrl, title)
+      .then((article) => {
+        toast('Saved to Later');
+        void navigate(`/a/${article.id}`, { replace: true });
+      })
+      .catch(() => {
+        setError('Could not save this link. Please try again.');
+      });
+  }, [searchParams, navigate]);
+
+  if (error) {
+    return (
+      <div className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center gap-3 text-center">
+        <AlertTriangle className="size-8 text-muted-foreground" />
+        <h1 className="text-lg font-semibold text-foreground">Couldn't save link</h1>
+        <p className="text-sm text-muted-foreground">{error}</p>
+        <button
+          type="button"
+          onClick={() => void navigate('/')}
+          className="mt-2 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Go home
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[50vh] flex-1 items-center justify-center p-8">
+      <div className="flex flex-col items-center gap-3">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Saving shared link…</p>
+      </div>
+    </div>
+  );
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -45,6 +45,15 @@
       "purpose": "monochrome"
     }
   ],
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  },
   "shortcuts": [
     {
       "name": "Today",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,42 @@ export default defineConfig({
               expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 30 },
             },
           },
+          {
+            // Article list/search responses: serve stale copy instantly while
+            // revalidating, and fall back to it entirely when offline.
+            urlPattern: /^\/api\/(articles|search)(\?.*)?$/,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'api-article-lists',
+              expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Single article metadata: prefer the network, fall back to the
+            // last-seen copy so a previously opened article still renders.
+            urlPattern: /^\/api\/articles\/\d+$/,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'api-article-detail',
+              networkTimeoutSeconds: 3,
+              expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 14 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Article body fetch is a POST; cache it too so a previously read
+            // article's body is available with no network.
+            urlPattern: /^\/api\/articles\/\d+\/body$/,
+            method: 'POST',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'api-article-body',
+              networkTimeoutSeconds: 3,
+              expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 14 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
         ],
       },
     }),


### PR DESCRIPTION
## Summary

Closes #653.

- **Share target**: `public/manifest.webmanifest` now declares a GET `share_target` pointing at `/share-target`. A new `ShareTargetPage` reads the shared `url`/`text`/`title` params, extracts the first http(s) link, and calls a new backend endpoint `POST /api/articles/from-url` to save it as a personal article in the Later queue, then redirects to `/a/{id}`.
- **Backend**: `save_shared_url` (backend/news_dashboard/main.py) validates the URL via the existing `validate_server_fetch_url` SSRF guard, dedupes by URL, creates/reuses a per-user "Shared Links" private source, inserts the article, transitions it to `later` state for the user, and eagerly prefetches the body via the existing `fetch_and_cache_body` helper so it's ready for offline reading right away.
- **Offline reading**: extended the VitePWA workbox `runtimeCaching` in `vite.config.ts` with bounded, expiring caches for `/api/articles`/`/api/search` (stale-while-revalidate), `/api/articles/:id` (network-first), and `/api/articles/:id/body` (network-first, POST). A previously opened article's data and body remain available with no network.
- **Offline indicator**: new `useOnlineStatus` hook + `OfflineIndicator` banner, shown in the article reader (`ArticlePage`) and the main `AppShell`.

## Scope notes

- Reused the existing `later` workflow state (rather than inventing a new one) so shared links show up in the existing Later queue.
- Did not add a separate manual "save for offline" button on list items — opening an article already triggers body prefetch/caching, which satisfies the acceptance criterion ("previously opened articles render with no network").
- The e2e dev server runs VitePWA with `devOptions.enabled: false` (no real service worker in dev), so the offline e2e tests exercise app-level behavior (mocked API routes are still fulfilled by Playwright while `context.setOffline(true)`, and SPA client-side navigation doesn't require a new document fetch) rather than the production workbox cache directly.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 662/662 passed, including new `frontend/src/__tests__/shareTargetPage.test.tsx`
- [x] `npx playwright test --project=chromium-desktop` — new `e2e/pwa-share-offline.spec.ts` (4/4 passed) and the new share_target manifest check in `e2e/pwa.spec.ts` pass; the 13 pre-existing failures elsewhere in the suite (favicon count, brand-mark visibility, etc.) reproduce identically on unmodified `main` and are unrelated to this change
- [x] `uv run ruff check/format`, `mypy`, `ty`, `pyrefly` on the backend — all clean (via pre-commit hooks on the commit)
- [ ] Backend pytest suite — could not run locally (this sandbox has no Docker/Postgres available); relying on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)