### PR TITLE
feat: save reusable search views (#762)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -542,6 +542,19 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_article_tags_user_tag ON article_tags(user_id, tag_id)",
     "CREATE INDEX IF NOT EXISTS idx_article_tags_article ON article_tags(article_id)",
+    """
+    CREATE TABLE IF NOT EXISTS user_saved_searches (
+      id         SERIAL PRIMARY KEY,
+      user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name       TEXT NOT NULL,
+      filters    JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (user_id, name)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_saved_searches_user"
+    " ON user_saved_searches(user_id, updated_at DESC)",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS recap_enabled BOOLEAN NOT NULL DEFAULT TRUE",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS recap_day TEXT NOT NULL DEFAULT 'mon'",
     """

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -3244,6 +3244,7 @@ from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
 from news_dashboard.reading_list.router import router as reading_list_router  # noqa: E402
 from news_dashboard.reading_progress.router import router as reading_progress_router  # noqa: E402
 from news_dashboard.recaps.router import router as recaps_router  # noqa: E402
+from news_dashboard.saved_searches.router import router as saved_searches_router  # noqa: E402
 
 api.include_router(ai_stats_router)
 api.include_router(ai_memory_router)
@@ -3252,6 +3253,7 @@ api.include_router(quizzes_router)
 api.include_router(reading_list_router)
 api.include_router(reading_progress_router)
 api.include_router(recaps_router)
+api.include_router(saved_searches_router)
 
 app.include_router(api)
 app.include_router(admin)

--- a/backend/news_dashboard/saved_searches/__init__.py
+++ b/backend/news_dashboard/saved_searches/__init__.py
@@ -1,0 +1,1 @@
+"""Saved search feature package."""

--- a/backend/news_dashboard/saved_searches/models.py
+++ b/backend/news_dashboard/saved_searches/models.py
@@ -1,0 +1,28 @@
+"""Request models for reusable saved search views."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SavedSearchFilters(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    q: str = ""
+    states: list[str] = Field(default_factory=list)
+    categories: list[str] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
+    starred_only: bool = False
+    include_archived: bool = False
+    date_range: str = "all"
+    tag_id: int | None = None
+
+
+class SavedSearchCreateRequest(BaseModel):
+    name: str
+    filters: SavedSearchFilters
+
+
+class SavedSearchUpdateRequest(BaseModel):
+    name: str | None = None
+    filters: SavedSearchFilters | None = None

--- a/backend/news_dashboard/saved_searches/router.py
+++ b/backend/news_dashboard/saved_searches/router.py
@@ -1,0 +1,62 @@
+"""HTTP routes for reusable saved search views."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from news_dashboard.auth import require_auth
+from news_dashboard.saved_searches import service
+from news_dashboard.saved_searches.models import (
+    SavedSearchCreateRequest,
+    SavedSearchUpdateRequest,
+)
+
+router = APIRouter()
+
+
+@router.get("/api/search/saved")
+def list_saved_searches_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": service.list_saved_searches(current_user["id"])}
+
+
+@router.post("/api/search/saved")
+def create_saved_search_endpoint(
+    payload: SavedSearchCreateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    if not payload.name.strip():
+        raise HTTPException(status_code=400, detail="name must not be empty")
+    return service.create_saved_search(current_user["id"], payload.name, payload.filters)
+
+
+@router.patch("/api/search/saved/{search_id}")
+def update_saved_search_endpoint(
+    search_id: int,
+    payload: SavedSearchUpdateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    if payload.name is not None and not payload.name.strip():
+        raise HTTPException(status_code=400, detail="name must not be empty")
+    saved = service.update_saved_search(
+        search_id,
+        current_user["id"],
+        name=payload.name,
+        filters=payload.filters,
+    )
+    if saved is None:
+        raise HTTPException(status_code=404, detail="saved search not found")
+    return saved
+
+
+@router.delete("/api/search/saved/{search_id}")
+def delete_saved_search_endpoint(
+    search_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, bool]:
+    if not service.delete_saved_search(search_id, current_user["id"]):
+        raise HTTPException(status_code=404, detail="saved search not found")
+    return {"deleted": True}

--- a/backend/news_dashboard/saved_searches/service.py
+++ b/backend/news_dashboard/saved_searches/service.py
@@ -1,0 +1,136 @@
+"""Persistence and validation for per-user saved search views."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from psycopg.types.json import Jsonb
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.saved_searches.models import SavedSearchFilters
+
+_ALLOWED_STATES = {"today", "later", "done", "skipped", "archived"}
+_ALLOWED_DATE_RANGES = {"all", "today", "week", "month"}
+_MAX_TEXT = 200
+_MAX_ITEMS = 50
+
+
+def _clean_strings(values: list[str], allowed: set[str] | None = None) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for value in values[:_MAX_ITEMS]:
+        item = value.strip()
+        if not item or len(item) > _MAX_TEXT:
+            continue
+        if allowed is not None and item not in allowed:
+            continue
+        if item not in seen:
+            cleaned.append(item)
+            seen.add(item)
+    return cleaned
+
+
+def normalize_filters(filters: SavedSearchFilters) -> dict[str, Any]:
+    date_range = filters.date_range if filters.date_range in _ALLOWED_DATE_RANGES else "all"
+    return {
+        "q": filters.q.strip()[:_MAX_TEXT],
+        "states": _clean_strings(filters.states, _ALLOWED_STATES),
+        "categories": _clean_strings(filters.categories),
+        "sources": _clean_strings(filters.sources),
+        "starred_only": filters.starred_only,
+        "include_archived": filters.include_archived,
+        "date_range": date_range,
+        "tag_id": filters.tag_id if filters.tag_id and filters.tag_id > 0 else None,
+    }
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    item = dict(row)
+    item["filters"] = dict(item["filters"])
+    return item
+
+
+def list_saved_searches(
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, user_id, name, filters, created_at, updated_at
+            FROM user_saved_searches
+            WHERE user_id = %s
+            ORDER BY name ASC
+            """,
+            (user_id,),
+        ).fetchall()
+    return [_row_to_dict(row) for row in rows]
+
+
+def create_saved_search(
+    user_id: int,
+    name: str,
+    filters: SavedSearchFilters,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_saved_searches (user_id, name, filters)
+            VALUES (%s, %s, %s::jsonb)
+            RETURNING id, user_id, name, filters, created_at, updated_at
+            """,
+            (user_id, name.strip(), Jsonb(normalize_filters(filters))),
+        ).fetchone()
+    return _row_to_dict(row)
+
+
+def update_saved_search(
+    search_id: int,
+    user_id: int,
+    name: str | None = None,
+    filters: SavedSearchFilters | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    init_db(db_path, database_url=database_url)
+    assignments = ["updated_at = NOW()"]
+    params: list[Any] = []
+    if name is not None:
+        assignments.append("name = %s")
+        params.append(name.strip())
+    if filters is not None:
+        assignments.append("filters = %s::jsonb")
+        params.append(Jsonb(normalize_filters(filters)))
+    params.extend([search_id, user_id])
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            f"""
+            UPDATE user_saved_searches
+            SET {", ".join(assignments)}
+            WHERE id = %s AND user_id = %s
+            RETURNING id, user_id, name, filters, created_at, updated_at
+            """,
+            params,
+        ).fetchone()
+    return _row_to_dict(row) if row else None
+
+
+def delete_saved_search(
+    search_id: int,
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> bool:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            "DELETE FROM user_saved_searches WHERE id = %s AND user_id = %s RETURNING id",
+            (search_id, user_id),
+        ).fetchone()
+    return row is not None

--- a/backend/tests/test_saved_searches.py
+++ b/backend/tests/test_saved_searches.py
@@ -1,0 +1,107 @@
+"""Tests for per-user saved search views."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import create_user, require_auth
+from news_dashboard.main import app
+from news_dashboard.saved_searches.models import SavedSearchFilters
+from news_dashboard.saved_searches.service import create_saved_search, list_saved_searches
+
+
+@pytest.fixture
+def db(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    return pg_clean
+
+
+def _make_user(db_path: str, username: str) -> int:
+    return int(create_user(username, "password123", db_path=db_path)["id"])
+
+
+def _authed_client(user_id: int) -> TestClient:
+    client = TestClient(app, raise_server_exceptions=True)
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": f"user-{user_id}",
+        "email": None,
+        "is_admin": False,
+    }
+    return client
+
+
+def test_create_and_list_saved_searches(db: str) -> None:
+    alice = _make_user(db, "alice")
+    saved = create_saved_search(
+        alice,
+        "AI starred",
+        SavedSearchFilters(q=" agents ", states=["today"], starred_only=True),
+        db_path=db,
+    )
+
+    assert saved["name"] == "AI starred"
+    assert saved["filters"]["q"] == "agents"
+    assert saved["filters"]["states"] == ["today"]
+    assert saved["filters"]["starred_only"] is True
+    assert [item["id"] for item in list_saved_searches(alice, db_path=db)] == [saved["id"]]
+
+
+def test_saved_searches_are_private_per_user(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    create_saved_search(alice, "Alice view", SavedSearchFilters(q="postgres"), db_path=db)
+
+    assert [item["name"] for item in list_saved_searches(alice, db_path=db)] == ["Alice view"]
+    assert list_saved_searches(bob, db_path=db) == []
+
+
+def test_saved_search_filters_are_normalized(db: str) -> None:
+    alice = _make_user(db, "alice")
+    saved = create_saved_search(
+        alice,
+        "Mixed",
+        SavedSearchFilters(
+            q="x" * 250,
+            states=["today", "invalid", "today"],
+            date_range="future",
+            tag_id=-1,
+        ),
+        db_path=db,
+    )
+
+    assert saved["filters"]["q"] == "x" * 200
+    assert saved["filters"]["states"] == ["today"]
+    assert saved["filters"]["date_range"] == "all"
+    assert saved["filters"]["tag_id"] is None
+
+
+def test_saved_search_api_crud_and_user_scope(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    alice_client = _authed_client(alice)
+
+    created = alice_client.post(
+        "/api/search/saved",
+        json={
+            "name": "Kubernetes",
+            "filters": {"q": "k8s", "states": ["later"], "date_range": "week"},
+        },
+    )
+    assert created.status_code == 200
+    saved_id = created.json()["id"]
+
+    bob_client = _authed_client(bob)
+    assert bob_client.get("/api/search/saved").json()["items"] == []
+    bob_update = bob_client.patch(f"/api/search/saved/{saved_id}", json={"name": "Hijack"})
+    assert bob_update.status_code == 404
+
+    alice_client = _authed_client(alice)
+    renamed = alice_client.patch(f"/api/search/saved/{saved_id}", json={"name": "Infra"})
+    assert renamed.status_code == 200
+    assert renamed.json()["name"] == "Infra"
+
+    deleted = alice_client.delete(f"/api/search/saved/{saved_id}")
+    assert deleted.status_code == 200
+    assert alice_client.get("/api/search/saved").json()["items"] == []

--- a/docs/user-guide/search.md
+++ b/docs/user-guide/search.md
@@ -49,6 +49,16 @@ Results show:
 
 Click any result to open the article in the main view.
 
+## Saved Views
+
+Use **Save view** on the Search page to store the current query and filters as a
+manual preset. Saved views are private to your account. Selecting one replaces
+the current Search URL parameters, so results refresh through the same search
+path as ordinary filters.
+
+Saved views are reusable shortcuts only. They do not send alerts, scheduled
+notifications, or email digests.
+
 ## Search scope
 
 Search looks across **all articles in your database**, regardless of:

--- a/frontend/src/__tests__/search.test.tsx
+++ b/frontend/src/__tests__/search.test.tsx
@@ -32,6 +32,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(api, 'fetchSources').mockResolvedValue([]);
   vi.spyOn(tagsApi, 'fetchTags').mockResolvedValue([]);
+  vi.spyOn(workflowApi, 'fetchSavedSearches').mockResolvedValue([]);
 });
 
 function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
@@ -369,6 +370,138 @@ describe('SearchPage — tag filter', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Tag · rust/i })).toBeTruthy();
+    });
+  });
+});
+
+describe('SearchPage — saved views', () => {
+  it('saves the current URL-backed filters', async () => {
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
+    const createSpy = vi.spyOn(workflowApi, 'createSavedSearch').mockResolvedValue({
+      id: 1,
+      user_id: 1,
+      name: 'AI later',
+      filters: {
+        q: 'agents',
+        states: ['later'],
+        categories: [],
+        sources: [],
+        starred_only: true,
+        include_archived: false,
+        date_range: 'week',
+        tag_id: null,
+      },
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    vi.stubGlobal(
+      'prompt',
+      vi.fn(() => 'AI later')
+    );
+
+    renderSearch('?q=agents&states=later&starred_only=1&date_range=week');
+    await userEvent.click(screen.getByRole('button', { name: 'Save view' }));
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        {
+          name: 'AI later',
+          filters: {
+            q: 'agents',
+            states: ['later'],
+            categories: [],
+            sources: [],
+            starred_only: true,
+            include_archived: false,
+            date_range: 'week',
+            tag_id: null,
+          },
+        },
+        expect.anything()
+      );
+    });
+  });
+
+  it('loads a saved view by updating search parameters', async () => {
+    const searchSpy = vi
+      .spyOn(workflowApi, 'searchArticlesFiltered')
+      .mockResolvedValue(makePage([]));
+    vi.spyOn(workflowApi, 'fetchSavedSearches').mockResolvedValue([
+      {
+        id: 2,
+        user_id: 1,
+        name: 'Python done',
+        filters: {
+          q: 'python',
+          states: ['done'],
+          categories: ['python'],
+          sources: [],
+          starred_only: false,
+          include_archived: true,
+          date_range: 'month',
+          tag_id: null,
+        },
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    renderSearch();
+    await screen.findByRole('option', { name: 'Python done' });
+    await userEvent.selectOptions(screen.getByLabelText('Saved search views'), '2');
+
+    await waitFor(() => {
+      expect(searchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: 'python',
+          states: ['done'],
+          categories: ['python'],
+          includeArchived: true,
+          dateRange: 'month',
+        })
+      );
+    });
+  });
+
+  it('renames and deletes the selected saved view', async () => {
+    vi.spyOn(workflowApi, 'searchArticlesFiltered').mockResolvedValue(makePage([]));
+    vi.spyOn(workflowApi, 'fetchSavedSearches').mockResolvedValue([
+      {
+        id: 3,
+        user_id: 1,
+        name: 'Old name',
+        filters: {
+          q: 'rust',
+          states: [],
+          categories: [],
+          sources: [],
+          starred_only: false,
+          include_archived: false,
+          date_range: 'all',
+          tag_id: null,
+        },
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    const updateSpy = vi.spyOn(workflowApi, 'updateSavedSearch').mockResolvedValue({} as never);
+    const deleteSpy = vi
+      .spyOn(workflowApi, 'deleteSavedSearch')
+      .mockResolvedValue({ deleted: true });
+    vi.stubGlobal(
+      'prompt',
+      vi.fn(() => 'New name')
+    );
+
+    renderSearch();
+    await screen.findByRole('option', { name: 'Old name' });
+    await userEvent.selectOptions(screen.getByLabelText('Saved search views'), '3');
+    await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(3, { name: 'New name' });
+      expect(deleteSpy).toHaveBeenCalledWith(3, expect.anything());
     });
   });
 });

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -177,6 +177,26 @@ export interface SearchFilters {
   offset?: number;
 }
 
+export interface SavedSearchFilters {
+  q: string;
+  states: WorkflowState[];
+  categories: string[];
+  sources: string[];
+  starred_only: boolean;
+  include_archived: boolean;
+  date_range: 'all' | 'today' | 'week' | 'month';
+  tag_id: number | null;
+}
+
+export interface SavedSearchView {
+  id: number;
+  user_id: number;
+  name: string;
+  filters: SavedSearchFilters;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface SearchArticlePage {
   items: WorkflowArticle[];
   total: number;
@@ -214,4 +234,33 @@ export async function searchArticlesFiltered(filters: SearchFilters): Promise<Se
     offset: data.offset ?? filters.offset ?? 0,
     hasMore: Boolean(data.has_more),
   };
+}
+
+export async function fetchSavedSearches(): Promise<SavedSearchView[]> {
+  const data = await requestJson<{ items: SavedSearchView[] }>('/api/search/saved');
+  return data.items;
+}
+
+export async function createSavedSearch(payload: {
+  name: string;
+  filters: SavedSearchFilters;
+}): Promise<SavedSearchView> {
+  return requestJson<SavedSearchView>('/api/search/saved', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateSavedSearch(
+  id: number,
+  payload: { name?: string; filters?: SavedSearchFilters }
+): Promise<SavedSearchView> {
+  return requestJson<SavedSearchView>(`/api/search/saved/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteSavedSearch(id: number): Promise<{ deleted: boolean }> {
+  return requestJson<{ deleted: boolean }>(`/api/search/saved/${id}`, { method: 'DELETE' });
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Search as SearchIcon } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
 import { EmptyState } from '@/components/EmptyState';
@@ -8,7 +8,14 @@ import { useArticleListNav } from '@/hooks/useArticleListNav';
 import { useTriageMutations } from '@/hooks/useTriageMutations';
 import { useFocusedArticle } from '@/contexts/focusedArticle';
 import { setReaderList } from '@/lib/readerList';
-import { searchArticlesFiltered } from '@/api/workflowApi';
+import {
+  createSavedSearch,
+  deleteSavedSearch,
+  fetchSavedSearches,
+  searchArticlesFiltered,
+  updateSavedSearch,
+} from '@/api/workflowApi';
+import type { SavedSearchFilters, SavedSearchView } from '@/api/workflowApi';
 import { fetchSources } from '@/api';
 import { fetchTags } from '@/api/tagsApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
@@ -71,11 +78,47 @@ function encodedFilters(
   return p;
 }
 
+function currentSavedFilters(
+  q: string,
+  states: WorkflowState[],
+  categories: string[],
+  sources: string[],
+  starredOnly: boolean,
+  includeArchived: boolean,
+  dateRange: string,
+  tagId: string
+): SavedSearchFilters {
+  return {
+    q,
+    states,
+    categories,
+    sources,
+    starred_only: starredOnly,
+    include_archived: includeArchived,
+    date_range: (dateRange || 'all') as SavedSearchFilters['date_range'],
+    tag_id: tagId ? Number(tagId) : null,
+  };
+}
+
+function filtersToParams(filters: SavedSearchFilters): URLSearchParams {
+  return encodedFilters(
+    filters.q,
+    filters.states,
+    filters.categories,
+    filters.sources,
+    filters.starred_only,
+    filters.include_archived,
+    filters.date_range,
+    filters.tag_id ? String(filters.tag_id) : ''
+  );
+}
+
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 export function SearchPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
 
   const q = searchParams.get('q') ?? '';
   const states = parseList(searchParams, 'states') as WorkflowState[];
@@ -144,6 +187,43 @@ export function SearchPage() {
     queryKey: ['tags'],
     queryFn: fetchTags,
     staleTime: 60_000,
+  });
+
+  const { data: savedSearches = [] } = useQuery({
+    queryKey: ['saved-searches'],
+    queryFn: fetchSavedSearches,
+    staleTime: 30_000,
+  });
+
+  const savedFilters = currentSavedFilters(
+    q,
+    states,
+    categories,
+    sources,
+    starredOnly,
+    includeArchived,
+    dateRange,
+    tagId
+  );
+  const invalidateSavedSearches = () =>
+    queryClient.invalidateQueries({ queryKey: ['saved-searches'] });
+  const createSavedMutation = useMutation({
+    mutationFn: createSavedSearch,
+    onSuccess: invalidateSavedSearches,
+  });
+  const updateSavedMutation = useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: number;
+      payload: { name?: string; filters?: SavedSearchFilters };
+    }) => updateSavedSearch(id, payload),
+    onSuccess: invalidateSavedSearches,
+  });
+  const deleteSavedMutation = useMutation({
+    mutationFn: deleteSavedSearch,
+    onSuccess: invalidateSavedSearches,
   });
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
@@ -288,6 +368,22 @@ export function SearchPage() {
             />
           )}
         </div>
+
+        <SavedSearchControls
+          savedSearches={savedSearches}
+          onLoad={(view) => setSearchParams(filtersToParams(view.filters), { replace: true })}
+          onSave={(name) => createSavedMutation.mutate({ name, filters: savedFilters })}
+          onRename={(view, name) => updateSavedMutation.mutate({ id: view.id, payload: { name } })}
+          onUpdate={(view) =>
+            updateSavedMutation.mutate({ id: view.id, payload: { filters: savedFilters } })
+          }
+          onDelete={(view) => deleteSavedMutation.mutate(view.id)}
+          busy={
+            createSavedMutation.isPending ||
+            updateSavedMutation.isPending ||
+            deleteSavedMutation.isPending
+          }
+        />
       </div>
 
       {/* Result count */}
@@ -360,6 +456,94 @@ function Chip({
     >
       {children}
     </button>
+  );
+}
+
+function SavedSearchControls({
+  savedSearches,
+  onLoad,
+  onSave,
+  onRename,
+  onUpdate,
+  onDelete,
+  busy,
+}: {
+  savedSearches: SavedSearchView[];
+  onLoad: (view: SavedSearchView) => void;
+  onSave: (name: string) => void;
+  onRename: (view: SavedSearchView, name: string) => void;
+  onUpdate: (view: SavedSearchView) => void;
+  onDelete: (view: SavedSearchView) => void;
+  busy: boolean;
+}) {
+  const [selectedId, setSelectedId] = useState('');
+  const selected = savedSearches.find((view) => String(view.id) === selectedId) ?? null;
+
+  function askName(defaultName = ''): string | null {
+    const value = window.prompt('Saved view name', defaultName);
+    const trimmed = value?.trim() ?? '';
+    return trimmed ? trimmed : null;
+  }
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2">
+      <select
+        aria-label="Saved search views"
+        value={selectedId}
+        onChange={(event) => {
+          const view = savedSearches.find((item) => String(item.id) === event.target.value);
+          setSelectedId(event.target.value);
+          if (view) onLoad(view);
+        }}
+        className="h-8 min-w-44 rounded-md border border-border bg-surface px-2 text-xs text-foreground"
+      >
+        <option value="">Saved views</option>
+        {savedSearches.map((view) => (
+          <option key={view.id} value={view.id}>
+            {view.name}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => {
+          const name = askName();
+          if (name) onSave(name);
+        }}
+        className="h-8 px-2.5 rounded-md border border-border bg-surface text-xs font-medium text-foreground hover:border-border-strong disabled:opacity-60"
+      >
+        Save view
+      </button>
+      <button
+        type="button"
+        disabled={busy || !selected}
+        onClick={() => selected && onUpdate(selected)}
+        className="h-8 px-2.5 rounded-md border border-border bg-surface text-xs font-medium text-foreground hover:border-border-strong disabled:opacity-60"
+      >
+        Update
+      </button>
+      <button
+        type="button"
+        disabled={busy || !selected}
+        onClick={() => {
+          if (!selected) return;
+          const name = askName(selected.name);
+          if (name) onRename(selected, name);
+        }}
+        className="h-8 px-2.5 rounded-md border border-border bg-surface text-xs font-medium text-foreground hover:border-border-strong disabled:opacity-60"
+      >
+        Rename
+      </button>
+      <button
+        type="button"
+        disabled={busy || !selected}
+        onClick={() => selected && onDelete(selected)}
+        className="h-8 px-2.5 rounded-md border border-border bg-surface text-xs font-medium text-foreground hover:border-border-strong disabled:opacity-60"
+      >
+        Delete
+      </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #762

## Summary
- add per-user PostgreSQL-backed saved search views with CRUD API endpoints
- wire Search page controls to save, load, rename, update, and delete URL-backed filters
- document saved views as manual presets, not alerts

## Tests
- PATH="$PWD/.venv/bin:$PATH" make lint
- PATH="$PWD/.venv/bin:$PATH" make typecheck
- PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_saved_searches.py backend/tests/test_search_filters.py -q
- npm run test:frontend -- frontend/src/__tests__/search.test.tsx
- npm run build
- PATH="$PWD/.venv/bin:$PATH" make test (1 transient PostgreSQL connection timeout in backend/tests/test_postgres_types.py::test_pg_private_source_visibility after 1720 passed; isolated rerun passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)