### PR TITLE
feat: add V8 Blog as a JavaScript runtime source (#771)

### DIFF
--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -377,6 +377,14 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         priority=78,
         interest_tags=("programming", "frontend", "software-development"),
     ),
+    SourceDefinition(
+        "v8-blog",
+        "V8 Blog",
+        "https://v8.dev/blog.atom",
+        "developer-tools",
+        priority=72,
+        interest_tags=("javascript", "performance", "frontend"),
+    ),
     # ── Trending / repositories ───────────────────────────────────────────────
     SourceDefinition(
         "hacker-news-best",

--- a/backend/tests/test_v8_blog_source.py
+++ b/backend/tests/test_v8_blog_source.py
@@ -1,0 +1,84 @@
+"""Tests for V8 Blog default source (issue #771)."""
+
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard.ingest import sync_sources
+from news_dashboard.sources import DEFAULT_SOURCES
+
+# Unit tests (no DB)
+
+
+def test_v8_blog_in_default_sources() -> None:
+    """v8-blog SourceDefinition exists in DEFAULT_SOURCES."""
+    by_slug = {s.slug: s for s in DEFAULT_SOURCES}
+    assert "v8-blog" in by_slug, f"v8-blog not found; slugs: {sorted(by_slug)[:10]}..."
+
+
+def test_v8_blog_metadata() -> None:
+    """v8-blog has the expected metadata fields."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "v8-blog")
+    assert src.name == "V8 Blog"
+    assert src.url == "https://v8.dev/blog.atom"
+    assert src.category == "developer-tools"
+    assert src.kind == "rss_feed"
+    assert src.priority == 72
+    assert src.enabled is True
+    assert src.lang == "en"
+
+
+def test_v8_blog_interest_tags() -> None:
+    """v8-blog carries tags that match onboarding interests."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "v8-blog")
+    assert "javascript" in src.interest_tags
+    assert "performance" in src.interest_tags
+    assert "frontend" in src.interest_tags
+
+
+def test_v8_blog_routes_to_rss_feed() -> None:
+    """v8-blog kind is rss_feed, which ingest routes correctly."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "v8-blog")
+    assert src.kind == "rss_feed"
+
+
+# Integration tests (PostgreSQL)
+
+
+def test_v8_blog_sync_persists_row(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """sync_sources() creates a sources row for v8-blog."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        row = conn.execute(
+            "SELECT slug, name, url, category, kind, priority, enabled "
+            "FROM sources WHERE slug = 'v8-blog'"
+        ).fetchone()
+
+    assert row is not None, "v8-blog row missing from sources table"
+    assert row["slug"] == "v8-blog"
+    assert row["name"] == "V8 Blog"
+    assert row["url"] == "https://v8.dev/blog.atom"
+    assert row["category"] == "developer-tools"
+    assert row["kind"] == "rss_feed"
+    assert row["priority"] == 72
+    assert row["enabled"] is True
+
+
+def test_v8_blog_sync_idempotent(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Running sync_sources twice does not duplicate v8-blog."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        count = conn.execute("SELECT COUNT(*) AS c FROM sources WHERE slug = 'v8-blog'").fetchone()[
+            "c"
+        ]
+
+    assert count == 1


### PR DESCRIPTION
## Summary
- Adds a `v8-blog` `SourceDefinition` to `DEFAULT_SOURCES` (developer-tools category, `rss_feed` kind, priority 72, tags: javascript/performance/frontend) pointing at `https://v8.dev/blog.atom`.
- No changes to ingest routing, sync logic, or noise filters were needed — the feed uses the existing `rss_feed` path.

Closes #771

## Test plan
- [x] `backend/tests/test_v8_blog_source.py` (new): asserts default-source metadata, interest tags, rss_feed routing, and PostgreSQL-backed `sync_sources()` persistence/idempotency (6 tests, all passing against `nd-test-pg`).
- [x] `backend/tests/test_new_feeds.py` and `backend/tests/test_onboarding_interests.py` pass unchanged (13 tests).
- [x] `ruff check`, `ruff format`, `mypy` clean on changed files.
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)