### PR TITLE
ops: add app healthchecks to Compose services (#760)

### DIFF
--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -15,6 +15,7 @@ import yaml  # type: ignore[import-untyped]
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+COMPOSE_PROD_FILE = REPO_ROOT / "docker-compose.prod.yml"
 
 _REQUIRED_AUTH_VARS = {
     "SESSION_SECRET",
@@ -64,3 +65,49 @@ def test_compose_app_service_has_auth_env_vars() -> None:
 
     assert not missing, f"Auth env vars not declared in compose: {missing}"
     assert not empty, f"Auth env vars have no default value in compose: {empty}"
+
+
+def test_compose_prod_file_exists() -> None:
+    assert COMPOSE_PROD_FILE.exists(), f"docker-compose.prod.yml not found at {COMPOSE_PROD_FILE}"
+
+
+def _assert_app_healthcheck_uses_no_extra_tools(compose_file: Path) -> None:
+    """The news-dashboard service healthcheck must not rely on curl/wget.
+
+    The production image (python:3.14-slim) does not install curl or wget, so
+    the healthcheck must use the Python standard library to probe /api/ready.
+    """
+    compose = yaml.safe_load(compose_file.read_text())
+    services = compose.get("services", {})
+    assert "news-dashboard" in services, "news-dashboard service missing from compose"
+
+    healthcheck = services["news-dashboard"].get("healthcheck")
+    assert healthcheck is not None, (
+        f"news-dashboard service in {compose_file.name} has no healthcheck"
+    )
+
+    test = healthcheck.get("test")
+    assert isinstance(test, list), f"healthcheck.test in {compose_file.name} must be a list"
+    assert test, f"healthcheck.test in {compose_file.name} must be non-empty"
+    assert test[0] == "CMD", (
+        f"healthcheck.test in {compose_file.name} must use exec form (CMD), not CMD-SHELL"
+    )
+
+    command = " ".join(test)
+    assert "curl" not in command, f"healthcheck in {compose_file.name} must not depend on curl"
+    assert "wget" not in command, f"healthcheck in {compose_file.name} must not depend on wget"
+    assert "/api/ready" in command, f"healthcheck in {compose_file.name} must probe /api/ready"
+    assert "127.0.0.1" in command, (
+        f"healthcheck in {compose_file.name} must probe the local container"
+    )
+
+    for field in ("interval", "timeout", "retries", "start_period"):
+        assert field in healthcheck, f"healthcheck in {compose_file.name} is missing '{field}'"
+
+
+def test_compose_app_healthcheck_configured() -> None:
+    _assert_app_healthcheck_uses_no_extra_tools(COMPOSE_FILE)
+
+
+def test_compose_prod_app_healthcheck_configured() -> None:
+    _assert_app_healthcheck_uses_no_extra_tools(COMPOSE_PROD_FILE)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,6 +34,18 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/api/ready', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,18 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/api/ready', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -234,27 +234,38 @@ News Dashboard exposes several health and readiness endpoints for monitoring and
 
 ### Docker Probe Configuration
 
-Add health checks to your `docker-compose.prod.yml` or `docker run`:
+The production image is based on `python:3.14-slim` and does not install `curl`
+or `wget`, so `docker-compose.yml` and `docker-compose.prod.yml` ship a
+healthcheck that calls `/api/ready` with the Python standard library instead:
 
 ```yaml
 # docker-compose.prod.yml snippet for the news-dashboard service
 healthcheck:
-  test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
+  test:
+    [
+      "CMD",
+      "python",
+      "-c",
+      "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/api/ready', timeout=5).read()",
+    ]
   interval: 30s
-  timeout: 5s
+  timeout: 10s
   retries: 3
   start_period: 30s
 ```
 
-If `curl` is not available in the container, use `wget` or the `/api/live` endpoint
-which has no dependencies:
+`/api/ready` was chosen over `/api/live` so `docker compose ps` reflects
+database connectivity, not just process liveness. If you only want process
+liveness, swap the path for `/api/live` in the snippet above.
+
+For `docker run`, use the same Python-based probe:
 
 ```bash
 docker run -d \
   --name news-dashboard \
-  --health-cmd "wget -qO- http://localhost:8080/api/live" \
+  --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/api/ready', timeout=5).read()\"" \
   --health-interval 30s \
-  --health-timeout 5s \
+  --health-timeout 10s \
   --health-retries 3 \
   --health-start-period 30s \
   # ... other options ...


### PR DESCRIPTION
## Summary

Closes #760.

- `docker-compose.yml` and `docker-compose.prod.yml` only defined a healthcheck for the `postgres` service; the `news-dashboard` app service had none, so `docker compose ps` couldn't distinguish "process running" from "app actually healthy" during DB outages or startup failures.
- Added a `healthcheck` block to the `news-dashboard` service in both Compose files using `python -c "import urllib.request; ..."` against `http://127.0.0.1:8080/api/ready` — the production image (`python:3.14-slim`) doesn't install `curl` or `wget`, so the probe avoids adding OS packages.
- `/api/ready` was chosen (matches the existing Kubernetes readiness probe) so Compose status reflects database connectivity, not just liveness.
- Updated `docs/SELF_HOSTING.md`'s Docker Probe Configuration section to match the checked-in Compose healthcheck instead of the old curl/wget-based snippet.
- Extended `backend/tests/test_compose_auth_env.py` with tests asserting both Compose files declare a `news-dashboard` healthcheck that avoids curl/wget, probes `/api/ready` on `127.0.0.1`, and has interval/timeout/retries/start_period set.

## Test plan

- [x] `python -m pytest backend/tests/test_compose_auth_env.py -q` — 5 passed
- [x] `python -m pytest backend/tests/test_compose_auth_env.py backend/tests/test_health_endpoints.py -q` — 8 passed
- [x] `docker compose config` and `docker compose -f docker-compose.prod.yml config` validate cleanly
- [x] `docker compose up -d --build` locally, confirmed `docker compose ps` reports the app as `(healthy)` after startup
- [x] pre-commit (ruff, ruff-format, mypy, ty, pyrefly) passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)