### PR TITLE
feat: show "Also covered by" duplicate sources on article rows

### DIFF
--- a/frontend/src/__tests__/articleRow.test.tsx
+++ b/frontend/src/__tests__/articleRow.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ArticleRow } from '../components/article/ArticleRow';
+import type { WorkflowArticle } from '../lib/workflowTypes';
+
+vi.mock('../hooks/useTriageMutations', () => ({
+  useTriageMutations: () => ({ setState: vi.fn(), toggleStar: vi.fn(), sendLater: vi.fn() }),
+  ARTICLES_KEY: 'articles',
+}));
+
+function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
+  return {
+    id: '42',
+    title: 'Readable article',
+    sourceId: 'source',
+    sourceName: 'Source',
+    category: 'ai-llm',
+    url: 'https://example.com/readable',
+    publishedAt: '2026-06-16T10:00:00Z',
+    ingestedAt: '2026-06-16T11:00:00Z',
+    reason: 'This is why it matters.',
+    summary: 'Summary text.',
+    signal: 'high',
+    tags: ['ai'],
+    bodyStatus: 'missing',
+    state: 'today',
+    starred: false,
+    ...overrides,
+  };
+}
+
+function renderRow(article: WorkflowArticle) {
+  return render(
+    <MemoryRouter initialEntries={['/today']}>
+      <Routes>
+        <Route path="/today" element={<ArticleRow article={article} />} />
+        <Route path="/a/:id" element={<div data-testid="reader">Reader</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ArticleRow — also covered by duplicate sources (#929)', () => {
+  it('shows an "Also covered by" line naming duplicate sources', () => {
+    renderRow(makeArticle({ alsoFrom: ['The Verge', 'Ars Technica'] }));
+    expect(screen.getByText('Also covered by The Verge, Ars Technica')).toBeTruthy();
+  });
+
+  it('renders nothing when also_from is absent', () => {
+    renderRow(makeArticle({ alsoFrom: undefined }));
+    expect(screen.queryByText(/Also covered by/)).toBeNull();
+  });
+
+  it('renders nothing when also_from is an empty array', () => {
+    renderRow(makeArticle({ alsoFrom: [] }));
+    expect(screen.queryByText(/Also covered by/)).toBeNull();
+  });
+
+  it('shows all names with no "+more" suffix at exactly 3 duplicates', () => {
+    renderRow(makeArticle({ alsoFrom: ['Source A', 'Source B', 'Source C'] }));
+    expect(screen.getByText('Also covered by Source A, Source B, Source C')).toBeTruthy();
+    expect(screen.queryByText(/more/)).toBeNull();
+  });
+
+  it('collapses more than 3 duplicate sources to "+N more"', () => {
+    renderRow(
+      makeArticle({ alsoFrom: ['Source A', 'Source B', 'Source C', 'Source D', 'Source E'] })
+    );
+    expect(screen.getByText('Also covered by Source A, Source B, Source C, +2 more')).toBeTruthy();
+  });
+
+  it('keeps rendering the row normally alongside the existing metadata', () => {
+    renderRow(makeArticle({ alsoFrom: ['The Verge'], recommendationScore: 82 }));
+    expect(screen.getByText('Readable article')).toBeTruthy();
+    expect(screen.getByTestId('recommendation-label')).toBeTruthy();
+    expect(screen.getByText('Also covered by The Verge')).toBeTruthy();
+  });
+});

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -81,6 +81,7 @@ export function adaptArticle(a: LegacyArticle): WorkflowArticle {
     starred_at,
     later_until: a.later_until ?? undefined,
     restored_at: a.restored_at ?? undefined,
+    alsoFrom: a.also_from,
   };
 }
 

--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -14,6 +14,15 @@ interface Props {
   showLaterUntil?: boolean;
 }
 
+const MAX_ALSO_FROM_SHOWN = 3;
+
+/** "A, B, C" for ≤3 names; "A, B, C, +N more" beyond that. */
+function formatAlsoFrom(names: string[]): string {
+  const shown = names.slice(0, MAX_ALSO_FROM_SHOWN).join(', ');
+  const remaining = names.length - MAX_ALSO_FROM_SHOWN;
+  return remaining > 0 ? `${shown}, +${remaining} more` : shown;
+}
+
 function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
   const { setState, toggleStar } = useTriageMutations();
 
@@ -68,6 +77,11 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
               <Star className="size-3.5 shrink-0 fill-star text-star" strokeWidth={1.5} />
             )}
           </div>
+          {article.alsoFrom && article.alsoFrom.length > 0 && (
+            <div className="mb-1 truncate text-[11px] text-muted-foreground">
+              Also covered by {formatAlsoFrom(article.alsoFrom)}
+            </div>
+          )}
           <h3 className="text-[15px] leading-snug font-semibold tracking-tight text-foreground mb-1.5">
             {article.title}
           </h3>

--- a/frontend/src/lib/workflowTypes.ts
+++ b/frontend/src/lib/workflowTypes.ts
@@ -52,6 +52,8 @@ export interface WorkflowArticle {
   starred_at?: string;
   later_until?: string;
   restored_at?: string;
+  /** Names of other sources also carrying this canonical story; undefined/empty when there are no known duplicates. */
+  alsoFrom?: string[];
 }
 
 export interface UndoSnapshot {


### PR DESCRIPTION
]Closes #929

Threads `also_from` from the API through the WorkflowArticle adapter
(workflowApi.ts) into ArticleRow, since the row component consumes the
adapted type rather than the raw API shape. Renders nothing when the
field is absent/empty; joins up to 3 names then "+N more" beyond that.

No backend changes — the article-detail endpoint doesn't attach
also_from, so ArticlePage is left out of scope per the issue.