### PR TITLE
feat: enhance OTP email with News Dashboard branding

### DIFF
--- a/backend/news_dashboard/email.py
+++ b/backend/news_dashboard/email.py
@@ -29,24 +29,85 @@ def send_otp_email(to_email: str, otp: str) -> None:
 
     html_body = f"""\
 <!DOCTYPE html>
-<html>
-<body style="font-family:sans-serif;color:#1a1a1a;max-width:480px;margin:0 auto;padding:24px">
-  <h2 style="margin-bottom:8px">Your sign-in code</h2>
-  <p style="color:#555;margin-bottom:24px">
-    Use the code below to sign in. It expires in&nbsp;10&nbsp;minutes.
-  </p>
-  <div style="font-size:36px;font-weight:700;letter-spacing:8px;text-align:center;
-              padding:20px;background:#f5f5f5;border-radius:8px">
-    {otp}
-  </div>
-  <p style="color:#888;font-size:12px;margin-top:24px">
-    If you did not request this code, you can safely ignore this email.
-  </p>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Your News Dashboard sign-in code</title>
+</head>
+<body style="margin:0;padding:0;background:#f0f4f8;font-family:'Helvetica Neue',Arial,sans-serif">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0"
+         style="background:#f0f4f8;padding:32px 0">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="480" cellspacing="0" cellpadding="0"
+               style="max-width:480px;width:100%;background:#ffffff;border-radius:12px;
+                      overflow:hidden;box-shadow:0 4px 24px rgba(0,0,0,.08)">
+
+          <!-- Branded header -->
+          <tr>
+            <td style="background:#1e293b;padding:28px 32px;text-align:center">
+              <p style="margin:0;font-size:26px">📰</p>
+              <h1 style="margin:8px 0 4px;color:#ffffff;font-size:22px;
+                         font-weight:700;letter-spacing:-.3px">News Dashboard</h1>
+              <p style="margin:0;color:#94a3b8;font-size:13px">
+                Your personalised news intelligence platform
+              </p>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:36px 32px 24px">
+              <h2 style="margin:0 0 12px;color:#1e293b;font-size:20px;font-weight:700">
+                Your sign-in code
+              </h2>
+              <p style="margin:0 0 28px;color:#475569;font-size:15px;line-height:1.6">
+                Use the one-time code below to sign in to&nbsp;<strong>News&nbsp;Dashboard</strong>.
+                It expires in&nbsp;<strong>10&nbsp;minutes</strong>.
+              </p>
+
+              <!-- OTP block -->
+              <div style="background:#eff6ff;border:2px solid #2563eb;border-radius:10px;
+                          padding:24px;text-align:center;margin-bottom:28px">
+                <p style="margin:0 0 6px;color:#3b82f6;font-size:11px;
+                           font-weight:600;letter-spacing:1.5px;text-transform:uppercase">
+                  One-time code
+                </p>
+                <span style="display:inline-block;font-size:40px;font-weight:800;
+                             letter-spacing:10px;color:#1e40af;line-height:1">
+                  {otp}
+                </span>
+              </div>
+
+              <p style="margin:0;color:#94a3b8;font-size:12px;line-height:1.6;
+                         border-top:1px solid #e2e8f0;padding-top:20px">
+                If you did not request this code, you can safely ignore this email.
+                Someone may have entered your email address by mistake.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f8fafc;padding:16px 32px;text-align:center;
+                       border-top:1px solid #e2e8f0">
+              <p style="margin:0;color:#94a3b8;font-size:11px">
+                This email was sent by <strong>News Dashboard</strong>.
+                Do not reply to this email.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
 </body>
 </html>"""
 
     msg = MIMEMultipart("alternative")
-    msg["Subject"] = "Your sign-in code"
+    msg["Subject"] = "Your News Dashboard sign-in code"
     msg["From"] = username
     msg["To"] = to_email
     msg.attach(MIMEText(html_body, "html"))

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -1,0 +1,91 @@
+"""Tests for the OTP email content and branding."""
+
+from __future__ import annotations
+
+import smtplib
+from email import message_from_string
+from email.message import Message
+from unittest.mock import patch
+
+
+def _capture_sent_message(to_email: str, otp: str) -> Message:
+    """Call send_otp_email with fake SMTP and return the captured MIME message."""
+    import news_dashboard.email as email_mod
+
+    captured: list[tuple[str, str, str]] = []
+
+    class _FakeSMTP:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> _FakeSMTP:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def ehlo(self) -> None:
+            pass
+
+        def starttls(self) -> None:
+            pass
+
+        def login(self, user: str, _pw: str) -> None:
+            pass
+
+        def sendmail(self, frm: str, to: str, raw: str) -> None:
+            captured.append((frm, to, raw))
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"SMTP_USERNAME": "noreply@example.com", "SMTP_PASSWORD": "secret"},
+        ),
+        patch.object(smtplib, "SMTP", _FakeSMTP),
+    ):
+        email_mod.send_otp_email(to_email, otp)
+
+    assert len(captured) == 1, "Expected exactly one email to be sent"
+    return message_from_string(captured[0][2])
+
+
+def _extract_html_body(msg: Message) -> str | None:
+    """Return the decoded text of the first text/html part, or None."""
+    parts: list[Message] = list(msg.walk()) if msg.is_multipart() else [msg]
+    for part in parts:
+        if part.get_content_type() == "text/html":
+            raw = part.get_payload(decode=True)
+            if isinstance(raw, bytes):
+                return raw.decode("utf-8")
+    return None
+
+
+def test_otp_email_subject_contains_news_dashboard() -> None:
+    """Subject must clearly identify the News Dashboard application."""
+    msg = _capture_sent_message("user@example.com", "123456")
+    subject = msg["Subject"]
+    assert subject is not None
+    assert "News Dashboard" in subject, f"Subject missing 'News Dashboard': {subject!r}"
+
+
+def test_otp_email_html_body_contains_news_dashboard() -> None:
+    """HTML body must reference the application name so the user knows where the OTP came from."""
+    msg = _capture_sent_message("user@example.com", "654321")
+    html_body = _extract_html_body(msg)
+    assert html_body is not None, "No HTML part found in the email"
+    assert "News Dashboard" in html_body, f"HTML body missing 'News Dashboard': {html_body[:300]!r}"
+
+
+def test_otp_email_html_body_contains_otp_code() -> None:
+    """The OTP code must appear in the HTML body."""
+    otp = "789012"
+    msg = _capture_sent_message("user@example.com", otp)
+    html_body = _extract_html_body(msg)
+    assert html_body is not None, "No HTML part found in the email"
+    assert otp in html_body, f"OTP code {otp!r} not found in HTML body"
+
+
+def test_otp_email_from_header_uses_smtp_username() -> None:
+    """From header must equal the configured SMTP_USERNAME."""
+    msg = _capture_sent_message("user@example.com", "111222")
+    assert msg["From"] == "noreply@example.com"


### PR DESCRIPTION
Closes #964

Enhances the OTP sign-in email so users immediately recognise it as coming from the **News Dashboard** application.

### Changes
- **Subject**: changed from `Your sign-in code` → `Your News Dashboard sign-in code`
- **HTML body**: full branded redesign with:
  - Dark header card with 📰 emoji, "News Dashboard" title, and tagline
  - Blue-themed OTP code block (brand colour `#2563eb`) with "One-time code" label
  - Footer naming the application
- **Test**: new `backend/tests/test_email.py` with 4 unit tests (no network, no DB) asserting subject branding, HTML body branding, OTP code presence, and From header

🤖 Generated with [Claude Code](https://claude.com/claude-code)