### PR TITLE
security: serve baseline browser security headers from FastAPI (#759)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,10 @@ METRICS_ENABLED=false
 # (1/true/yes/on). Off by default so a public deployment doesn't leak its
 # full API surface. Enable for local development.
 ENABLE_API_DOCS=true
+# Sends Strict-Transport-Security when truthy (1/true/yes/on). Off by default
+# since HSTS is only correct behind HTTPS; leave unset for local HTTP dev or
+# when a TLS-terminating proxy (e.g. Caddy) already sets it.
+ENABLE_HSTS=false
 # Optional, opt-in error tracking. Point at a Sentry or GlitchTip-compatible DSN
 # to capture unhandled backend exceptions. Unset (default) initializes no SDK
 # and makes no network calls. In production, store this as the SENTRY_DSN

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -357,6 +357,24 @@ async def enforce_csrf_origin(request: Request, call_next: Any) -> Any:
     return await call_next(request)
 
 
+# ── Baseline browser security headers ───────────────────────────────────────
+
+
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next: Any) -> Any:
+    """Attach conservative security headers to every response.
+
+    Applies to API and static frontend responses alike, so the app carries
+    this baseline itself regardless of whether it's fronted by the Caddy
+    deployment in ``deploy/Caddyfile`` or run directly (Docker/Compose).
+    """
+    from news_dashboard.security_headers import apply_security_headers
+
+    response = await call_next(request)
+    apply_security_headers(response)
+    return response
+
+
 # ── AI-facing payload limits ─────────────────────────────────────────────────
 # Bounds for user-supplied text that reaches retrieval, prompt construction, or
 # storage, so a malformed client can't send oversized LLM requests or noisy

