### PR TITLE
fix: skip version-file sync when the rolling PR is queued for merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,16 +359,29 @@ jobs:
             echo "Version files already in sync — nothing to propose."
             exit 0
           fi
+          # A branch whose PR is in the merge queue rejects pushes (GH006).
+          # That's an expected race, not an error: the queued PR merges, and
+          # the next release proposes the remaining catch-up.
+          PR_NUMBER="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$PR_NUMBER" ]; then
+            QUEUED="$(gh api graphql \
+              -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){isInMergeQueue}}}' \
+              -f o="${GITHUB_REPOSITORY%/*}" -f r="${GITHUB_REPOSITORY#*/}" -F n="$PR_NUMBER" \
+              --jq '.data.repository.pullRequest.isInMergeQueue')"
+            if [ "$QUEUED" = "true" ]; then
+              echo "Sync PR #$PR_NUMBER is queued in the merge queue — skipping; the next release will catch up."
+              exit 0
+            fi
+          fi
           git switch -c "$BRANCH"
           git add VERSION pyproject.toml CHANGELOG.md
           git commit -m "chore: sync VERSION and CHANGELOG for v$V"
           git push -f origin "HEAD:refs/heads/$BRANCH"
-          OPEN_PRS="$(gh pr list --head "$BRANCH" --state open --json number --jq length)"
-          if [ "$OPEN_PRS" = "0" ]; then
+          if [ -z "$PR_NUMBER" ]; then
             gh pr create --base main --head "$BRANCH" \
               --title "chore: sync VERSION and CHANGELOG for v$V" \
               --body "$(printf 'Automated catch-up of the committed VERSION, pyproject.toml, and CHANGELOG.md to match the released tag v%s.\n\nIf the required checks never start, close and reopen this PR (or configure a VERSIONING_SYNC_TOKEN secret so they start automatically).' "$V")"
           else
-            gh pr edit "$BRANCH" --title "chore: sync VERSION and CHANGELOG for v$V"
-            echo "Sync PR already open — branch force-pushed with the latest catch-up."
+            gh pr edit "$PR_NUMBER" --title "chore: sync VERSION and CHANGELOG for v$V"
+            echo "Sync PR #$PR_NUMBER already open — branch force-pushed with the latest catch-up."
           fi

--- a/scripts/test_release_sync_workflow.py
+++ b/scripts/test_release_sync_workflow.py
@@ -38,6 +38,14 @@ class TestReleaseSyncJob(unittest.TestCase):
             if expected not in self.workflow:
                 self.fail(f"release.yml sync job does not update {expected}")
 
+    def test_sync_job_skips_when_rolling_pr_is_queued_for_merge(self) -> None:
+        # A branch whose PR sits in the merge queue rejects pushes (GH006), and
+        # the next release catches up anyway — the job must skip, not fail.
+        if "isInMergeQueue" not in self.workflow:
+            self.fail("sync job must check whether the rolling PR is in the merge queue")
+        if "queued in the merge queue" not in self.workflow:
+            self.fail("sync job must log why it skipped when the rolling PR is queued")
+
     def test_sync_job_opens_a_rolling_pr_instead_of_pushing_main(self) -> None:
         if "bot/sync-versioning" not in self.workflow:
             self.fail("sync job must push a rolling bot/sync-versioning branch")


### PR DESCRIPTION
Closes #975

The `sync-version-files` job failed with GH006 when a release force-pushed `bot/sync-versioning` while the previous catch-up PR was in the merge queue (seen on the v1.92.0 run while #973 was queued). The job now looks up the open rolling PR, asks GraphQL for `isInMergeQueue`, and exits 0 with a log line when queued — the next release catches up the remainder. Real push failures still fail the job. The PR-create/edit branch reuses the looked-up PR number instead of a second list query.

Guarded by a new shape test in `scripts/test_release_sync_workflow.py` (red before the fix, green after); full `scripts/` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)