### PR TITLE
fix: spread knowledge graph layout instead of clamping nodes into wall rows (#938)

### DIFF
--- a/frontend/src/__tests__/forceLayout.test.ts
+++ b/frontend/src/__tests__/forceLayout.test.ts
@@ -55,6 +55,66 @@ describe('forceLayout', () => {
     expect(mean(connected)).toBeLessThan(mean(unconnected));
   });
 
+  describe('with a large sparse graph (realistic entity extraction shape)', () => {
+    const MARGIN = 28;
+    const bigNodes = Array.from({ length: 60 }, (_, i) => ({ id: `b${i}` }));
+    const bigEdges = [
+      // hub-and-spoke around b0
+      ...Array.from({ length: 8 }, (_, i) => ({
+        source: 'b0',
+        target: `b${i + 1}`,
+        weight: 1 + (i % 3),
+      })),
+      // a chain b10..b20
+      ...Array.from({ length: 10 }, (_, i) => ({
+        source: `b${i + 10}`,
+        target: `b${i + 11}`,
+        weight: 1,
+      })),
+      // a few cross links; the rest of the nodes stay isolated
+      { source: 'b5', target: 'b15', weight: 2 },
+      { source: 'b8', target: 'b30', weight: 1 },
+      { source: 'b25', target: 'b40', weight: 3 },
+    ];
+
+    it('does not pile nodes up along the viewport boundary', () => {
+      const layout = forceLayout(bigNodes, bigEdges, W, H, MARGIN);
+      let onBoundary = 0;
+      for (const { x, y } of layout.values()) {
+        const atEdge =
+          Math.abs(x - MARGIN) < 0.5 ||
+          Math.abs(x - (W - MARGIN)) < 0.5 ||
+          Math.abs(y - MARGIN) < 0.5 ||
+          Math.abs(y - (H - MARGIN)) < 0.5;
+        if (atEdge) onBoundary++;
+      }
+      // A fitted layout touches the boundary only at its bounding-box extremes.
+      expect(onBoundary).toBeLessThanOrEqual(Math.ceil(bigNodes.length * 0.15));
+    });
+
+    it('keeps every pair of nodes far enough apart for labels to stay legible', () => {
+      const layout = forceLayout(bigNodes, bigEdges, W, H, MARGIN);
+      const pts = [...layout.values()];
+      let minDist = Infinity;
+      for (let i = 0; i < pts.length; i++) {
+        for (let j = i + 1; j < pts.length; j++) {
+          minDist = Math.min(minDist, Math.hypot(pts[i].x - pts[j].x, pts[i].y - pts[j].y));
+        }
+      }
+      expect(minDist).toBeGreaterThanOrEqual(24);
+    });
+
+    it('stays inside the margin bounds', () => {
+      const layout = forceLayout(bigNodes, bigEdges, W, H, MARGIN);
+      for (const { x, y } of layout.values()) {
+        expect(x).toBeGreaterThanOrEqual(MARGIN);
+        expect(x).toBeLessThanOrEqual(W - MARGIN);
+        expect(y).toBeGreaterThanOrEqual(MARGIN);
+        expect(y).toBeLessThanOrEqual(H - MARGIN);
+      }
+    });
+  });
+
   it('ignores edges that reference unknown nodes', () => {
     const layout = forceLayout(
       [{ id: 'a' }, { id: 'b' }],

--- a/frontend/src/lib/forceLayout.ts
+++ b/frontend/src/lib/forceLayout.ts
@@ -18,13 +18,19 @@ const REPULSION = 0.08; // fraction of area per node pair
 const SPRING = 0.02;
 const CENTERING = 0.01;
 const COOLING = 0.98;
+const MIN_SEPARATION = 30; // px between node centers so labels stay legible
+const SEPARATION_PASSES = 40;
 
 /**
  * Deterministic force-directed layout: nodes start evenly spaced on a circle
  * (so the result is reproducible without randomness), then iterate pairwise
  * repulsion, weighted spring attraction along edges, and a centering pull,
- * with a cooling step cap. Positions are clamped to the viewport with an
- * optional `margin` so node circles never clip at the SVG boundary.
+ * with a cooling step cap.
+ *
+ * The simulation itself runs unclamped — clamping each iteration piles nodes
+ * up along the viewport edges in straight rows. Instead the finished layout is
+ * rescaled to fit the viewport minus `margin`, then minimum-separation passes
+ * push near-coincident nodes apart so circles and labels don't overlap.
  */
 export function forceLayout(
   nodes: ForceNode[],
@@ -105,13 +111,90 @@ export function forceLayout(
       const magnitude = Math.hypot(f.x, f.y) || 1;
       const step = Math.min(magnitude, maxStep);
       layout.set(id, {
-        x: Math.min(width - margin, Math.max(margin, p.x + (f.x / magnitude) * step)),
-        y: Math.min(height - margin, Math.max(margin, p.y + (f.y / magnitude) * step)),
+        x: p.x + (f.x / magnitude) * step,
+        y: p.y + (f.y / magnitude) * step,
       });
     }
 
     maxStep *= COOLING;
   }
 
+  fitToViewport(layout, width, height, margin);
+  separate(layout, ids, width, height, margin);
   return layout;
+}
+
+/** Rescale the layout's bounding box to fill the viewport minus `margin`. */
+function fitToViewport(
+  layout: Map<string, ForcePoint>,
+  width: number,
+  height: number,
+  margin: number
+): void {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const p of layout.values()) {
+    minX = Math.min(minX, p.x);
+    maxX = Math.max(maxX, p.x);
+    minY = Math.min(minY, p.y);
+    maxY = Math.max(maxY, p.y);
+  }
+  const spanX = maxX - minX;
+  const spanY = maxY - minY;
+  const innerW = width - 2 * margin;
+  const innerH = height - 2 * margin;
+  for (const [id, p] of layout) {
+    layout.set(id, {
+      x: spanX < 1 ? width / 2 : margin + ((p.x - minX) / spanX) * innerW,
+      y: spanY < 1 ? height / 2 : margin + ((p.y - minY) / spanY) * innerH,
+    });
+  }
+}
+
+/**
+ * Push pairs closer than MIN_SEPARATION apart, clamped to the viewport.
+ * Moves are small relative to the canvas, so clamping here cannot recreate
+ * the wall pile-up the simulation avoids.
+ */
+function separate(
+  layout: Map<string, ForcePoint>,
+  ids: string[],
+  width: number,
+  height: number,
+  margin: number
+): void {
+  const clampX = (x: number) => Math.min(width - margin, Math.max(margin, x));
+  const clampY = (y: number) => Math.min(height - margin, Math.max(margin, y));
+  for (let pass = 0; pass < SEPARATION_PASSES; pass++) {
+    let moved = false;
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const a = layout.get(ids[i])!;
+        const b = layout.get(ids[j])!;
+        let dx = b.x - a.x;
+        let dy = b.y - a.y;
+        let dist = Math.hypot(dx, dy);
+        if (dist >= MIN_SEPARATION) continue;
+        if (dist < 1e-3) {
+          // Deterministic direction for coincident points.
+          dx = i - j;
+          dy = 1;
+          dist = Math.hypot(dx, dy);
+        }
+        const shift = (MIN_SEPARATION - dist) / 2 / dist;
+        layout.set(ids[i], {
+          x: clampX(a.x - dx * shift),
+          y: clampY(a.y - dy * shift),
+        });
+        layout.set(ids[j], {
+          x: clampX(b.x + dx * shift),
+          y: clampY(b.y + dy * shift),
+        });
+        moved = true;
+      }
+    }
+    if (!moved) break;
+  }
 }


### PR DESCRIPTION
Closes #938

## Problem

The Knowledge Graph rendered as strange horizontal rows of nodes hugging the top and bottom of the canvas, with overlapping labels and long crossing edges. `forceLayout` clamped node positions to the viewport on **every simulation iteration**; pairwise repulsion is strong relative to the canvas, so nodes got shoved into the clamp boundary and slid along it into rows. With a realistic 60-node graph, **all 60 nodes** ended up pinned to the boundary, and the closest pair sat 10px apart.

## Fix

- Run the force simulation unclamped (the centering pull keeps it bounded).
- Fit the finished layout's bounding box to the viewport minus margin, so the graph fills the canvas instead of hugging its walls.
- Add deterministic minimum-separation passes (30px between centers) so node circles and labels stay legible.

## Tests

New cases in `frontend/src/__tests__/forceLayout.test.ts` with a realistic sparse 60-node graph: no boundary pile-up (≤15% of nodes on the margin line, previously 100%), ≥24px minimum pairwise distance (previously ~10px), and positions stay inside the margin bounds. All pre-existing tests (determinism, bounds, connected-closer-than-unconnected, ghost edges) still pass; full frontend gate is green (eslint, prettier, tsc, 742 vitest tests, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)