### PR TITLE
fix: prevent AI stats viewport crash

### DIFF
--- a/frontend/src/__tests__/useInteractiveViewport.test.tsx
+++ b/frontend/src/__tests__/useInteractiveViewport.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useInteractiveViewport } from '../lib/useInteractiveViewport';
+
+const OPTIONS = { width: 800, height: 600 };
+
+describe('useInteractiveViewport', () => {
+  it('creates a fresh non-null viewport for every mount and reset', () => {
+    const first = renderHook(() => useInteractiveViewport(OPTIONS));
+
+    first.result.current.viewport.tx = 42;
+    first.result.current.viewport.ty = 24;
+    first.result.current.viewport.scale = 2;
+    first.unmount();
+
+    const second = renderHook(() => useInteractiveViewport(OPTIONS));
+    expect(second.result.current.viewport).toEqual({ tx: 0, ty: 0, scale: 1 });
+
+    second.result.current.viewport.tx = 12;
+    act(() => second.result.current.resetViewport());
+
+    expect(second.result.current.viewport).toEqual({ tx: 0, ty: 0, scale: 1 });
+  });
+});

--- a/frontend/src/lib/useInteractiveViewport.ts
+++ b/frontend/src/lib/useInteractiveViewport.ts
@@ -37,7 +37,9 @@ export interface UseInteractiveViewportReturn {
   clientToCanvas: (clientX: number, clientY: number) => { x: number; y: number };
 }
 
-const INITIAL: Viewport = { tx: 0, ty: 0, scale: 1 };
+function initialViewport(): Viewport {
+  return { tx: 0, ty: 0, scale: 1 };
+}
 
 export function useInteractiveViewport({
   minScale = 0.2,
@@ -45,7 +47,7 @@ export function useInteractiveViewport({
   width,
   height,
 }: UseInteractiveViewportOptions): UseInteractiveViewportReturn {
-  const [viewport, setViewport] = useState<Viewport>(INITIAL);
+  const [viewport, setViewport] = useState<Viewport>(initialViewport);
   const [isPanning, setIsPanning] = useState(false);
   const svgRef = useRef<SVGSVGElement | null>(null);
 
@@ -148,7 +150,7 @@ export function useInteractiveViewport({
     [width, height, minScale, maxScale]
   );
 
-  const resetViewport = useCallback(() => setViewport(INITIAL), []);
+  const resetViewport = useCallback(() => setViewport(initialViewport()), []);
 
   return {
     viewport,


### PR DESCRIPTION
Closes #908

## Summary
- initialize interactive viewport state with a fresh object for each hook mount
- reset viewport with a fresh object so AI Stats SVG transforms always have tx/ty/scale
- add a regression test for mount/reset viewport state isolation

## Tests
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test:frontend
- npm run build
- npm run test:frontend -- frontend/src/__tests__/useInteractiveViewport.test.tsx frontend/src/__tests__/aiStatsPage.test.tsx frontend/src/__tests__/knowledgeGraph.test.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)