### PR TITLE
feat: make email OTP the primary login option, Keycloak secondary

### DIFF
--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -127,7 +127,7 @@ describe('RequireAuth', () => {
     expect(screen.queryByText('Protected content')).toBeNull();
   });
 
-  it('redirects straight to Keycloak when /api/auth/me returns 401 and Keycloak is enabled', async () => {
+  it('shows the in-app login page (not an immediate Keycloak redirect) on 401 when Keycloak is enabled', async () => {
     vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401 Unauthorized'));
     vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
       provider: 'keycloak',
@@ -158,10 +158,10 @@ describe('RequireAuth', () => {
       );
 
       await waitFor(() => {
-        expect(assign).toHaveBeenCalledWith('/auth/login');
+        expect(screen.getByText('Login page')).toBeTruthy();
       });
+      expect(assign).not.toHaveBeenCalled();
       expect(screen.queryByText('Protected content')).toBeNull();
-      expect(screen.queryByText('Login page')).toBeNull();
     } finally {
       Object.defineProperty(window, 'location', {
         configurable: true,
@@ -348,5 +348,32 @@ describe('LoginPage', () => {
       expect(registerLink).toBeTruthy();
       expect(registerLink.getAttribute('href')).toBe('/auth/register');
     });
+  });
+
+  it('shows the email OTP form by default with Keycloak as a secondary option when Keycloak is enabled', async () => {
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'keycloak',
+      keycloak_enabled: true,
+      login_url: '/auth/login',
+      logout_url: '/auth/logout',
+      registration_url: '/auth/register',
+    });
+
+    renderWithRouter(
+      <Routes>
+        <Route path="/" element={<LoginPage />} />
+      </Routes>
+    );
+
+    await waitFor(() => {
+      // OTP email form is the primary/default option.
+      expect(screen.getByLabelText(/email address/i)).toBeTruthy();
+      expect(screen.getByRole('button', { name: /send code/i })).toBeTruthy();
+    });
+    // Keycloak remains available as a secondary option.
+    const loginLink = screen.getByRole('link', { name: /sign in with keycloak/i });
+    expect(loginLink.getAttribute('href')).toBe('/auth/login');
+    // No password fields in Keycloak mode (password login is disabled server-side).
+    expect(screen.queryByLabelText(/^password$/i)).toBeNull();
   });
 });

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { fetchAuthConfig, fetchMe } from '@/api';
+import { fetchMe } from '@/api';
 import { useAuth } from '@/contexts/auth';
 
 interface Props {
@@ -19,12 +19,10 @@ export function RequireAuth({ children }: Props) {
         setUser(user);
         setChecked(true);
       })
-      .catch(async () => {
-        const config = await fetchAuthConfig().catch(() => null);
-        if (config?.provider === 'keycloak') {
-          window.location.assign(config.login_url ?? '/auth/login');
-          return;
-        }
+      .catch(() => {
+        // Always route to the in-app login page. Even when Keycloak is enabled,
+        // the login page offers email OTP as the primary option with Keycloak as
+        // a secondary choice, so we no longer redirect straight to Keycloak.
         void navigate('/login', { state: { from: location.pathname }, replace: true });
       });
     // Run once on mount only

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -28,7 +28,14 @@ export function LoginPage() {
 
   useEffect(() => {
     void fetchAuthConfig()
-      .then(setAuthConfig)
+      .then((config) => {
+        setAuthConfig(config);
+        // When Keycloak SSO is enabled, password login is disabled server-side,
+        // so default to the email OTP flow (Keycloak stays as a secondary option).
+        if (config.provider === 'keycloak') {
+          setMode('otp');
+        }
+      })
       .catch(() =>
         setAuthConfig({
           provider: 'password',
@@ -83,8 +90,8 @@ export function LoginPage() {
     }
   }
 
-  const keycloakLoginUrl =
-    authConfig?.provider === 'keycloak' ? (authConfig.login_url ?? '/auth/login') : null;
+  const keycloakEnabled = authConfig?.provider === 'keycloak';
+  const keycloakLoginUrl = keycloakEnabled ? (authConfig.login_url ?? '/auth/login') : null;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
@@ -97,26 +104,7 @@ export function LoginPage() {
           </div>
         </div>
 
-        {keycloakLoginUrl ? (
-          <div className="space-y-4">
-            <a
-              href={keycloakLoginUrl}
-              className="flex w-full items-center justify-center rounded-md bg-foreground px-4 py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-90"
-            >
-              {t('auth.sign_in_with_keycloak')}
-            </a>
-            {authConfig?.registration_url && (
-              <div className="text-center">
-                <a
-                  href={authConfig.registration_url}
-                  className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
-                >
-                  {t('auth.create_account')}
-                </a>
-              </div>
-            )}
-          </div>
-        ) : mode === 'password' ? (
+        {mode === 'password' ? (
           <div className="space-y-4">
             <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">
               <div className="space-y-1">
@@ -219,18 +207,39 @@ export function LoginPage() {
               </button>
             </form>
 
-            <div className="text-center">
-              <button
-                type="button"
-                onClick={() => {
-                  setMode('password');
-                  setError(null);
-                }}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
-              >
-                {t('auth.back_to_password')}
-              </button>
-            </div>
+            {keycloakLoginUrl ? (
+              <div className="space-y-3 border-t border-border pt-4">
+                <a
+                  href={keycloakLoginUrl}
+                  className="flex w-full items-center justify-center rounded-md border border-border bg-surface px-4 py-2.5 text-sm font-medium text-foreground transition-opacity hover:opacity-90"
+                >
+                  {t('auth.sign_in_with_keycloak')}
+                </a>
+                {authConfig?.registration_url && (
+                  <div className="text-center">
+                    <a
+                      href={authConfig.registration_url}
+                      className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+                    >
+                      {t('auth.create_account')}
+                    </a>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="text-center">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMode('password');
+                    setError(null);
+                  }}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+                >
+                  {t('auth.back_to_password')}
+                </button>
+              </div>
+            )}
           </div>
         ) : (
           <div className="space-y-4">


### PR DESCRIPTION
Closes #958

## Summary
Makes email OTP the primary sign-in option when Keycloak SSO is enabled, with Keycloak available as a secondary option.

Previously, an unauthenticated visit was redirected straight to Keycloak (`RequireAuth` called `window.location.assign(login_url)`), and the app's own login page only rendered the Keycloak button. Email OTP already works server-side under Keycloak (the `/api/auth/otp/*` endpoints resolve users by email from the local users table that mirrors Keycloak users) — it was just never surfaced in the UI.

## Changes
- `RequireAuth`: on 401, always route to the in-app `/login` page instead of redirecting straight to Keycloak.
- `LoginPage`: in Keycloak mode, default to the email-OTP flow and render "Sign in with Keycloak" (plus registration) as a secondary option below it. Password-provider deployments are unchanged.

## Tests
- Updated `RequireAuth` test: 401 + Keycloak enabled now shows the in-app login page (no immediate redirect).
- New `LoginPage` test: Keycloak enabled → OTP email form is default, Keycloak link present, no password fields.
- Full frontend suite green (761 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)