### PR TITLE
feat: add Cloudflare Blog as an infrastructure source (#751)

### DIFF
--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -303,6 +303,14 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         priority=70,
         interest_tags=("web", "frontend", "product-news"),
     ),
+    SourceDefinition(
+        "cloudflare-blog",
+        "Cloudflare Blog",
+        "https://blog.cloudflare.com/rss/",
+        "cloud-infra",
+        priority=70,
+        interest_tags=("cloud", "infra", "security"),
+    ),
     # ── Engineering ──────────────────────────────────────────────────────────
     SourceDefinition(
         "pragmatic-engineer",

--- a/backend/tests/test_cloudflare_blog_source.py
+++ b/backend/tests/test_cloudflare_blog_source.py
@@ -1,0 +1,92 @@
+"""Tests for Cloudflare Blog default source (issue #751)."""
+
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard.ingest import sync_sources
+from news_dashboard.sources import DEFAULT_SOURCES
+
+# ── Unit tests (no DB) ───────────────────────────────────────────────────
+
+
+def test_cloudflare_blog_in_default_sources() -> None:
+    """cloudflare-blog SourceDefinition exists in DEFAULT_SOURCES."""
+    by_slug = {s.slug: s for s in DEFAULT_SOURCES}
+    assert "cloudflare-blog" in by_slug, (
+        f"cloudflare-blog not found; slugs: {sorted(by_slug)[:10]}..."
+    )
+
+
+def test_cloudflare_blog_metadata() -> None:
+    """cloudflare-blog has the expected metadata fields."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "cloudflare-blog")
+    assert src.name == "Cloudflare Blog"
+    assert src.url == "https://blog.cloudflare.com/rss/"
+    assert src.category == "cloud-infra"
+    assert src.kind == "rss_feed"
+    assert src.priority == 70
+    assert src.enabled is True
+    assert src.lang == "en"
+
+
+def test_cloudflare_blog_interest_tags() -> None:
+    """cloudflare-blog carries tags that match onboarding interests."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "cloudflare-blog")
+    assert "cloud" in src.interest_tags
+    assert "infra" in src.interest_tags
+    assert "security" in src.interest_tags
+
+
+def test_cloudflare_blog_routes_to_rss_feed() -> None:
+    """cloudflare-blog kind is rss_feed, which ingest routes correctly."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "cloudflare-blog")
+    assert src.kind == "rss_feed"
+
+
+# ── Integration tests (PostgreSQL) ────────────────────────────────────────
+
+
+def test_cloudflare_blog_sync_persists_row(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sync_sources() creates a sources row for cloudflare-blog."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        row = conn.execute(
+            "SELECT slug, name, url, category, kind, priority, enabled "
+            "FROM sources WHERE slug = 'cloudflare-blog'"
+        ).fetchone()
+
+    assert row is not None, "cloudflare-blog row missing from sources table"
+    assert row["slug"] == "cloudflare-blog"
+    assert row["name"] == "Cloudflare Blog"
+    assert row["url"] == "https://blog.cloudflare.com/rss/"
+    assert row["category"] == "cloud-infra"
+    assert row["kind"] == "rss_feed"
+    assert row["priority"] == 70
+    assert row["enabled"] is True
+
+
+def test_cloudflare_blog_sync_idempotent(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running sync_sources twice does not duplicate cloudflare-blog."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS c FROM sources WHERE slug = 'cloudflare-blog'"
+        ).fetchone()["c"]
+
+    assert count == 1


### PR DESCRIPTION
## Summary
- Adds `cloudflare-blog` to `DEFAULT_SOURCES` (`backend/news_dashboard/sources.py`) in the cloud/infra section: `https://blog.cloudflare.com/rss/`, category `cloud-infra`, kind `rss_feed`, priority `70`, interest tags `cloud, infra, security`.
- No ingest routing changes needed — `rss_feed` sources already go through the existing `_fetch_feed_entries()` path.

Closes #751

## Test plan
- [x] `make lint` — ruff check + format, passes
- [x] `make typecheck` — mypy, ty, pyrefly all pass
- [x] New `backend/tests/test_cloudflare_blog_source.py`: metadata, interest tags, routing, `sync_sources()` row persistence, and idempotency — all pass against Postgres
- [x] `backend/tests/test_new_feeds.py`, `test_onboarding_interests.py`, `test_source_health.py`, `test_nitter_feed.py` — no regressions (61 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)