### PR TITLE
feat: import from Pocket/Instapaper/Omnivore into the reading list (#657)

### DIFF
--- a/backend/news_dashboard/reading_list/importers.py
+++ b/backend/news_dashboard/reading_list/importers.py
@@ -1,0 +1,165 @@
+"""Parsers for third-party read-it-later export formats.
+
+Supports Pocket (CSV), Instapaper (CSV), and Omnivore (JSON) exports so
+users migrating from those services can bring their saved articles into
+the reading list. Each parser normalizes rows into a single
+:class:`ImportedItem` shape the import endpoint can insert uniformly.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+class ImportParseError(ValueError):
+    """Raised when a file cannot be parsed as the requested export format."""
+
+
+@dataclass
+class ImportedItem:
+    url: str
+    title: str | None = None
+    created_at: datetime | None = None
+    tags: list[str] = field(default_factory=list)
+    status: str = "unread"
+
+
+def _parse_epoch(value: str | None) -> datetime | None:
+    if not value or not value.strip():
+        return None
+    try:
+        return datetime.fromtimestamp(int(value.strip()), tz=UTC)
+    except (ValueError, OSError):
+        return None
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _split_tags(value: str | None) -> list[str]:
+    if not value or not value.strip():
+        return []
+    return [tag.strip() for tag in value.split(",") if tag.strip()]
+
+
+def _decode(contents: bytes) -> str:
+    try:
+        return contents.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        message = "File is not valid UTF-8 text"
+        raise ImportParseError(message) from exc
+
+
+def parse_pocket_csv(contents: bytes) -> list[ImportedItem]:
+    """Parse a Pocket CSV export: title,url,time_added,tags,status."""
+    text = _decode(contents)
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None or "url" not in {f.lower() for f in reader.fieldnames}:
+        message = "Pocket export must be a CSV with a 'url' column"
+        raise ImportParseError(message)
+    lower_fields = {f.lower(): f for f in reader.fieldnames}
+    items: list[ImportedItem] = []
+    for row in reader:
+        url = (row.get(lower_fields["url"]) or "").strip()
+        if not url:
+            continue
+        raw_status = (row.get(lower_fields.get("status", ""), "") or "").strip().lower()
+        items.append(
+            ImportedItem(
+                url=url,
+                title=(row.get(lower_fields.get("title", "")) or "").strip() or None,
+                created_at=_parse_epoch(row.get(lower_fields.get("time_added", ""))),
+                tags=_split_tags(row.get(lower_fields.get("tags", ""))),
+                status="archived" if raw_status == "archive" else "unread",
+            )
+        )
+    return items
+
+
+def parse_instapaper_csv(contents: bytes) -> list[ImportedItem]:
+    """Parse an Instapaper CSV export: URL,Title,Selection,Folder,Timestamp."""
+    text = _decode(contents)
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None or "url" not in {f.lower() for f in reader.fieldnames}:
+        message = "Instapaper export must be a CSV with a 'URL' column"
+        raise ImportParseError(message)
+    lower_fields = {f.lower(): f for f in reader.fieldnames}
+    items: list[ImportedItem] = []
+    for row in reader:
+        url = (row.get(lower_fields["url"]) or "").strip()
+        if not url:
+            continue
+        folder = (row.get(lower_fields.get("folder", ""), "") or "").strip().lower()
+        timestamp_key = lower_fields.get("timestamp")
+        items.append(
+            ImportedItem(
+                url=url,
+                title=(row.get(lower_fields.get("title", "")) or "").strip() or None,
+                created_at=_parse_epoch(row.get(timestamp_key)) if timestamp_key else None,
+                tags=[],
+                status="archived" if folder in {"archive", "archived"} else "unread",
+            )
+        )
+    return items
+
+
+def parse_omnivore_json(contents: bytes) -> list[ImportedItem]:
+    """Parse an Omnivore JSON export: a list of {url, title, labels, savedAt, state}."""
+    text = _decode(contents)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        message = "Omnivore export must be valid JSON"
+        raise ImportParseError(message) from exc
+    if isinstance(data, dict):
+        found = data.get("items", data.get("articles"))
+        if not isinstance(found, list):
+            message = "Omnivore export must be a JSON array, or an object with an 'items' array"
+            raise ImportParseError(message)
+        data = found
+    if not isinstance(data, list):
+        message = "Omnivore export must be a JSON array of items"
+        raise ImportParseError(message)
+    items: list[ImportedItem] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url") or entry.get("originalArticleUrl") or "").strip()
+        if not url:
+            continue
+        raw_labels = entry.get("labels") or []
+        tags = [
+            str(label.get("name")).strip() if isinstance(label, dict) else str(label).strip()
+            for label in raw_labels
+        ]
+        state = str(entry.get("state") or "").strip().upper()
+        title = entry.get("title")
+        items.append(
+            ImportedItem(
+                url=url,
+                title=str(title).strip() if title else None,
+                created_at=_parse_iso(entry.get("savedAt")),
+                tags=[tag for tag in tags if tag],
+                status="archived" if state == "ARCHIVED" else "unread",
+            )
+        )
+    return items
+
+
+PARSERS = {
+    "pocket": parse_pocket_csv,
+    "instapaper": parse_instapaper_csv,
+    "omnivore": parse_omnivore_json,
+}
+
+MAX_IMPORT_ITEMS = 5000

--- a/backend/news_dashboard/reading_list/router.py
+++ b/backend/news_dashboard/reading_list/router.py
@@ -9,10 +9,21 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Response,
+    UploadFile,
+)
 
 from news_dashboard.auth import require_auth
 from news_dashboard.reading_list import service
+from news_dashboard.reading_list.importers import MAX_IMPORT_ITEMS, PARSERS, ImportParseError
 from news_dashboard.reading_list.models import (
     ReadingListAddRequest,
     ReadingListReorderRequest,
@@ -38,6 +49,32 @@ def add_reading_list_item_endpoint(
     else:
         response.status_code = 200
     return item
+
+
+@router.post("/api/reading-list/import")
+async def import_reading_list_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    file: Annotated[UploadFile, File()],
+    source: Annotated[str, Form()],
+) -> dict[str, Any]:
+    """Import saved articles from a Pocket, Instapaper, or Omnivore export."""
+    parser = PARSERS.get(source.strip().lower())
+    if parser is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported import source {source!r}; expected one of {sorted(PARSERS)}",
+        )
+    contents = await file.read()
+    try:
+        items = parser(contents)
+    except ImportParseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        result = service.import_items(current_user["id"], items, max_items=MAX_IMPORT_ITEMS)
+    except service.ImportTooLargeError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+    return result
 
 
 @router.get("/api/reading-list")

--- a/backend/news_dashboard/reading_list/service.py
+++ b/backend/news_dashboard/reading_list/service.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from news_dashboard.db import connect, init_db
+from news_dashboard.reading_list.importers import ImportedItem
 from news_dashboard.reading_list.metadata import detect_kind, fetch_url_metadata
 
 logger = logging.getLogger(__name__)
@@ -237,3 +238,80 @@ def process_pending_items(*, limit: int = 20, database_url: str | None = None) -
     for row in rows:
         fetch_metadata_for_item(row["id"], database_url=database_url)
     return len(rows)
+
+
+class ImportTooLargeError(ValueError):
+    """Raised when an import file has more items than the batch cap allows."""
+
+
+def import_items(
+    user_id: int,
+    items: list[ImportedItem],
+    *,
+    max_items: int,
+    database_url: str | None = None,
+) -> dict[str, int]:
+    """Bulk-insert reading list items from a third-party export.
+
+    Titles carried over from the export are trusted as-is (fetch_status is
+    marked ``ok`` so the background sweep never overwrites them); items
+    without a title are left ``pending`` for the usual metadata fetch.
+    Duplicates (by normalized URL, per user) are skipped rather than
+    failed. Tags have no home on reading list items yet, so they are
+    folded into the item's note as a readable summary.
+    """
+    if len(items) > max_items:
+        message = f"Import contains {len(items)} items; the limit is {max_items}"
+        raise ImportTooLargeError(message)
+
+    init_db(database_url=database_url)
+    added = 0
+    skipped = 0
+    failed = 0
+    with connect(database_url=database_url) as conn:
+        for item in items:
+            try:
+                _require_http_url(item.url)
+            except InvalidReadingListUrlError:
+                failed += 1
+                continue
+            normalized = normalize_url(item.url)
+            kind = detect_kind(item.url)
+            note = f"Tags: {', '.join(item.tags)}" if item.tags else None
+            fetch_status = "ok" if item.title else "pending"
+            row = conn.execute(
+                """
+                INSERT INTO reading_list_items(
+                    user_id, url, normalized_url, title, kind, fetch_status,
+                    status, note, priority, created_at, done_at
+                )
+                VALUES (
+                  %s, %s, %s, %s, %s, %s, %s, %s,
+                  (SELECT COALESCE(MAX(priority), 0) + 1
+                     FROM reading_list_items WHERE user_id = %s),
+                  COALESCE(%s, NOW()),
+                  CASE WHEN %s = 'archived' THEN COALESCE(%s, NOW()) END
+                )
+                ON CONFLICT (user_id, normalized_url) DO NOTHING
+                RETURNING id
+                """,
+                (
+                    user_id,
+                    item.url,
+                    normalized,
+                    item.title,
+                    kind,
+                    fetch_status,
+                    item.status,
+                    note,
+                    user_id,
+                    item.created_at,
+                    item.status,
+                    item.created_at,
+                ),
+            ).fetchone()
+            if row is not None:
+                added += 1
+            else:
+                skipped += 1
+    return {"added": added, "skipped": skipped, "failed": failed}

--- a/backend/tests/test_reading_list_import.py
+++ b/backend/tests/test_reading_list_import.py
@@ -1,0 +1,251 @@
+"""Tests for importing Pocket/Instapaper/Omnivore exports into the reading list."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+from news_dashboard.reading_list import importers, service
+
+POCKET_CSV = (
+    "title,url,time_added,tags,status\n"
+    "First Post,https://example.com/a,1700000000,tech,unread\n"
+    'Archived Post,https://example.com/b,1700000100,"tech,news",archive\n'
+)
+
+INSTAPAPER_CSV = (
+    "URL,Title,Selection,Folder,Timestamp\n"
+    "https://example.com/c,Third Post,,Unread,1700000200\n"
+    "https://example.com/d,Fourth Post,,Archive,1700000300\n"
+)
+
+OMNIVORE_JSON = """
+[
+  {"url": "https://example.com/e", "title": "Fifth Post", "labels": [{"name": "reading"}],
+   "savedAt": "2023-11-14T00:00:00Z", "state": "SUCCEEDED"},
+  {"url": "https://example.com/f", "title": "Sixth Post", "labels": ["archive-tag"],
+   "savedAt": "2023-11-15T00:00:00Z", "state": "ARCHIVED"}
+]
+"""
+
+
+# ── Parser unit tests ────────────────────────────────────────────────────────
+
+
+def test_parse_pocket_csv() -> None:
+    items = importers.parse_pocket_csv(POCKET_CSV.encode())
+    assert [i.url for i in items] == ["https://example.com/a", "https://example.com/b"]
+    assert items[0].title == "First Post"
+    assert items[0].status == "unread"
+    assert items[0].tags == ["tech"]
+    assert items[1].status == "archived"
+    assert items[1].tags == ["tech", "news"]
+    assert items[0].created_at is not None
+
+
+def test_parse_pocket_csv_requires_url_column() -> None:
+    with pytest.raises(importers.ImportParseError):
+        importers.parse_pocket_csv(b"title,link\nA,https://example.com\n")
+
+
+def test_parse_instapaper_csv() -> None:
+    items = importers.parse_instapaper_csv(INSTAPAPER_CSV.encode())
+    assert [i.url for i in items] == ["https://example.com/c", "https://example.com/d"]
+    assert items[0].status == "unread"
+    assert items[1].status == "archived"
+    assert items[1].title == "Fourth Post"
+
+
+def test_parse_omnivore_json() -> None:
+    items = importers.parse_omnivore_json(OMNIVORE_JSON.encode())
+    assert [i.url for i in items] == ["https://example.com/e", "https://example.com/f"]
+    assert items[0].status == "unread"
+    assert items[0].tags == ["reading"]
+    assert items[1].status == "archived"
+    assert items[1].tags == ["archive-tag"]
+
+
+def test_parse_omnivore_json_rejects_malformed_input() -> None:
+    with pytest.raises(importers.ImportParseError):
+        importers.parse_omnivore_json(b"not json")
+
+
+def test_parse_omnivore_json_rejects_non_list() -> None:
+    with pytest.raises(importers.ImportParseError):
+        importers.parse_omnivore_json(b'{"foo": "bar"}')
+
+
+# ── API integration tests (Postgres) ────────────────────────────────────────
+
+
+def _setup_db(monkeypatch: pytest.MonkeyPatch, pg_url: str) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    init_db(database_url=pg_url)
+    return pg_url
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_import_pocket_creates_saved_items(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("pocket.csv", POCKET_CSV, "text/csv")},
+                data={"source": "pocket"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {"added": 2, "skipped": 0, "failed": 0}
+
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            "SELECT url, title, status, note, fetch_status FROM reading_list_items"
+            " WHERE user_id = %s ORDER BY url",
+            (user_id,),
+        ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["url"] == "https://example.com/a"
+    assert rows[0]["title"] == "First Post"
+    assert rows[0]["status"] == "unread"
+    assert rows[0]["fetch_status"] == "ok"
+    assert rows[1]["status"] == "archived"
+    assert rows[1]["note"] == "Tags: tech, news"
+
+
+def test_reimport_same_file_skips_duplicates(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            first = client.post(
+                "/api/reading-list/import",
+                files={"file": ("pocket.csv", POCKET_CSV, "text/csv")},
+                data={"source": "pocket"},
+            )
+            second = client.post(
+                "/api/reading-list/import",
+                files={"file": ("pocket.csv", POCKET_CSV, "text/csv")},
+                data={"source": "pocket"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert first.json() == {"added": 2, "skipped": 0, "failed": 0}
+    assert second.json() == {"added": 0, "skipped": 2, "failed": 0}
+
+    with connect(database_url=database_url) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM reading_list_items WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()["count"]
+    assert count == 2
+
+
+def test_import_instapaper(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("instapaper.csv", INSTAPAPER_CSV, "text/csv")},
+                data={"source": "instapaper"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json() == {"added": 2, "skipped": 0, "failed": 0}
+
+
+def test_import_omnivore(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("omnivore.json", OMNIVORE_JSON, "application/json")},
+                data={"source": "omnivore"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json() == {"added": 2, "skipped": 0, "failed": 0}
+
+
+def test_import_rejects_malformed_file(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("garbage.json", "not json", "application/json")},
+                data={"source": "omnivore"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 400
+
+
+def test_import_rejects_unknown_source(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("x.csv", "url\nhttps://example.com\n", "text/csv")},
+                data={"source": "readwise"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 400
+
+
+def test_import_enforces_batch_cap(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    items = [importers.ImportedItem(url=f"https://example.com/{i}") for i in range(3)]
+
+    with pytest.raises(service.ImportTooLargeError):
+        service.import_items(user_id, items, max_items=2, database_url=database_url)

--- a/frontend/src/__tests__/readingList.test.tsx
+++ b/frontend/src/__tests__/readingList.test.tsx
@@ -136,4 +136,35 @@ describe('ReadingListPage', () => {
       expect(deleteSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  it('imports a Pocket export and shows the added/skipped/failed summary', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([]);
+    const importSpy = vi
+      .spyOn(readingListApi, 'importReadingList')
+      .mockResolvedValue({ added: 2, skipped: 1, failed: 0 });
+
+    renderPage();
+    const file = new File(['title,url\nA,https://example.com/a\n'], 'pocket.csv', {
+      type: 'text/csv',
+    });
+    const input = screen.getByLabelText(/import reading list export/i);
+    await userEvent.upload(input, file);
+
+    await waitFor(() => {
+      expect(importSpy).toHaveBeenCalledWith(file, 'pocket');
+    });
+    expect(await screen.findByText(/2 added/)).toBeTruthy();
+  });
+
+  it('shows an error message when import fails', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([]);
+    vi.spyOn(readingListApi, 'importReadingList').mockRejectedValue(new Error('bad file'));
+
+    renderPage();
+    const file = new File(['not json'], 'omnivore.json', { type: 'application/json' });
+    const input = screen.getByLabelText(/import reading list export/i);
+    await userEvent.upload(input, file);
+
+    expect(await screen.findByText(/import failed: bad file/i)).toBeTruthy();
+  });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -52,7 +52,7 @@ import type {
   WeeklyRecap,
 } from './types';
 
-async function readErrorMessage(response: Response): Promise<string> {
+export async function readErrorMessage(response: Response): Promise<string> {
   try {
     const body: unknown = await (response.json() as Promise<unknown>);
     if (body && typeof body === 'object') {

--- a/frontend/src/api/readingListApi.ts
+++ b/frontend/src/api/readingListApi.ts
@@ -1,6 +1,6 @@
 /** API layer for the reading list (#893). */
 
-import { requestJson } from '../api';
+import { HttpError, readErrorMessage, requestJson } from '../api';
 
 export type ReadingListStatus = 'unread' | 'done' | 'archived';
 export type ReadingListKind = 'article' | 'video' | 'channel' | 'link';
@@ -63,4 +63,28 @@ export async function reorderReadingList(orderedIds: number[]): Promise<ReadingL
 
 export async function deleteReadingListItem(id: number): Promise<void> {
   await requestJson(`/api/reading-list/${id}`, { method: 'DELETE' });
+}
+
+export type ReadingListImportSource = 'pocket' | 'instapaper' | 'omnivore';
+
+export interface ReadingListImportResult {
+  added: number;
+  skipped: number;
+  failed: number;
+}
+
+export async function importReadingList(
+  file: File,
+  source: ReadingListImportSource
+): Promise<ReadingListImportResult> {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('source', source);
+  const response = await fetch('/api/reading-list/import', {
+    method: 'POST',
+    credentials: 'same-origin',
+    body: form,
+  });
+  if (!response.ok) throw new HttpError(response.status, await readErrorMessage(response));
+  return response.json() as Promise<ReadingListImportResult>;
 }

--- a/frontend/src/pages/ReadingListPage.tsx
+++ b/frontend/src/pages/ReadingListPage.tsx
@@ -11,6 +11,7 @@ import {
   RotateCcw,
   Trash2,
   TriangleAlert,
+  Upload,
   Users,
 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -18,13 +19,22 @@ import {
   addReadingListItem,
   deleteReadingListItem,
   fetchReadingList,
+  importReadingList,
   reorderReadingList,
   updateReadingListItem,
+  type ReadingListImportResult,
+  type ReadingListImportSource,
   type ReadingListItem,
   type ReadingListKind,
   type ReadingListStatus,
 } from '@/api/readingListApi';
 import { EmptyState } from '@/components/EmptyState';
+
+const IMPORT_SOURCES: { value: ReadingListImportSource; label: string }[] = [
+  { value: 'pocket', label: 'Pocket (CSV)' },
+  { value: 'instapaper', label: 'Instapaper (CSV)' },
+  { value: 'omnivore', label: 'Omnivore (JSON)' },
+];
 
 const KIND_META: Record<ReadingListKind, { label: string; Icon: typeof Newspaper }> = {
   article: { label: 'Article', Icon: Newspaper },
@@ -152,6 +162,9 @@ export function ReadingListPage() {
   const queryClient = useQueryClient();
   const [newUrl, setNewUrl] = useState('');
   const [filter, setFilter] = useState<ReadingListStatus>('unread');
+  const [importSource, setImportSource] = useState<ReadingListImportSource>('pocket');
+  const [importResult, setImportResult] = useState<ReadingListImportResult | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
 
   const { data: items = [], isLoading } = useQuery({
     queryKey: ['reading-list', filter],
@@ -184,6 +197,20 @@ export function ReadingListPage() {
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteReadingListItem(id),
     onSuccess: invalidate,
+  });
+
+  const importMutation = useMutation({
+    mutationFn: ({ file, source }: { file: File; source: ReadingListImportSource }) =>
+      importReadingList(file, source),
+    onSuccess: (result) => {
+      setImportResult(result);
+      setImportError(null);
+      invalidate();
+    },
+    onError: (err) => {
+      setImportResult(null);
+      setImportError(err instanceof Error ? err.message : 'Import failed');
+    },
   });
 
   function handleAdd() {
@@ -241,6 +268,60 @@ export function ReadingListPage() {
           Could not save that link — check that it is a valid http(s) URL.
         </p>
       ) : null}
+
+      <div className="px-4 md:px-5 pb-3 flex items-center gap-2">
+        <select
+          value={importSource}
+          onChange={(e) => setImportSource(e.target.value as ReadingListImportSource)}
+          className="h-9 rounded-md border border-border bg-surface px-2 text-sm outline-none focus:border-border-strong"
+        >
+          {IMPORT_SOURCES.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => document.getElementById('reading-list-import-input')?.click()}
+          disabled={importMutation.isPending}
+          className="h-9 px-3 rounded-md border border-border text-sm font-medium hover:bg-surface disabled:opacity-50 inline-flex items-center gap-1.5"
+        >
+          <Upload className="size-4" />
+          {importMutation.isPending ? 'Importing…' : 'Import export file'}
+        </button>
+        <input
+          id="reading-list-import-input"
+          aria-label="Import reading list export"
+          type="file"
+          accept=".csv,.json"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            const input = e.target;
+            importMutation.mutate(
+              { file, source: importSource },
+              { onSettled: () => (input.value = '') }
+            );
+          }}
+        />
+      </div>
+      {(importResult ?? importError) && (
+        <div className="px-4 md:px-5 pb-3 text-xs">
+          {importError ? (
+            <p className="text-destructive">Import failed: {importError}</p>
+          ) : (
+            importResult && (
+              <p className="text-muted-foreground">
+                <span className="text-foreground font-medium">{importResult.added} added</span>
+                {' · '}
+                {importResult.skipped} skipped · {importResult.failed} failed
+              </p>
+            )
+          )}
+        </div>
+      )}
 
       <div className="px-4 md:px-5 pb-3 flex items-center gap-1">
         {(['unread', 'done'] as const).map((status) => (


### PR DESCRIPTION
Closes #657.

## Summary
- Add `POST /api/reading-list/import` (multipart: `file` + `source`) accepting Pocket (CSV), Instapaper (CSV), and Omnivore (JSON) exports.
- Parsers (`backend/news_dashboard/reading_list/importers.py`) normalize each export's rows into `url`/`title`/`created_at`/`tags`/`status` and reject malformed files with a clear error.
- `service.import_items` bulk-inserts into `reading_list_items`, relying on the existing `(user_id, normalized_url)` unique constraint to dedupe — re-importing the same file skips everything instead of duplicating. Saved timestamps and archive/unread state are preserved; a batch cap (`MAX_IMPORT_ITEMS = 5000`) returns HTTP 413 for oversized files.
- Imports don't fetch article bodies inline: items with a title from the export are marked `fetch_status='ok'` immediately (so the background sweep won't overwrite them), and titleless items fall into the existing `pending` metadata-fetch sweep the scheduler already runs.
- Tags have no home on reading-list items yet, so they're folded into the item's `note` (e.g. `"Tags: tech, news"`) rather than adding a new column — flagged here for follow-up if/when reading-list tagging lands.

### Design note
The issue predates the Reading List feature (#893/#901). Since Reading List now models "saved for later" per-user with its own dedup/status, I targeted imports there instead of the older article+starred-state system, which is a better fit for ad-hoc saved links from a different service.

- Frontend: `ReadingListPage` gets a source picker + "Import export file" button, mirroring the existing OPML import pattern in `SourcesPage`; shows an added/skipped/failed summary or an error message.

## Test results
- Backend: `pytest backend/tests/test_reading_list_import.py backend/tests/test_reading_list.py` — 36 passed.
- Backend: `ruff check`, `ruff format --check`, `mypy` — all clean.
- Frontend: `vitest run readingList.test` — 8 passed (2 new: import success + import failure).
- Frontend: `eslint`, `tsc` (typecheck) — clean.
- Full pre-commit suite (ruff, mypy, ty, pyrefly, eslint, prettier, tsc) passed on commit.

## Test plan
- [x] Import a Pocket CSV export — creates saved articles, preserves title/timestamp/tags/archive-status
- [x] Import an Instapaper CSV export
- [x] Import an Omnivore JSON export
- [x] Re-importing the same file skips duplicates (no new rows)
- [x] Malformed file / unknown source rejected with 400
- [x] Oversized import rejected with 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)