### PR TITLE
fix: align manual app build versioning (#741)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,6 +22,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        run: bash scripts/next_version.sh >> "$GITHUB_OUTPUT"
+
+      - name: Inject version (not committed — only for this build)
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          CODE: ${{ steps.version.outputs.code }}
+        run: bash scripts/inject_app_version.sh android
 
       - uses: actions/setup-java@v4
         with:
@@ -47,7 +59,7 @@ jobs:
         id: apk
         run: |
           APK=$(find android/app/build/outputs/apk/release -name "*.apk" | head -1)
-          VERSION=$(cat VERSION)
+          VERSION="${{ steps.version.outputs.version }}"
           DEST="news-dashboard-android-v${VERSION}-manual-${{ github.run_number }}.apk"
           cp "$APK" "$DEST"
           echo "path=$DEST" >> "$GITHUB_OUTPUT"
@@ -55,6 +67,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: news-dashboard-apk-manual
+          name: news-dashboard-apk-v${{ steps.version.outputs.version }}-manual
           path: ${{ steps.apk.outputs.path }}
           retention-days: 7

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -17,6 +17,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        run: bash scripts/next_version.sh >> "$GITHUB_OUTPUT"
+
+      - name: Inject version (not committed — only for this build)
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: bash scripts/inject_app_version.sh desktop
 
       - uses: actions/setup-node@v4
         with:
@@ -30,7 +41,7 @@ jobs:
 
       - name: Build universal DMG
         working-directory: desktop
-        run: npm run build:mac
+        run: npm run build:mac -- --publish never
 
       - name: Find DMG
         id: dmg
@@ -38,9 +49,18 @@ jobs:
           DMG=$(find desktop/dist -name "*.dmg" | head -1)
           echo "path=$DMG" >> "$GITHUB_OUTPUT"
           ls -lh "$DMG"
+          MANIFEST=$(find desktop/dist -name "latest-mac.yml" | head -1)
+          echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: news-dashboard-dmg-manual
+          name: news-dashboard-dmg-v${{ steps.version.outputs.version }}-manual
           path: ${{ steps.dmg.outputs.path }}
+          retention-days: 7
+
+      - uses: actions/upload-artifact@v4
+        if: steps.dmg.outputs.manifest != ''
+        with:
+          name: latest-mac-v${{ steps.version.outputs.version }}-manual
+          path: ${{ steps.dmg.outputs.manifest }}
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,17 +144,9 @@ jobs:
 
       - name: Inject version (not committed — only for this build)
         env:
-          V: ${{ needs.release.outputs.version }}
+          VERSION: ${{ needs.release.outputs.version }}
           CODE: ${{ needs.release.outputs.code }}
-        run: |
-          # Patterns require at least one digit to avoid matching empty strings
-          # (POSIX BRE: [0-9][0-9]* = one or more).
-          sed -i "s/versionCode [0-9][0-9]*/versionCode $CODE/" android/app/build.gradle
-          sed -i "s/versionName \"[0-9][^\"]*\"/versionName \"$V\"/" android/app/build.gradle
-          jq --arg v "$V" --argjson c "$CODE" \
-            '.appVersionName = $v | .appVersionCode = $c' \
-            android/twa-manifest.json > /tmp/twa.json
-          mv /tmp/twa.json android/twa-manifest.json
+        run: bash scripts/inject_app_version.sh android
 
       - uses: actions/setup-java@v4
         with:
@@ -225,11 +217,8 @@ jobs:
 
       - name: Inject version (not committed — only for this build)
         env:
-          V: ${{ needs.release.outputs.version }}
-        run: |
-          jq --arg v "$V" '.version = $v' \
-            desktop/package.json > /tmp/pkg.json
-          mv /tmp/pkg.json desktop/package.json
+          VERSION: ${{ needs.release.outputs.version }}
+        run: bash scripts/inject_app_version.sh desktop
 
       - uses: actions/setup-node@v4
         with:

--- a/scripts/inject_app_version.sh
+++ b/scripts/inject_app_version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Inject computed app versions into packaging metadata for CI builds.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TARGET="${1:-}"
+VERSION="${VERSION:-${V:-}}"
+CODE="${CODE:-}"
+
+if [ -z "$TARGET" ]; then
+  echo "usage: scripts/inject_app_version.sh android|desktop" >&2
+  exit 2
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "VERSION or V must be set" >&2
+  exit 2
+fi
+
+case "$TARGET" in
+  android)
+    if [ -z "$CODE" ]; then
+      echo "CODE must be set for Android version injection" >&2
+      exit 2
+    fi
+
+    # Patterns require at least one digit to avoid matching empty strings
+    # (POSIX BRE: [0-9][0-9]* = one or more).
+    sed -i "s/versionCode [0-9][0-9]*/versionCode $CODE/" android/app/build.gradle
+    sed -i "s/versionName \"[0-9][^\"]*\"/versionName \"$VERSION\"/" android/app/build.gradle
+    jq --arg v "$VERSION" --argjson c "$CODE" \
+      '.appVersionName = $v | .appVersionCode = $c' \
+      android/twa-manifest.json > /tmp/twa.json
+    mv /tmp/twa.json android/twa-manifest.json
+    ;;
+  desktop)
+    jq --arg v "$VERSION" '.version = $v' \
+      desktop/package.json > /tmp/pkg.json
+    mv /tmp/pkg.json desktop/package.json
+    ;;
+  *)
+    echo "unknown target: $TARGET" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/test_manual_app_workflows.py
+++ b/scripts/test_manual_app_workflows.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+ANDROID = WORKFLOWS / "android.yml"
+DESKTOP = WORKFLOWS / "desktop.yml"
+RELEASE = WORKFLOWS / "release.yml"
+
+
+class TestManualAppWorkflows(unittest.TestCase):
+    def test_manual_workflows_compute_versions_from_git_history(self) -> None:
+        for path in (ANDROID, DESKTOP):
+            workflow = path.read_text()
+
+            if "fetch-depth: 0" not in workflow:
+                self.fail(f"{path.relative_to(ROOT)} does not fetch tag history")
+            if 'bash scripts/next_version.sh >> "$GITHUB_OUTPUT"' not in workflow:
+                self.fail(f"{path.relative_to(ROOT)} does not compute the tag-derived version")
+
+    def test_workflows_use_shared_version_injection_script(self) -> None:
+        expected_calls = {
+            ANDROID: "bash scripts/inject_app_version.sh android",
+            DESKTOP: "bash scripts/inject_app_version.sh desktop",
+            RELEASE: "bash scripts/inject_app_version.sh",
+        }
+
+        for path, expected_call in expected_calls.items():
+            workflow = path.read_text()
+
+            if expected_call not in workflow:
+                self.fail(f"{path.relative_to(ROOT)} is missing {expected_call}")
+
+    def test_manual_desktop_build_never_publishes_and_uploads_update_manifest(self) -> None:
+        workflow = DESKTOP.read_text()
+
+        for expected in (
+            "npm run build:mac -- --publish never",
+            'find desktop/dist -name "latest-mac.yml"',
+            "steps.dmg.outputs.manifest",
+            "latest-mac-v${{ steps.version.outputs.version }}-manual",
+        ):
+            if expected not in workflow:
+                self.fail(f"{DESKTOP.relative_to(ROOT)} is missing {expected}")
+
+    def test_manual_artifacts_include_computed_version(self) -> None:
+        expected_names = {
+            ANDROID: (
+                "news-dashboard-android-v${VERSION}-manual-${{ github.run_number }}.apk",
+                "news-dashboard-apk-v${{ steps.version.outputs.version }}-manual",
+            ),
+            DESKTOP: ("news-dashboard-dmg-v${{ steps.version.outputs.version }}-manual",),
+        }
+
+        for path, expected_parts in expected_names.items():
+            workflow = path.read_text()
+
+            for expected in expected_parts:
+                if expected not in workflow:
+                    self.fail(f"{path.relative_to(ROOT)} is missing versioned artifact {expected}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #741

## Summary
- Added a shared `scripts/inject_app_version.sh` helper for Android and desktop packaging metadata.
- Updated manual Android and desktop workflows to fetch tag history, compute `scripts/next_version.sh`, inject computed versions before builds, and use versioned artifact names.
- Updated manual desktop builds to pass `--publish never` and upload `latest-mac.yml` when generated.
- Added workflow regression tests for manual app versioning drift.

## Tests
- `bash -n scripts/inject_app_version.sh`
- `python -m pytest scripts/test_manual_app_workflows.py -q`
- `python -m pytest scripts -q`
- `make lint`
- `make typecheck`
- `source .env && make test` (backend: 1548 passed, 1 skipped; frontend: 70 files / 733 tests passed)
- `npm run build --silent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
