### PR TITLE
fix: capture drag state eagerly so batched mouseup can't crash the viewport

### DIFF
--- a/frontend/src/__tests__/useInteractiveViewport.test.tsx
+++ b/frontend/src/__tests__/useInteractiveViewport.test.tsx
@@ -5,6 +5,26 @@ import { useInteractiveViewport } from '../lib/useInteractiveViewport';
 
 const OPTIONS = { width: 800, height: 600 };
 
+function makeSvg(): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, width: OPTIONS.width, height: OPTIONS.height }) as DOMRect;
+  return svg;
+}
+
+function mouseEvent(
+  target: SVGSVGElement,
+  clientX: number,
+  clientY: number
+): React.MouseEvent<SVGSVGElement> {
+  return {
+    target,
+    clientX,
+    clientY,
+    preventDefault: () => undefined,
+  } as unknown as React.MouseEvent<SVGSVGElement>;
+}
+
 describe('useInteractiveViewport', () => {
   it('creates a fresh non-null viewport for every mount and reset', () => {
     const first = renderHook(() => useInteractiveViewport(OPTIONS));
@@ -21,5 +41,53 @@ describe('useInteractiveViewport', () => {
     act(() => second.result.current.resetViewport());
 
     expect(second.result.current.viewport).toEqual({ tx: 0, ty: 0, scale: 1 });
+  });
+
+  it('pans without crashing when mouseup lands in the same batch as mousemove', () => {
+    const { result } = renderHook(() => useInteractiveViewport(OPTIONS));
+    const svg = makeSvg();
+    result.current.svgRef.current = svg;
+
+    act(() => {
+      result.current.svgProps.onMouseDown(mouseEvent(svg, 100, 100));
+    });
+
+    // React 18 batches both updates: the mousemove queues a viewport updater
+    // and the mouseup clears the drag ref before that updater runs.
+    act(() => {
+      result.current.svgProps.onMouseMove(mouseEvent(svg, 130, 120));
+      result.current.svgProps.onMouseUp();
+    });
+
+    expect(result.current.viewport).toEqual({ tx: 30, ty: 20, scale: 1 });
+    expect(result.current.isPanning).toBe(false);
+  });
+
+  it('starts each pan from the current viewport position', () => {
+    const { result } = renderHook(() => useInteractiveViewport(OPTIONS));
+    const svg = makeSvg();
+    result.current.svgRef.current = svg;
+
+    act(() => {
+      result.current.svgProps.onMouseDown(mouseEvent(svg, 100, 100));
+    });
+    act(() => {
+      result.current.svgProps.onMouseMove(mouseEvent(svg, 130, 120));
+    });
+    act(() => {
+      result.current.svgProps.onMouseUp();
+    });
+    expect(result.current.viewport).toEqual({ tx: 30, ty: 20, scale: 1 });
+
+    act(() => {
+      result.current.svgProps.onMouseDown(mouseEvent(svg, 200, 200));
+    });
+    act(() => {
+      result.current.svgProps.onMouseMove(mouseEvent(svg, 210, 205));
+    });
+    act(() => {
+      result.current.svgProps.onMouseUp();
+    });
+    expect(result.current.viewport).toEqual({ tx: 40, ty: 25, scale: 1 });
   });
 });

--- a/frontend/src/lib/useInteractiveViewport.ts
+++ b/frontend/src/lib/useInteractiveViewport.ts
@@ -72,44 +72,37 @@ export function useInteractiveViewport({
     [width, height]
   );
 
-  const onMouseDown = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
-    // Only pan on the background (target is the SVG or a <rect> backdrop)
-    const tag = (e.target as SVGElement).tagName.toLowerCase();
-    if (tag !== 'svg' && tag !== 'rect' && tag !== 'line' && tag !== 'path') return;
-    e.preventDefault();
-    dragStart.current = {
-      clientX: e.clientX,
-      clientY: e.clientY,
-      tx: 0,
-      ty: 0,
-    };
-    setViewport((v) => {
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      // Only pan on the background (target is the SVG or a <rect> backdrop)
+      const tag = (e.target as SVGElement).tagName.toLowerCase();
+      if (tag !== 'svg' && tag !== 'rect' && tag !== 'line' && tag !== 'path') return;
+      e.preventDefault();
       dragStart.current = {
         clientX: e.clientX,
         clientY: e.clientY,
-        tx: v.tx,
-        ty: v.ty,
+        tx: viewport.tx,
+        ty: viewport.ty,
       };
-      return v;
-    });
-    setIsPanning(true);
-  }, []);
+      setIsPanning(true);
+    },
+    [viewport.tx, viewport.ty]
+  );
 
   const onMouseMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
-      if (!dragStart.current) return;
+      // Capture eagerly: a mouseup batched with this event nulls the ref
+      // before the queued updater runs at render time.
+      const start = dragStart.current;
+      if (!start) return;
       const svg = svgRef.current;
       if (!svg) return;
       const rect = svg.getBoundingClientRect();
       const scaleX = width / rect.width;
       const scaleY = height / rect.height;
-      const dx = (e.clientX - dragStart.current.clientX) * scaleX;
-      const dy = (e.clientY - dragStart.current.clientY) * scaleY;
-      setViewport((v) => ({
-        ...v,
-        tx: dragStart.current!.tx + dx,
-        ty: dragStart.current!.ty + dy,
-      }));
+      const tx = start.tx + (e.clientX - start.clientX) * scaleX;
+      const ty = start.ty + (e.clientY - start.clientY) * scaleY;
+      setViewport((v) => ({ ...v, tx, ty }));
     },
     [width, height]
   );


### PR DESCRIPTION
Closes #922

## Problem

The AI Stats page crashed in production with `TypeError: Cannot read properties of null (reading 'tx')` originating inside a `useState` call. Root cause in `useInteractiveViewport` (shared by `KnowledgeGraph` and `EmbeddingMapChart`):

- `onMouseMove` queued `setViewport((v) => ({ ...v, tx: dragStart.current!.tx + dx, ... }))` — the updater dereferences the ref **lazily at render time**. With React 18 automatic batching, a `mouseup`/`mouseleave` in the same batch nulls `dragStart.current` before the queued updater runs, so the next render throws inside `useState` and unmounts the page. This matches the production stack trace exactly (verified against the deployed minified bundle).
- `onMouseDown` mutated `dragStart.current` inside a `setViewport` updater — an impure updater that could also resurrect a phantom drag after `mouseup`.

#909 fixed a different (shared-initial-state) issue in this hook; the race above survived it.

## Fix

- Capture pan-start values eagerly in the `onMouseMove` handler; the state updater is now pure and the hook has no `!` assertions left.
- `onMouseDown` writes `dragStart.current` directly, reading the current viewport via `useCallback` deps — no side effects inside updaters.

## Tests

New regression test dispatches `mousemove` + `mouseup` in a single React batch during a drag; it reproduced the exact production `TypeError` before the fix and passes after. A second test verifies consecutive pans accumulate from the current viewport position. A frontend-wide sweep found no other unguarded ref dereferences inside state updaters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)