### PR TITLE
fix: useEffect missing dependency array in ArticlePage keyboard handler (#827)

### DIFF
--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -464,6 +464,26 @@ describe('ArticlePage — keyboard shortcuts', () => {
       'noopener,noreferrer'
     );
   });
+
+  it('stops re-attaching the keydown listener once the article and body have settled', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    renderReader();
+    await waitFor(() => screen.getByText('Test Article Title'));
+    // Wait for the async body fetch to resolve so `article` stops changing identity
+    // (one re-registration is expected here, when article goes from null to loaded).
+    await waitFor(() => screen.getByText('Text'));
+
+    const keydownCallCount = () => addSpy.mock.calls.filter(([type]) => type === 'keydown').length;
+    const settledCount = keydownCallCount();
+    expect(settledCount).toBeGreaterThan(0);
+
+    // Trigger extra re-renders (state updates unrelated to the keyboard deps)
+    // — the listener must not be torn down and re-attached for these.
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    expect(keydownCallCount()).toBe(settledCount);
+  });
 });
 
 // ─── Touch gesture handling ────────────────────────────────────────────────────

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -203,7 +203,7 @@ export function ArticlePage() {
     staleTime: 30_000,
   });
 
-  const article = rawArticle ? adaptArticle(rawArticle) : null;
+  const article = useMemo(() => (rawArticle ? adaptArticle(rawArticle) : null), [rawArticle]);
   const [showOriginal, setShowOriginal] = useState(false);
 
   useEffect(() => {
@@ -257,33 +257,36 @@ export function ArticlePage() {
   const nextId =
     idx >= 0 && idx < (readerList?.ids.length ?? 0) - 1 ? readerList!.ids[idx + 1] : null;
 
-  const goBack = () => void navigate(-1);
-  const goPrev = () => {
+  const goBack = useCallback(() => void navigate(-1), [navigate]);
+  const goPrev = useCallback(() => {
     if (prevId) void navigate(`/a/${prevId}`, { replace: true });
-  };
-  const goNext = () => {
+  }, [navigate, prevId]);
+  const goNext = useCallback(() => {
     if (nextId) void navigate(`/a/${nextId}`, { replace: true });
-  };
+  }, [navigate, nextId]);
 
   // Triage mutations — inline (no extra hook so we stay self-contained)
-  async function doAction(state: WorkflowState, label: string) {
-    if (!article) return;
-    if (state === 'skipped' && article.starred) {
-      toast.error("Starred articles can't be skipped");
-      return;
-    }
-    try {
-      await patchArticleState(article.id, state, article.starred);
-      void queryClient.invalidateQueries({ queryKey: ['articles'] });
-      void queryClient.invalidateQueries({ queryKey: ['summary'] });
-      toast(label);
-      goBack();
-    } catch {
-      toast.error('Action failed');
-    }
-  }
+  const doAction = useCallback(
+    async (state: WorkflowState, label: string) => {
+      if (!article) return;
+      if (state === 'skipped' && article.starred) {
+        toast.error("Starred articles can't be skipped");
+        return;
+      }
+      try {
+        await patchArticleState(article.id, state, article.starred);
+        void queryClient.invalidateQueries({ queryKey: ['articles'] });
+        void queryClient.invalidateQueries({ queryKey: ['summary'] });
+        toast(label);
+        goBack();
+      } catch {
+        toast.error('Action failed');
+      }
+    },
+    [article, queryClient, goBack]
+  );
 
-  async function doStar() {
+  const doStar = useCallback(async () => {
     if (!article) return;
     const next = !article.starred;
     try {
@@ -296,7 +299,7 @@ export function ArticlePage() {
     } catch {
       toast.error('Action failed');
     }
-  }
+  }, [article, id, queryClient, goBack]);
 
   async function saveCurrentArticleOffline() {
     if (!article) return;
@@ -455,7 +458,7 @@ export function ArticlePage() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  });
+  }, [goBack, goPrev, goNext, article, doAction, doStar]);
 
   const signalColor =
     article?.signal === 'high'


### PR DESCRIPTION
Closes #827

## Summary
- The keyboard-shortcut `useEffect` in `ArticlePage.tsx` had no dependency array, so it removed and re-added the `keydown` listener on every render.
- `article` was recomputed via `adaptArticle(rawArticle)` fresh on every render (a new object each time), so it's now memoized with `useMemo` on `rawArticle`.
- `goBack`, `goPrev`, `goNext`, `doAction`, and `doStar` are now wrapped in `useCallback` so their identities stay stable across renders.
- Added the dependency array `[goBack, goPrev, goNext, article, doAction, doStar]` to the keyboard `useEffect`.

## Test plan
- [x] Added a regression test verifying the `keydown` listener is not re-attached once the article and body have settled (one re-registration is expected when article goes from `null` to loaded, then it must stay stable across further re-renders).
- [x] `npm run lint -- --max-warnings 0` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Full frontend test suite: `npx vitest run` — 771/771 passed
- [x] Manually verified via test coverage that all existing keyboard shortcuts (Escape, ArrowLeft, ArrowRight, r, d, l, s, x, e, o) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)