### PR TITLE
feat: import from Pocket/Instapaper/Omnivore (#657)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -19,6 +19,7 @@ from fastapi import (
     Depends,
     FastAPI,
     File,
+    Form,
     HTTPException,
     Query,
     Request,
@@ -90,6 +91,11 @@ from news_dashboard.ingest import (
 )
 from news_dashboard.ingest_events import stream_ingest_events
 from news_dashboard.login_throttle import clear_failures, is_throttled, record_failure
+from news_dashboard.reading_list_import import (
+    SUPPORTED_SERVICES,
+    ReadingListImportError,
+    import_reading_list,
+)
 from news_dashboard.run_history import get_ingest_run_sources, list_ingest_runs
 from news_dashboard.scheduler import (
     get_interval_minutes,
@@ -1892,6 +1898,27 @@ def import_opml(
                 failed.append({"url": xml_url, "error": "failed to import source"})
 
     return {"added": added, "skipped": skipped, "failed": failed}
+
+
+@api.post("/api/reading-list/import")
+def import_reading_list_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    file: Annotated[UploadFile, File()],
+    service: Annotated[str, Form()],
+) -> dict[str, Any]:
+    """Import saved articles from a Pocket/Instapaper/Omnivore export file."""
+    service = service.strip().lower()
+    if service not in SUPPORTED_SERVICES:
+        allowed = sorted(SUPPORTED_SERVICES)
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported service: {service!r} (expected one of {allowed})",
+        )
+    contents = file.file.read()
+    try:
+        return import_reading_list(current_user["id"], service, file.filename or "", contents)
+    except ReadingListImportError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 # ── Personalization nudges ────────────────────────────────────────────────────

--- a/backend/news_dashboard/reading_list_import.py
+++ b/backend/news_dashboard/reading_list_import.py
@@ -1,0 +1,398 @@
+"""Import saved articles from third-party read-it-later services.
+
+Supports Pocket (CSV or HTML export), Instapaper (CSV export), and Omnivore
+(JSON export). Each imported item becomes an article (deduped by canonical
+URL against anything already visible to the importing user), gets the
+user's ``later`` workflow state, and has its tags (if any) applied. Article
+bodies are never fetched during import — that happens lazily later via the
+normal body-fetch/insights path, same as freshly ingested articles.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.db import connect, init_db, insert_article_sql
+from news_dashboard.ingest import _find_canonical, canonicalize_url
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_SERVICES = frozenset({"pocket", "instapaper", "omnivore"})
+
+# Keep imports fast and bounded; anything beyond this is dropped and reported
+# via the `truncated` flag rather than processed in the background (there is
+# no background job queue in this codebase to hand it off to).
+MAX_IMPORT_ITEMS = 2000
+
+_SERVICE_SOURCE_NAMES = {
+    "pocket": "Pocket Import",
+    "instapaper": "Instapaper Import",
+    "omnivore": "Omnivore Import",
+}
+
+
+class ReadingListImportError(ValueError):
+    """Raised when the uploaded export file can't be parsed at all."""
+
+
+@dataclass
+class ImportedItem:
+    url: str
+    title: str
+    saved_at: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+
+# ── Parsers ───────────────────────────────────────────────────────────────────
+
+
+def _split_tags(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    seps = "|" if "|" in raw else ","
+    return [t.strip() for t in raw.split(seps) if t.strip()]
+
+
+def parse_pocket_csv(text: str) -> list[ImportedItem]:
+    """Parse Pocket's CSV export (columns: title,url,time_added,tags,status)."""
+    reader = csv.DictReader(StringIO(text))
+    if reader.fieldnames is None:
+        message = "Pocket CSV export has no header row"
+        raise ReadingListImportError(message)
+    fields = {(f or "").strip().lower(): f for f in reader.fieldnames}
+    url_field = fields.get("url")
+    if url_field is None:
+        message = "Pocket CSV export is missing a 'url' column"
+        raise ReadingListImportError(message)
+    title_field = fields.get("title")
+    time_field = fields.get("time_added")
+    tags_field = fields.get("tags")
+
+    items: list[ImportedItem] = []
+    for row in reader:
+        url = (row.get(url_field) or "").strip()
+        if not url:
+            continue
+        title = (row.get(title_field, "") if title_field else "").strip() or url
+        saved_at = None
+        if time_field:
+            raw_time = (row.get(time_field) or "").strip()
+            if raw_time.isdigit():
+                from datetime import datetime, timezone
+
+                saved_at = (
+                    datetime.fromtimestamp(int(raw_time), tz=timezone.utc)
+                    .replace(microsecond=0)
+                    .isoformat()
+                )
+        tags = _split_tags(row.get(tags_field) if tags_field else None)
+        items.append(ImportedItem(url=url, title=title, saved_at=saved_at, tags=tags))
+    return items
+
+
+class _PocketHtmlParser(HTMLParser):
+    """Parse Pocket's legacy HTML export: `<li><a href=... tags="...">Title</a></li>`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.items: list[ImportedItem] = []
+        self._in_anchor = False
+        self._current: dict[str, Any] = {}
+        self._text_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        attr_dict = dict(attrs)
+        href = (attr_dict.get("href") or "").strip()
+        if not href:
+            return
+        self._in_anchor = True
+        self._text_parts = []
+        from datetime import datetime, timezone
+
+        saved_at = None
+        time_added = attr_dict.get("time_added")
+        if time_added and time_added.isdigit():
+            saved_at = (
+                datetime.fromtimestamp(int(time_added), tz=timezone.utc)
+                .replace(microsecond=0)
+                .isoformat()
+            )
+        self._current = {
+            "url": href,
+            "saved_at": saved_at,
+            "tags": _split_tags(attr_dict.get("tags")),
+        }
+
+    def handle_data(self, data: str) -> None:
+        if self._in_anchor:
+            self._text_parts.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag != "a" or not self._in_anchor:
+            return
+        self._in_anchor = False
+        title = "".join(self._text_parts).strip() or self._current["url"]
+        self.items.append(
+            ImportedItem(
+                url=self._current["url"],
+                title=title,
+                saved_at=self._current["saved_at"],
+                tags=self._current["tags"],
+            )
+        )
+
+
+def parse_pocket_html(text: str) -> list[ImportedItem]:
+    parser = _PocketHtmlParser()
+    parser.feed(text)
+    if not parser.items:
+        message = "No links found in Pocket HTML export"
+        raise ReadingListImportError(message)
+    return parser.items
+
+
+def parse_instapaper_csv(text: str) -> list[ImportedItem]:
+    """Parse Instapaper's CSV export (columns: URL,Title,Selection,Folder)."""
+    reader = csv.DictReader(StringIO(text))
+    if reader.fieldnames is None:
+        message = "Instapaper CSV export has no header row"
+        raise ReadingListImportError(message)
+    fields = {(f or "").strip().lower(): f for f in reader.fieldnames}
+    url_field = fields.get("url")
+    if url_field is None:
+        message = "Instapaper CSV export is missing a 'URL' column"
+        raise ReadingListImportError(message)
+    title_field = fields.get("title")
+    folder_field = fields.get("folder")
+
+    items: list[ImportedItem] = []
+    for row in reader:
+        url = (row.get(url_field) or "").strip()
+        if not url:
+            continue
+        title = (row.get(title_field, "") if title_field else "").strip() or url
+        folder = (row.get(folder_field, "") if folder_field else "").strip()
+        tags = [folder] if folder and folder.lower() not in ("unread", "archive") else []
+        items.append(ImportedItem(url=url, title=title, tags=tags))
+    return items
+
+
+def parse_omnivore_json(text: str) -> list[ImportedItem]:
+    """Parse an Omnivore export: a JSON array of `{url, title, savedAt, labels}` objects."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        message = f"Invalid Omnivore JSON export: {exc}"
+        raise ReadingListImportError(message) from exc
+
+    if isinstance(data, dict):
+        data = data.get("articles") or data.get("items") or []
+    if not isinstance(data, list):
+        message = "Omnivore export must be a JSON array (or an object with an 'articles' list)"
+        raise ReadingListImportError(message)
+
+    items: list[ImportedItem] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url") or entry.get("originalArticleUrl") or "").strip()
+        if not url:
+            continue
+        title = str(entry.get("title") or "").strip() or url
+        saved_at = entry.get("savedAt") or entry.get("saved_at")
+        labels = entry.get("labels") or []
+        tags: list[str] = []
+        for label in labels:
+            if isinstance(label, dict):
+                name = str(label.get("name") or "").strip()
+            else:
+                name = str(label or "").strip()
+            if name:
+                tags.append(name)
+        items.append(
+            ImportedItem(
+                url=url,
+                title=title,
+                saved_at=str(saved_at) if saved_at else None,
+                tags=tags,
+            )
+        )
+    return items
+
+
+def parse_export(service: str, filename: str, contents: bytes) -> list[ImportedItem]:
+    if service not in SUPPORTED_SERVICES:
+        message = f"unsupported service: {service!r} (expected one of {sorted(SUPPORTED_SERVICES)})"
+        raise ReadingListImportError(message)
+
+    try:
+        text = contents.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        message = f"Could not decode file as UTF-8: {exc}"
+        raise ReadingListImportError(message) from exc
+
+    if service == "pocket":
+        stripped = text.lstrip()
+        is_html = stripped.startswith("<") or filename.lower().endswith((".html", ".htm"))
+        return parse_pocket_html(text) if is_html else parse_pocket_csv(text)
+    if service == "instapaper":
+        return parse_instapaper_csv(text)
+    return parse_omnivore_json(text)
+
+
+# ── Import orchestration ──────────────────────────────────────────────────────
+
+
+def _ensure_import_source(conn: Any, user_id: int, service: str) -> str:
+    """Return the slug of this user's private, disabled source for `service` imports.
+
+    Disabled so scheduled ingestion never tries to fetch it as a feed; it exists
+    only to give imported articles a `source_slug` and a private-visibility owner.
+    """
+    slug = f"import-{service}-{user_id}"
+    name = _SERVICE_SOURCE_NAMES[service]
+    url = f"urn:reading-list-import:{service}"
+    conn.execute(
+        """
+        INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+        VALUES (%s, %s, %s, %s, %s, 0, FALSE, %s)
+        ON CONFLICT (slug) DO NOTHING
+        """,
+        (slug, name, url, "imported", "reading_list_import", user_id),
+    )
+    return slug
+
+
+def _get_or_create_tag_id(conn: Any, user_id: int, name: str, cache: dict[str, int]) -> int:
+    if name in cache:
+        return cache[name]
+    row = conn.execute(
+        """
+        INSERT INTO user_tags (user_id, name)
+        VALUES (%s, %s)
+        ON CONFLICT (user_id, name) DO UPDATE SET name = EXCLUDED.name
+        RETURNING id
+        """,
+        (user_id, name),
+    ).fetchone()
+    tag_id = int(row["id"] if isinstance(row, dict) else row[0])
+    cache[name] = tag_id
+    return tag_id
+
+
+def import_reading_list(
+    user_id: int,
+    service: str,
+    filename: str,
+    contents: bytes,
+    db_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Import a Pocket/Instapaper/Omnivore export for `user_id`.
+
+    Returns a summary: `{"added": [...], "skipped": [...], "failed": [...],
+    "truncated": bool}`. Safe to call repeatedly with the same file — already
+    imported articles are matched by canonical URL and reported as skipped
+    rather than duplicated.
+    """
+    items = parse_export(service, filename, contents)
+
+    truncated = len(items) > MAX_IMPORT_ITEMS
+    items = items[:MAX_IMPORT_ITEMS]
+
+    init_db(db_path)
+    added: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+    tag_cache: dict[str, int] = {}
+
+    with connect(db_path) as conn:
+        source_slug = _ensure_import_source(conn, user_id, service)
+        source_name = _SERVICE_SOURCE_NAMES[service]
+
+        for item in items:
+            url = item.url.strip()
+            if not url.lower().startswith(("http://", "https://")):
+                failed.append({"url": url, "error": "invalid or unsupported URL scheme"})
+                continue
+
+            try:
+                with conn.transaction():
+                    canonical = canonicalize_url(url)
+                    existing_id = _find_canonical(
+                        conn, canonical, item.title, owner_user_id=user_id
+                    )
+                    if existing_id is not None:
+                        article_id = existing_id
+                        is_new = False
+                    else:
+                        conn.execute(
+                            insert_article_sql(),
+                            (
+                                url,
+                                canonical,
+                                item.title,
+                                source_slug,
+                                source_name,
+                                "imported",
+                                "reading_list_import",
+                                item.saved_at,
+                                "",
+                                f"Imported from {source_name}.",
+                                50,
+                                ",".join(item.tags),
+                                None,
+                                None,
+                                None,
+                            ),
+                        )
+                        row = conn.execute(
+                            "SELECT id FROM articles WHERE url = %s", (url,)
+                        ).fetchone()
+                        if row is None:
+                            failed.append({"url": url, "error": "failed to import article"})
+                            continue
+                        article_id = int(row["id"] if isinstance(row, dict) else row[0])
+                        is_new = True
+
+                    # Only claim a workflow state if the user doesn't already have one for
+                    # this article — re-importing shouldn't revert progress on articles
+                    # already triaged (e.g. marked done) via normal ingestion.
+                    conn.execute(
+                        """
+                        INSERT INTO user_article_state (user_id, article_id, state)
+                        VALUES (%s, %s, 'later')
+                        ON CONFLICT (user_id, article_id) DO NOTHING
+                        """,
+                        (user_id, article_id),
+                    )
+
+                    for tag_name in item.tags:
+                        tag_id = _get_or_create_tag_id(conn, user_id, tag_name, tag_cache)
+                        conn.execute(
+                            """
+                            INSERT INTO article_tags (user_id, article_id, tag_id)
+                            VALUES (%s, %s, %s)
+                            ON CONFLICT (user_id, article_id, tag_id) DO NOTHING
+                            """,
+                            (user_id, article_id, tag_id),
+                        )
+            except Exception:
+                logger.exception("Failed to import reading-list item: %s", url)
+                failed.append({"url": url, "error": "failed to import article"})
+                continue
+
+            if is_new:
+                added.append({"url": url, "title": item.title})
+            else:
+                skipped.append({"url": url, "reason": "duplicate"})
+
+    return {"added": added, "skipped": skipped, "failed": failed, "truncated": truncated}

--- a/backend/tests/test_reading_list_import.py
+++ b/backend/tests/test_reading_list_import.py
@@ -1,0 +1,214 @@
+"""Tests for the Pocket/Instapaper/Omnivore reading-list import endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from io import BytesIO
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+from news_dashboard.reading_list_import import (
+    ReadingListImportError,
+    parse_instapaper_csv,
+    parse_omnivore_json,
+    parse_pocket_csv,
+    parse_pocket_html,
+)
+
+
+@pytest.fixture
+def client(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash, is_admin)"
+            " VALUES (1, 'reader', 'x', FALSE)"
+        )
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        yield test_client
+
+
+# ── Unit tests: parsers ────────────────────────────────────────────────────────
+
+
+def test_parse_pocket_csv_basic() -> None:
+    csv_text = (
+        "title,url,time_added,tags,status\nMy Article,https://a.com/1,1700000000,tech|rust,unread\n"
+    )
+    items = parse_pocket_csv(csv_text)
+    assert len(items) == 1
+    assert items[0].url == "https://a.com/1"
+    assert items[0].title == "My Article"
+    assert items[0].tags == ["tech", "rust"]
+    assert items[0].saved_at is not None
+
+
+def test_parse_pocket_csv_missing_url_column_raises() -> None:
+    with pytest.raises(ReadingListImportError):
+        parse_pocket_csv("title,tags\nNo URL,tech\n")
+
+
+def test_parse_pocket_html_basic() -> None:
+    html = (
+        "<ul>"
+        '<li><a href="https://a.com/1" time_added="1700000000" tags="tech,rust">'
+        "Article One</a></li>"
+        '<li><a href="https://b.com/2">Article Two</a></li>'
+        "</ul>"
+    )
+    items = parse_pocket_html(html)
+    assert len(items) == 2
+    assert items[0].url == "https://a.com/1"
+    assert items[0].tags == ["tech", "rust"]
+    assert items[1].title == "Article Two"
+    assert items[1].tags == []
+
+
+def test_parse_instapaper_csv_basic() -> None:
+    csv_text = "URL,Title,Selection,Folder\nhttps://c.com/1,Some Title,,Reading\n"
+    items = parse_instapaper_csv(csv_text)
+    assert len(items) == 1
+    assert items[0].url == "https://c.com/1"
+    assert items[0].title == "Some Title"
+    assert items[0].tags == ["Reading"]
+
+
+def test_parse_omnivore_json_basic() -> None:
+    json_text = (
+        '[{"url": "https://d.com/1", "title": "D Title", "savedAt": "2026-01-01T00:00:00Z", '
+        '"labels": [{"name": "ai"}, "python"]}]'
+    )
+    items = parse_omnivore_json(json_text)
+    assert len(items) == 1
+    assert items[0].url == "https://d.com/1"
+    assert items[0].tags == ["ai", "python"]
+
+
+def test_parse_omnivore_json_invalid_raises() -> None:
+    with pytest.raises(ReadingListImportError):
+        parse_omnivore_json("not json at all")
+
+
+# ── Integration tests: import endpoint ─────────────────────────────────────────
+
+
+POCKET_CSV = (
+    "title,url,time_added,tags,status\n"
+    "Article One,https://example.com/one,1700000000,tech|rust,unread\n"
+    "Article Two,https://example.com/two,1700000100,,unread\n"
+)
+
+INSTAPAPER_CSV = "URL,Title,Selection,Folder\nhttps://example.com/three,Article Three,,Unread\n"
+
+OMNIVORE_JSON = (
+    '[{"url": "https://example.com/four", "title": "Article Four", '
+    '"savedAt": "2026-01-01T00:00:00Z", "labels": [{"name": "ai"}]}]'
+)
+
+
+def test_import_pocket_csv_creates_saved_articles(client: TestClient, pg_clean: str) -> None:
+    response = client.post(
+        "/api/reading-list/import",
+        data={"service": "pocket"},
+        files={"file": ("pocket.csv", BytesIO(POCKET_CSV.encode()), "text/csv")},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["added"]) == 2
+    assert data["skipped"] == []
+    assert data["failed"] == []
+    assert data["truncated"] is False
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT a.id, uas.state FROM articles a"
+            " JOIN user_article_state uas ON uas.article_id = a.id"
+            " WHERE a.url = %s AND uas.user_id = 1",
+            ("https://example.com/one",),
+        ).fetchone()
+        assert row is not None
+        assert row["state"] == "later"
+
+        tags = conn.execute(
+            "SELECT t.name FROM article_tags at JOIN user_tags t ON t.id = at.tag_id"
+            " JOIN articles a ON a.id = at.article_id"
+            " WHERE a.url = %s AND at.user_id = 1",
+            ("https://example.com/one",),
+        ).fetchall()
+        tag_names = {r["name"] for r in tags}
+        assert tag_names == {"tech", "rust"}
+
+
+def test_import_instapaper_csv_creates_saved_article(client: TestClient, pg_clean: str) -> None:
+    response = client.post(
+        "/api/reading-list/import",
+        data={"service": "instapaper"},
+        files={"file": ("instapaper.csv", BytesIO(INSTAPAPER_CSV.encode()), "text/csv")},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["added"]) == 1
+    assert data["added"][0]["url"] == "https://example.com/three"
+
+
+def test_import_omnivore_json_creates_saved_article(client: TestClient, pg_clean: str) -> None:
+    response = client.post(
+        "/api/reading-list/import",
+        data={"service": "omnivore"},
+        files={"file": ("omnivore.json", BytesIO(OMNIVORE_JSON.encode()), "application/json")},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["added"]) == 1
+    assert data["added"][0]["url"] == "https://example.com/four"
+
+
+def test_reimporting_same_file_skips_duplicates(client: TestClient, pg_clean: str) -> None:
+    first = client.post(
+        "/api/reading-list/import",
+        data={"service": "pocket"},
+        files={"file": ("pocket.csv", BytesIO(POCKET_CSV.encode()), "text/csv")},
+    )
+    assert first.status_code == 200
+    assert len(first.json()["added"]) == 2
+
+    second = client.post(
+        "/api/reading-list/import",
+        data={"service": "pocket"},
+        files={"file": ("pocket.csv", BytesIO(POCKET_CSV.encode()), "text/csv")},
+    )
+    assert second.status_code == 200
+    data = second.json()
+    assert data["added"] == []
+    assert len(data["skipped"]) == 2
+    assert all(item["reason"] == "duplicate" for item in data["skipped"])
+
+    with connect(database_url=pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS n FROM articles WHERE url = %s",
+            ("https://example.com/one",),
+        ).fetchone()
+        assert count["n"] == 1
+
+
+def test_import_rejects_malformed_csv(client: TestClient, pg_clean: str) -> None:
+    response = client.post(
+        "/api/reading-list/import",
+        data={"service": "pocket"},
+        files={"file": ("bad.csv", BytesIO(b"not,the,right,columns\n1,2,3,4\n"), "text/csv")},
+    )
+    assert response.status_code == 400
+    assert "url" in response.json()["detail"].lower()
+
+
+def test_import_rejects_unsupported_service(client: TestClient, pg_clean: str) -> None:
+    response = client.post(
+        "/api/reading-list/import",
+        data={"service": "readwise"},
+        files={"file": ("f.csv", BytesIO(b"url\nhttps://a.com\n"), "text/csv")},
+    )
+    assert response.status_code == 400

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -25,6 +25,8 @@ import type {
   QuizResult,
   ReadingDna,
   ReadingGoal,
+  ReadingListImportResult,
+  ReadingListImportService,
   RecommendationPreferences,
   ReceivedShare,
   ShareDetail,
@@ -818,4 +820,22 @@ export async function importOpml(file: File): Promise<OpmlImportResult> {
   });
   if (!response.ok) throw new HttpError(response.status, await readErrorMessage(response));
   return response.json() as Promise<OpmlImportResult>;
+}
+
+// ── Reading list import (Pocket / Instapaper / Omnivore) ──────────────────────
+
+export async function importReadingList(
+  file: File,
+  service: ReadingListImportService
+): Promise<ReadingListImportResult> {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('service', service);
+  const response = await fetch('/api/reading-list/import', {
+    method: 'POST',
+    credentials: 'same-origin',
+    body: form,
+  });
+  if (!response.ok) throw new HttpError(response.status, await readErrorMessage(response));
+  return response.json() as Promise<ReadingListImportResult>;
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -12,17 +12,20 @@ import {
   Bell,
   BellOff,
   Trash2,
+  Upload,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTheme } from '@/hooks/useTheme';
 import { cn } from '@/lib/utils';
 import type { Theme } from '@/lib/theme';
+import type { ReadingListImportResult, ReadingListImportService } from '@/types';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
 import { useAuth } from '@/contexts/auth';
 import {
   deleteOwnAccount,
   downloadUserExport,
   fetchNotificationSettings,
+  importReadingList,
   recalculateMyRecommendations,
   subscribePush,
   unsubscribePush,
@@ -733,6 +736,97 @@ function DataExportSection() {
   );
 }
 
+const READING_LIST_SERVICES: { v: ReadingListImportService; label: string }[] = [
+  { v: 'pocket', label: 'Pocket' },
+  { v: 'instapaper', label: 'Instapaper' },
+  { v: 'omnivore', label: 'Omnivore' },
+];
+
+function ReadingListImportSection() {
+  const [service, setService] = useState<ReadingListImportService>('pocket');
+  const [isImporting, setIsImporting] = useState(false);
+  const [result, setResult] = useState<ReadingListImportResult | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const handleFile = async (file: File) => {
+    setIsImporting(true);
+    setResult(null);
+    setErrorMsg(null);
+    try {
+      setResult(await importReadingList(file, service));
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Import failed.');
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        Import Reading List
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Bring your saved articles over from Pocket, Instapaper, or Omnivore. Import creates saved
+          (&quot;Later&quot;) articles with tags preserved where available; re-importing the same
+          file won&apos;t create duplicates.
+        </p>
+        <div className="flex items-center gap-2 flex-wrap">
+          <select
+            aria-label="Reading list export service"
+            value={service}
+            onChange={(e) => setService(e.target.value as ReadingListImportService)}
+            disabled={isImporting}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-xs"
+          >
+            {READING_LIST_SERVICES.map(({ v, label }) => (
+              <option key={v} value={v}>
+                {label}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => document.getElementById('reading-list-file-input')?.click()}
+            disabled={isImporting}
+            className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-60"
+          >
+            {isImporting ? (
+              <RefreshCw className="size-3 animate-spin" />
+            ) : (
+              <Upload className="size-3" />
+            )}
+            {isImporting ? 'Importing…' : 'Choose export file'}
+          </button>
+          <input
+            id="reading-list-file-input"
+            aria-label="Import reading list export"
+            type="file"
+            accept=".csv,.html,.htm,.json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              const input = e.target;
+              if (file) void handleFile(file);
+              input.value = '';
+            }}
+          />
+        </div>
+
+        {result && (
+          <p className="text-xs text-green-600 dark:text-green-400">
+            Imported {result.added.length} article{result.added.length === 1 ? '' : 's'}
+            {result.skipped.length > 0 ? `, skipped ${result.skipped.length} duplicate(s)` : ''}
+            {result.failed.length > 0 ? `, ${result.failed.length} failed` : ''}.
+            {result.truncated ? ' File was truncated to the first 2000 items.' : ''}
+          </p>
+        )}
+        {errorMsg && <p className="text-xs text-destructive">{errorMsg}</p>}
+      </div>
+    </section>
+  );
+}
+
 type DeleteAccountState = 'idle' | 'confirming' | 'deleting' | 'error';
 
 function DeleteAccountSection() {
@@ -873,6 +967,8 @@ export function SettingsPage() {
       <PersonalizationSection />
 
       <DataExportSection />
+
+      <ReadingListImportSection />
 
       <DailyBriefSection />
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -550,3 +550,12 @@ export interface OpmlImportResult {
   skipped: { url: string; reason: string }[];
   failed: { url: string; error: string }[];
 }
+
+export type ReadingListImportService = 'pocket' | 'instapaper' | 'omnivore';
+
+export interface ReadingListImportResult {
+  added: { url: string; title: string }[];
+  skipped: { url: string; reason: string }[];
+  failed: { url: string; error: string }[];
+  truncated: boolean;
+}


### PR DESCRIPTION
## Summary

Closes #657.

- Adds `POST /api/reading-list/import` accepting Pocket exports (CSV or legacy HTML), Instapaper exports (CSV), and Omnivore exports (JSON).
- Each item is deduped against existing articles by canonical URL (reusing the same `_find_canonical` logic ingestion uses), gets the user's `later` workflow state (without clobbering state on an article the user already triaged), and has its tags applied/created as needed.
- A private, disabled `sources` row per user/service (`import-<service>-<user_id>`) gives imported articles a `source_slug` without ever being picked up by scheduled ingestion.
- Article bodies are never fetched during import — normal lazy body-fetch/insights handles that later, same as freshly-ingested articles.
- Returns an `added`/`skipped`/`failed` summary plus a `truncated` flag (imports are capped at 2000 items; there's no background job queue in this codebase to hand overflow off to).
- Malformed exports (missing required columns, invalid JSON) are rejected with a 400 and a clear error message.
- Adds a "Import Reading List" section to Settings with a service picker and file upload, mirroring the existing OPML import UX in Sources.

## Test plan

- [x] `backend/tests/test_reading_list_import.py` — unit tests for all four parsers (Pocket CSV/HTML, Instapaper CSV, Omnivore JSON) plus integration tests: creates saved articles per service, re-importing the same file skips duplicates (no duplicate `articles` rows), tags are applied, malformed files/unsupported services return 400.
- [x] `ruff check`, `mypy`, pre-commit hooks (ruff format, ty, pyrefly, eslint, prettier, tsc) all pass.
- [x] Ran `pytest tests/test_reading_list_import.py tests/test_opml.py tests/test_tags.py` — 40 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)