### PR TITLE
fix: validate custom source kinds (#742)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -464,12 +464,24 @@ class EnabledUpdate(BaseModel):
     enabled: bool
 
 
+USER_CREATED_SOURCE_KINDS = frozenset({"rss_feed", "reddit_feed", "lobsters_feed", "mastodon_feed"})
+
+
 class CreateSourceRequest(BaseModel):
     url: str
     name: str
     category: str = "tech"
     slug: str | None = None
     kind: str = "rss_feed"
+
+    def validate_kind(self) -> None:
+        if self.kind in USER_CREATED_SOURCE_KINDS:
+            return
+        allowed = ", ".join(sorted(USER_CREATED_SOURCE_KINDS))
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported source kind '{self.kind}'. Supported kinds: {allowed}",
+        )
 
     def validated_slug(self, name: str) -> str:
         """Return a non-empty slug, normalised from name if not provided."""
@@ -1732,6 +1744,8 @@ def create_source(
 
     if not payload.name.strip():
         raise HTTPException(status_code=400, detail="name must not be empty")
+
+    payload.validate_kind()
 
     try:
         validate_server_fetch_url(payload.url)

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -233,6 +233,67 @@ def test_api_create_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatc
         assert "my-blog" in slugs
 
 
+@pytest.mark.parametrize(
+    "kind",
+    ["rss_feed", "reddit_feed", "lobsters_feed", "mastodon_feed"],
+)
+def test_api_create_private_source_accepts_supported_kinds(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, kind: str
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+    slug = f"my-{kind.replace('_', '-')}"
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources",
+            json={
+                "url": f"https://example.com/{kind}.xml",
+                "name": f"My {kind}",
+                "category": "tech",
+                "slug": slug,
+                "kind": kind,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["slug"] == slug
+    assert data["kind"] == kind
+    assert data["owner_user_id"] == uid
+
+
+def test_api_create_private_source_rejects_unsupported_kind_without_insert(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources",
+            json={
+                "url": "https://example.com/scraped",
+                "name": "Scraped Custom Source",
+                "category": "tech",
+                "slug": "scraped-custom-source",
+                "kind": "scraped_page",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "unsupported source kind 'scraped_page'" in resp.json()["detail"]
+
+    with connect(pg_clean) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM sources WHERE slug = %s",
+            ("scraped-custom-source",),
+        ).fetchone()
+    assert row is None
+
+
 def test_api_create_private_source_rejects_unsafe_url(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -283,6 +283,32 @@ describe('SourcesPage', () => {
     expect(screen.queryByText('slug already exists')).toBeNull();
   });
 
+  it('shows backend validation details when createSource rejects source kind', async () => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.createSource.mockRejectedValue(
+      new apiMock.HttpError(
+        400,
+        "unsupported source kind 'scraped_page'. Supported kinds: lobsters_feed, mastodon_feed, reddit_feed, rss_feed"
+      )
+    );
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    await screen.findByRole('dialog');
+
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'My Blog' } });
+    fireEvent.change(screen.getByLabelText(/feed url/i), {
+      target: { value: 'https://myblog.com/feed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^add source$/i }));
+
+    expect(await screen.findByText(/unsupported source kind 'scraped_page'/i)).toBeTruthy();
+    expect(
+      screen.queryByText('Could not add source. Check the feed URL and try again.')
+    ).toBeNull();
+  });
+
   it('shows friendly copy rather than a raw server string for generic createSource failures', async () => {
     apiMock.fetchSources.mockResolvedValue([source()]);
     apiMock.createSource.mockRejectedValue(new Error('500 Internal Server Error'));

--- a/frontend/src/lib/errorPresentation.ts
+++ b/frontend/src/lib/errorPresentation.ts
@@ -185,6 +185,9 @@ export function sourceActionErrorMessage(err: unknown, action: SourceActionKind)
   if (err instanceof HttpError && err.status === 409) {
     return 'That slug is already in use — choose a different slug or source.';
   }
+  if (action === 'add' && err instanceof HttpError && (err.status === 400 || err.status === 422)) {
+    return err.message;
+  }
   switch (action) {
     case 'add':
       return 'Could not add source. Check the feed URL and try again.';


### PR DESCRIPTION
Closes #742

## Summary
- Add a backend allowlist for user-created source kinds and reject unsupported custom source kinds before inserting a source row.
- Cover all supported custom source kinds plus the unsupported-kind/no-row-insert path in source subscription API tests.
- Show backend 400/422 add-source validation details in the existing add-source dialog error area.

## Test results
- `source ./.env && pytest backend/tests/test_source_subscriptions.py -q` ✅ 25 passed
- `npm run test:frontend -- --run frontend/src/__tests__/feedsPages.test.tsx` ✅ 33 passed
- `make lint` ✅
- `make typecheck` ✅
- `npm run build` ✅
- `npm run test:frontend` ✅ 71 files / 737 tests passed; tests log expected localhost `ECONNREFUSED` noise
- `source ./.env && make test` ❌ unrelated existing failures in legacy tests that pass tmp_path database files into PostgreSQL-only runtime init, e.g. `backend/tests/test_search_filters.py` and `backend/tests/test_source_health.py` failing with missing PostgreSQL tables while initializing tmp_path DBs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
