### PR TITLE
feat: preview private sources before saving (#777)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -730,6 +730,15 @@ def _fetch_entries_by_kind(source: SourceDefinition) -> list[dict[str, Any]]:
     return _fetch_feed_entries(source)
 
 
+def preview_source_entries(source: SourceDefinition) -> list[dict[str, Any]]:
+    """Fetch candidate entries for a source without writing run history or articles.
+
+    Raises FeedFetchError on failure. Reuses the same fetch path as ingestion so a
+    preview reflects what a real ingest run would find.
+    """
+    return _fetch_entries_by_kind(source)
+
+
 def _ingest_source(
     source: SourceDefinition, db_path: Path | str | None = None
 ) -> SourceIngestOutcome:

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -81,10 +81,13 @@ from news_dashboard.briefings import (
 from news_dashboard.db import connect, describe_database, init_db, row_to_dict
 from news_dashboard.error_tracking import frontend_error_tracking_dsn, init_error_tracking
 from news_dashboard.ingest import (
+    FeedFetchError,
+    clean_html,
     get_user_summary,
     ingest_all,
     list_articles,
     now_iso,
+    preview_source_entries,
     search_articles_page,
     send_article_later,
     set_article_starred,
@@ -109,6 +112,7 @@ from news_dashboard.source_health import (
     generate_subscription_cleanup_suggestions,
     list_source_health,
 )
+from news_dashboard.sources import SourceDefinition
 from news_dashboard.stats import (
     article_counts,
     articles_over_time,
@@ -517,6 +521,20 @@ class CreateSourceRequest(BaseModel):
                 detail="slug must contain only lowercase letters, digits, and hyphens",
             )
         return slug
+
+
+class PreviewSourceRequest(BaseModel):
+    url: str
+    kind: str = "rss_feed"
+
+    def validate_kind(self) -> None:
+        if self.kind in USER_CREATED_SOURCE_KINDS:
+            return
+        allowed = ", ".join(sorted(USER_CREATED_SOURCE_KINDS))
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported source kind '{self.kind}'. Supported kinds: {allowed}",
+        )
 
 
 class SourceCleanupRequest(BaseModel):
@@ -1795,6 +1813,45 @@ def create_source(
         )
         row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
     return row_to_dict(row)
+
+
+_PREVIEW_MAX_ITEMS = 5
+
+
+@api.post("/api/sources/preview")
+def preview_source(
+    payload: PreviewSourceRequest,
+    _current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Fetch a candidate source without persisting a source or article rows."""
+    payload.validate_kind()
+
+    try:
+        validate_server_fetch_url(payload.url)
+    except UnsafeUrlError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    source = SourceDefinition(
+        slug="preview", name="preview", url=payload.url, category="preview", kind=payload.kind
+    )
+    try:
+        entries = preview_source_entries(source)
+    except FeedFetchError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    items = [
+        {
+            "title": clean_html(entry.get("title") or "Untitled")[:200],
+            "url": entry.get("url", ""),
+            "date": entry.get("date"),
+        }
+        for entry in entries[:_PREVIEW_MAX_ITEMS]
+    ]
+    return {
+        "kind": payload.kind,
+        "entry_count": len(entries),
+        "items": items,
+    }
 
 
 @api.delete("/api/sources/{slug}")

--- a/backend/tests/test_source_preview.py
+++ b/backend/tests/test_source_preview.py
@@ -1,0 +1,193 @@
+"""Tests for #777 — preview a private source before saving it."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard import ingest as ingest_module
+from news_dashboard.auth import create_user
+from news_dashboard.db import connect
+from news_dashboard.ingest import FeedFetchError, sync_sources
+
+
+def _make_user(db_path: Path | str, username: str = "alice") -> int:
+    user = create_user(username, "pw", db_path=db_path)
+    return int(user["id"])
+
+
+def _api_client(db_path: Path | str, user_id: int) -> Any:
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    fake = {"id": user_id, "username": "testuser", "email": None, "is_admin": False}
+
+    @contextmanager
+    def _ctx() -> Generator[TestClient]:
+        app.dependency_overrides[require_auth] = lambda: fake
+        try:
+            with TestClient(app, raise_server_exceptions=True) as c:
+                yield c
+        finally:
+            app.dependency_overrides.pop(require_auth, None)
+
+    return _ctx()
+
+
+def test_api_preview_source_returns_entries(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    fake_entries = [
+        {"url": "https://example.com/a", "title": "Post A", "description": "", "date": None},
+        {"url": "https://example.com/b", "title": "Post B", "description": "", "date": None},
+    ]
+    monkeypatch.setattr(ingest_module, "_parse_feed_url", lambda _url: fake_entries)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources/preview",
+            json={"url": "https://example.com/feed.xml", "kind": "rss_feed"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["entry_count"] == 2
+    assert [i["title"] for i in data["items"]] == ["Post A", "Post B"]
+
+
+def test_api_preview_source_caps_returned_items(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    fake_entries = [
+        {"url": f"https://example.com/{i}", "title": f"Post {i}", "description": "", "date": None}
+        for i in range(20)
+    ]
+    monkeypatch.setattr(ingest_module, "_parse_feed_url", lambda _url: fake_entries)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources/preview",
+            json={"url": "https://example.com/feed.xml", "kind": "rss_feed"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["entry_count"] == 20
+    assert len(data["items"]) == 5
+
+
+def test_api_preview_source_empty_feed(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    monkeypatch.setattr(ingest_module, "_parse_feed_url", lambda _url: [])
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources/preview",
+            json={"url": "https://example.com/empty.xml", "kind": "rss_feed"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["entry_count"] == 0
+    assert data["items"] == []
+
+
+def test_api_preview_source_unreachable_feed_returns_422(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    def _boom(_url: str) -> list[dict[str, Any]]:
+        msg = "Feed parse failed: not a feed"
+        raise FeedFetchError(msg)
+
+    monkeypatch.setattr(ingest_module, "_parse_feed_url", _boom)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources/preview",
+            json={"url": "https://example.com/broken.xml", "kind": "rss_feed"},
+        )
+
+    assert resp.status_code == 422
+    assert "Feed parse failed" in resp.json()["detail"]
+
+
+def test_api_preview_source_rejects_unsupported_kind(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources/preview",
+            json={"url": "https://example.com/scraped", "kind": "scraped_page"},
+        )
+
+    assert resp.status_code == 400
+    assert "unsupported source kind 'scraped_page'" in resp.json()["detail"]
+
+
+def test_api_preview_source_rejects_unsafe_url(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources/preview",
+            json={"url": "http://127.0.0.1/admin", "kind": "rss_feed"},
+        )
+
+    assert resp.status_code == 400
+    assert "unsafe" in resp.json()["detail"]
+
+
+def test_api_preview_source_does_not_persist_source_or_articles(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    fake_entries = [
+        {"url": "https://example.com/a", "title": "Post A", "description": "", "date": None},
+    ]
+    monkeypatch.setattr(ingest_module, "_parse_feed_url", lambda _url: fake_entries)
+
+    with _api_client(pg_clean, uid) as client:
+        resp = client.post(
+            "/api/sources/preview",
+            json={"url": "https://example.com/feed.xml", "kind": "rss_feed"},
+        )
+    assert resp.status_code == 200
+
+    with connect(pg_clean) as conn:
+        source_row = conn.execute(
+            "SELECT 1 FROM sources WHERE url = %s", ("https://example.com/feed.xml",)
+        ).fetchone()
+        article_row = conn.execute(
+            "SELECT 1 FROM articles WHERE url = %s", ("https://example.com/a",)
+        ).fetchone()
+    assert source_row is None
+    assert article_row is None

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -349,6 +349,23 @@ describe('sources, summary, ingest', () => {
     expect(calls[0].url).toBe('/api/sources/s/enabled');
     expect(calls[0].init?.body).toBe(JSON.stringify({ enabled: false }));
   });
+
+  it('previewSource POSTs url and kind and returns the preview result', async () => {
+    const { calls } = stubFetch(() =>
+      jsonOk({ kind: 'rss_feed', entry_count: 2, items: [{ title: 'A', url: 'u', date: null }] })
+    );
+    const result = await api.previewSource({
+      url: 'https://example.com/feed.xml',
+      kind: 'rss_feed',
+    });
+    expect(calls[0].url).toBe('/api/sources/preview');
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].init?.body).toBe(
+      JSON.stringify({ url: 'https://example.com/feed.xml', kind: 'rss_feed' })
+    );
+    expect(result.entry_count).toBe(2);
+    expect(result.items).toEqual([{ title: 'A', url: 'u', date: null }]);
+  });
 });
 
 describe('scheduler endpoints', () => {

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -27,6 +27,7 @@ const apiMock = vi.hoisted(() => {
     updateSourceEnabled: vi.fn(),
     applySourceCleanup: vi.fn(),
     createSource: vi.fn(),
+    previewSource: vi.fn(),
     deleteSource: vi.fn(),
     fetchSchedulerStatus: vi.fn(),
     setSchedulerInterval: vi.fn(),
@@ -328,6 +329,74 @@ describe('SourcesPage', () => {
       await screen.findByText('Could not add source. Check the feed URL and try again.')
     ).toBeTruthy();
     expect(screen.queryByText('500 Internal Server Error')).toBeNull();
+  });
+
+  it('previews a source and shows a sample of entries', async () => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.previewSource.mockResolvedValue({
+      kind: 'rss_feed',
+      entry_count: 2,
+      items: [
+        { title: 'First post', url: 'https://myblog.com/1', date: null },
+        { title: 'Second post', url: 'https://myblog.com/2', date: null },
+      ],
+    });
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    await screen.findByRole('dialog');
+
+    fireEvent.change(screen.getByLabelText(/feed url/i), {
+      target: { value: 'https://myblog.com/feed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /test source/i }));
+
+    await waitFor(() =>
+      expect(apiMock.previewSource).toHaveBeenCalledWith({
+        url: 'https://myblog.com/feed',
+        kind: 'rss_feed',
+      })
+    );
+    expect(await screen.findByText('Found 2 entries')).toBeTruthy();
+    expect(screen.getByText('First post')).toBeTruthy();
+    expect(screen.getByText('Second post')).toBeTruthy();
+  });
+
+  it('shows an empty-feed message when preview finds no entries', async () => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.previewSource.mockResolvedValue({ kind: 'rss_feed', entry_count: 0, items: [] });
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    await screen.findByRole('dialog');
+
+    fireEvent.change(screen.getByLabelText(/feed url/i), {
+      target: { value: 'https://myblog.com/empty' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /test source/i }));
+
+    expect(await screen.findByText('Source responded but no entries were found.')).toBeTruthy();
+  });
+
+  it('shows a readable error when preview fails', async () => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.previewSource.mockRejectedValue(
+      new apiMock.HttpError(422, 'Feed parse failed: not a feed')
+    );
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    await screen.findByRole('dialog');
+
+    fireEvent.change(screen.getByLabelText(/feed url/i), {
+      target: { value: 'https://myblog.com/broken' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /test source/i }));
+
+    expect(await screen.findByText(/Feed parse failed: not a feed/i)).toBeTruthy();
   });
 
   it('shows delete button for sources owned by current user', async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -246,6 +246,30 @@ export async function createSource(payload: CreateSourcePayload): Promise<Source
   });
 }
 
+export interface PreviewSourcePayload {
+  url: string;
+  kind?: string;
+}
+
+export interface SourcePreviewItem {
+  title: string;
+  url: string;
+  date: string | null;
+}
+
+export interface SourcePreviewResult {
+  kind: string;
+  entry_count: number;
+  items: SourcePreviewItem[];
+}
+
+export async function previewSource(payload: PreviewSourcePayload): Promise<SourcePreviewResult> {
+  return requestJson<SourcePreviewResult>('/api/sources/preview', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
 export async function deleteSource(slug: string): Promise<{ status: string }> {
   return requestJson<{ status: string }>(`/api/sources/${slug}`, { method: 'DELETE' });
 }

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -25,8 +25,10 @@ import {
   fetchSourceCleanupSuggestions,
   fetchSources,
   importOpml,
+  previewSource,
   updateSourceEnabled,
 } from '@/api';
+import type { SourcePreviewResult } from '@/api';
 import { relativeTime } from '@/lib/format';
 import { sourceActionErrorMessage } from '@/lib/errorPresentation';
 import type { Source, SourceCleanupSuggestion, OpmlImportResult } from '@/types';
@@ -118,6 +120,8 @@ function AddSourceDialog({
 }) {
   const [form, setForm] = useState<AddSourceFormState>(EMPTY_FORM);
   const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<SourcePreviewResult | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
 
   const mutation = useMutation({
     mutationFn: () =>
@@ -131,11 +135,25 @@ function AddSourceDialog({
     onSuccess: () => {
       setForm(EMPTY_FORM);
       setError(null);
+      setPreview(null);
+      setPreviewError(null);
       onCreated();
       onClose();
     },
     onError: (err: Error) => {
       setError(sourceActionErrorMessage(err, 'add'));
+    },
+  });
+
+  const previewMutation = useMutation({
+    mutationFn: () => previewSource({ url: form.url, kind: form.kind }),
+    onSuccess: (result) => {
+      setPreview(result);
+      setPreviewError(null);
+    },
+    onError: (err: Error) => {
+      setPreview(null);
+      setPreviewError(sourceActionErrorMessage(err, 'add'));
     },
   });
 
@@ -145,10 +163,24 @@ function AddSourceDialog({
     mutation.mutate();
   }
 
+  function handlePreview() {
+    setPreviewError(null);
+    setPreview(null);
+    previewMutation.mutate();
+  }
+
   function handleClose() {
     setForm(EMPTY_FORM);
     setError(null);
+    setPreview(null);
+    setPreviewError(null);
     onClose();
+  }
+
+  function handleUrlOrKindChange(next: Partial<AddSourceFormState>) {
+    setForm((f) => ({ ...f, ...next }));
+    setPreview(null);
+    setPreviewError(null);
   }
 
   return (
@@ -165,7 +197,7 @@ function AddSourceDialog({
             <select
               id="src-kind"
               value={form.kind}
-              onChange={(e) => setForm((f) => ({ ...f, kind: e.target.value }))}
+              onChange={(e) => handleUrlOrKindChange({ kind: e.target.value })}
               className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
             >
               <option value="rss_feed">RSS Feed</option>
@@ -195,10 +227,42 @@ function AddSourceDialog({
               type="url"
               placeholder="https://example.com/feed.xml"
               value={form.url}
-              onChange={(e) => setForm((f) => ({ ...f, url: e.target.value }))}
+              onChange={(e) => handleUrlOrKindChange({ url: e.target.value })}
               required
             />
           </div>
+          <div className="flex items-center justify-between gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!form.url.trim() || previewMutation.isPending}
+              onClick={handlePreview}
+            >
+              {previewMutation.isPending ? 'Testing…' : 'Test source'}
+            </Button>
+          </div>
+          {previewError && <p className="text-xs text-[color:var(--err)]">{previewError}</p>}
+          {preview && (
+            <div className="rounded-md border border-input bg-muted/30 p-2 text-xs">
+              {preview.entry_count === 0 ? (
+                <p className="text-muted-foreground">Source responded but no entries were found.</p>
+              ) : (
+                <>
+                  <p className="mb-1 font-medium text-[color:var(--ok)]">
+                    Found {preview.entry_count} entr{preview.entry_count === 1 ? 'y' : 'ies'}
+                  </p>
+                  <ul className="flex flex-col gap-1">
+                    {preview.items.map((item, i) => (
+                      <li key={i} className="truncate text-muted-foreground" title={item.title}>
+                        {item.title}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
           <div className="grid grid-cols-2 gap-3">
             <div className="flex flex-col gap-1">
               <label className="text-xs font-medium text-muted-foreground" htmlFor="src-category">


### PR DESCRIPTION
## Summary
- Adds `POST /api/sources/preview`, which fetches a candidate source (RSS, Reddit, Lobsters, or Mastodon) using the same fetch path as ingestion, without inserting a `sources` or `articles` row.
- Reuses the existing SSRF/private-network URL checks and the same accepted-kind validation as `POST /api/sources`.
- Returns the entry count plus a capped sample (5) of candidate titles/URLs/dates.
- Adds a "Test source" action to the Add source dialog in `SourcesPage.tsx` that shows a sample of entries, an empty-feed message, or a readable error before saving.

Closes #777.

## Implementation notes
- `preview_source_entries()` in `backend/news_dashboard/ingest.py` is a thin public wrapper around the existing `_fetch_entries_by_kind`, which already has no side effects (no run history, no DB writes).
- The preview endpoint only accepts `USER_CREATED_SOURCE_KINDS` (same set as source creation), so it stays compatible with #742's intent of no arbitrary runtime source kinds.

## Test plan
- [x] Backend: `backend/tests/test_source_preview.py` — valid preview, capped item count, empty feed, unreachable feed (422), unsupported kind (400), unsafe URL (400), and no-persistence assertions for both `sources` and `articles` tables.
- [x] Frontend: `frontend/src/__tests__/api.test.ts` covers the new `previewSource` API helper; `frontend/src/__tests__/feedsPages.test.tsx` covers preview success, empty-feed, and error states in the Add source dialog.
- [x] `pytest backend/tests/ -k source` — 218 passed
- [x] `npx vitest run frontend/src/__tests__/feedsPages.test.tsx frontend/src/__tests__/api.test.ts` — 98 passed
- [x] `npm run typecheck`, `ruff check`, `mypy` all pass; pre-commit hooks passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)