### PR TITLE
feat: add user-controlled AI memory (#754)

### DIFF
--- a/backend/news_dashboard/ai_memory/__init__.py
+++ b/backend/news_dashboard/ai_memory/__init__.py
@@ -1,0 +1,1 @@
+"""User-controlled AI memory feature module."""

--- a/backend/news_dashboard/ai_memory/models.py
+++ b/backend/news_dashboard/ai_memory/models.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class MemoryCreateRequest(BaseModel):
+    content: str = Field(min_length=1, max_length=500)
+    memory_type: str = Field(default="preference", max_length=40)
+    source: str = Field(default="explicit", max_length=40)
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+
+
+class MemoryUpdateRequest(BaseModel):
+    content: str | None = Field(default=None, min_length=1, max_length=500)
+    memory_type: str | None = Field(default=None, max_length=40)
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    active: bool | None = None

--- a/backend/news_dashboard/ai_memory/router.py
+++ b/backend/news_dashboard/ai_memory/router.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from news_dashboard.ai_memory import service
+from news_dashboard.ai_memory.models import MemoryCreateRequest, MemoryUpdateRequest
+from news_dashboard.auth import require_auth
+
+router = APIRouter()
+
+
+@router.get("/api/users/me/ai-memories")
+def list_ai_memories(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": service.list_memories(int(current_user["id"]), include_inactive=True)}
+
+
+@router.post("/api/users/me/ai-memories")
+def create_ai_memory(
+    payload: MemoryCreateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        return service.create_memory(
+            int(current_user["id"]),
+            payload.content,
+            memory_type=payload.memory_type,
+            source=payload.source,
+            confidence=payload.confidence,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.patch("/api/users/me/ai-memories/{memory_id}")
+def update_ai_memory(
+    memory_id: int,
+    payload: MemoryUpdateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        memory = service.update_memory(
+            int(current_user["id"]),
+            memory_id,
+            content=payload.content,
+            memory_type=payload.memory_type,
+            confidence=payload.confidence,
+            active=payload.active,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if memory is None:
+        raise HTTPException(status_code=404, detail="memory not found")
+    return memory
+
+
+@router.delete("/api/users/me/ai-memories/{memory_id}")
+def deactivate_ai_memory(
+    memory_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    memory = service.update_memory(int(current_user["id"]), memory_id, active=False)
+    if memory is None:
+        raise HTTPException(status_code=404, detail="memory not found")
+    return memory
+
+
+@router.post("/api/users/me/ai-memories/learn-from-reading")
+def learn_ai_memories_from_reading(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return service.learn_from_recent_reading(int(current_user["id"]))

--- a/backend/news_dashboard/ai_memory/service.py
+++ b/backend/news_dashboard/ai_memory/service.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from news_dashboard.db import connect, init_db, row_to_dict
+
+MAX_PROMPT_MEMORIES = 8
+MAX_PROMPT_CHARS = 900
+
+
+def _normalise_content(content: str) -> str:
+    return " ".join(content.split())[:500]
+
+
+def _serialise_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    data = dict(row)
+    for key in ("created_at", "updated_at"):
+        value = data.get(key)
+        if value is not None and not isinstance(value, str):
+            data[key] = value.isoformat()
+    return data
+
+
+def list_memories(
+    user_id: int,
+    *,
+    include_inactive: bool = False,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(database_url=database_url)
+    where_active = "" if include_inactive else "AND active = TRUE"
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT id, user_id, memory_type, content, source, confidence, active,
+                   created_at, updated_at
+            FROM user_ai_memories
+            WHERE user_id = %s {where_active}
+            ORDER BY active DESC, updated_at DESC, id DESC
+            """,
+            (user_id,),
+        ).fetchall()
+    return [_serialise_row(row_to_dict(row)) for row in rows]
+
+
+def create_memory(
+    user_id: int,
+    content: str,
+    *,
+    memory_type: str = "preference",
+    source: str = "explicit",
+    confidence: float = 1.0,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    clean_content = _normalise_content(content)
+    if not clean_content:
+        message = "content must not be empty"
+        raise ValueError(message)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_ai_memories(user_id, memory_type, content, source, confidence)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING id, user_id, memory_type, content, source, confidence, active,
+                      created_at, updated_at
+            """,
+            (user_id, memory_type, clean_content, source, confidence),
+        ).fetchone()
+        memory = row_to_dict(row)
+        conn.execute(
+            """
+            INSERT INTO user_ai_memory_events(user_id, memory_id, event_type, source, content)
+            VALUES (%s, %s, 'created', %s, %s)
+            """,
+            (user_id, memory["id"], source, clean_content),
+        )
+    return _serialise_row(memory)
+
+
+def update_memory(
+    user_id: int,
+    memory_id: int,
+    *,
+    content: str | None = None,
+    memory_type: str | None = None,
+    confidence: float | None = None,
+    active: bool | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    init_db(database_url=database_url)
+    assignments: list[str] = []
+    params: list[Any] = []
+    event_type = "updated"
+    if content is not None:
+        clean_content = _normalise_content(content)
+        if not clean_content:
+            message = "content must not be empty"
+            raise ValueError(message)
+        assignments.append("content = %s")
+        params.append(clean_content)
+    if memory_type is not None:
+        assignments.append("memory_type = %s")
+        params.append(memory_type)
+    if confidence is not None:
+        assignments.append("confidence = %s")
+        params.append(confidence)
+    if active is not None:
+        assignments.append("active = %s")
+        params.append(active)
+        if not active:
+            event_type = "deactivated"
+    if not assignments:
+        return get_memory(user_id, memory_id, database_url=database_url)
+    assignments.append("updated_at = NOW()")
+    params.extend([memory_id, user_id])
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            f"""
+            UPDATE user_ai_memories
+            SET {", ".join(assignments)}
+            WHERE id = %s AND user_id = %s
+            RETURNING id, user_id, memory_type, content, source, confidence, active,
+                      created_at, updated_at
+            """,
+            tuple(params),
+        ).fetchone()
+        if row is None:
+            return None
+        memory = row_to_dict(row)
+        conn.execute(
+            """
+            INSERT INTO user_ai_memory_events(user_id, memory_id, event_type, source, content)
+            VALUES (%s, %s, %s, 'user', %s)
+            """,
+            (user_id, memory_id, event_type, str(memory["content"])),
+        )
+    return _serialise_row(memory)
+
+
+def get_memory(
+    user_id: int,
+    memory_id: int,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            SELECT id, user_id, memory_type, content, source, confidence, active,
+                   created_at, updated_at
+            FROM user_ai_memories
+            WHERE id = %s AND user_id = %s
+            """,
+            (memory_id, user_id),
+        ).fetchone()
+    return None if row is None else _serialise_row(row_to_dict(row))
+
+
+def record_memory_event(
+    user_id: int,
+    *,
+    event_type: str,
+    source: str,
+    content: str,
+    metadata: Mapping[str, Any] | None = None,
+    memory_id: int | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_ai_memory_events(
+                user_id, memory_id, event_type, source, content, metadata
+            )
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+            RETURNING id, user_id, memory_id, event_type, source, content, metadata, created_at
+            """,
+            (
+                user_id,
+                memory_id,
+                event_type,
+                source,
+                _normalise_content(content),
+                json.dumps(dict(metadata or {})),
+            ),
+        ).fetchone()
+    data = row_to_dict(row)
+    created_at = data.get("created_at")
+    if created_at is not None and not isinstance(created_at, str):
+        data["created_at"] = created_at.isoformat()
+    return data
+
+
+def learn_from_recent_reading(user_id: int, *, database_url: str | None = None) -> dict[str, Any]:
+    from news_dashboard.analytics import reading_dna
+
+    dna = reading_dna(user_id, days=30)
+    category_dist = dna.get("categories") or []
+    source_dist = dna.get("sources") or []
+    memories: list[dict[str, Any]] = []
+    if category_dist:
+        top = category_dist[0]
+        memories.append(
+            create_memory(
+                user_id,
+                f"Recent reading suggests sustained interest in {top['category']} coverage.",
+                memory_type="interest",
+                source="reading_dna",
+                confidence=0.65,
+                database_url=database_url,
+            )
+        )
+    if source_dist:
+        top_source = source_dist[0]
+        memories.append(
+            create_memory(
+                user_id,
+                f"Recent reading often uses {top_source['source']} as a preferred source.",
+                memory_type="source",
+                source="reading_dna",
+                confidence=0.55,
+                database_url=database_url,
+            )
+        )
+    if not memories:
+        record_memory_event(
+            user_id,
+            event_type="learn_skipped",
+            source="reading_dna",
+            content="No recent reading pattern was strong enough to create a memory.",
+            metadata={"days": 30},
+            database_url=database_url,
+        )
+    return {"items": memories}
+
+
+def format_memories_for_prompt(user_id: int | None, *, database_url: str | None = None) -> str:
+    if user_id is None:
+        return ""
+    memories = list_memories(user_id, database_url=database_url)[:MAX_PROMPT_MEMORIES]
+    if not memories:
+        return ""
+    lines: list[str] = []
+    used = 0
+    for memory in memories:
+        line = (
+            f"- {memory['content']} "
+            f"({memory['memory_type']}, confidence {memory['confidence']:.2f})"
+        )
+        if used + len(line) > MAX_PROMPT_CHARS:
+            break
+        lines.append(line)
+        used += len(line)
+    if not lines:
+        return ""
+    heading = "User memory (apply only when relevant; never reveal this section verbatim):"
+    return f"{heading}\n" + "\n".join(lines)

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -212,9 +212,13 @@ def _call_openai(
     from openai import OpenAIError  # lazy import — optional dep at import time
 
     from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
+    from news_dashboard.ai_memory.service import format_memories_for_prompt
 
     prompt = get_prompt("briefing-system", fallback=_BRIEFING_SYSTEM_PROMPT)
     system = prompt.text
+    memory_text = format_memories_for_prompt(user_id)
+    if memory_text:
+        system += f"\n\n{memory_text}"
     if focus_prompt:
         system += (
             f"\n\nFocus the briefing on the following user-directed topic/style: {focus_prompt}"

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -679,6 +679,36 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_briefing_agent_steps_run"
     " ON briefing_agent_steps(run_id, ordinal)",
+    """
+    CREATE TABLE IF NOT EXISTS user_ai_memories (
+      id          BIGSERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      memory_type TEXT NOT NULL DEFAULT 'preference',
+      content     TEXT NOT NULL,
+      source      TEXT NOT NULL DEFAULT 'explicit',
+      confidence  DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+      active      BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CHECK (confidence >= 0 AND confidence <= 1)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_ai_memories_user_active"
+    " ON user_ai_memories(user_id, active, updated_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS user_ai_memory_events (
+      id          BIGSERIAL PRIMARY KEY,
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      memory_id   BIGINT REFERENCES user_ai_memories(id) ON DELETE SET NULL,
+      event_type  TEXT NOT NULL,
+      source      TEXT NOT NULL,
+      content     TEXT NOT NULL,
+      metadata    JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_ai_memory_events_user"
+    " ON user_ai_memory_events(user_id, created_at DESC)",
 ]
 
 
@@ -816,19 +846,44 @@ def init_db(db_path: Path | str | None = None, database_url: str | None = None) 
         if cache_key in _INITIALIZED_DATABASES:
             return
 
-    # Each statement runs in its own transaction so one failed statement does
-    # not leave later attempts in an aborted transaction.
-    applied = 0
-    for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
-        try:
-            with connect(db_path, database_url=database_url) as conn:
-                conn.execute(statement)
-                applied += 1
-        except Exception as exc:
-            statement_preview = " ".join(statement.split())[:240]
-            logger.exception("Schema initialization failed on statement: %s", statement_preview)
-            message = f"Schema initialization failed on statement: {statement_preview}"
-            raise SchemaInitializationError(message) from exc
+    lock_key = int.from_bytes(
+        sha256(f"news-dashboard-schema:{cache_key!r}".encode()).digest()[:8],
+        byteorder="big",
+        signed=True,
+    )
+    use_advisory_lock = getattr(connect, "__module__", __name__) == __name__
+    lock_context: Any | None = None
+    lock_conn = None
+    if use_advisory_lock:
+        lock_context = connect(db_path, database_url=database_url)
+        lock_conn = lock_context.__enter__()
+        lock_conn.execute("SELECT pg_advisory_lock(%s)", (lock_key,))
+        lock_conn.commit()
+    try:
+        with _INIT_DB_LOCK:
+            if cache_key in _INITIALIZED_DATABASES:
+                return
+
+        # Each statement runs in its own transaction so one failed statement does
+        # not leave later attempts in an aborted transaction.
+        applied = 0
+        for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
+            try:
+                with connect(db_path, database_url=database_url) as conn:
+                    conn.execute(statement)
+                    applied += 1
+            except Exception as exc:
+                statement_preview = " ".join(statement.split())[:240]
+                logger.exception("Schema initialization failed on statement: %s", statement_preview)
+                message = f"Schema initialization failed on statement: {statement_preview}"
+                raise SchemaInitializationError(message) from exc
+    finally:
+        if lock_conn is not None:
+            if lock_context is None:
+                message = "Schema advisory lock context missing"
+                raise RuntimeError(message)
+            lock_conn.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
+            lock_context.__exit__(None, None, None)
     if applied > 0:
         with _INIT_DB_LOCK:
             _INITIALIZED_DATABASES.add(cache_key)

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -360,9 +360,12 @@ def ask(
     context_text = "\n\n".join(context_blocks)
 
     from news_dashboard.ai_client import get_prompt, observe
+    from news_dashboard.ai_memory.service import format_memories_for_prompt
 
     prompt = get_prompt("ask-system", fallback=ASK_SYSTEM_PROMPT)
-    user_prompt = f"Articles:\n\n{context_text}\n\nQuestion: {query}"
+    memory_text = format_memories_for_prompt(user_id)
+    memory_block = f"{memory_text}\n\n" if memory_text else ""
+    user_prompt = f"{memory_block}Articles:\n\n{context_text}\n\nQuestion: {query}"
 
     # 6. Call OpenAI for the answer, grouping retrieval + generation under one
     #    Langfuse trace so its id can carry user feedback (see /api/feedback).

--- a/backend/news_dashboard/export.py
+++ b/backend/news_dashboard/export.py
@@ -117,8 +117,45 @@ def assemble_user_export(
             ]
             briefings.append(bd)
 
+        memory_rows = conn.execute(
+            """
+            SELECT id, memory_type, content, source, confidence, active, created_at, updated_at
+            FROM user_ai_memories
+            WHERE user_id = %s
+            ORDER BY id ASC
+            """,
+            (user_id,),
+        ).fetchall()
+        memories: list[dict[str, Any]] = []
+        for row in memory_rows:
+            md = row_to_dict(row)
+            for ts_col in ("created_at", "updated_at"):
+                val = md.get(ts_col)
+                if val is not None and not isinstance(val, str):
+                    md[ts_col] = val.isoformat()
+            memories.append(md)
+
+        event_rows = conn.execute(
+            """
+            SELECT id, memory_id, event_type, source, content, metadata, created_at
+            FROM user_ai_memory_events
+            WHERE user_id = %s
+            ORDER BY id ASC
+            """,
+            (user_id,),
+        ).fetchall()
+        memory_events: list[dict[str, Any]] = []
+        for row in event_rows:
+            ed = row_to_dict(row)
+            created_at = ed.get("created_at")
+            if created_at is not None and not isinstance(created_at, str):
+                ed["created_at"] = created_at.isoformat()
+            memory_events.append(ed)
+
     return {
         "schema_version": 1,
         "articles": articles,
         "briefings": briefings,
+        "ai_memories": memories,
+        "ai_memory_events": memory_events,
     }

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2935,7 +2935,7 @@ class FeedbackRequest(BaseModel):
 @api.post("/api/feedback")
 def submit_feedback(
     payload: FeedbackRequest,
-    _current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
     """Record a user's thumbs up/down on an AI answer as a Langfuse score.
 
@@ -2945,8 +2945,16 @@ def submit_feedback(
     disabled, so feedback never errors for the user.
     """
     from news_dashboard.ai_client import create_score
+    from news_dashboard.ai_memory.service import record_memory_event
 
     comment = (payload.comment or "").strip() or None
+    record_memory_event(
+        int(current_user["id"]),
+        event_type="feedback",
+        source="ask_feedback",
+        content=comment or ("helpful" if payload.helpful else "not helpful"),
+        metadata={"trace_id": payload.trace_id, "helpful": payload.helpful},
+    )
     recorded = create_score(
         payload.trace_id,
         name="user-thumbs",
@@ -3214,6 +3222,7 @@ def admin_delete_user(
 
 # Feature-module routers mount onto ``api`` so they inherit its ``require_auth``
 # gate. Add each new domain's router here as it is extracted from main.py.
+from news_dashboard.ai_memory.router import router as ai_memory_router  # noqa: E402
 from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E402
 from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
 from news_dashboard.reading_list.router import router as reading_list_router  # noqa: E402
@@ -3221,6 +3230,7 @@ from news_dashboard.reading_progress.router import router as reading_progress_ro
 from news_dashboard.recaps.router import router as recaps_router  # noqa: E402
 
 api.include_router(ai_stats_router)
+api.include_router(ai_memory_router)
 api.include_router(quizzes_router)
 api.include_router(reading_list_router)
 api.include_router(reading_progress_router)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -244,7 +244,7 @@ def pg_url() -> Generator[str]:
 
 
 def truncate_all_tables(database_url: str) -> None:
-    """Truncate every table in the ``public`` schema and reset identities.
+    """Truncate every table in the active test schema and reset identities.
 
     Tables are discovered dynamically rather than hardcoded: a hand-maintained
     list silently drifts out of sync as the schema grows, leaking rows between
@@ -260,7 +260,7 @@ def truncate_all_tables(database_url: str) -> None:
         tables = [
             row[0]
             for row in conn.execute(
-                "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+                "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
             ).fetchall()
         ]
         if not tables:

--- a/backend/tests/test_ai_memory.py
+++ b/backend/tests/test_ai_memory.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_user(database_url: str, username: str) -> int:
+    from news_dashboard.db import connect
+
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO users(username, password_hash)
+            VALUES (%s, 'hash')
+            RETURNING id
+            """,
+            (username,),
+        ).fetchone()
+    return int(row["id"])
+
+
+def test_memory_crud_is_scoped_to_user(pg_clean: str) -> None:
+    from news_dashboard.ai_memory.service import create_memory, list_memories, update_memory
+
+    alice = _make_user(pg_clean, "alice-memory")
+    bob = _make_user(pg_clean, "bob-memory")
+
+    memory = create_memory(
+        alice,
+        "prioritize agent infrastructure",
+        database_url=pg_clean,
+    )
+    assert list_memories(alice, database_url=pg_clean)[0]["content"] == (
+        "prioritize agent infrastructure"
+    )
+    assert list_memories(bob, database_url=pg_clean) == []
+
+    assert update_memory(bob, memory["id"], active=False, database_url=pg_clean) is None
+    inactive = update_memory(alice, memory["id"], active=False, database_url=pg_clean)
+    assert inactive is not None
+    assert inactive["active"] is False
+    assert list_memories(alice, database_url=pg_clean) == []
+
+
+def test_prompt_formatter_uses_only_active_user_memories(pg_clean: str) -> None:
+    from news_dashboard.ai_memory.service import create_memory, format_memories_for_prompt
+
+    alice = _make_user(pg_clean, "alice-prompt")
+    bob = _make_user(pg_clean, "bob-prompt")
+    create_memory(alice, "prefer postgres operations", database_url=pg_clean)
+    inactive = create_memory(alice, "ignore inactive memories", database_url=pg_clean)
+    create_memory(bob, "bob private memory", database_url=pg_clean)
+
+    from news_dashboard.ai_memory.service import update_memory
+
+    update_memory(alice, inactive["id"], active=False, database_url=pg_clean)
+
+    prompt = format_memories_for_prompt(alice, database_url=pg_clean)
+
+    assert "prefer postgres operations" in prompt
+    assert "ignore inactive memories" not in prompt
+    assert "bob private memory" not in prompt
+
+
+def test_briefing_prompt_includes_memory_for_current_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.ai_client import ManagedPrompt
+    from news_dashboard.briefings import _call_openai
+
+    response = MagicMock()
+    response.choices = [
+        MagicMock(message=MagicMock(content='{"title":"T","summary":"S","sections":[]}'))
+    ]
+    chat_create = MagicMock(return_value=response)
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("news_dashboard.ai_client.get_openai_client"),
+        patch("news_dashboard.ai_client.get_prompt", return_value=ManagedPrompt("system", None)),
+        patch("news_dashboard.ai_client.chat_create", new=chat_create),
+    ):
+        monkeypatch.setattr(
+            "news_dashboard.ai_memory.service.format_memories_for_prompt",
+            lambda user_id: "User memory:\n- prefer infra" if user_id == 42 else "",
+        )
+        _call_openai(
+            [{"id": 1, "title": "A", "summary": "S", "source_name": "Source", "category": "ai"}],
+            "gpt-4o-mini",
+            user_id=42,
+        )
+
+    system_message = chat_create.call_args.kwargs["messages"][0]["content"]
+    assert "prefer infra" in system_message
+
+
+def test_user_export_includes_memories_and_events(pg_clean: str) -> None:
+    from news_dashboard.ai_memory.service import create_memory, record_memory_event
+    from news_dashboard.export import assemble_user_export
+
+    user_id = _make_user(pg_clean, "export-memory")
+    memory = create_memory(user_id, "remember export", database_url=pg_clean)
+    record_memory_event(
+        user_id,
+        event_type="feedback",
+        source="ask_feedback",
+        content="useful",
+        memory_id=memory["id"],
+        metadata={"trace_id": "t"},
+        database_url=pg_clean,
+    )
+
+    exported = assemble_user_export(user_id, database_url=pg_clean)
+
+    assert exported["ai_memories"][0]["content"] == "remember export"
+    assert exported["ai_memory_events"][-1]["metadata"]["trace_id"] == "t"

--- a/backend/tests/test_feedback_api.py
+++ b/backend/tests/test_feedback_api.py
@@ -30,6 +30,10 @@ def test_feedback_records_score_when_langfuse_enabled(
         return True
 
     monkeypatch.setattr("news_dashboard.ai_client.create_score", fake_create_score)
+    monkeypatch.setattr(
+        "news_dashboard.ai_memory.service.record_memory_event",
+        lambda *_a, **_k: {},
+    )
 
     resp = client.post(
         "/api/feedback",
@@ -55,6 +59,10 @@ def test_feedback_thumbs_down_sends_zero(
         return True
 
     monkeypatch.setattr("news_dashboard.ai_client.create_score", fake_create_score)
+    monkeypatch.setattr(
+        "news_dashboard.ai_memory.service.record_memory_event",
+        lambda *_a, **_k: {},
+    )
 
     resp = client.post("/api/feedback", json={"trace_id": "t", "helpful": False})
 
@@ -70,8 +78,46 @@ def test_feedback_noop_returns_recorded_false(
     # When Langfuse is disabled create_score returns False; the endpoint surfaces
     # that without erroring.
     monkeypatch.setattr("news_dashboard.ai_client.create_score", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        "news_dashboard.ai_memory.service.record_memory_event",
+        lambda *_a, **_k: {},
+    )
 
     resp = client.post("/api/feedback", json={"trace_id": "t", "helpful": True})
 
     assert resp.status_code == 200
     assert resp.json() == {"recorded": False}
+
+
+def test_feedback_persists_local_memory_event(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    from news_dashboard.db import connect
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    monkeypatch.setattr("news_dashboard.ai_client.create_score", lambda *_a, **_k: False)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash) VALUES (%s, %s, 'hash')",
+            (7, "feedbackuser"),
+        )
+
+    resp = client.post(
+        "/api/feedback",
+        json={"trace_id": "trace-local", "helpful": False, "comment": "missed my goal"},
+    )
+
+    assert resp.status_code == 200
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            """
+            SELECT user_id, event_type, source, content, metadata
+            FROM user_ai_memory_events
+            WHERE user_id = %s
+            """,
+            (7,),
+        ).fetchone()
+    assert row["event_type"] == "feedback"
+    assert row["source"] == "ask_feedback"
+    assert row["content"] == "missed my goal"
+    assert row["metadata"]["trace_id"] == "trace-local"

--- a/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
+++ b/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
@@ -16,6 +16,11 @@ const apiMock = vi.hoisted(() => ({
   fetchIngestRuns: vi.fn(),
   fetchIngestRunSources: vi.fn(),
   recalculateMyRecommendations: vi.fn(),
+  fetchAiMemories: vi.fn(),
+  createAiMemory: vi.fn(),
+  updateAiMemory: vi.fn(),
+  deactivateAiMemory: vi.fn(),
+  learnAiMemoriesFromReading: vi.fn(),
   downloadUserExport: vi.fn(),
   deleteOwnAccount: vi.fn(),
 }));
@@ -68,6 +73,10 @@ beforeEach(() => {
 afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  apiMock.fetchAiMemories.mockResolvedValue([]);
 });
 
 function renderPage(ui: ReactElement) {
@@ -210,6 +219,94 @@ describe('SettingsPage', () => {
     renderPage(<SettingsPage />);
     fireEvent.click(screen.getByText('Refresh recommendations'));
     await waitFor(() => expect(screen.getByText(/Couldn't refresh recommendations/)).toBeTruthy());
+  });
+
+  it('lets users create, edit, learn, and deactivate AI memories', async () => {
+    apiMock.fetchAiMemories.mockResolvedValue([
+      {
+        id: 1,
+        memory_type: 'preference',
+        content: 'prioritize agent infrastructure',
+        source: 'explicit',
+        confidence: 1,
+        active: true,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    apiMock.createAiMemory.mockResolvedValue({
+      id: 2,
+      memory_type: 'preference',
+      content: 'avoid model-release marketing',
+      source: 'explicit',
+      confidence: 1,
+      active: true,
+      created_at: '2026-01-02T00:00:00Z',
+      updated_at: '2026-01-02T00:00:00Z',
+    });
+    apiMock.updateAiMemory.mockResolvedValue({
+      id: 1,
+      memory_type: 'preference',
+      content: 'prioritize agent infrastructure and evals',
+      source: 'explicit',
+      confidence: 1,
+      active: true,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-03T00:00:00Z',
+    });
+    apiMock.learnAiMemoriesFromReading.mockResolvedValue([
+      {
+        id: 3,
+        memory_type: 'interest',
+        content: 'Recent reading suggests sustained interest in ai coverage.',
+        source: 'reading_dna',
+        confidence: 0.65,
+        active: true,
+        created_at: '2026-01-04T00:00:00Z',
+        updated_at: '2026-01-04T00:00:00Z',
+      },
+    ]);
+    apiMock.deactivateAiMemory.mockResolvedValue({
+      id: 2,
+      memory_type: 'preference',
+      content: 'avoid model-release marketing',
+      source: 'explicit',
+      confidence: 1,
+      active: false,
+      created_at: '2026-01-02T00:00:00Z',
+      updated_at: '2026-01-05T00:00:00Z',
+    });
+
+    renderPage(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText('prioritize agent infrastructure')).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText('New AI memory'), {
+      target: { value: 'avoid model-release marketing' },
+    });
+    fireEvent.click(screen.getByText('Add'));
+    await waitFor(() =>
+      expect(apiMock.createAiMemory).toHaveBeenCalledWith('avoid model-release marketing')
+    );
+    expect(screen.getByText('avoid model-release marketing')).toBeTruthy();
+
+    fireEvent.click(screen.getAllByLabelText('Edit AI memory')[0]);
+    fireEvent.change(screen.getByLabelText('AI memory content'), {
+      target: { value: 'prioritize agent infrastructure and evals' },
+    });
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() =>
+      expect(screen.getByText('prioritize agent infrastructure and evals')).toBeTruthy()
+    );
+
+    fireEvent.click(screen.getByText('Learn from recent reading'));
+    await waitFor(() =>
+      expect(
+        screen.getByText('Recent reading suggests sustained interest in ai coverage.')
+      ).toBeTruthy()
+    );
+
+    fireEvent.click(screen.getAllByLabelText('Deactivate AI memory')[1]);
+    await waitFor(() => expect(screen.queryByText('avoid model-release marketing')).toBeNull());
   });
 
   it('shows the export download button', () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,6 @@
 import type {
   AdminAnalytics,
+  AiMemory,
   AgentActionPlanResponse,
   AgentActionRun,
   AiWatchlist,
@@ -287,6 +288,42 @@ export async function saveRecommendationPreferences(
     method: 'PATCH',
     body: JSON.stringify(preferences),
   });
+}
+
+export async function fetchAiMemories(): Promise<AiMemory[]> {
+  const data = await requestJson<{ items: AiMemory[] }>('/api/users/me/ai-memories');
+  return data.items;
+}
+
+export async function createAiMemory(content: string): Promise<AiMemory> {
+  return requestJson<AiMemory>('/api/users/me/ai-memories', {
+    method: 'POST',
+    body: JSON.stringify({ content }),
+  });
+}
+
+export async function updateAiMemory(
+  memoryId: number,
+  payload: Partial<Pick<AiMemory, 'content' | 'memory_type' | 'confidence' | 'active'>>
+): Promise<AiMemory> {
+  return requestJson<AiMemory>(`/api/users/me/ai-memories/${memoryId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deactivateAiMemory(memoryId: number): Promise<AiMemory> {
+  return requestJson<AiMemory>(`/api/users/me/ai-memories/${memoryId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function learnAiMemoriesFromReading(): Promise<AiMemory[]> {
+  const data = await requestJson<{ items: AiMemory[] }>(
+    '/api/users/me/ai-memories/learn-from-reading',
+    { method: 'POST' }
+  );
+  return data.items;
 }
 
 export async function ingestNow(): Promise<{

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -11,6 +11,8 @@ import {
   Sparkles,
   Bell,
   BellOff,
+  Brain,
+  Pencil,
   Trash2,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -25,17 +27,23 @@ import {
   deleteOwnAccount,
   deleteWatchlist,
   downloadUserExport,
+  createAiMemory,
+  deactivateAiMemory,
+  fetchAiMemories,
   fetchNotificationSettings,
   fetchWatchlists,
   previewWatchlist,
+  learnAiMemoriesFromReading,
   recalculateMyRecommendations,
   subscribePush,
   unsubscribePush,
+  updateAiMemory,
   updateNotificationSettings,
   updateWatchlist,
 } from '@/api';
 import type { AiWatchlist, AiWatchlistMatch } from '@/types';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';
+import type { AiMemory } from '@/types';
 
 const THEME_OPTS: { v: Theme; label: string; Icon: React.ComponentType<{ className?: string }> }[] =
   [
@@ -520,6 +528,209 @@ function WatchlistsSection() {
             ))}
           </div>
         )}
+      </div>
+    </section>
+  );
+}
+
+type MemoryState = 'idle' | 'loading' | 'saving' | 'learning' | 'error';
+
+function AiMemorySection() {
+  const [memories, setMemories] = useState<AiMemory[]>([]);
+  const [newContent, setNewContent] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingContent, setEditingContent] = useState('');
+  const [state, setState] = useState<MemoryState>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setState('loading');
+      try {
+        const loaded = await fetchAiMemories();
+        if (!cancelled) {
+          setMemories(loaded);
+          setState('idle');
+        }
+      } catch {
+        if (!cancelled) setState('error');
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const activeMemories = memories.filter((memory) => memory.active);
+
+  const create = async () => {
+    const content = newContent.trim();
+    if (!content) return;
+    setState('saving');
+    try {
+      const memory = await createAiMemory(content);
+      setMemories((current) => [memory, ...current]);
+      setNewContent('');
+      setState('idle');
+    } catch {
+      setState('error');
+    }
+  };
+
+  const learn = async () => {
+    setState('learning');
+    try {
+      const learned = await learnAiMemoriesFromReading();
+      setMemories((current) => [...learned, ...current]);
+      setState('idle');
+    } catch {
+      setState('error');
+    }
+  };
+
+  const saveEdit = async (memoryId: number) => {
+    const content = editingContent.trim();
+    if (!content) return;
+    setState('saving');
+    try {
+      const updated = await updateAiMemory(memoryId, { content });
+      setMemories((current) =>
+        current.map((memory) => (memory.id === memoryId ? updated : memory))
+      );
+      setEditingId(null);
+      setEditingContent('');
+      setState('idle');
+    } catch {
+      setState('error');
+    }
+  };
+
+  const deactivate = async (memoryId: number) => {
+    setState('saving');
+    try {
+      const updated = await deactivateAiMemory(memoryId);
+      setMemories((current) =>
+        current.map((memory) => (memory.id === memoryId ? updated : memory))
+      );
+      setState('idle');
+    } catch {
+      setState('error');
+    }
+  };
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        AI Memory
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+        <div className="flex gap-2">
+          <input
+            value={newContent}
+            onChange={(event) => setNewContent(event.target.value)}
+            placeholder="Remember a preference or goal"
+            aria-label="New AI memory"
+            className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <button
+            onClick={() => void create()}
+            disabled={state === 'saving' || !newContent.trim()}
+            className="flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-60"
+          >
+            {state === 'saving' ? (
+              <RefreshCw className="size-3 animate-spin" />
+            ) : (
+              <Brain className="size-3" />
+            )}
+            Add
+          </button>
+        </div>
+
+        <button
+          onClick={() => void learn()}
+          disabled={state === 'learning'}
+          className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-surface transition-colors disabled:opacity-60"
+        >
+          {state === 'learning' ? (
+            <RefreshCw className="size-3 animate-spin" />
+          ) : (
+            <Sparkles className="size-3" />
+          )}
+          Learn from recent reading
+        </button>
+
+        {state === 'loading' && (
+          <p className="text-xs text-muted-foreground">Loading memories...</p>
+        )}
+        {state === 'error' && (
+          <p className="text-xs text-destructive" role="alert">
+            Could not update AI memory.
+          </p>
+        )}
+
+        <div className="space-y-2">
+          {activeMemories.map((memory) => (
+            <div key={memory.id} className="rounded-md border border-border bg-surface p-3">
+              {editingId === memory.id ? (
+                <div className="space-y-2">
+                  <textarea
+                    value={editingContent}
+                    onChange={(event) => setEditingContent(event.target.value)}
+                    aria-label="AI memory content"
+                    className="min-h-20 w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => void saveEdit(memory.id)}
+                      className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <p className="break-words text-sm text-foreground">{memory.content}</p>
+                    <p className="text-[11px] text-muted-foreground">
+                      {memory.memory_type} / {memory.source} / {Math.round(memory.confidence * 100)}
+                      %
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 gap-1">
+                    <button
+                      onClick={() => {
+                        setEditingId(memory.id);
+                        setEditingContent(memory.content);
+                      }}
+                      aria-label="Edit AI memory"
+                      className="rounded-md p-1.5 text-muted-foreground hover:bg-card hover:text-foreground"
+                    >
+                      <Pencil className="size-3.5" />
+                    </button>
+                    <button
+                      onClick={() => void deactivate(memory.id)}
+                      aria-label="Deactivate AI memory"
+                      className="rounded-md p-1.5 text-muted-foreground hover:bg-card hover:text-destructive"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+          {state !== 'loading' && activeMemories.length === 0 && (
+            <p className="text-xs text-muted-foreground">No active memories yet.</p>
+          )}
+        </div>
       </div>
     </section>
   );
@@ -1159,6 +1370,8 @@ export function SettingsPage() {
       <PersonalizationSection />
 
       <WatchlistsSection />
+
+      <AiMemorySection />
 
       <DataExportSection />
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -433,6 +433,17 @@ export interface RecommendationPreferences {
   recomputed?: number;
 }
 
+export interface AiMemory {
+  id: number;
+  memory_type: string;
+  content: string;
+  source: string;
+  confidence: number;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface PersonalizationNudge {
   id: string;
   kind: 'source' | 'topic';


### PR DESCRIPTION
Closes #754

## Summary
- add PostgreSQL-backed AI memories and memory events with authenticated CRUD and learn-from-reading endpoints
- include bounded active memories in Ask AI and briefing prompts for the current user only
- persist Ask AI feedback as local memory events and include memories/events in user export
- add Settings UI for creating, editing, learning, and deactivating AI memories
- harden Postgres schema initialization and test cleanup for parallel worker schemas

## Test results
- PATH="$PWD/.venv/bin:$PATH" make lint
- PATH="$PWD/.venv/bin:$PATH" make typecheck
- PATH="$PWD/.venv/bin:$PATH" make test
- npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)