### PR TITLE
fix: cap What's New dialog height and scroll the item list

### DIFF
--- a/frontend/src/__tests__/whatsNew.test.tsx
+++ b/frontend/src/__tests__/whatsNew.test.tsx
@@ -135,4 +135,13 @@ describe('WhatsNewDialog', () => {
     render(<WhatsNewDialog state={makeState({ open: false })} />);
     expect(screen.queryByText(/What's new/)).toBeNull();
   });
+
+  it('caps dialog height and scrolls the item list instead of overflowing the page', () => {
+    const manyItems = Array.from({ length: 50 }, (_, i) => `Change number ${i + 1}`);
+    render(<WhatsNewDialog state={makeState({ items: manyItems })} />);
+    const dialogContent = screen.getByRole('dialog');
+    expect(dialogContent.className).toMatch(/max-h-\[85vh\]/);
+    const list = screen.getByRole('list');
+    expect(list.className).toMatch(/overflow-y-auto/);
+  });
 });

--- a/frontend/src/components/WhatsNewDialog.tsx
+++ b/frontend/src/components/WhatsNewDialog.tsx
@@ -23,7 +23,7 @@ export function WhatsNewDialog({ state }: WhatsNewDialogProps) {
         if (!v) dismiss();
       }}
     >
-      <DialogContent className="max-w-sm">
+      <DialogContent className="max-w-sm max-h-[85vh] flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle>✨ What's new</DialogTitle>
           <DialogDescription>
@@ -33,7 +33,7 @@ export function WhatsNewDialog({ state }: WhatsNewDialogProps) {
           </DialogDescription>
         </DialogHeader>
         {hasItems ? (
-          <ul className="mt-1 space-y-1.5 text-sm text-foreground">
+          <ul className="mt-1 min-h-0 flex-1 space-y-1.5 overflow-y-auto text-sm text-foreground">
             {items.map((item) => (
               <li key={item} className="flex gap-2">
                 <span className="mt-0.5 text-muted-foreground select-none">•</span>


### PR DESCRIPTION
Closes #941

## Summary
- The "What's New" dialog (`WhatsNewDialog`) had no max height, so releases with many changelog items pushed the "Got it" button and version footer off-screen and made the popup unreadable.
- Caps `DialogContent` at `max-h-[85vh]` as a flex column and makes the item `<ul>` scroll internally (`flex-1 min-h-0 overflow-y-auto`) so header/footer stay visible.

## Test plan
- [x] `npm run test:frontend` — 743 tests pass, including new test asserting `max-h-[85vh]` on the dialog and `overflow-y-auto` on the item list with 50 items.
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run build` all pass.
- [x] Manually verified in a running dev server (Radix Dialog rendered with 40 long items): dialog height 745px stays within an 877px viewport; item list `scrollHeight` (2634px) exceeds `clientHeight` (563px), confirming internal scroll instead of page overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)