### PR TITLE
refactor: add global React Error Boundary to catch unhandled render errors (#828)

### DIFF
--- a/frontend/src/__tests__/errorBoundary.test.tsx
+++ b/frontend/src/__tests__/errorBoundary.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ErrorBoundary } from '../components/ErrorBoundary';
+import * as errorTracking from '../lib/errorTracking';
+
+function Bomb(): never {
+  throw new Error('test');
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(errorTracking, 'reportError').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('shows a friendly error UI instead of a blank screen when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+  });
+
+  it('calls reportError when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(errorTracking.reportError).toHaveBeenCalled();
+    const [errorArg, contextArg] = vi.mocked(errorTracking.reportError).mock.calls[0];
+    expect(errorArg).toBeInstanceOf(Error);
+    expect(typeof contextArg?.componentStack).toBe('string');
+  });
+
+  it('renders children normally when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>All good</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('reloads the page when the Reload button is clicked', async () => {
+    const reload = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+
+    try {
+      render(
+        <ErrorBoundary>
+          <Bomb />
+        </ErrorBoundary>
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Reload' }));
+      expect(reload).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { LogOut, MoreHorizontal, Search, WifiOff } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { AppLogo } from './AppLogo';
+import { ErrorBoundary } from './ErrorBoundary';
 import { CommandPalette } from './CommandPalette';
 import { ShortcutOverlay } from './ShortcutOverlay';
 import { WhatsNewDialog } from './WhatsNewDialog';
@@ -222,7 +223,9 @@ export function AppShell() {
   if (isReader) {
     return (
       <>
-        <Outlet />
+        <ErrorBoundary>
+          <Outlet />
+        </ErrorBoundary>
         <CommandPalette
           open={paletteOpen}
           onOpenChange={setPaletteOpen}
@@ -341,7 +344,9 @@ export function AppShell() {
         <div className="md:flex md:max-w-6xl md:mx-auto md:gap-0">
           <DesktopRail pathname={pathname} />
           <div className="flex-1 min-w-0">
-            <Outlet />
+            <ErrorBoundary>
+              <Outlet />
+            </ErrorBoundary>
           </div>
         </div>
       </main>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,55 @@
+import { Component, type ComponentType, type ErrorInfo, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { reportError } from '@/lib/errorTracking';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    reportError(error, { componentStack: errorInfo.componentStack });
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+          <h1 className="text-lg font-semibold text-foreground">Something went wrong</h1>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            An unexpected error occurred. Reloading the page usually fixes this.
+          </p>
+          <Button onClick={() => window.location.reload()}>Reload</Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function withErrorBoundary<P extends object>(
+  WrappedComponent: ComponentType<P>
+): ComponentType<P> {
+  function ComponentWithErrorBoundary(props: P) {
+    return (
+      <ErrorBoundary>
+        <WrappedComponent {...props} />
+      </ErrorBoundary>
+    );
+  }
+  ComponentWithErrorBoundary.displayName = `withErrorBoundary(${
+    WrappedComponent.displayName ?? WrappedComponent.name ?? 'Component'
+  })`;
+  return ComponentWithErrorBoundary;
+}

--- a/frontend/src/lib/errorTracking.ts
+++ b/frontend/src/lib/errorTracking.ts
@@ -6,6 +6,8 @@ interface PublicConfig {
   sentry_dsn: string | null;
 }
 
+let sentryEnabled = false;
+
 export async function initErrorTracking(): Promise<void> {
   try {
     const res = await fetch('/api/config');
@@ -15,7 +17,24 @@ export async function initErrorTracking(): Promise<void> {
 
     const Sentry = await import('@sentry/react');
     Sentry.init({ dsn: config.sentry_dsn, sendDefaultPii: true });
+    sentryEnabled = true;
   } catch {
     // Network/parse failures must never block app startup.
   }
+}
+
+// Reports a caught error to Sentry when it's enabled, otherwise logs to the
+// console. Never throws, since this is called from render-error handlers.
+export function reportError(error: unknown, context?: Record<string, unknown>): void {
+  if (!sentryEnabled) {
+    console.error(error, context);
+    return;
+  }
+  void import('@sentry/react')
+    .then((Sentry) => {
+      Sentry.captureException(error, context ? { extra: context } : undefined);
+    })
+    .catch(() => {
+      // Reporting must never throw from an error boundary.
+    });
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import './globals.css';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { initErrorTracking } from './lib/errorTracking';
 import { initTheme } from './lib/theme';
 import { queryClient } from './lib/queryClient';
@@ -14,9 +15,11 @@ void initErrorTracking();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <AppRouter />
-      <Toaster position="bottom-center" toastOptions={{ className: '!text-sm' }} />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AppRouter />
+        <Toaster position="bottom-center" toastOptions={{ className: '!text-sm' }} />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
Closes #828

## Summary
- Adds `frontend/src/components/ErrorBoundary.tsx`, a class component (`getDerivedStateFromError` + `componentDidCatch`) that renders a friendly full-page error UI with a "Reload" button on uncaught render errors, and calls `reportError` in `componentDidCatch`.
- Adds `reportError` to `frontend/src/lib/errorTracking.ts`: forwards to `Sentry.captureException` when Sentry was initialized (DSN configured), otherwise logs to the console. Never throws.
- Wraps `<AppRouter />` in `frontend/src/main.tsx` with `<ErrorBoundary>` (top-level safety net).
- Wraps both `<Outlet />` usages in `frontend/src/components/AppShell.tsx` (reader mode and the normal shell) with a page-level `<ErrorBoundary>`, so a crashing page no longer takes down the header/sidebar nav — the user can still navigate away.
- Exports `withErrorBoundary` HOC for wrapping individual lazy-loaded pages if needed later.

## Test plan
- [x] New `frontend/src/__tests__/errorBoundary.test.tsx`: renders a component that throws inside the boundary, asserts the friendly error UI appears (not a blank screen), asserts `reportError` was called with the error and component stack, asserts the "Reload" button calls `window.location.reload()`, and asserts normal children render unaffected when there's no error.
- [x] `npm run typecheck` passes
- [x] `npx eslint` clean on all changed/added files
- [x] `npx prettier --check` clean
- [x] Full frontend test suite: 76 files / 775 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)