### PR TITLE
feat: auto-create users on OTP authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ TOKEN_SECRET=
 BCRYPT_ROUNDS=
 # Days a login session stays valid. Default 30.
 SESSION_DAYS=30
+# Auto-create an account when an unknown email requests an OTP code. Default true.
+# Set to false to restrict OTP login to existing users only.
+OTP_AUTO_REGISTER=true
 # First local admin account, created only when no users exist yet.
 BOOTSTRAP_ADMIN_USERNAME=admin
 BOOTSTRAP_ADMIN_PASSWORD=change-me

--- a/backend/news_dashboard/auth.py
+++ b/backend/news_dashboard/auth.py
@@ -529,6 +529,26 @@ def _verify_otp_hash(otp: str, otp_hash: str) -> bool:
         return False
 
 
+def otp_auto_register_enabled() -> bool:
+    """Whether an unknown email requesting an OTP should get a new account."""
+    return _truthy(os.getenv("OTP_AUTO_REGISTER", "true"))
+
+
+def get_or_create_otp_user(email: str) -> dict[str, Any] | None:
+    """Return the user for this email, creating one if auto-registration is on.
+
+    The new account uses the full email as its username and a random password
+    (OTP login never checks it). Returns None only when no user exists and
+    auto-registration is disabled.
+    """
+    user = get_user_by_email(email)
+    if user is not None:
+        return user
+    if not otp_auto_register_enabled():
+        return None
+    return create_user(email, secrets.token_urlsafe(32), email=email)
+
+
 def create_otp_for_user(user_id: int) -> str:
     """Generate a 6-digit OTP, store its hash, and return the plaintext pin."""
     otp = _generate_otp()

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -52,7 +52,7 @@ from news_dashboard.auth import (
     create_user,
     delete_user,
     exchange_keycloak_code,
-    get_user_by_email,
+    get_or_create_otp_user,
     get_user_by_id,
     init_auth,
     keycloak_auth_metadata,
@@ -746,7 +746,7 @@ def otp_request(payload: OTPRequestPayload, background_tasks: BackgroundTasks) -
         raise HTTPException(status_code=429, detail="Too many code requests; try again later")
     record_failure(request_key)
 
-    user = get_user_by_email(payload.email)
+    user = get_or_create_otp_user(payload.email)
     if user:
         otp = create_otp_for_user(int(user["id"]))
         background_tasks.add_task(send_otp_email, payload.email, otp)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -18,6 +18,7 @@ from news_dashboard.auth import (
     create_user,
     delete_user,
     ensure_keycloak_user,
+    get_user_by_email,
     get_user_by_id,
     hash_password,
     init_auth,
@@ -542,6 +543,51 @@ def test_otp_request_endpoint_returns_sent_for_unknown_email(
     resp = client.post("/api/auth/otp/request", json={"email": "ghost@example.com"})
     assert resp.status_code == 200
     assert resp.json() == {"status": "sent"}
+
+
+def test_otp_request_auto_registers_unknown_email(
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import news_dashboard.email as email_mod
+
+    monkeypatch.setenv("OTP_AUTO_REGISTER", "true")
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(email_mod, "send_otp_email", lambda to, code: sent.append((to, code)))
+
+    client = _fresh_client()
+    resp = client.post("/api/auth/otp/request", json={"email": "newbie@example.com"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "sent"}
+
+    # A user was created with the full email as username, and an OTP was sent.
+    assert len(sent) == 1
+    _, code = sent[0]
+    user = get_user_by_email("newbie@example.com")
+    assert user is not None
+    assert user["username"] == "newbie@example.com"
+
+    # The freshly created account can complete the OTP login flow.
+    resp = client.post("/api/auth/otp/login", json={"email": "newbie@example.com", "otp": code})
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "newbie@example.com"
+
+
+def test_otp_request_no_auto_register_when_disabled(
+    tmp_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import news_dashboard.email as email_mod
+
+    monkeypatch.setenv("OTP_AUTO_REGISTER", "false")
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(email_mod, "send_otp_email", lambda to, code: sent.append((to, code)))
+
+    client = _fresh_client()
+    resp = client.post("/api/auth/otp/request", json={"email": "ghost2@example.com"})
+    # Enumeration-safe response is preserved, but no user or OTP is created.
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "sent"}
+    assert sent == []
+    assert get_user_by_email("ghost2@example.com") is None
 
 
 def test_otp_login_endpoint_full_flow(tmp_db: str, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -537,8 +537,13 @@ def test_otp_expired_rejected(tmp_db: str) -> None:
 
 
 def test_otp_request_endpoint_returns_sent_for_unknown_email(
-    tmp_db: str, clean_throttle: None
+    tmp_db: str, clean_throttle: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import news_dashboard.email as email_mod
+
+    # Default auto-registration means an unknown email now sends a real OTP; stub
+    # the SMTP send so the test exercises only the enumeration-safe response.
+    monkeypatch.setattr(email_mod, "send_otp_email", lambda *_args: None)
     client = _fresh_client()
     resp = client.post("/api/auth/otp/request", json={"email": "ghost@example.com"})
     assert resp.status_code == 200
@@ -803,8 +808,11 @@ def test_otp_request_throttles_known_email(
 
 
 def test_otp_request_throttles_unknown_email_at_same_threshold(
-    tmp_db: str, clean_throttle: None
+    tmp_db: str, clean_throttle: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    import news_dashboard.email as email_mod
+
+    monkeypatch.setattr(email_mod, "send_otp_email", lambda *_args: None)
     client = _fresh_client()
     for _ in range(5):
         resp = client.post("/api/auth/otp/request", json={"email": "ghost2@example.com"})


### PR DESCRIPTION
Closes #965

## What

`/api/auth/otp/request` previously only created and sent a one-time code when a user already existed for the submitted email, so unknown emails silently got nothing and OTP login always failed with "Invalid or expired code" — there was no way to onboard a new user via OTP.

This makes OTP a self-service sign-up path: when an unknown email requests a code and `OTP_AUTO_REGISTER` is enabled (**default true**), a user is created with `username = <full email>` and a random password, then the OTP is sent.

## How it's gated

- `OTP_AUTO_REGISTER` env flag, defaulting to `true`.
- Set to a falsy value to restore the previous "known emails only" behavior.

## Safety

- Enumeration-safe response (`{"status": "sent"}`) is unchanged.
- Existing per-email request throttling also caps auto-registration.

## Tests

- `test_otp_request_auto_registers_unknown_email` — unknown email + flag on → user created (email as username), OTP sent, full login flow succeeds.
- `test_otp_request_no_auto_register_when_disabled` — flag off → no user/OTP created, still returns `{"status": "sent"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)