### PR TITLE
feat: add local AI eval dashboard (#758)

### DIFF
--- a/backend/news_dashboard/ai_evals.py
+++ b/backend/news_dashboard/ai_evals.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+
+MAX_TEXT_CHARS = 2000
+MAX_COMMENT_CHARS = 500
+DEFAULT_PROMPT_VERSION = "local"
+DEFAULT_MODEL_VERSION = "local"
+
+
+def _bounded(value: Any, limit: int = MAX_TEXT_CHARS) -> Any:
+    if isinstance(value, str):
+        text = re.sub(r"\s+", " ", value).strip()
+        return text[:limit]
+    if isinstance(value, Mapping):
+        return {str(k): _bounded(v, limit) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_bounded(v, limit) for v in value[:20]]
+    return value
+
+
+def record_feedback_example(
+    *,
+    user_id: int,
+    trace_id: str,
+    helpful: bool,
+    comment: str | None = None,
+    feature: str = "ask-ai",
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> int:
+    init_db(db_path, database_url=database_url)
+    expected = {
+        "feedback_helpful": helpful,
+        "comment": _bounded(comment or "", MAX_COMMENT_CHARS),
+    }
+    with connect(db_path, database_url=database_url) as conn:
+        creator_row = conn.execute("SELECT id FROM users WHERE id = %s", (user_id,)).fetchone()
+        creator_id = user_id if creator_row is not None else None
+        row = conn.execute(
+            """
+            INSERT INTO ai_eval_examples
+              (feature, prompt_version, model_version, input, expected_properties,
+               source_trace_id, feedback_helpful, created_by_user_id)
+            VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                feature,
+                DEFAULT_PROMPT_VERSION,
+                DEFAULT_MODEL_VERSION,
+                json.dumps({"trace_id": _bounded(trace_id, 200)}),
+                json.dumps(expected),
+                _bounded(trace_id, 200),
+                helpful,
+                creator_id,
+            ),
+        ).fetchone()
+    return int(row["id"])
+
+
+def score_output(
+    output: Mapping[str, Any],
+    expected: Mapping[str, Any],
+) -> tuple[bool, float, str | None]:
+    failures: list[str] = []
+    citations = _int_set(output.get("citations") or output.get("citation_ids") or [])
+    allowed = _int_set(expected.get("allowed_citation_ids") or expected.get("citation_ids") or [])
+    if allowed and not citations.issubset(allowed):
+        failures.append("unknown citations")
+    if expected.get("requires_citation") and not citations:
+        failures.append("missing citations")
+    if expected.get("weak_retrieval"):
+        answer = str(output.get("answer") or output.get("text") or "").lower()
+        if "insufficient" not in answer and "not enough context" not in answer:
+            failures.append("missing insufficient-context response")
+    if expected.get("briefing"):
+        sections = output.get("sections")
+        if not isinstance(sections, list):
+            failures.append("invalid briefing JSON shape")
+        elif allowed:
+            for section in sections:
+                if isinstance(section, Mapping):
+                    section_citations = _int_set(section.get("citations") or [])
+                    if not section_citations.issubset(allowed):
+                        failures.append("unknown briefing citations")
+                        break
+    min_chars = _optional_int(expected.get("min_chars"))
+    max_chars = _optional_int(expected.get("max_chars"))
+    text = json.dumps(output, sort_keys=True)
+    if min_chars is not None and len(text) < min_chars:
+        failures.append("response too short")
+    if max_chars is not None and len(text) > max_chars:
+        failures.append("response too long")
+    passed = not failures
+    return passed, 1.0 if passed else 0.0, "; ".join(failures) or None
+
+
+def run_local_evals(
+    *,
+    feature: str | None = None,
+    prompt_version: str = DEFAULT_PROMPT_VERSION,
+    model_version: str = DEFAULT_MODEL_VERSION,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        run = conn.execute(
+            """
+            INSERT INTO ai_eval_runs(feature, prompt_version, model_version)
+            VALUES (%s, %s, %s)
+            RETURNING id
+            """,
+            (feature, prompt_version, model_version),
+        ).fetchone()
+        run_id = int(run["id"])
+        params: tuple[Any, ...]
+        where = ""
+        if feature:
+            where = "WHERE feature = %s"
+            params = (feature,)
+        else:
+            params = ()
+        examples = conn.execute(
+            f"""
+            SELECT id, input, expected_properties
+            FROM ai_eval_examples
+            {where}
+            ORDER BY id
+            """,
+            params,
+        ).fetchall()
+        passed_count = 0
+        for example in examples:
+            expected = dict(example["expected_properties"] or {})
+            output = _expected_output(example["input"], expected)
+            passed, score, failure_reason = score_output(output, expected)
+            if passed:
+                passed_count += 1
+            conn.execute(
+                """
+                INSERT INTO ai_eval_results
+                  (run_id, example_id, output, score, passed, failure_reason)
+                VALUES (%s, %s, %s::jsonb, %s, %s, %s)
+                """,
+                (
+                    run_id,
+                    int(example["id"]),
+                    json.dumps(_bounded(output)),
+                    score,
+                    passed,
+                    failure_reason,
+                ),
+            )
+        total = len(examples)
+        failed = total - passed_count
+        status = "passed" if failed == 0 else "failed"
+        conn.execute(
+            """
+            UPDATE ai_eval_runs
+            SET status = %s, total = %s, passed = %s, failed = %s, finished_at = NOW()
+            WHERE id = %s
+            """,
+            (status, total, passed_count, failed, run_id),
+        )
+    return {"run_id": run_id, "total": total, "passed": passed_count, "failed": failed}
+
+
+def admin_quality_summary(
+    *,
+    days: int = 30,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(db_path, database_url=database_url)
+    days = max(1, min(days, 365))
+    start = datetime.now(timezone.utc) - timedelta(days=days)
+    with connect(db_path, database_url=database_url) as conn:
+        feedback = conn.execute(
+            """
+            SELECT feature,
+                   COUNT(*) AS total,
+                   COUNT(*) FILTER (WHERE feedback_helpful IS TRUE) AS positive,
+                   COUNT(*) FILTER (WHERE feedback_helpful IS FALSE) AS negative
+            FROM ai_eval_examples
+            WHERE created_at >= %s
+            GROUP BY feature
+            ORDER BY total DESC, feature
+            """,
+            (start,),
+        ).fetchall()
+        evals = conn.execute(
+            """
+            SELECT COALESCE(feature, 'all') AS feature,
+                   COUNT(*) AS runs,
+                   COALESCE(SUM(total), 0) AS total,
+                   COALESCE(SUM(passed), 0) AS passed,
+                   COALESCE(SUM(failed), 0) AS failed
+            FROM ai_eval_runs
+            WHERE started_at >= %s AND status != 'running'
+            GROUP BY 1
+            ORDER BY 1
+            """,
+            (start,),
+        ).fetchall()
+        failures = conn.execute(
+            """
+            SELECT r.feature, e.id AS example_id, er.failure_reason, er.created_at
+            FROM ai_eval_results er
+            JOIN ai_eval_runs r ON r.id = er.run_id
+            JOIN ai_eval_examples e ON e.id = er.example_id
+            WHERE er.created_at >= %s AND er.passed IS FALSE
+            ORDER BY er.created_at DESC
+            LIMIT 10
+            """,
+            (start,),
+        ).fetchall()
+    return {
+        "range_days": days,
+        "feedback": [dict(row) for row in feedback],
+        "evals": [
+            {
+                **dict(row),
+                "pass_rate": round(float(row["passed"]) / float(row["total"]), 3)
+                if int(row["total"])
+                else 0.0,
+            }
+            for row in evals
+        ],
+        "recent_failures": [dict(row) for row in failures],
+    }
+
+
+def _expected_output(input_data: Any, expected: Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(expected.get("fake_output"), Mapping):
+        return dict(expected["fake_output"])
+    if isinstance(input_data, Mapping) and isinstance(input_data.get("fake_output"), Mapping):
+        return dict(input_data["fake_output"])
+    return {"answer": "insufficient context", "citations": expected.get("citation_ids", [])}
+
+
+def _int_set(value: Any) -> set[int]:
+    if not isinstance(value, list):
+        return set()
+    result: set[int] = set()
+    for item in value:
+        maybe = _optional_int(item)
+        if maybe is not None:
+            result.add(maybe)
+    return result
+
+
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -117,6 +117,20 @@ def improve_prompt(
     flush()
 
 
+@app.command(name="eval-ai")
+def eval_ai(feature: str | None = None) -> None:
+    """Run deterministic local AI eval examples."""
+    from news_dashboard.ai_evals import run_local_evals
+
+    result = run_local_evals(feature=feature)
+    typer.echo(
+        f"eval run {result['run_id']}: "
+        f"{result['passed']}/{result['total']} passed, {result['failed']} failed"
+    )
+    if int(result["failed"]) > 0:
+        raise typer.Exit(code=1)
+
+
 @app.command(name="seed-demo")
 def seed_demo_cmd() -> None:
     """Seed demo data: guest user + sample articles (requires DEMO_MODE=true)."""

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -710,6 +710,50 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_user_ai_memory_events_user"
     " ON user_ai_memory_events(user_id, created_at DESC)",
     """
+    CREATE TABLE IF NOT EXISTS ai_eval_examples (
+      id                  BIGSERIAL PRIMARY KEY,
+      feature             TEXT NOT NULL,
+      prompt_version      TEXT NOT NULL DEFAULT 'local',
+      model_version       TEXT NOT NULL DEFAULT 'local',
+      input               JSONB NOT NULL DEFAULT '{}'::jsonb,
+      expected_properties JSONB NOT NULL DEFAULT '{}'::jsonb,
+      source_trace_id     TEXT,
+      feedback_helpful    BOOLEAN,
+      created_by_user_id  INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ai_eval_examples_feature ON ai_eval_examples(feature)",
+    """
+    CREATE TABLE IF NOT EXISTS ai_eval_runs (
+      id             BIGSERIAL PRIMARY KEY,
+      feature        TEXT,
+      prompt_version TEXT NOT NULL DEFAULT 'local',
+      model_version  TEXT NOT NULL DEFAULT 'local',
+      status         TEXT NOT NULL DEFAULT 'running'
+                       CHECK(status IN ('running','passed','failed')),
+      total          INTEGER NOT NULL DEFAULT 0,
+      passed         INTEGER NOT NULL DEFAULT 0,
+      failed         INTEGER NOT NULL DEFAULT 0,
+      started_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      finished_at    TIMESTAMPTZ
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ai_eval_runs_started ON ai_eval_runs(started_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS ai_eval_results (
+      id              BIGSERIAL PRIMARY KEY,
+      run_id          BIGINT NOT NULL REFERENCES ai_eval_runs(id) ON DELETE CASCADE,
+      example_id      BIGINT NOT NULL REFERENCES ai_eval_examples(id) ON DELETE CASCADE,
+      output          JSONB NOT NULL DEFAULT '{}'::jsonb,
+      score           DOUBLE PRECISION NOT NULL DEFAULT 0,
+      passed          BOOLEAN NOT NULL DEFAULT FALSE,
+      failure_reason  TEXT,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ai_eval_results_run ON ai_eval_results(run_id)",
+    """
     CREATE TABLE IF NOT EXISTS mcp_tokens (
       id            BIGSERIAL PRIMARY KEY,
       user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2945,9 +2945,16 @@ def submit_feedback(
     disabled, so feedback never errors for the user.
     """
     from news_dashboard.ai_client import create_score
+    from news_dashboard.ai_evals import record_feedback_example
     from news_dashboard.ai_memory.service import record_memory_event
 
     comment = (payload.comment or "").strip() or None
+    record_feedback_example(
+        user_id=int(current_user["id"]),
+        trace_id=payload.trace_id,
+        helpful=payload.helpful,
+        comment=comment,
+    )
     record_memory_event(
         int(current_user["id"]),
         event_type="feedback",
@@ -3131,6 +3138,13 @@ def admin_ai_metrics(days: Annotated[int, Query(ge=1, le=365)] = 30) -> dict[str
     from news_dashboard.ai_client import fetch_metrics
 
     return fetch_metrics(days=days)
+
+
+@admin.get("/ai/quality")
+def admin_ai_quality(days: Annotated[int, Query(ge=1, le=365)] = 30) -> dict[str, Any]:
+    from news_dashboard.ai_evals import admin_quality_summary
+
+    return admin_quality_summary(days=days)
 
 
 @admin.get("/users")

--- a/backend/tests/test_ai_evals.py
+++ b/backend/tests/test_ai_evals.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from news_dashboard.ai_evals import admin_quality_summary, run_local_evals, score_output
+from news_dashboard.cli import app
+from news_dashboard.db import connect
+
+
+def test_score_output_rejects_unknown_citation() -> None:
+    passed, score, reason = score_output(
+        {"answer": "See this.", "citations": [9]},
+        {"allowed_citation_ids": [1, 2], "requires_citation": True},
+    )
+
+    assert passed is False
+    assert score == 0.0
+    assert reason == "unknown citations"
+
+
+def test_run_local_evals_records_pass_and_failure(pg_clean: str) -> None:
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO ai_eval_examples(feature, input, expected_properties)
+            VALUES
+              ('ask-ai', %s::jsonb, %s::jsonb),
+              ('briefing-generation', %s::jsonb, %s::jsonb)
+            """,
+            (
+                json.dumps({"fake_output": {"answer": "insufficient context", "citations": []}}),
+                json.dumps({"weak_retrieval": True}),
+                json.dumps({"fake_output": {"sections": [{"citations": [2]}]}}),
+                json.dumps({"briefing": True, "allowed_citation_ids": [1]}),
+            ),
+        )
+
+    result = run_local_evals(database_url=pg_clean)
+
+    assert result["total"] == 2
+    assert result["passed"] == 1
+    assert result["failed"] == 1
+    summary = admin_quality_summary(database_url=pg_clean)
+    assert summary["evals"][0]["failed"] == 1
+    assert summary["recent_failures"][0]["failure_reason"] == "unknown briefing citations"
+
+
+def test_eval_ai_cli_exits_nonzero_on_failed_eval(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO ai_eval_examples(feature, input, expected_properties)
+            VALUES ('ask-ai', %s::jsonb, %s::jsonb)
+            """,
+            (
+                json.dumps({"fake_output": {"answer": "too long", "citations": []}}),
+                json.dumps({"max_chars": 2}),
+            ),
+        )
+
+    result = CliRunner().invoke(app, ["eval-ai"])
+
+    assert result.exit_code == 1
+    assert "0/1 passed, 1 failed" in result.output

--- a/backend/tests/test_ai_quality_api.py
+++ b/backend/tests/test_ai_quality_api.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_admin, require_auth
+from news_dashboard.main import app
+
+
+def test_admin_ai_quality_requires_admin(monkeypatch: Any) -> None:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 2,
+        "username": "reader",
+        "is_admin": False,
+    }
+    app.dependency_overrides[require_admin] = lambda: (_ for _ in ()).throw(
+        HTTPException(status_code=403, detail="admin role required")
+    )
+
+    response = TestClient(app, raise_server_exceptions=False).get("/api/admin/ai/quality")
+
+    assert response.status_code == 403
+    app.dependency_overrides.pop(require_auth, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+def test_admin_ai_quality_returns_local_summary(monkeypatch: Any) -> None:
+    def fake_summary(*, days: int) -> dict[str, Any]:
+        assert days == 14
+        return {"range_days": 14, "feedback": [], "evals": [], "recent_failures": []}
+
+    monkeypatch.setattr("news_dashboard.ai_evals.admin_quality_summary", fake_summary)
+
+    response = TestClient(app).get("/api/admin/ai/quality?days=14")
+
+    assert response.status_code == 200
+    assert response.json()["range_days"] == 14

--- a/backend/tests/test_feedback_api.py
+++ b/backend/tests/test_feedback_api.py
@@ -121,3 +121,17 @@ def test_feedback_persists_local_memory_event(
     assert row["source"] == "ask_feedback"
     assert row["content"] == "missed my goal"
     assert row["metadata"]["trace_id"] == "trace-local"
+
+    with connect(database_url=pg_clean) as conn:
+        eval_row = conn.execute(
+            """
+            SELECT feature, source_trace_id, feedback_helpful, expected_properties
+            FROM ai_eval_examples
+            WHERE created_by_user_id = %s
+            """,
+            (7,),
+        ).fetchone()
+    assert eval_row["feature"] == "ask-ai"
+    assert eval_row["source_trace_id"] == "trace-local"
+    assert eval_row["feedback_helpful"] is False
+    assert eval_row["expected_properties"]["comment"] == "missed my goal"

--- a/frontend/src/__tests__/analyticsPage.test.tsx
+++ b/frontend/src/__tests__/analyticsPage.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiMock = vi.hoisted(() => ({
+  fetchAdminAnalytics: vi.fn(),
+  fetchAdminAiQuality: vi.fn(),
+}));
+vi.mock('../api', () => apiMock);
+
+import { AnalyticsPage } from '../pages/AnalyticsPage';
+
+const analytics = {
+  range_days: 30,
+  generated_at: '2026-07-03T00:00:00Z',
+  summary: {
+    dau: 1,
+    wau: 2,
+    mau: 3,
+    stickiness: 0.33,
+    total_minutes: 12,
+    total_sessions: 4,
+    avg_session_minutes: 3,
+    total_reads: 5,
+    total_events: 6,
+  },
+  active_over_time: [],
+  users: [],
+  route_popularity: [],
+  feature_usage: [],
+  article_dwell: [],
+  category_consumption: [],
+  source_consumption: [],
+  hourly_heatmap: [],
+  skip_rate_trend: [],
+  recommendation_funnel: { recommended: 0, read: 0, skipped: 0 },
+};
+
+describe('AnalyticsPage AI quality panel', () => {
+  beforeEach(() => {
+    apiMock.fetchAdminAnalytics.mockResolvedValue(analytics);
+    apiMock.fetchAdminAiQuality.mockResolvedValue({
+      range_days: 30,
+      feedback: [{ feature: 'ask-ai', total: 3, positive: 2, negative: 1 }],
+      evals: [{ feature: 'ask-ai', runs: 1, total: 4, passed: 3, failed: 1, pass_rate: 0.75 }],
+      recent_failures: [
+        {
+          feature: 'ask-ai',
+          example_id: 7,
+          failure_reason: 'unknown citations',
+          created_at: '2026-07-03T00:00:00Z',
+        },
+      ],
+    });
+  });
+
+  it('renders local feedback and eval pass rate', async () => {
+    render(<AnalyticsPage />);
+
+    expect(await screen.findByText('AI quality')).toBeTruthy();
+    expect(screen.getByText('75%')).toBeTruthy();
+    expect(screen.getByText('2 up / 1 down')).toBeTruthy();
+    expect(screen.getByText('unknown citations')).toBeTruthy();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,6 @@
 import type {
   AdminAnalytics,
+  AdminAiQuality,
   AiMemory,
   AgentActionPlanResponse,
   AgentActionRun,
@@ -581,6 +582,10 @@ export async function fetchMe(): Promise<User> {
 
 export async function fetchAdminAnalytics(days = 30): Promise<AdminAnalytics> {
   return requestJson<AdminAnalytics>(`/api/admin/analytics?days=${days}`);
+}
+
+export async function fetchAdminAiQuality(days = 30): Promise<AdminAiQuality> {
+  return requestJson<AdminAiQuality>(`/api/admin/ai/quality?days=${days}`);
 }
 
 export async function loginUser(username: string, password: string): Promise<User> {

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -10,8 +10,8 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { fetchAdminAnalytics } from '../api';
-import type { AdminAnalytics } from '../types';
+import { fetchAdminAiQuality, fetchAdminAnalytics } from '../api';
+import type { AdminAiQuality, AdminAnalytics } from '../types';
 
 const CHART_COLORS = [
   'var(--color-chart-1)',
@@ -35,6 +35,7 @@ const DOW = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 export function AnalyticsPage() {
   const [days, setDays] = useState(30);
   const [data, setData] = useState<AdminAnalytics | null>(null);
+  const [quality, setQuality] = useState<AdminAiQuality | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -42,10 +43,11 @@ export function AnalyticsPage() {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    fetchAdminAnalytics(days)
-      .then((result) => {
+    Promise.all([fetchAdminAnalytics(days), fetchAdminAiQuality(days)])
+      .then(([result, qualityResult]) => {
         if (!cancelled) {
           setData(result);
+          setQuality(qualityResult);
           setLoading(false);
         }
       })
@@ -113,6 +115,8 @@ export function AnalyticsPage() {
         <Stat label="Avg session" value={loading || !s ? '…' : `${s.avg_session_minutes}m`} />
         <Stat label="Articles read" value={fmt(s?.total_reads, loading)} />
       </section>
+
+      <AiQualityPanel data={quality} loading={loading} />
 
       <ChartSection title="Active users & time" sub="Daily active users and minutes spent">
         <div className="h-56 -mx-2">
@@ -370,6 +374,64 @@ function heatIntensity(value: number): number {
   if (value <= 0) return 0;
   const scaled = Math.log1p(value) / Math.log1p(HEAT_SATURATION);
   return Math.min(100, Math.round(scaled * 90) + 10);
+}
+
+function AiQualityPanel({ data, loading }: { data: AdminAiQuality | null; loading: boolean }) {
+  const totals = data?.feedback.reduce(
+    (acc, row) => ({
+      total: acc.total + row.total,
+      positive: acc.positive + row.positive,
+      negative: acc.negative + row.negative,
+    }),
+    { total: 0, positive: 0, negative: 0 }
+  );
+  const passRate = data?.evals[0]?.pass_rate;
+  return (
+    <ChartSection title="AI quality" sub="Local feedback and deterministic eval trends">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        <Stat label="Feedback" value={fmt(totals?.total, loading)} />
+        <Stat label="Positive" value={fmt(totals?.positive, loading)} />
+        <Stat label="Negative" value={fmt(totals?.negative, loading)} />
+        <Stat
+          label="Eval pass rate"
+          value={loading || passRate === undefined ? '…' : `${Math.round(passRate * 100)}%`}
+          accent
+        />
+      </div>
+      <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h4 className="text-xs font-semibold uppercase text-subtle mb-2">Feedback by feature</h4>
+          <div className="space-y-2">
+            {(data?.feedback ?? []).slice(0, 5).map((row) => (
+              <div key={row.feature} className="flex items-center justify-between text-sm">
+                <span className="font-medium">{row.feature}</span>
+                <span className="text-muted-foreground">
+                  {row.positive} up / {row.negative} down
+                </span>
+              </div>
+            ))}
+            {!loading && !data?.feedback.length && (
+              <p className="text-sm text-muted-foreground">No local AI feedback yet.</p>
+            )}
+          </div>
+        </div>
+        <div>
+          <h4 className="text-xs font-semibold uppercase text-subtle mb-2">Recent failures</h4>
+          <div className="space-y-2">
+            {(data?.recent_failures ?? []).slice(0, 3).map((row) => (
+              <div key={`${row.example_id}-${row.created_at}`} className="text-sm">
+                <div className="font-medium">{row.feature ?? 'all'}</div>
+                <div className="text-muted-foreground">{row.failure_reason ?? 'failed check'}</div>
+              </div>
+            ))}
+            {!loading && !data?.recent_failures.length && (
+              <p className="text-sm text-muted-foreground">No recent eval failures.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </ChartSection>
+  );
 }
 
 function Stat({

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -542,6 +542,25 @@ export interface AdminAnalytics {
   recommendation_funnel: { recommended: number; read: number; skipped: number };
 }
 
+export interface AdminAiQuality {
+  range_days: number;
+  feedback: { feature: string; total: number; positive: number; negative: number }[];
+  evals: {
+    feature: string;
+    runs: number;
+    total: number;
+    passed: number;
+    failed: number;
+    pass_rate: number;
+  }[];
+  recent_failures: {
+    feature: string | null;
+    example_id: number;
+    failure_reason: string | null;
+    created_at: string;
+  }[];
+}
+
 export interface ReadingGoal {
   id: number;
   user_id: number;


### PR DESCRIPTION
Closes #758

## Summary
- add PostgreSQL-backed local AI eval example, run, and result tables
- persist Ask AI feedback as bounded local eval examples alongside Langfuse scoring
- add deterministic eval scoring, `news-dashboard eval-ai`, and admin AI quality summary API
- show local feedback counts, eval pass rate, and recent failures on the admin analytics page

## Tests
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make typecheck`
- `PATH="$PWD/.venv/bin:$PATH" dotenv -f .env run -- python -m pytest backend/tests/test_ai_evals.py backend/tests/test_ai_quality_api.py backend/tests/test_feedback_api.py`
- `npm run test:frontend -- analyticsPage.test.tsx`
- `npm run test:frontend --silent`
- `PATH="$PWD/.venv/bin:$PATH" dotenv -f .env run -- make test` ran 1,700 backend tests green but failed 17 legacy tmp_path database tests with missing base tables during local PostgreSQL schema setup; frontend phase was run separately and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)