### PR TITLE
feat: add GitHub Security Lab feed as a security source (#769)

### DIFF
--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -278,6 +278,14 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         priority=76,
         interest_tags=("security", "infra", "software-development"),
     ),
+    SourceDefinition(
+        "github-security-lab",
+        "GitHub Security Lab",
+        "https://github.blog/tag/github-security-lab/feed/",
+        "security",
+        priority=74,
+        interest_tags=("security", "infra", "product-news"),
+    ),
     # ── Cloud / infra ────────────────────────────────────────────────────────
     SourceDefinition(
         "kubernetes-blog",

--- a/backend/tests/test_github_security_lab_source.py
+++ b/backend/tests/test_github_security_lab_source.py
@@ -1,0 +1,90 @@
+"""Tests for GitHub Security Lab default source (issue #769)."""
+
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard.ingest import sync_sources
+from news_dashboard.sources import DEFAULT_SOURCES
+
+# Unit tests (no DB)
+
+
+def test_github_security_lab_in_default_sources() -> None:
+    """github-security-lab SourceDefinition exists in DEFAULT_SOURCES."""
+    by_slug = {s.slug: s for s in DEFAULT_SOURCES}
+    assert "github-security-lab" in by_slug, (
+        f"github-security-lab not found; slugs: {sorted(by_slug)[:10]}..."
+    )
+
+
+def test_github_security_lab_metadata() -> None:
+    """github-security-lab has the expected metadata fields."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "github-security-lab")
+    assert src.name == "GitHub Security Lab"
+    assert src.url == "https://github.blog/tag/github-security-lab/feed/"
+    assert src.category == "security"
+    assert src.kind == "rss_feed"
+    assert src.priority == 74
+    assert src.enabled is True
+    assert src.lang == "en"
+
+
+def test_github_security_lab_interest_tags() -> None:
+    """github-security-lab carries tags that match onboarding interests."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "github-security-lab")
+    assert "security" in src.interest_tags
+    assert "infra" in src.interest_tags
+    assert "product-news" in src.interest_tags
+
+
+def test_github_security_lab_routes_to_rss_feed() -> None:
+    """github-security-lab kind is rss_feed, which ingest routes correctly."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "github-security-lab")
+    assert src.kind == "rss_feed"
+
+
+# Integration tests (PostgreSQL)
+
+
+def test_github_security_lab_sync_persists_row(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """sync_sources() creates a sources row for github-security-lab."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        row = conn.execute(
+            "SELECT slug, name, url, category, kind, priority, enabled "
+            "FROM sources WHERE slug = 'github-security-lab'"
+        ).fetchone()
+
+    assert row is not None, "github-security-lab row missing from sources table"
+    assert row["slug"] == "github-security-lab"
+    assert row["name"] == "GitHub Security Lab"
+    assert row["url"] == "https://github.blog/tag/github-security-lab/feed/"
+    assert row["category"] == "security"
+    assert row["kind"] == "rss_feed"
+    assert row["priority"] == 74
+    assert row["enabled"] is True
+
+
+def test_github_security_lab_sync_idempotent(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running sync_sources twice does not duplicate github-security-lab."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS c FROM sources WHERE slug = 'github-security-lab'"
+        ).fetchone()["c"]
+
+    assert count == 1


### PR DESCRIPTION
## Summary
- Adds a `github-security-lab` `SourceDefinition` to `DEFAULT_SOURCES` in the security section of `backend/news_dashboard/sources.py`, per the fields requested in #769 (slug, name, RSS feed URL, `security` category, `rss_feed` kind, priority 74, interest tags `security`/`infra`/`product-news`).
- No custom noise filters were needed; the feed follows the same shape as the existing `trail-of-bits-blog` security source.

Closes #769

## Test plan
- [x] `pytest backend/tests/test_github_security_lab_source.py` — new unit + Postgres-backed sync tests (metadata, interest tags, routing, `sync_sources()` persistence, idempotency)
- [x] `pytest backend/tests/test_new_feeds.py backend/tests/test_onboarding_interests.py` — existing source/onboarding suites still pass
- [x] `ruff check` / `ruff format --check` on changed files
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly) pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)