--- a/backend/news_dashboard/security_headers.py
+++ b/backend/news_dashboard/security_headers.py
@@ -1,0 +1,42 @@
+"""Baseline browser security headers for FastAPI responses.
+
+The edge Caddy config (``deploy/Caddyfile``) already sets these headers for
+the ``news.lihor.ro`` deployment, but the app can also be run directly via
+``docker run``, ``docker-compose.prod.yml``, or a different reverse proxy
+where Caddy isn't in front of it. This makes the baseline part of the app's
+own contract instead of depending on which front door is used.
+
+``Strict-Transport-Security`` is opt-in via ``ENABLE_HSTS`` since it's only
+correct behind HTTPS; setting it on plain local HTTP dev would tell browsers
+to force TLS on a server that doesn't offer it.
+"""
+
+from __future__ import annotations
+
+import os
+
+from starlette.responses import Response
+
+X_CONTENT_TYPE_OPTIONS = "nosniff"
+X_FRAME_OPTIONS = "DENY"
+REFERRER_POLICY = "no-referrer"
+PERMISSIONS_POLICY = "camera=(), microphone=(), geolocation=()"
+HSTS_VALUE = "max-age=31536000; includeSubDomains; preload"
+
+
+def hsts_enabled() -> bool:
+    return os.getenv("ENABLE_HSTS", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def apply_security_headers(response: Response) -> None:
+    """Set conservative baseline security headers, without overriding existing ones.
+
+    Uses ``setdefault`` so an upstream proxy or a route that deliberately sets
+    a stricter value keeps its own choice.
+    """
+    response.headers.setdefault("X-Content-Type-Options", X_CONTENT_TYPE_OPTIONS)
+    response.headers.setdefault("X-Frame-Options", X_FRAME_OPTIONS)
+    response.headers.setdefault("Referrer-Policy", REFERRER_POLICY)
+    response.headers.setdefault("Permissions-Policy", PERMISSIONS_POLICY)
+    if hsts_enabled():
+        response.headers.setdefault("Strict-Transport-Security", HSTS_VALUE)

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,73 @@
+"""Tests for the baseline browser security headers middleware."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import app
+
+
+def _client() -> TestClient:
+    app.dependency_overrides.clear()
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.mark.smoke
+def test_public_route_gets_baseline_headers() -> None:
+    with patch("news_dashboard.main.connect"):
+        resp = _client().get("/api/live")
+
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["Referrer-Policy"] == "no-referrer"
+    assert resp.headers["Permissions-Policy"] == "camera=(), microphone=(), geolocation=()"
+
+
+@pytest.mark.smoke
+def test_404_response_still_gets_baseline_headers() -> None:
+    resp = _client().get("/api/does-not-exist")
+
+    assert resp.status_code == 404
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["X-Frame-Options"] == "DENY"
+
+
+@pytest.mark.smoke
+def test_hsts_absent_by_default() -> None:
+    with patch("news_dashboard.main.connect"):
+        resp = _client().get("/api/live")
+
+    assert "Strict-Transport-Security" not in resp.headers
+
+
+@pytest.mark.smoke
+def test_hsts_present_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLE_HSTS", "true")
+    import news_dashboard.security_headers as security_headers_module
+
+    importlib.reload(security_headers_module)
+    try:
+        with patch("news_dashboard.main.connect"):
+            resp = _client().get("/api/live")
+        assert resp.headers["Strict-Transport-Security"] == (
+            "max-age=31536000; includeSubDomains; preload"
+        )
+    finally:
+        monkeypatch.delenv("ENABLE_HSTS", raising=False)
+        importlib.reload(security_headers_module)
+
+
+@pytest.mark.smoke
+def test_setdefault_does_not_override_existing_header() -> None:
+    from starlette.responses import Response
+
+    from news_dashboard.security_headers import apply_security_headers
+
+    response = Response(content="ok", headers={"X-Frame-Options": "SAMEORIGIN"})
+    apply_security_headers(response)
+
+    assert response.headers["X-Frame-Options"] == "SAMEORIGIN"

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -156,8 +156,24 @@ See the [README Configuration section](../README.md#configuration) for the compl
 | Variable | Description |
 |----------|-------------|
 | `ENABLE_API_DOCS` | Set to `true` to serve the interactive API docs (`/docs`, `/redoc`, `/openapi.json`). Off by default so a public deployment doesn't leak its full API surface to anonymous visitors; enable it for local development or trusted environments. |
+| `ENABLE_HSTS` | Set to `true` to have the app send `Strict-Transport-Security` itself. Off by default, since HSTS is only correct behind HTTPS — leave it unset for local HTTP dev, or when a TLS-terminating proxy (e.g. Caddy, see below) already sets it. |
 
 > **Important**: Never commit secrets to version control. Use environment variables or a `.env` file (not committed to Git) to manage sensitive values.
+
+### Baseline browser security headers
+
+The app itself sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+`Referrer-Policy: no-referrer`, and a conservative `Permissions-Policy` on
+every response (API and static frontend alike), so this baseline applies
+regardless of which front door is used — `docker run`, `docker-compose.prod.yml`,
+or a reverse proxy other than Caddy. `Strict-Transport-Security` stays opt-in
+via `ENABLE_HSTS` above.
+
+The documented Caddy deployment ([HTTPS with Caddy](https://docs.lihor.ro/docs/configuration/https-caddy),
+config in `deploy/Caddyfile`) also sets these headers at the edge, including
+HSTS. The two layers are compatible — headers the app already set are left
+alone (`setdefault` semantics), so the edge proxy can still enforce a
+stricter policy.
 
 ### Optional article body extraction (Crawl4AI)
 


### PR DESCRIPTION
## Summary
- Add a FastAPI middleware that sets baseline browser security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `Permissions-Policy`) on every response, API and static frontend alike, via `setdefault` so an upstream proxy can still override with a stricter policy.
- `Strict-Transport-Security` stays opt-in via a new `ENABLE_HSTS` env var, since it's only correct behind HTTPS and would be misleading for local HTTP dev.
- Documented the new behavior and `ENABLE_HSTS` in `docs/SELF_HOSTING.md`, noting it's compatible with the existing `deploy/Caddyfile` edge headers.

Closes #759

## Test plan
- [x] `pytest -m smoke -v` — 35 passed, including 5 new tests in `backend/tests/test_security_headers.py` covering: baseline headers on a public route, headers present on a 404 (guarantees the middleware wraps other middlewares/routes), HSTS absent by default, HSTS present when `ENABLE_HSTS=true`, and `setdefault` not overriding an existing header.
- [x] `ruff check` / `ruff format --check` / `mypy` clean on changed files
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly) pass on the commit
- [ ] Manual `curl -I` verification against a running container (not done in this sandbox — no Docker available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)