### PR TITLE
fix: make pytest-xdist worker schemas safe across concurrent pytest sessions

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,6 +17,7 @@ session behaviour should clear ``app.dependency_overrides`` themselves.
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Generator
 from pathlib import Path
 
@@ -54,16 +55,36 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 
 _SCHEMA_SWEEP_LOCK_KEY = 727271
+_WORKER_SCHEMA_RE = re.compile(r"^test_[A-Za-z0-9]+_(\d+)$")
+
+
+def _pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # Any other errno (e.g. EPERM for a live process owned by someone
+        # else) means the PID still exists — treat it as alive.
+        return True
+    return True
 
 
 def sweep_stale_test_schemas(dsn: str) -> None:
     """Drop leaked ``test_%`` schemas from crashed pytest-xdist runs.
 
     Guarded by a Postgres advisory lock. This must only be called before any
-    xdist worker has created its own ``test_{worker_id}`` schema (i.e. from
-    ``pytest_configure`` in the xdist *master* process, never from a worker's
-    ``pg_url`` fixture) — otherwise the sweep can race with, and drop, a
-    schema another already-running worker is actively using.
+    xdist worker has created its own ``test_{worker_id}_{pid}`` schema (i.e.
+    from ``pytest_configure`` in the xdist *master* process, never from a
+    worker's ``pg_url`` fixture) — otherwise the sweep can race with, and
+    drop, a schema another already-running worker is actively using.
+
+    Worker schemas are named ``test_<worker_id>_<pid>``; a schema in that
+    shape is only swept once its owning PID is no longer alive, so a second,
+    concurrently-running pytest session sharing the same database cannot have
+    its live worker schemas destroyed by this session's startup sweep.
+    Schemas that don't match the pattern (e.g. leaked from an older run) are
+    dropped unconditionally, as before.
     """
     import psycopg
     from psycopg import sql
@@ -81,6 +102,9 @@ def sweep_stale_test_schemas(dsn: str) -> None:
                 r"WHERE schema_name LIKE 'test\_%' ESCAPE '\'"
             ).fetchall()
             for (schema_name,) in rows:
+                match = _WORKER_SCHEMA_RE.match(schema_name)
+                if match and _pid_is_alive(int(match.group(1))):
+                    continue
                 conn.execute(
                     sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(schema_name))
                 )
@@ -170,7 +194,10 @@ def pg_url() -> Generator[str]:
     original_url = service_url
 
     if service_url and worker_id and worker_id != "master":
-        worker_schema = f"test_{worker_id}"
+        # Suffix with this worker's own PID (unique system-wide while alive)
+        # so two concurrent pytest sessions sharing one database never reuse
+        # the same schema name — see sweep_stale_test_schemas.
+        worker_schema = f"test_{worker_id}_{os.getpid()}"
 
         # Create/recreate the schema using the base DSN
         from psycopg import sql

--- a/backend/tests/test_conftest_schema_sweep.py
+++ b/backend/tests/test_conftest_schema_sweep.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 import uuid
 
 import pytest
@@ -70,6 +72,98 @@ def test_sweep_stale_test_schemas() -> None:
                     assert row is not None
                 finally:
                     holder_conn.execute("SELECT pg_advisory_unlock(%s)", (_SCHEMA_SWEEP_LOCK_KEY,))
