### PR TITLE
fix: wire SMTP_USERNAME/SMTP_PASSWORD through to production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,7 @@ jobs:
             --set-string "postgresql.password=dummy-postgres-password-for-render-only" \
             --set "app.ai.existingSecret=news-dashboard-ai" \
             --set "app.push.existingSecret=news-dashboard-push" \
+            --set "app.email.existingSecret=news-dashboard-email" \
             --set-string "app.ai.freeLlmBaseUrl=http://192.168.0.75:9130/v1" \
             --set-string "app.ai.briefingModel=gpt-4o" \
             --set-string "app.ai.langfuse.host=http://langfuse.local" \
@@ -601,6 +602,10 @@ jobs:
   # │  SENTRY_DSN_      Optional Sentry project DSN for frontend/UI error   │
   # │  FRONTEND         tracking. Stored as a secret and exposed publicly   │
   # │                   through GET /api/config as SENTRY_DSN_FRONTEND.     │
+  # │                                                                      │
+  # │  SMTP_USERNAME    Optional Gmail SMTP creds used to send OTP sign-in  │
+  # │  SMTP_PASSWORD    emails (send_otp_email). SMTP_PASSWORD must be a    │
+  # │                   Gmail App Password, not the account password.      │
   # └──────────────────────────────────────────────────────────────────────┘
   deploy:
     name: Deploy to mini PC
@@ -632,6 +637,8 @@ jobs:
           VAPID_EMAIL: ${{ vars.VAPID_EMAIL }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_DSN_FRONTEND: ${{ secrets.SENTRY_DSN_FRONTEND }}
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -716,6 +723,22 @@ jobs:
             push_helm_args+=(--set-string "app.push.email=$VAPID_EMAIL")
           fi
 
+          email_secret_args=()
+          if [ -n "$SMTP_USERNAME" ]; then
+            email_secret_args+=(--from-literal=SMTP_USERNAME="$SMTP_USERNAME")
+          fi
+          if [ -n "$SMTP_PASSWORD" ]; then
+            email_secret_args+=(--from-literal=SMTP_PASSWORD="$SMTP_PASSWORD")
+          fi
+
+          email_helm_args=()
+          if [ ${#email_secret_args[@]} -gt 0 ]; then
+            kubectl -n news-dashboard create secret generic news-dashboard-email \
+              "${email_secret_args[@]}" \
+              --dry-run=client -o yaml | kubectl apply -f -
+            email_helm_args+=(--set app.email.existingSecret=news-dashboard-email)
+          fi
+
           sentry_helm_args=()
           sentry_secret_args=()
           if [ -n "$SENTRY_DSN" ]; then
@@ -756,6 +779,7 @@ jobs:
             --set-string postgresql.password="$POSTGRES_PASSWORD"
             "${ai_helm_args[@]}"
             "${push_helm_args[@]}"
+            "${email_helm_args[@]}"
             "${sentry_helm_args[@]}"
           )
           helm "${helm_args[@]}"

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -103,6 +103,22 @@ spec:
               value: {{ .Values.app.push.email | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.app.email }}
+{{- if .Values.app.email.existingSecret }}
+            - name: SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.email.existingSecret | quote }}
+                  key: {{ .Values.app.email.smtpUsernameKey | default "SMTP_USERNAME" | quote }}
+                  optional: true
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.email.existingSecret | quote }}
+                  key: {{ .Values.app.email.smtpPasswordKey | default "SMTP_PASSWORD" | quote }}
+                  optional: true
+{{- end }}
+{{- end }}
 {{- if .Values.app.auth.enabled }}
             - name: KEYCLOAK_AUTH_ENABLED
               value: "1"

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -110,6 +110,11 @@ app:
     vapidPrivateKeyKey: VAPID_PRIVATE_KEY
     # VAPID claims email address. Omit or leave empty to default safely.
     email: ""
+  email:
+    # Optional: pre-existing Secret with Gmail SMTP creds for OTP sign-in emails.
+    existingSecret: ""
+    smtpUsernameKey: SMTP_USERNAME
+    smtpPasswordKey: SMTP_PASSWORD
   sentry:
     # Optional: pre-existing Secret with SENTRY_DSN and/or SENTRY_DSN_FRONTEND.
     existingSecret: ""

--- a/scripts/test_helm_email_secret.py
+++ b/scripts/test_helm_email_secret.py
@@ -1,0 +1,39 @@
+# ruff: noqa: S101
+"""Chart render tests for wiring SMTP_USERNAME/SMTP_PASSWORD via app.email."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHART = ROOT / "helm" / "news-dashboard"
+
+
+def _helm_template(extra_sets: list[str]) -> str:
+    cmd = [
+        "helm",
+        "template",
+        "test-release",
+        str(CHART),
+        "--set",
+        "app.auth.sessionSecret=dummy-secret-for-test",
+        "--set-string",
+        "postgresql.password=dummy-postgres-password-for-render-only",
+        *extra_sets,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603
+    return result.stdout
+
+
+def test_email_env_absent_by_default() -> None:
+    rendered = _helm_template([])
+    assert "SMTP_USERNAME" not in rendered
+    assert "SMTP_PASSWORD" not in rendered
+
+
+def test_email_env_wired_from_existing_secret() -> None:
+    rendered = _helm_template(["--set", "app.email.existingSecret=news-dashboard-email"])
+    assert "SMTP_USERNAME" in rendered
+    assert "SMTP_PASSWORD" in rendered
+    assert "news-dashboard-email" in rendered


### PR DESCRIPTION
Closes #947

## Summary
- OTP sign-in emails (`send_otp_email`) need `SMTP_USERNAME`/`SMTP_PASSWORD`, but the deploy job and Helm chart never injected them into the backend pod — unlike the existing `app.push` (VAPID) wiring — so OTP emails silently failed in production.
- Added `app.email.existingSecret`/`smtpUsernameKey`/`smtpPasswordKey` to `helm/news-dashboard/values.yaml`, mirroring `app.push`.
- `deployment.yaml` now injects `SMTP_USERNAME`/`SMTP_PASSWORD` from `app.email.existingSecret` when set.
- The deploy job in `ci.yml` creates a `news-dashboard-email` k8s secret from the `SMTP_USERNAME`/`SMTP_PASSWORD` GitHub secrets (already set) and passes `--set app.email.existingSecret=news-dashboard-email` to Helm, mirroring the `news-dashboard-push` block.

## Test plan
- [x] New `scripts/test_helm_email_secret.py`: asserts `SMTP_USERNAME`/`SMTP_PASSWORD` are absent from the rendered chart by default, and present (sourced from the named secret) when `app.email.existingSecret` is set.
- [x] `helm lint ./helm/news-dashboard` passes.
- [x] `helm template` renders correctly with and without `app.email.existingSecret` set.
- [x] Full `scripts/` pytest suite (84 tests) passes locally.
- [x] ruff / mypy / pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)