### PR TITLE
feat: add proactive AI watchlists and nudges (#755)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ OPENAI_AGENT_ACTIONS_MODEL=
 OPENAI_OPTIMIZER_MODEL=
 OPENAI_PERSPECTIVES_MODEL=
 OPENAI_QUIZ_MODEL=
+OPENAI_WATCHLIST_MODEL=
 
 # --- Tracing (optional) -------------------------------------------------------
 # Tracing activates only when both keys below are set; otherwise a plain OpenAI client is used.
@@ -100,6 +101,8 @@ INGEST_INTERVAL_MINUTES=30
 ENTITY_EXTRACTION_INTERVAL_MINUTES=30
 # Interval for the reading-list metadata sweep retrying pending link previews. Default 5.
 READING_LIST_FETCH_INTERVAL_MINUTES=5
+# Interval for the proactive AI watchlist evaluator (watchlist_agent.py). Default 15.
+WATCHLIST_EVALUATION_INTERVAL_MINUTES=15
 DIGEST_CRON=0 8 * * *
 BRIEFING_CRON=0 9 * * *
 RECOMMENDATIONS_CRON=30 7 * * *

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -617,6 +617,36 @@ POSTGRES_MULTIUSER_SCHEMA = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_agent_action_steps_run ON agent_action_steps(run_id, ordinal)",
+    """
+    CREATE TABLE IF NOT EXISTS user_ai_watchlists (
+      id           SERIAL PRIMARY KEY,
+      user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      label        TEXT NOT NULL,
+      query        TEXT NOT NULL,
+      threshold    DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+      enabled      BOOLEAN NOT NULL DEFAULT TRUE,
+      notify_push  BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CHECK (threshold >= 0 AND threshold <= 1)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_ai_watchlists_user"
+    " ON user_ai_watchlists(user_id, enabled)",
+    """
+    CREATE TABLE IF NOT EXISTS user_ai_nudges (
+      id           BIGSERIAL PRIMARY KEY,
+      user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      watchlist_id INTEGER NOT NULL REFERENCES user_ai_watchlists(id) ON DELETE CASCADE,
+      article_id   BIGINT  NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+      score        DOUBLE PRECISION NOT NULL,
+      explanation  TEXT,
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (user_id, watchlist_id, article_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_ai_nudges_user"
+    " ON user_ai_nudges(user_id, created_at DESC)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2035,6 +2035,111 @@ def dismiss_personalization_nudge(
     )
 
 
+# ── AI watchlists ──────────────────────────────────────────────────────────────
+
+
+class WatchlistCreateRequest(BaseModel):
+    label: str
+    query: str
+    threshold: float = 0.5
+    enabled: bool = True
+    notify_push: bool = True
+
+
+class WatchlistUpdateRequest(BaseModel):
+    label: str | None = None
+    query: str | None = None
+    threshold: float | None = None
+    enabled: bool | None = None
+    notify_push: bool | None = None
+
+
+class WatchlistPreviewRequest(BaseModel):
+    query: str
+    threshold: float = 0.5
+
+
+@api.get("/api/watchlists")
+def list_watchlists_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.watchlist_agent import list_watchlists
+
+    return {"items": list_watchlists(int(current_user["id"]))}
+
+
+@api.post("/api/watchlists")
+def create_watchlist_endpoint(
+    payload: WatchlistCreateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.watchlist_agent import create_watchlist
+
+    try:
+        return create_watchlist(
+            int(current_user["id"]),
+            payload.label,
+            payload.query,
+            threshold=payload.threshold,
+            enabled=payload.enabled,
+            notify_push=payload.notify_push,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@api.patch("/api/watchlists/{watchlist_id}")
+def update_watchlist_endpoint(
+    watchlist_id: int,
+    payload: WatchlistUpdateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.watchlist_agent import WatchlistNotFoundError, update_watchlist
+
+    try:
+        return update_watchlist(
+            int(current_user["id"]),
+            watchlist_id,
+            **payload.model_dump(exclude_unset=True),
+        )
+    except WatchlistNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="watchlist not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@api.delete("/api/watchlists/{watchlist_id}")
+def delete_watchlist_endpoint(
+    watchlist_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.watchlist_agent import delete_watchlist
+
+    if not delete_watchlist(int(current_user["id"]), watchlist_id):
+        raise HTTPException(status_code=404, detail="watchlist not found")
+    return {"deleted": True}
+
+
+@api.post("/api/watchlists/preview")
+def preview_watchlist_endpoint(
+    payload: WatchlistPreviewRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.watchlist_agent import preview_matches
+
+    matches = preview_matches(int(current_user["id"]), payload.query, threshold=payload.threshold)
+    return {"items": matches}
+
+
+@api.get("/api/watchlists/nudges")
+def list_watchlist_nudges_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.watchlist_agent import list_nudges
+
+    return {"items": list_nudges(int(current_user["id"]))}
+
+
 @api.patch("/api/sources/{slug}/enabled")
 def set_source_enabled(
     slug: str,

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -342,6 +342,23 @@ def _run_reading_list_fetch() -> tuple[str, str | None] | None:
     return "success", f"fetched {processed} item(s)"
 
 
+def _run_watchlist_evaluation() -> tuple[str, str | None]:
+    from news_dashboard.watchlist_agent import evaluate_watchlists
+
+    logger.info("Watchlist evaluation starting…")
+    try:
+        summary = evaluate_watchlists()
+        msg = (
+            f"{summary['watchlists_evaluated']} watchlist(s) evaluated, "
+            f"{summary['nudges_created']} nudge(s) created"
+        )
+        logger.info("Watchlist evaluation: %s", msg)
+        return "success", msg
+    except Exception as exc:
+        logger.exception("Watchlist evaluation failed")
+        return "failure", str(exc)[:500]
+
+
 def _run_and_record(
     job_name: str,
     fn: Callable[[], tuple[str, str | None] | None],
@@ -406,6 +423,10 @@ def _job_weekly_recaps() -> None:
 
 def _job_reading_list_fetch() -> None:
     _run_and_record("reading_list_fetch", _run_reading_list_fetch)
+
+
+def _job_watchlist_evaluation() -> None:
+    _run_and_record("watchlist_evaluation", _run_watchlist_evaluation)
 
 
 def _parse_cron_hm(cron: str, default_minute: str, default_hour: str) -> tuple[str, str]:
@@ -540,6 +561,14 @@ def start_scheduler() -> None:
         trigger="interval",
         minutes=int(os.getenv("READING_LIST_FETCH_INTERVAL_MINUTES", "5")),
         id="reading_list_fetch",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _job_watchlist_evaluation,
+        trigger="interval",
+        minutes=int(os.getenv("WATCHLIST_EVALUATION_INTERVAL_MINUTES", "15")),
+        id="watchlist_evaluation",
         replace_existing=True,
     )
 

--- a/backend/news_dashboard/watchlist_agent.py
+++ b/backend/news_dashboard/watchlist_agent.py
@@ -1,0 +1,472 @@
+"""Proactive AI watchlist matching and nudge generation.
+
+A watchlist lets a user describe a topic or goal (free-text query) and get
+notified when a newly ingested article matches it. Matching runs in two
+layers:
+
+1. Deterministic term-overlap scoring against title/summary/tags — always
+   available, works with zero AI configuration.
+2. Optional LLM judgment (only attempted when an AI key is configured) that
+   replaces the deterministic score with a more nuanced one.
+
+The scheduled evaluator only reads articles and writes ``user_ai_nudges``
+rows (plus an optional push notification); it never mutates article state
+(star/archive/etc) — see issue #755.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+from news_dashboard.db import connect, init_db, row_to_dict
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_THRESHOLD = 0.5
+_MAX_LABEL_LEN = 120
+_MAX_QUERY_LEN = 500
+_PREVIEW_LIMIT = 10
+_EVAL_CANDIDATES_LIMIT = 25  # recent articles considered per watchlist per run
+_AI_MAX_ARTICLE_CHARS = 2_000
+_STOPWORDS = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "of",
+        "in",
+        "on",
+        "for",
+        "to",
+        "is",
+        "are",
+        "about",
+        "with",
+        "new",
+        "news",
+    }
+)
+
+_AI_JUDGE_PROMPT = (
+    "You judge whether a news article matches a user's watchlist topic. "
+    "Given the watchlist description and the article title/summary, respond "
+    "with ONLY a JSON object (no prose, no code fences) shaped "
+    '{"score": <0.0-1.0>, "explanation": "<one short sentence>"}. '
+    "score reflects how relevant the article is to the watchlist topic."
+)
+
+
+class WatchlistNotFoundError(Exception):
+    """Raised when a watchlist id doesn't exist or isn't owned by the user."""
+
+
+# ── matching ─────────────────────────────────────────────────────────────────
+
+
+def _tokenize(text: str) -> set[str]:
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    return {w for w in words if w not in _STOPWORDS and len(w) > 1}
+
+
+def _article_text(article: dict[str, Any]) -> str:
+    parts = [
+        str(article.get("title") or ""),
+        str(article.get("summary") or ""),
+        str(article.get("tags") or ""),
+    ]
+    return " ".join(p for p in parts if p)
+
+
+def deterministic_match(query: str, article: dict[str, Any]) -> tuple[float, str]:
+    """Score 0..1 = fraction of query terms present in the article's text."""
+    query_terms = _tokenize(query)
+    if not query_terms:
+        return 0.0, "empty watchlist query"
+    article_terms = _tokenize(_article_text(article))
+    matched = sorted(query_terms & article_terms)
+    score = len(matched) / len(query_terms)
+    explanation = f"Matched terms: {', '.join(matched)}" if matched else "No matching terms found"
+    return score, explanation
+
+
+def _ai_config() -> tuple[str, str | None, str] | None:
+    from news_dashboard.ai_client import free_llm_config
+
+    api_key, base_url = free_llm_config()
+    if not api_key:
+        return None
+    model = os.getenv("OPENAI_WATCHLIST_MODEL", "gpt-4o-mini")
+    return api_key, base_url, model
+
+
+def _parse_ai_response(text: str) -> tuple[float, str] | None:
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.strip("`").removeprefix("json").strip()
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        score = float(payload.get("score", 0.0))
+    except (TypeError, ValueError):
+        return None
+    score = max(0.0, min(1.0, score))
+    explanation = str(payload.get("explanation") or "").strip()[:280]
+    return score, explanation
+
+
+def ai_match(
+    query: str, article: dict[str, Any], *, user_id: int | None = None
+) -> tuple[float, str] | None:
+    """Ask the configured LLM to judge relevance.
+
+    Returns ``None`` when no AI key is configured or the call/parse fails, so
+    callers can fall back to :func:`deterministic_match`.
+    """
+    config = _ai_config()
+    if config is None:
+        return None
+    api_key, base_url, model = config
+    try:
+        from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
+
+        client = get_chat_client(api_key=api_key, base_url=base_url)
+        prompt = get_prompt("watchlist-match", fallback=_AI_JUDGE_PROMPT)
+        text = _article_text(article)[:_AI_MAX_ARTICLE_CHARS]
+        result = chat_create(
+            client,
+            name="watchlist-match",
+            tags=["watchlist"],
+            user_id=user_id,
+            prompt=prompt,
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": f"{prompt.text}\n\nWatchlist: {query}\n\nArticle:\n{text}",
+                }
+            ],
+            max_tokens=150,
+        )
+        response_text = result.choices[0].message.content or ""
+        return _parse_ai_response(response_text)
+    except Exception:
+        logger.exception("AI watchlist match failed for query=%r", query)
+        return None
+
+
+AiJudge = Any  # Callable[[str, dict[str, Any]], tuple[float, str] | None]
+
+
+def _score_candidates(
+    query: str,
+    candidates: list[dict[str, Any]],
+    *,
+    threshold: float,
+    ai_judge: AiJudge | None,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for article in candidates:
+        score, explanation = deterministic_match(query, article)
+        if ai_judge is not None:
+            judged = ai_judge(query, article)
+            if judged is not None:
+                score, explanation = judged
+        if score >= threshold:
+            results.append(
+                {"article": article, "score": round(score, 3), "explanation": explanation}
+            )
+    results.sort(key=lambda r: r["score"], reverse=True)
+    return results
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────────────
+
+
+def list_watchlists(
+    user_id: int, *, db_path: Any = None, database_url: str | None = None
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            "SELECT * FROM user_ai_watchlists WHERE user_id = %s ORDER BY created_at DESC",
+            (user_id,),
+        ).fetchall()
+    return [row_to_dict(r) for r in rows]
+
+
+def get_watchlist(
+    user_id: int, watchlist_id: int, *, db_path: Any = None, database_url: str | None = None
+) -> dict[str, Any] | None:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT * FROM user_ai_watchlists WHERE id = %s AND user_id = %s",
+            (watchlist_id, user_id),
+        ).fetchone()
+    return row_to_dict(row) if row else None
+
+
+def create_watchlist(  # noqa: PLR0913
+    user_id: int,
+    label: str,
+    query: str,
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    enabled: bool = True,
+    notify_push: bool = True,
+    db_path: Any = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    label = label.strip()[:_MAX_LABEL_LEN]
+    query = query.strip()[:_MAX_QUERY_LEN]
+    if not label or not query:
+        msg = "label and query are required"
+        raise ValueError(msg)
+    if not 0.0 <= threshold <= 1.0:
+        msg = "threshold must be between 0 and 1"
+        raise ValueError(msg)
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_ai_watchlists(user_id, label, query, threshold, enabled, notify_push)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING *
+            """,
+            (user_id, label, query, threshold, enabled, notify_push),
+        ).fetchone()
+    return row_to_dict(row)
+
+
+def update_watchlist(  # noqa: PLR0913
+    user_id: int,
+    watchlist_id: int,
+    *,
+    label: str | None = None,
+    query: str | None = None,
+    threshold: float | None = None,
+    enabled: bool | None = None,
+    notify_push: bool | None = None,
+    db_path: Any = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(db_path, database_url=database_url)
+    fields: list[str] = []
+    params: list[Any] = []
+    if label is not None:
+        fields.append("label = %s")
+        params.append(label.strip()[:_MAX_LABEL_LEN])
+    if query is not None:
+        fields.append("query = %s")
+        params.append(query.strip()[:_MAX_QUERY_LEN])
+    if threshold is not None:
+        if not 0.0 <= threshold <= 1.0:
+            msg = "threshold must be between 0 and 1"
+            raise ValueError(msg)
+        fields.append("threshold = %s")
+        params.append(threshold)
+    if enabled is not None:
+        fields.append("enabled = %s")
+        params.append(enabled)
+    if notify_push is not None:
+        fields.append("notify_push = %s")
+        params.append(notify_push)
+
+    if not fields:
+        existing = get_watchlist(user_id, watchlist_id, db_path=db_path, database_url=database_url)
+        if existing is None:
+            raise WatchlistNotFoundError(str(watchlist_id))
+        return existing
+
+    fields.append("updated_at = NOW()")
+    params.extend([watchlist_id, user_id])
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            f"UPDATE user_ai_watchlists SET {', '.join(fields)} "
+            "WHERE id = %s AND user_id = %s RETURNING *",
+            params,
+        ).fetchone()
+    if row is None:
+        raise WatchlistNotFoundError(str(watchlist_id))
+    return row_to_dict(row)
+
+
+def delete_watchlist(
+    user_id: int, watchlist_id: int, *, db_path: Any = None, database_url: str | None = None
+) -> bool:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            "DELETE FROM user_ai_watchlists WHERE id = %s AND user_id = %s RETURNING id",
+            (watchlist_id, user_id),
+        ).fetchone()
+    return row is not None
+
+
+# ── preview & evaluation ─────────────────────────────────────────────────────
+
+
+def preview_matches(
+    user_id: int,
+    query: str,
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    limit: int = _PREVIEW_LIMIT,
+    use_ai: bool = True,
+    db_path: Any = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return recent articles visible to *user_id* that match *query*.
+
+    Used by the settings UI so a user can see what a watchlist would have
+    matched before saving it.
+    """
+    from news_dashboard.ingest import search_articles
+
+    init_db(db_path, database_url=database_url)
+    dsn = db_path if db_path is not None else database_url
+    candidates = search_articles(
+        q=query,
+        limit=50,
+        db_path=dsn,
+        user_id=user_id,
+        include_archived=False,
+    )
+    ai_judge = ai_match if use_ai else None
+    scored = _score_candidates(query, candidates, threshold=threshold, ai_judge=ai_judge)
+    return scored[:limit]
+
+
+def evaluate_watchlists(
+    *,
+    db_path: Any = None,
+    database_url: str | None = None,
+    use_ai: bool = True,
+    ai_judge: AiJudge | None = None,
+) -> dict[str, int]:
+    """Evaluate every enabled watchlist against recent visible articles.
+
+    Creates at most one ``user_ai_nudges`` row per (user, watchlist, article)
+    via a unique constraint + ``ON CONFLICT DO NOTHING``, and sends a push
+    notification when the watchlist has ``notify_push`` enabled. Never
+    mutates article state. A failure evaluating one watchlist does not stop
+    the others.
+    """
+    from news_dashboard.ingest import search_articles
+    from news_dashboard.push import send_push_for_user
+
+    init_db(db_path, database_url=database_url)
+    dsn = db_path if db_path is not None else database_url
+    judge = ai_judge if ai_judge is not None else (ai_match if use_ai else None)
+
+    with connect(db_path, database_url=database_url) as conn:
+        watchlists = [
+            row_to_dict(r)
+            for r in conn.execute(
+                "SELECT * FROM user_ai_watchlists WHERE enabled = TRUE"
+            ).fetchall()
+        ]
+
+    evaluated = 0
+    nudges_created = 0
+    for wl in watchlists:
+        evaluated += 1
+        user_id = int(wl["user_id"])
+        try:
+            candidates = search_articles(
+                q=str(wl["query"]),
+                limit=_EVAL_CANDIDATES_LIMIT,
+                db_path=dsn,
+                user_id=user_id,
+                include_archived=False,
+            )
+        except Exception:
+            logger.exception("Watchlist evaluation: search failed for watchlist %s", wl["id"])
+            continue
+
+        threshold = float(wl["threshold"])
+        matches = _score_candidates(
+            str(wl["query"]), candidates, threshold=threshold, ai_judge=judge
+        )
+        for match in matches:
+            created = _record_nudge(
+                user_id=user_id,
+                watchlist_id=int(wl["id"]),
+                article_id=int(match["article"]["id"]),
+                score=match["score"],
+                explanation=match["explanation"],
+                db_path=db_path,
+                database_url=database_url,
+            )
+            if not created:
+                continue
+            nudges_created += 1
+            if wl.get("notify_push"):
+                try:
+                    send_push_for_user(
+                        user_id,
+                        f"Watchlist: {wl['label']}",
+                        str(match["article"].get("title") or ""),
+                        target_url=f"/article/{match['article']['id']}",
+                        database_url=dsn,
+                    )
+                except Exception:
+                    logger.exception("Watchlist push failed for user_id=%s", user_id)
+
+    return {"watchlists_evaluated": evaluated, "nudges_created": nudges_created}
+
+
+def _record_nudge(
+    *,
+    user_id: int,
+    watchlist_id: int,
+    article_id: int,
+    score: float,
+    explanation: str,
+    db_path: Any,
+    database_url: str | None,
+) -> bool:
+    """Insert a nudge row; returns False when one already existed (dedup)."""
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_ai_nudges(user_id, watchlist_id, article_id, score, explanation)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (user_id, watchlist_id, article_id) DO NOTHING
+            RETURNING id
+            """,
+            (user_id, watchlist_id, article_id, score, explanation),
+        ).fetchone()
+    return row is not None
+
+
+def list_nudges(
+    user_id: int, *, limit: int = 50, db_path: Any = None, database_url: str | None = None
+) -> list[dict[str, Any]]:
+    """Return recent nudges for *user_id*, most recent first."""
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT n.id, n.watchlist_id, n.article_id, n.score, n.explanation, n.created_at,
+                   w.label AS watchlist_label, a.title AS article_title
+            FROM user_ai_nudges n
+            JOIN user_ai_watchlists w ON w.id = n.watchlist_id
+            JOIN articles a ON a.id = n.article_id
+            WHERE n.user_id = %s
+            ORDER BY n.created_at DESC
+            LIMIT %s
+            """,
+            (user_id, limit),
+        ).fetchall()
+    return [row_to_dict(r) for r in rows]

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1153,3 +1153,67 @@ def test_run_reading_list_fetch_reports_count() -> None:
     status, message = result
     assert status == "success"
     assert "2" in (message or "")
+
+
+def test_start_scheduler_registers_watchlist_evaluation_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WATCHLIST_EVALUATION_INTERVAL_MINUTES", "10")
+    mock_sched = _start_with_env(monkeypatch)
+    jobs = {c.kwargs.get("id"): c.kwargs for c in mock_sched.add_job.call_args_list}
+    assert "watchlist_evaluation" in jobs
+    assert jobs["watchlist_evaluation"]["trigger"] == "interval"
+    assert jobs["watchlist_evaluation"]["minutes"] == 10
+
+
+def test_run_watchlist_evaluation_reports_summary() -> None:
+    from news_dashboard.scheduler import _run_watchlist_evaluation
+
+    with patch(
+        "news_dashboard.watchlist_agent.evaluate_watchlists",
+        return_value={"watchlists_evaluated": 3, "nudges_created": 2},
+    ) as mock_eval:
+        status, message = _run_watchlist_evaluation()
+
+    mock_eval.assert_called_once()
+    assert status == "success"
+    assert "3" in (message or "")
+    assert "2" in (message or "")
+
+
+def test_run_watchlist_evaluation_reports_failure() -> None:
+    from news_dashboard.scheduler import _run_watchlist_evaluation
+
+    with patch(
+        "news_dashboard.watchlist_agent.evaluate_watchlists",
+        side_effect=RuntimeError("boom"),
+    ):
+        status, message = _run_watchlist_evaluation()
+
+    assert status == "failure"
+    assert "boom" in (message or "")
+
+
+def test_watchlist_evaluation_failure_does_not_abort_other_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing watchlist_evaluation job must not prevent other scheduled jobs.
+
+    _run_and_record swallows exceptions from fn() itself, but this test
+    verifies the wiring: a failing evaluate_watchlists still yields a
+    recorded ("failure", ...) outcome rather than propagating.
+    """
+    from news_dashboard.scheduler import _job_watchlist_evaluation
+
+    with (
+        patch(
+            "news_dashboard.watchlist_agent.evaluate_watchlists",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("news_dashboard.scheduled_job_history.save_job_run") as mock_save,
+        patch("news_dashboard.metrics.scheduler_job_runs_total"),
+    ):
+        _job_watchlist_evaluation()  # must not raise
+
+    mock_save.assert_called_once()
+    assert mock_save.call_args.kwargs["status"] == "failure"

--- a/backend/tests/test_watchlist_agent.py
+++ b/backend/tests/test_watchlist_agent.py
@@ -1,0 +1,434 @@
+"""Tests for AI watchlists: CRUD, visibility scoping, matching, and evaluation."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from news_dashboard.auth import create_user
+from news_dashboard.db import connect
+from news_dashboard.watchlist_agent import (
+    WatchlistNotFoundError,
+    ai_match,
+    create_watchlist,
+    delete_watchlist,
+    deterministic_match,
+    evaluate_watchlists,
+    get_watchlist,
+    list_nudges,
+    list_watchlists,
+    preview_matches,
+    update_watchlist,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _api_client(user_id: int) -> Any:
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_admin, require_auth
+    from news_dashboard.main import app
+
+    fake = {"id": user_id, "username": "testuser", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake
+    app.dependency_overrides[require_admin] = lambda: fake
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    user = create_user(username, "pw", db_path=database_url)
+    return int(user["id"])
+
+
+def _add_source(conn: Any, slug: str, name: str, *, owner_user_id: int | None = None) -> None:
+    conn.execute(
+        """
+        INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+        VALUES (%s, %s, %s, 'tech', 'rss_feed', 10, TRUE, %s)
+        """,
+        (slug, name, f"https://example.com/{slug}.xml", owner_user_id),
+    )
+
+
+def _add_article(
+    conn: Any,
+    *,
+    slug: str,
+    index: int,
+    title: str,
+    summary: str = "",
+    state: str | None = None,
+    user_id: int | None = None,
+) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+                              category, kind, summary)
+        VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', %s)
+        RETURNING id
+        """,
+        (
+            f"https://example.com/{slug}/{index}",
+            f"https://example.com/{slug}/{index}",
+            title,
+            slug,
+            slug,
+            summary,
+        ),
+    ).fetchone()
+    article_id = int(row["id"])
+    if state and user_id:
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state, archived_at)
+            VALUES (%s, %s, %s, CASE WHEN %s = 'archived' THEN NOW() ELSE NULL END)
+            """,
+            (user_id, article_id, state, state),
+        )
+    return article_id
+
+
+# ── deterministic matching ──────────────────────────────────────────────────
+
+
+def test_deterministic_match_scores_term_overlap() -> None:
+    score, explanation = deterministic_match(
+        "climate policy", {"title": "New climate policy announced", "summary": "", "tags": ""}
+    )
+    assert score == 1.0
+    assert "climate" in explanation
+    assert "policy" in explanation
+
+
+def test_deterministic_match_no_overlap() -> None:
+    score, explanation = deterministic_match(
+        "climate policy", {"title": "Local sports results", "summary": "", "tags": ""}
+    )
+    assert score == 0.0
+    assert "No matching" in explanation
+
+
+def test_deterministic_match_empty_query() -> None:
+    score, _ = deterministic_match("the a of", {"title": "anything"})
+    assert score == 0.0
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_and_list_watchlist(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    created = create_watchlist(
+        uid, "AI safety", "artificial intelligence safety", database_url=pg_clean
+    )
+    assert created["label"] == "AI safety"
+    assert created["threshold"] == pytest.approx(0.5)
+
+    items = list_watchlists(uid, database_url=pg_clean)
+    assert len(items) == 1
+    assert items[0]["id"] == created["id"]
+
+
+def test_create_watchlist_requires_label_and_query(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with pytest.raises(ValueError, match="label and query"):
+        create_watchlist(uid, "", "query", database_url=pg_clean)
+    with pytest.raises(ValueError, match="label and query"):
+        create_watchlist(uid, "label", "  ", database_url=pg_clean)
+
+
+def test_create_watchlist_rejects_bad_threshold(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with pytest.raises(ValueError, match="threshold"):
+        create_watchlist(uid, "label", "query", threshold=1.5, database_url=pg_clean)
+
+
+def test_update_watchlist(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    created = create_watchlist(uid, "label", "query", database_url=pg_clean)
+    updated = update_watchlist(
+        uid, created["id"], enabled=False, threshold=0.8, database_url=pg_clean
+    )
+    assert updated["enabled"] is False
+    assert updated["threshold"] == pytest.approx(0.8)
+
+
+def test_update_watchlist_not_found_raises(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with pytest.raises(WatchlistNotFoundError):
+        update_watchlist(uid, 999999, enabled=False, database_url=pg_clean)
+
+
+def test_update_watchlist_scoped_to_owner(pg_clean: str) -> None:
+    uid = _make_user(pg_clean, "alice")
+    other = _make_user(pg_clean, "bob")
+    created = create_watchlist(uid, "label", "query", database_url=pg_clean)
+    with pytest.raises(WatchlistNotFoundError):
+        update_watchlist(other, created["id"], enabled=False, database_url=pg_clean)
+
+
+def test_delete_watchlist(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    created = create_watchlist(uid, "label", "query", database_url=pg_clean)
+    assert delete_watchlist(uid, created["id"], database_url=pg_clean) is True
+    assert get_watchlist(uid, created["id"], database_url=pg_clean) is None
+    assert delete_watchlist(uid, created["id"], database_url=pg_clean) is False
+
+
+# ── preview & visibility scoping ────────────────────────────────────────────
+
+
+def test_preview_matches_visible_articles_only(pg_clean: str) -> None:
+    uid = _make_user(pg_clean, "alice")
+    other = _make_user(pg_clean, "bob")
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_source(conn, "bobs-feed", "Bob's Private Feed", owner_user_id=other)
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+        _add_article(conn, slug="bobs-feed", index=1, title="Quantum computing news for Bob")
+
+    matches = preview_matches(uid, "quantum computing", use_ai=False, database_url=pg_clean)
+    titles = {m["article"]["title"] for m in matches}
+    assert "Quantum computing breakthrough" in titles
+    assert "Quantum computing news for Bob" not in titles
+
+
+def test_preview_matches_excludes_archived(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(
+            conn,
+            slug="global-feed",
+            index=1,
+            title="Quantum computing archived article",
+            state="archived",
+            user_id=uid,
+        )
+
+    matches = preview_matches(uid, "quantum computing", use_ai=False, database_url=pg_clean)
+    assert matches == []
+
+
+def test_preview_matches_respects_threshold(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing news")
+
+    high_threshold = preview_matches(
+        uid,
+        "quantum computing breakthrough today",
+        threshold=0.9,
+        use_ai=False,
+        database_url=pg_clean,
+    )
+    assert high_threshold == []
+
+
+# ── evaluation & dedupe ──────────────────────────────────────────────────────
+
+
+def test_evaluate_watchlists_creates_nudge_and_dedupes(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+    create_watchlist(uid, "Quantum", "quantum computing", database_url=pg_clean)
+
+    with patch("news_dashboard.push.send_push_for_user") as mock_push:
+        summary = evaluate_watchlists(use_ai=False, database_url=pg_clean)
+    assert summary["watchlists_evaluated"] == 1
+    assert summary["nudges_created"] == 1
+    mock_push.assert_called_once()
+
+    nudges = list_nudges(uid, database_url=pg_clean)
+    assert len(nudges) == 1
+
+    # Running again must not create a duplicate nudge for the same article.
+    with patch("news_dashboard.push.send_push_for_user") as mock_push_again:
+        summary_again = evaluate_watchlists(use_ai=False, database_url=pg_clean)
+    assert summary_again["nudges_created"] == 0
+    mock_push_again.assert_not_called()
+    assert len(list_nudges(uid, database_url=pg_clean)) == 1
+
+
+def test_evaluate_watchlists_skips_disabled(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+    create_watchlist(uid, "Quantum", "quantum computing", enabled=False, database_url=pg_clean)
+
+    summary = evaluate_watchlists(use_ai=False, database_url=pg_clean)
+    assert summary["watchlists_evaluated"] == 0
+    assert summary["nudges_created"] == 0
+
+
+def test_evaluate_watchlists_respects_notify_push_opt_out(pg_clean: str) -> None:
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+    create_watchlist(uid, "Quantum", "quantum computing", notify_push=False, database_url=pg_clean)
+
+    with patch("news_dashboard.push.send_push_for_user") as mock_push:
+        summary = evaluate_watchlists(use_ai=False, database_url=pg_clean)
+    assert summary["nudges_created"] == 1
+    mock_push.assert_not_called()
+
+
+def test_evaluate_watchlists_uses_fake_ai_judge(pg_clean: str) -> None:
+    """AI-configured matching: a fake judge function overrides the deterministic score."""
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        # Search retrieval is keyword-based (candidates must contain the query
+        # terms), so the deterministic score would already be 1.0 here; the
+        # fake judge's score/explanation below prove the AI path overrides it.
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing conference recap")
+    create_watchlist(uid, "Quantum", "quantum computing", threshold=0.5, database_url=pg_clean)
+
+    def fake_judge(_query: str, _article: dict[str, Any]) -> tuple[float, str]:
+        return 0.7, "the AI judged this relevant"
+
+    with patch("news_dashboard.push.send_push_for_user"):
+        summary = evaluate_watchlists(database_url=pg_clean, ai_judge=fake_judge)
+
+    assert summary["nudges_created"] == 1
+    nudge = list_nudges(uid, database_url=pg_clean)[0]
+    assert nudge["explanation"] == "the AI judged this relevant"
+    assert nudge["score"] == pytest.approx(0.7)
+
+
+def test_evaluate_watchlists_continues_after_one_failure(pg_clean: str) -> None:
+    """A search failure for one watchlist must not abort evaluation of the others."""
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+    create_watchlist(uid, "Broken", "broken query", database_url=pg_clean)
+    create_watchlist(uid, "Quantum", "quantum computing", database_url=pg_clean)
+
+    from news_dashboard import ingest
+
+    real_search = ingest.search_articles
+    calls = {"count": 0}
+
+    def flaky_search(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            msg = "boom"
+            raise RuntimeError(msg)
+        return real_search(*args, **kwargs)
+
+    with (
+        patch("news_dashboard.ingest.search_articles", side_effect=flaky_search),
+        patch("news_dashboard.push.send_push_for_user"),
+    ):
+        summary = evaluate_watchlists(use_ai=False, database_url=pg_clean)
+
+    assert summary["watchlists_evaluated"] == 2
+    assert summary["nudges_created"] == 1
+
+
+def test_ai_match_returns_none_when_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FREE_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    result = ai_match("quantum computing", {"title": "Quantum computing news"})
+    assert result is None
+
+
+# ── API endpoint tests ────────────────────────────────────────────────────────
+
+
+def test_api_create_list_update_delete_watchlist(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    client = _api_client(uid)
+
+    resp = client.post(
+        "/api/watchlists", json={"label": "AI safety", "query": "artificial intelligence safety"}
+    )
+    assert resp.status_code == 200
+    created = resp.json()
+    watchlist_id = created["id"]
+    assert created["enabled"] is True
+
+    resp = client.get("/api/watchlists")
+    assert resp.status_code == 200
+    assert len(resp.json()["items"]) == 1
+
+    resp = client.patch(f"/api/watchlists/{watchlist_id}", json={"enabled": False})
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+
+    resp = client.delete(f"/api/watchlists/{watchlist_id}")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+
+    resp = client.get("/api/watchlists")
+    assert resp.json()["items"] == []
+
+
+def test_api_create_watchlist_rejects_blank_label(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    client = _api_client(uid)
+
+    resp = client.post("/api/watchlists", json={"label": "", "query": "quantum"})
+    assert resp.status_code == 400
+
+
+def test_api_update_missing_watchlist_returns_404(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    client = _api_client(uid)
+
+    resp = client.patch("/api/watchlists/999999", json={"enabled": False})
+    assert resp.status_code == 404
+
+
+def test_api_delete_missing_watchlist_returns_404(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    client = _api_client(uid)
+
+    resp = client.delete("/api/watchlists/999999")
+    assert resp.status_code == 404
+
+
+def test_api_preview_watchlist(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+    client = _api_client(uid)
+
+    resp = client.post("/api/watchlists/preview", json={"query": "quantum computing"})
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["article"]["title"] == "Quantum computing breakthrough"
+
+
+def test_api_list_watchlist_nudges(pg_clean: str, monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "global-feed", "Global Feed")
+        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+    create_watchlist(uid, "Quantum", "quantum computing", database_url=pg_clean)
+    with patch("news_dashboard.push.send_push_for_user"):
+        evaluate_watchlists(use_ai=False, database_url=pg_clean)
+
+    client = _api_client(uid)
+    resp = client.get("/api/watchlists/nudges")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["watchlist_label"] == "Quantum"

--- a/frontend/src/__tests__/dailyBriefSettings.test.tsx
+++ b/frontend/src/__tests__/dailyBriefSettings.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/api', () => ({
   subscribePush: mockSubscribePush,
   unsubscribePush: mockUnsubscribePush,
   recalculateMyRecommendations: mockRecalculate,
+  fetchWatchlists: vi.fn().mockResolvedValue([]),
 }));
 
 import { SettingsPage } from '../pages/SettingsPage';

--- a/frontend/src/__tests__/settingsPlatforms.test.tsx
+++ b/frontend/src/__tests__/settingsPlatforms.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/api', () => ({
     .mockResolvedValue({ briefing_time: '09:00', push_enabled: false }),
   subscribePush: vi.fn().mockResolvedValue({ subscribed: true }),
   unsubscribePush: vi.fn().mockResolvedValue({ unsubscribed: true }),
+  fetchWatchlists: vi.fn().mockResolvedValue([]),
 }));
 
 import { SettingsPage } from '../pages/SettingsPage';

--- a/frontend/src/__tests__/watchlistsSettings.test.tsx
+++ b/frontend/src/__tests__/watchlistsSettings.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/contexts/auth';
+
+const {
+  mockFetchWatchlists,
+  mockCreateWatchlist,
+  mockUpdateWatchlist,
+  mockDeleteWatchlist,
+  mockPreviewWatchlist,
+  mockFetchNotificationSettings,
+} = vi.hoisted(() => ({
+  mockFetchWatchlists: vi.fn(),
+  mockCreateWatchlist: vi.fn(),
+  mockUpdateWatchlist: vi.fn(),
+  mockDeleteWatchlist: vi.fn(),
+  mockPreviewWatchlist: vi.fn(),
+  mockFetchNotificationSettings: vi.fn(),
+}));
+
+vi.mock('@/api', () => ({
+  fetchWatchlists: mockFetchWatchlists,
+  createWatchlist: mockCreateWatchlist,
+  updateWatchlist: mockUpdateWatchlist,
+  deleteWatchlist: mockDeleteWatchlist,
+  previewWatchlist: mockPreviewWatchlist,
+  fetchNotificationSettings: mockFetchNotificationSettings,
+  recalculateMyRecommendations: vi.fn(),
+}));
+
+import { SettingsPage } from '../pages/SettingsPage';
+import type { AiWatchlist } from '../types';
+
+function renderSettings() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <SettingsPage />
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+const sampleWatchlist: AiWatchlist = {
+  id: 1,
+  user_id: 1,
+  label: 'AI safety',
+  query: 'artificial intelligence safety',
+  threshold: 0.5,
+  enabled: true,
+  notify_push: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
+  );
+  mockFetchWatchlists.mockResolvedValue([]);
+  mockCreateWatchlist.mockResolvedValue(sampleWatchlist);
+  mockUpdateWatchlist.mockResolvedValue({ ...sampleWatchlist, enabled: false });
+  mockDeleteWatchlist.mockResolvedValue({ deleted: true });
+  mockPreviewWatchlist.mockResolvedValue([]);
+  mockFetchNotificationSettings.mockResolvedValue({
+    briefing_time: '09:00',
+    push_enabled: false,
+    vapid_public_key: null,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('WatchlistsSection', () => {
+  it('renders the AI Watchlists heading', async () => {
+    renderSettings();
+    expect(await screen.findByText('AI Watchlists')).toBeInTheDocument();
+  });
+
+  it('lists existing watchlists', async () => {
+    mockFetchWatchlists.mockResolvedValue([sampleWatchlist]);
+    renderSettings();
+    expect(await screen.findByText('AI safety')).toBeInTheDocument();
+    expect(screen.getByText('artificial intelligence safety')).toBeInTheDocument();
+  });
+
+  it('creates a watchlist from the form', async () => {
+    const user = userEvent.setup();
+    renderSettings();
+    await screen.findByText('AI Watchlists');
+
+    await user.type(screen.getByPlaceholderText(/Label, e.g. AI safety/), 'AI safety');
+    await user.type(
+      screen.getByPlaceholderText(/What should this watch for/),
+      'artificial intelligence safety'
+    );
+    await user.click(screen.getByRole('button', { name: /Add watchlist/ }));
+
+    await waitFor(() => {
+      expect(mockCreateWatchlist).toHaveBeenCalledWith({
+        label: 'AI safety',
+        query: 'artificial intelligence safety',
+      });
+    });
+  });
+
+  it('previews matches for the current query', async () => {
+    mockPreviewWatchlist.mockResolvedValue([
+      {
+        article: { id: 42, title: 'Quantum computing breakthrough' },
+        score: 0.9,
+        explanation: 'Matched terms: quantum, computing',
+      },
+    ]);
+    const user = userEvent.setup();
+    renderSettings();
+    await screen.findByText('AI Watchlists');
+
+    await user.type(screen.getByPlaceholderText(/What should this watch for/), 'quantum computing');
+    await user.click(screen.getByRole('button', { name: /Preview matches/ }));
+
+    expect(await screen.findByText('Quantum computing breakthrough')).toBeInTheDocument();
+    expect(mockPreviewWatchlist).toHaveBeenCalledWith('quantum computing');
+  });
+
+  it('toggles a watchlist enabled state', async () => {
+    mockFetchWatchlists.mockResolvedValue([sampleWatchlist]);
+    const user = userEvent.setup();
+    renderSettings();
+    const label = await screen.findByText('AI safety');
+    const item = label.closest('li');
+    if (!item) throw new Error('watchlist list item not found');
+
+    const toggle = within(item).getByRole('switch');
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(mockUpdateWatchlist).toHaveBeenCalledWith(1, { enabled: false });
+    });
+  });
+
+  it('deletes a watchlist', async () => {
+    mockFetchWatchlists.mockResolvedValue([sampleWatchlist]);
+    const user = userEvent.setup();
+    renderSettings();
+    await screen.findByText('AI safety');
+
+    await user.click(screen.getByRole('button', { name: /Delete watchlist AI safety/ }));
+
+    await waitFor(() => {
+      expect(mockDeleteWatchlist).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,9 @@ import type {
   AdminAnalytics,
   AgentActionPlanResponse,
   AgentActionRun,
+  AiWatchlist,
+  AiWatchlistMatch,
+  AiWatchlistNudge,
   Article,
   ArticleCountsResult,
   ArticleHighlight,
@@ -822,6 +825,64 @@ export async function dismissPersonalizationNudge(
     method: 'POST',
     body: JSON.stringify({ nudge_id: nudgeId, cooldown_days: cooldownDays }),
   });
+}
+
+export async function fetchWatchlists(): Promise<AiWatchlist[]> {
+  const data = await requestJson<{ items: AiWatchlist[] }>('/api/watchlists');
+  return data.items;
+}
+
+export interface CreateWatchlistRequest {
+  label: string;
+  query: string;
+  threshold?: number;
+  enabled?: boolean;
+  notify_push?: boolean;
+}
+
+export async function createWatchlist(payload: CreateWatchlistRequest): Promise<AiWatchlist> {
+  return requestJson('/api/watchlists', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export interface UpdateWatchlistRequest {
+  label?: string;
+  query?: string;
+  threshold?: number;
+  enabled?: boolean;
+  notify_push?: boolean;
+}
+
+export async function updateWatchlist(
+  watchlistId: number,
+  payload: UpdateWatchlistRequest
+): Promise<AiWatchlist> {
+  return requestJson(`/api/watchlists/${watchlistId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteWatchlist(watchlistId: number): Promise<{ deleted: boolean }> {
+  return requestJson(`/api/watchlists/${watchlistId}`, { method: 'DELETE' });
+}
+
+export async function previewWatchlist(
+  query: string,
+  threshold?: number
+): Promise<AiWatchlistMatch[]> {
+  const data = await requestJson<{ items: AiWatchlistMatch[] }>('/api/watchlists/preview', {
+    method: 'POST',
+    body: JSON.stringify({ query, threshold }),
+  });
+  return data.items;
+}
+
+export async function fetchWatchlistNudges(): Promise<AiWatchlistNudge[]> {
+  const data = await requestJson<{ items: AiWatchlistNudge[] }>('/api/watchlists/nudges');
+  return data.items;
 }
 
 export async function downloadUserExport(): Promise<void> {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -21,14 +21,20 @@ import type { Theme } from '@/lib/theme';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
 import { useAuth } from '@/contexts/auth';
 import {
+  createWatchlist,
   deleteOwnAccount,
+  deleteWatchlist,
   downloadUserExport,
   fetchNotificationSettings,
+  fetchWatchlists,
+  previewWatchlist,
   recalculateMyRecommendations,
   subscribePush,
   unsubscribePush,
   updateNotificationSettings,
+  updateWatchlist,
 } from '@/api';
+import type { AiWatchlist, AiWatchlistMatch } from '@/types';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';
 
 const THEME_OPTS: { v: Theme; label: string; Icon: React.ComponentType<{ className?: string }> }[] =
@@ -346,6 +352,173 @@ function PersonalizationSection() {
         )}
         {state.status === 'error' && (
           <p className="text-xs text-destructive">Couldn't refresh recommendations. Try again.</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function WatchlistsSection() {
+  const [watchlists, setWatchlists] = useState<AiWatchlist[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [label, setLabel] = useState('');
+  const [query, setQuery] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<AiWatchlistMatch[] | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+
+  const load = async () => {
+    try {
+      setWatchlists(await fetchWatchlists());
+    } catch {
+      // keep whatever we had; the section stays usable
+    } finally {
+      setLoaded(true);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const handlePreview = async () => {
+    if (!query.trim()) return;
+    setPreviewLoading(true);
+    setError(null);
+    try {
+      setPreview(await previewWatchlist(query.trim()));
+    } catch {
+      setError("Couldn't preview matches. Try again.");
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!label.trim() || !query.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      await createWatchlist({ label: label.trim(), query: query.trim() });
+      setLabel('');
+      setQuery('');
+      setPreview(null);
+      await load();
+    } catch {
+      setError("Couldn't create watchlist. Try again.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleToggle = async (watchlist: AiWatchlist) => {
+    setWatchlists((prev) =>
+      prev.map((w) => (w.id === watchlist.id ? { ...w, enabled: !w.enabled } : w))
+    );
+    try {
+      await updateWatchlist(watchlist.id, { enabled: !watchlist.enabled });
+    } catch {
+      await load(); // resync on failure
+    }
+  };
+
+  const handleDelete = async (watchlistId: number) => {
+    setWatchlists((prev) => prev.filter((w) => w.id !== watchlistId));
+    try {
+      await deleteWatchlist(watchlistId);
+    } catch {
+      await load(); // resync on failure
+    }
+  };
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        AI Watchlists
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Describe a topic or goal and get notified when a new article matches it. Matching runs in
+          the background — it never stars or archives articles for you.
+        </p>
+
+        {loaded && watchlists.length > 0 && (
+          <ul className="space-y-2">
+            {watchlists.map((w) => (
+              <li
+                key={w.id}
+                className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="text-xs font-medium truncate">{w.label}</div>
+                  <div className="text-[11px] text-muted-foreground truncate">{w.query}</div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Switch checked={w.enabled} onCheckedChange={() => void handleToggle(w)} />
+                  <button
+                    onClick={() => void handleDelete(w.id)}
+                    aria-label={`Delete watchlist ${w.label}`}
+                    className="text-muted-foreground hover:text-destructive transition-colors"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="space-y-2 pt-1">
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Label, e.g. AI safety"
+            maxLength={120}
+            className="w-full rounded-md border border-border bg-surface px-2.5 py-1.5 text-xs"
+          />
+          <textarea
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="What should this watch for? e.g. artificial intelligence safety research"
+            maxLength={500}
+            rows={2}
+            className="w-full rounded-md border border-border bg-surface px-2.5 py-1.5 text-xs resize-none"
+          />
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => void handlePreview()}
+              disabled={previewLoading || !query.trim()}
+              className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium hover:bg-surface-2 transition-colors disabled:opacity-60"
+            >
+              {previewLoading ? 'Previewing…' : 'Preview matches'}
+            </button>
+            <button
+              onClick={() => void handleCreate()}
+              disabled={creating || !label.trim() || !query.trim()}
+              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-60"
+            >
+              {creating ? 'Adding…' : 'Add watchlist'}
+            </button>
+          </div>
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        {preview && (
+          <div className="space-y-1.5 pt-1">
+            <div className="text-[11px] text-muted-foreground">
+              {preview.length === 0
+                ? 'No recent articles match yet.'
+                : `${preview.length} recent match${preview.length === 1 ? '' : 'es'}:`}
+            </div>
+            {preview.map((m) => (
+              <div key={m.article.id} className="text-xs rounded-md bg-surface px-2.5 py-1.5">
+                <div className="font-medium truncate">{m.article.title}</div>
+                <div className="text-[11px] text-muted-foreground truncate">{m.explanation}</div>
+              </div>
+            ))}
+          </div>
         )}
       </div>
     </section>
@@ -984,6 +1157,8 @@ export function SettingsPage() {
       </section>
 
       <PersonalizationSection />
+
+      <WatchlistsSection />
 
       <DataExportSection />
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -446,6 +446,35 @@ export interface PersonalizationNudge {
   target_label: string;
 }
 
+export interface AiWatchlist {
+  id: number;
+  user_id: number;
+  label: string;
+  query: string;
+  threshold: number;
+  enabled: boolean;
+  notify_push: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AiWatchlistMatch {
+  article: Article;
+  score: number;
+  explanation: string;
+}
+
+export interface AiWatchlistNudge {
+  id: number;
+  watchlist_id: number;
+  article_id: number;
+  score: number;
+  explanation: string;
+  created_at: string;
+  watchlist_label: string;
+  article_title: string;
+}
+
 export interface AnalyticsSummary {
   dau: number;
   wau: number;


### PR DESCRIPTION
## Summary
Closes #755.

- Adds `user_ai_watchlists` (label, query, threshold, enabled, notify_push) and `user_ai_nudges` (dedup via unique `(user_id, watchlist_id, article_id)`) tables.
- `backend/news_dashboard/watchlist_agent.py`: CRUD, a preview endpoint helper, deterministic term-overlap matching (always available), and an optional LLM-judge path used only when an AI key is configured (`ai_match`, injectable as `ai_judge` for tests).
- New `watchlist_evaluation` scheduler job (default every 15 min, `WATCHLIST_EVALUATION_INTERVAL_MINUTES`) evaluates enabled watchlists against each user's visible, non-archived articles, creates at most one nudge per article/watchlist/user, and sends an opt-in push notification. A failure evaluating one watchlist doesn't abort the others (mirrors the existing `_run_and_record` pattern).
- CRUD + preview + nudge-list REST endpoints under `/api/watchlists`.
- Settings UI section (`WatchlistsSection` in `SettingsPage.tsx`) to create/toggle/delete watchlists and preview matches before saving.
- First implementation is read-only against article state — it only ever writes `user_ai_nudges` rows (per the issue's scope: no auto-star/archive/triage).

## Test plan
- [x] Backend: `pytest backend/tests/test_watchlist_agent.py backend/tests/test_scheduler.py backend/tests/test_env_example.py` — 103 passed (CRUD, visibility scoping across owners, archived exclusion, threshold filtering, dedup on re-evaluation, `notify_push` opt-out, fake-AI-judge override, one-watchlist-failure doesn't abort others, scheduler job registration/wiring, API endpoints).
- [x] Backend: full suite (`pytest -q`) — 1545 passed (2 pre-existing flaky errors from concurrent-worker schema-init races, reproduced clean in isolation; unrelated to this change).
- [x] Frontend: `vitest run` — 754 passed, including new `watchlistsSettings.test.tsx` (render, list, create, preview, toggle, delete).
- [x] `ruff check`, `mypy`, `ty`, `pyrefly`, `eslint`, `prettier`, `tsc --noEmit` all pass (pre-commit hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)