### PR TITLE
docs: clarify Article/WorkflowArticle boundary roles (#830)

### DIFF
--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -45,6 +45,13 @@ function legacyStatusToState(status: ArticleStatus): WorkflowState {
   }
 }
 
+/**
+ * Normalizes the raw (snake_case, legacy-status) server `Article` into the
+ * canonical `WorkflowArticle` the UI consumes. This can't be a zero-cost cast:
+ * the backend still returns snake_case field names and a legacy `status`
+ * enum, and remapping those to the `state`/camelCase model is out of scope
+ * for the frontend-only type consolidation (#830).
+ */
 export function adaptArticle(a: LegacyArticle): WorkflowArticle {
   const state: WorkflowState = a.state ?? legacyStatusToState(a.status);
   const starred = a.state != null ? Boolean(a.starred) : a.status === 'saved';

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,12 @@ export type { RecommendationSignals };
 
 export type ArticleStatus = 'new' | 'read' | 'saved' | 'skipped' | 'archived';
 
+/**
+ * Raw article shape as returned by the backend (snake_case, legacy `status`
+ * field). Use this only in `api.ts` function signatures and the adapter in
+ * `api/workflowApi.ts`; UI code should consume `WorkflowArticle` from
+ * `lib/workflowTypes` via `adaptArticle` instead.
+ */
 export interface Article {
   id: number;
   url: string;


### PR DESCRIPTION
Closes #830.

## Summary

Audited the type-consolidation work #830 asked for. The codebase had already migrated substantially since the issue was filed:

- `WorkflowArticle` (`frontend/src/lib/workflowTypes.ts`) already carries every field pages need: `body`, `bodyStatus`, `originalTitle`, `originalBody`, `detectedLang`, `recommendation*`, `alsoFrom`, `tags`, etc.
- `WorkflowArticle.starred` is already `boolean` (no `| number` union).
- Every page component (`ArchivePage`, `ArticlePage`, `LaterPage`, `SearchPage`, `StarredPage`, `ReadingDnaPage`, ...) already consumes `WorkflowArticle` — none import the legacy `Article` type for UI state.
- The legacy `Article` type from `types.ts` is now confined to the API boundary: `api.ts` function signatures, and the adapter layer (`api/workflowApi.ts`, `api/tagsApi.ts`) that calls `adaptArticle`.

What remained undone from the acceptance criteria was documentation: nothing stated that `Article` is the raw wire type and `WorkflowArticle` is canonical for the UI, so a future PR could easily reintroduce the duplication the issue was filed against.

This PR:
- Adds a doc comment on `Article` in `frontend/src/types.ts` clarifying it's the raw snake_case server response shape, intended only for `api.ts` signatures and the adapter boundary.
- Adds a doc comment on `adaptArticle` in `frontend/src/api/workflowApi.ts` explaining it's a real adapter (not reducible to a zero-cost cast) because the backend still returns snake_case fields and a legacy `status` enum — remapping the backend response shape itself is out of scope per the issue.

No behavior changes; no route/type shape changes.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm run test:frontend` — 75 files / 771 tests passed
- [x] Confirmed via grep that no page component imports both `Article` and `WorkflowArticle` for the same data (only the API-boundary modules and their tests reference the legacy `Article` type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)