+    finally:
+        with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+            admin_conn.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(scratch_db)
+                )
+            )
+
+
+def test_sweep_skips_schemas_owned_by_a_still_alive_process() -> None:
+    """PID-suffixed schemas whose owning process is still running are not dropped.
+
+    Two concurrent pytest sessions sharing one TEST_DATABASE_URL must not be
+    able to destroy each other's live worker schema: the sweep only treats a
+    ``test_<workerid>_<pid>`` schema as stale once that PID is gone.
+    """
+    import psycopg
+    from conftest import sweep_stale_test_schemas
+    from psycopg import sql
+
+    service_url = os.environ.get("TEST_DATABASE_URL")
+    if not service_url:
+        pytest.skip("TEST_DATABASE_URL not set")
+
+    base_url, _, _dbname = service_url.rpartition("/")
+    scratch_db = f"schema_sweep_scratch_{uuid.uuid4().hex[:12]}"
+    scratch_url = f"{base_url}/{scratch_db}"
+    admin_url = f"{base_url}/postgres"
+
+    with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+        try:
+            admin_conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(scratch_db)))
+        except psycopg.errors.InsufficientPrivilege:
+            pytest.skip("connected role lacks CREATEDB; cannot build an isolated scratch database")
+    try:
+        alive_schema = f"test_gw0_{os.getpid()}"
+
+        with psycopg.connect(scratch_url, autocommit=True) as conn:
+            conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(alive_schema)))
+
+            sweep_stale_test_schemas(scratch_url)
+
+            row = conn.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s",
+                (alive_schema,),
+            ).fetchone()
+            assert row is not None
+    finally:
+        with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+            admin_conn.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(scratch_db)
+                )
+            )
+
+
+def test_sweep_drops_schemas_owned_by_a_dead_process() -> None:
+    """PID-suffixed schemas whose owning process has exited are genuinely stale."""
+    import psycopg
+    from conftest import sweep_stale_test_schemas
+    from psycopg import sql
+
+    service_url = os.environ.get("TEST_DATABASE_URL")
+    if not service_url:
+        pytest.skip("TEST_DATABASE_URL not set")
+
+    base_url, _, _dbname = service_url.rpartition("/")
+    scratch_db = f"schema_sweep_scratch_{uuid.uuid4().hex[:12]}"
+    scratch_url = f"{base_url}/{scratch_db}"
+    admin_url = f"{base_url}/postgres"
+
+    with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+        try:
+            admin_conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(scratch_db)))
+        except psycopg.errors.InsufficientPrivilege:
+            pytest.skip("connected role lacks CREATEDB; cannot build an isolated scratch database")
+    try:
+        # A short-lived subprocess whose PID is guaranteed dead once it exits.
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait(timeout=5)
+        dead_schema = f"test_gw1_{proc.pid}"
+
+        with psycopg.connect(scratch_url, autocommit=True) as conn:
+            conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(dead_schema)))
+
+            sweep_stale_test_schemas(scratch_url)
+
+            row = conn.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s",
+                (dead_schema,),
+            ).fetchone()
+            assert row is None
     finally:
         with psycopg.connect(admin_url, autocommit=True) as admin_conn:
             admin_conn.execute(


### PR DESCRIPTION
Closes #913

## What & why

While debugging a live deadlock during #902's investigation, found and directly reproduced a real concurrency bug: two separate pytest sessions running `pytest -n auto` against the same shared `TEST_DATABASE_URL` reuse the same worker schema names (`test_gw0`, `test_gw1`, ... — the xdist worker slot restarts numbering from `gw0` on every new invocation, so it's not unique across concurrent runs). Worse, the startup sweep (`sweep_stale_test_schemas`, added in #876) drops *every* `test_%` schema it finds once it wins the advisory lock, with no way to distinguish "leaked from a crashed run" from "actively in use by another session running right now."

I reproduced this live: running a second `pytest` session while a first was still active caused the second session's startup sweep to destroy the first session's live worker schemas mid-run — one run went from 2 pre-existing flaky failures to **358 errors**. In an earlier, separate incident, this same race left two abandoned "idle in transaction" connections blocking a different session's test run for **10+ hours** before I found and cleared them manually.

## Fix

- Worker schema names now include the worker process's own PID: `test_<worker_id>_<pid>` — unique system-wide for as long as that process is alive, so two concurrent sessions can never collide on a schema name.
- `sweep_stale_test_schemas` is now PID-aware: for schemas matching the new naming pattern, it only drops the schema once that PID is confirmed dead (`os.kill(pid, 0)`). Schemas that don't match the pattern (legacy leaks) keep the old unconditional-drop behavior.

## Tests

Extended `backend/tests/test_conftest_schema_sweep.py`: a live-PID case (sweep must skip it) and a dead-PID case (spawn+wait a real subprocess to get a definitively-exited PID; sweep must drop it), alongside the existing non-PID-suffixed decoy case. All three pass, plus the full gate (ruff, mypy, ty, pyrefly).

**Live validation**: ran two genuinely concurrent `pytest -n auto` sessions against the shared container (143 tests total across both) — both completed cleanly with zero errors, zero leftover `test_%` schemas, and zero stuck connections afterward. This is the exact scenario that previously caused the 358-error meltdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)