### PR TITLE
feat: include subscriptions and preferences in personal export (#778)

### DIFF
--- a/backend/news_dashboard/export.py
+++ b/backend/news_dashboard/export.py
@@ -2,9 +2,234 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from news_dashboard.db import connect, row_to_dict
+
+SCHEMA_VERSION = 2
+
+# Safe, non-secret user columns. Excludes password_hash and
+# podcast_feed_token_version, which are never exported.
+_NOTIFICATION_COLS = (
+    "briefing_time, briefing_push_enabled, briefing_timezone, recap_enabled, recap_day, "
+    "analytics_enabled"
+)
+
+
+def _normalize_timestamps(d: dict[str, Any], columns: tuple[str, ...]) -> None:
+    for col in columns:
+        val = d.get(col)
+        if val is not None and not isinstance(val, str):
+            d[col] = val.isoformat()
+
+
+def _export_articles(conn: Any, user_id: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT
+            a.id,
+            a.canonical_url,
+            a.title,
+            a.source_slug,
+            a.source_name,
+            a.category,
+            a.kind,
+            a.published_at,
+            a.discovered_at,
+            a.summary,
+            a.reason,
+            a.tags,
+            a.body,
+            uas.state,
+            uas.starred,
+            uas.done_at,
+            uas.starred_at,
+            uas.skipped_at,
+            uas.archived_at,
+            uas.later_until,
+            uas.restored_at,
+            uas.updated_at
+        FROM user_article_state uas
+        JOIN articles a ON a.id = uas.article_id
+        WHERE uas.user_id = %s
+        ORDER BY a.id ASC
+        """,
+        (user_id,),
+    ).fetchall()
+
+    articles: list[dict[str, Any]] = []
+    for row in rows:
+        d = row_to_dict(row)
+        _normalize_timestamps(
+            d,
+            (
+                "done_at",
+                "starred_at",
+                "skipped_at",
+                "archived_at",
+                "later_until",
+                "restored_at",
+                "updated_at",
+            ),
+        )
+        articles.append(d)
+    return articles
+
+
+def _export_briefings(conn: Any, user_id: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT
+            b.id,
+            b.created_at,
+            b.scope,
+            b.since_at,
+            b.until_at,
+            b.status,
+            b.title,
+            b.summary,
+            b.focus_prompt,
+            b.model
+        FROM briefings b
+        WHERE b.user_id = %s
+        ORDER BY b.id ASC
+        """,
+        (user_id,),
+    ).fetchall()
+
+    briefings: list[dict[str, Any]] = []
+    for brow in rows:
+        bd = row_to_dict(brow)
+        _normalize_timestamps(bd, ("created_at", "since_at", "until_at"))
+
+        cited_rows = conn.execute(
+            """
+            SELECT ba.article_id, a.canonical_url
+            FROM briefing_articles ba
+            JOIN articles a ON a.id = ba.article_id
+            WHERE ba.briefing_id = %s
+            ORDER BY ba.article_id ASC
+            """,
+            (bd["id"],),
+        ).fetchall()
+        bd["cited_articles"] = [
+            {"article_id": r["article_id"], "canonical_url": r["canonical_url"]} for r in cited_rows
+        ]
+        briefings.append(bd)
+    return briefings
+
+
+def _export_ai_memories(conn: Any, user_id: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT id, memory_type, content, source, confidence, active, created_at, updated_at
+        FROM user_ai_memories
+        WHERE user_id = %s
+        ORDER BY id ASC
+        """,
+        (user_id,),
+    ).fetchall()
+    memories: list[dict[str, Any]] = []
+    for row in rows:
+        md = row_to_dict(row)
+        _normalize_timestamps(md, ("created_at", "updated_at"))
+        memories.append(md)
+    return memories
+
+
+def _export_ai_memory_events(conn: Any, user_id: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT id, memory_id, event_type, source, content, metadata, created_at
+        FROM user_ai_memory_events
+        WHERE user_id = %s
+        ORDER BY id ASC
+        """,
+        (user_id,),
+    ).fetchall()
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        ed = row_to_dict(row)
+        _normalize_timestamps(ed, ("created_at",))
+        events.append(ed)
+    return events
+
+
+def _export_source_subscriptions(conn: Any, user_id: int) -> list[dict[str, Any]]:
+    """Return the user's global source subscription state plus owned private sources.
+
+    Other users' private sources are excluded by the owner_user_id scope below.
+    """
+    rows = conn.execute(
+        """
+        SELECT s.slug, s.name, s.url, s.category, s.kind, s.owner_user_id,
+          CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, true)
+               ELSE (s.enabled IS TRUE) END AS subscribed
+        FROM sources s
+        LEFT JOIN user_sources us ON us.source_slug = s.slug AND us.user_id = %s
+        WHERE (s.owner_user_id IS NULL OR s.owner_user_id = %s)
+          AND s.deleted_at IS NULL
+        ORDER BY s.category, s.slug
+        """,
+        (user_id, user_id),
+    ).fetchall()
+    subscriptions: list[dict[str, Any]] = []
+    for row in rows:
+        sd = row_to_dict(row)
+        sd["subscribed"] = bool(sd["subscribed"])
+        sd["private"] = sd.pop("owner_user_id") is not None
+        subscriptions.append(sd)
+    return subscriptions
+
+
+def _export_recommendation_preferences(conn: Any, user_id: int) -> dict[str, Any]:
+    row = conn.execute(
+        "SELECT category_weights, novelty_weight FROM user_settings WHERE user_id = %s",
+        (user_id,),
+    ).fetchone()
+    if row is None:
+        return {"category_weights": {}, "novelty_weight": 1.0}
+    return {
+        "category_weights": row["category_weights"] or {},
+        "novelty_weight": float(row["novelty_weight"] or 1.0),
+    }
+
+
+def _export_onboarding(conn: Any, user_id: int) -> dict[str, Any]:
+    row = conn.execute(
+        "SELECT interests, completed_at, updated_at FROM user_interest_profiles WHERE user_id = %s",
+        (user_id,),
+    ).fetchone()
+    if row is None:
+        return {"interests": [], "completed_at": None, "updated_at": None}
+    d = row_to_dict(row)
+    _normalize_timestamps(d, ("completed_at", "updated_at"))
+    return d
+
+
+def _export_notification_settings(conn: Any, user_id: int) -> dict[str, Any]:
+    row = conn.execute(
+        f"SELECT {_NOTIFICATION_COLS} FROM users WHERE id = %s",
+        (user_id,),
+    ).fetchone()
+    if row is None:
+        return {
+            "briefing_time": "09:00",
+            "briefing_timezone": "UTC",
+            "push_enabled": False,
+            "recap_enabled": True,
+            "recap_day": "mon",
+            "analytics_enabled": True,
+        }
+    return {
+        "briefing_time": row["briefing_time"] or "09:00",
+        "briefing_timezone": row["briefing_timezone"] or "UTC",
+        "push_enabled": bool(row["briefing_push_enabled"]),
+        "recap_enabled": bool(row["recap_enabled"]),
+        "recap_day": row["recap_day"] or "mon",
+        "analytics_enabled": bool(row["analytics_enabled"]),
+    }
 
 
 def assemble_user_export(
@@ -17,145 +242,39 @@ def assemble_user_export(
     - articles the user has explicitly interacted with (user_article_state rows),
       joined with article metadata (title, URL, category, summary, tags, body).
     - user-owned briefings with their cited article IDs.
+    - source_subscriptions: the user's enabled/disabled state for global sources,
+      plus any private sources the user owns. Other users' private sources are
+      never included.
+    - preferences: recommendation weights, onboarding interests/completion
+      state, and notification settings (briefing time/timezone, push-enabled,
+      recap, analytics opt-in).
 
     Data is ordered by stable keys (id / created_at) so the output is
     deterministic enough for snapshot-style tests.
+
+    No secrets are exported: password hashes, session tokens, OTP hashes, MCP
+    API tokens, and raw push-subscription keys are never read here.
     """
     with connect(database_url=database_url) as conn:
-        article_rows = conn.execute(
-            """
-            SELECT
-                a.id,
-                a.canonical_url,
-                a.title,
-                a.source_slug,
-                a.source_name,
-                a.category,
-                a.kind,
-                a.published_at,
-                a.discovered_at,
-                a.summary,
-                a.reason,
-                a.tags,
-                a.body,
-                uas.state,
-                uas.starred,
-                uas.done_at,
-                uas.starred_at,
-                uas.skipped_at,
-                uas.archived_at,
-                uas.later_until,
-                uas.restored_at,
-                uas.updated_at
-            FROM user_article_state uas
-            JOIN articles a ON a.id = uas.article_id
-            WHERE uas.user_id = %s
-            ORDER BY a.id ASC
-            """,
-            (user_id,),
-        ).fetchall()
-
-        articles: list[dict[str, Any]] = []
-        for row in article_rows:
-            d = row_to_dict(row)
-            # Normalise timestamps to ISO strings for portability.
-            for ts_col in (
-                "done_at",
-                "starred_at",
-                "skipped_at",
-                "archived_at",
-                "later_until",
-                "restored_at",
-                "updated_at",
-            ):
-                val = d.get(ts_col)
-                if val is not None and not isinstance(val, str):
-                    d[ts_col] = val.isoformat()
-            articles.append(d)
-
-        briefing_rows = conn.execute(
-            """
-            SELECT
-                b.id,
-                b.created_at,
-                b.scope,
-                b.since_at,
-                b.until_at,
-                b.status,
-                b.title,
-                b.summary,
-                b.focus_prompt,
-                b.model
-            FROM briefings b
-            WHERE b.user_id = %s
-            ORDER BY b.id ASC
-            """,
-            (user_id,),
-        ).fetchall()
-
-        briefings: list[dict[str, Any]] = []
-        for brow in briefing_rows:
-            bd = row_to_dict(brow)
-            for ts_col in ("created_at", "since_at", "until_at"):
-                val = bd.get(ts_col)
-                if val is not None and not isinstance(val, str):
-                    bd[ts_col] = val.isoformat()
-
-            cited_rows = conn.execute(
-                """
-                SELECT ba.article_id, a.canonical_url
-                FROM briefing_articles ba
-                JOIN articles a ON a.id = ba.article_id
-                WHERE ba.briefing_id = %s
-                ORDER BY ba.article_id ASC
-                """,
-                (bd["id"],),
-            ).fetchall()
-            bd["cited_articles"] = [
-                {"article_id": r["article_id"], "canonical_url": r["canonical_url"]}
-                for r in cited_rows
-            ]
-            briefings.append(bd)
-
-        memory_rows = conn.execute(
-            """
-            SELECT id, memory_type, content, source, confidence, active, created_at, updated_at
-            FROM user_ai_memories
-            WHERE user_id = %s
-            ORDER BY id ASC
-            """,
-            (user_id,),
-        ).fetchall()
-        memories: list[dict[str, Any]] = []
-        for row in memory_rows:
-            md = row_to_dict(row)
-            for ts_col in ("created_at", "updated_at"):
-                val = md.get(ts_col)
-                if val is not None and not isinstance(val, str):
-                    md[ts_col] = val.isoformat()
-            memories.append(md)
-
-        event_rows = conn.execute(
-            """
-            SELECT id, memory_id, event_type, source, content, metadata, created_at
-            FROM user_ai_memory_events
-            WHERE user_id = %s
-            ORDER BY id ASC
-            """,
-            (user_id,),
-        ).fetchall()
-        memory_events: list[dict[str, Any]] = []
-        for row in event_rows:
-            ed = row_to_dict(row)
-            created_at = ed.get("created_at")
-            if created_at is not None and not isinstance(created_at, str):
-                ed["created_at"] = created_at.isoformat()
-            memory_events.append(ed)
+        articles = _export_articles(conn, user_id)
+        briefings = _export_briefings(conn, user_id)
+        memories = _export_ai_memories(conn, user_id)
+        memory_events = _export_ai_memory_events(conn, user_id)
+        source_subscriptions = _export_source_subscriptions(conn, user_id)
+        preferences = {
+            "recommendations": _export_recommendation_preferences(conn, user_id),
+            "onboarding": _export_onboarding(conn, user_id),
+            "notifications": _export_notification_settings(conn, user_id),
+        }
 
     return {
-        "schema_version": 1,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "includes_article_bodies": True,
         "articles": articles,
         "briefings": briefings,
         "ai_memories": memories,
         "ai_memory_events": memory_events,
+        "source_subscriptions": source_subscriptions,
+        "preferences": preferences,
     }

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1,8 +1,9 @@
-"""Tests for #474 personal reading archive export."""
+"""Tests for #474 personal reading archive export and #778 subscriptions/preferences."""
 
 from __future__ import annotations
 
 import pytest
+from psycopg.types.json import Jsonb
 
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect
@@ -71,7 +72,7 @@ def test_export_includes_user_article_state(pg_clean: str) -> None:
 
     result = assemble_user_export(uid, database_url=pg_clean)
 
-    assert result["schema_version"] == 1
+    assert result["schema_version"] == 2
     articles = result["articles"]
     assert len(articles) == 1
     a = articles[0]
@@ -163,6 +164,16 @@ def test_export_empty_for_new_user(pg_clean: str) -> None:
 
     assert result["articles"] == []
     assert result["briefings"] == []
+    assert result["preferences"]["recommendations"] == {
+        "category_weights": {},
+        "novelty_weight": 1.0,
+    }
+    assert result["preferences"]["onboarding"] == {
+        "interests": [],
+        "completed_at": None,
+        "updated_at": None,
+    }
+    assert result["preferences"]["notifications"]["push_enabled"] is False
 
 
 def test_export_deterministic_ordering(pg_clean: str) -> None:
@@ -204,7 +215,7 @@ def test_export_endpoint_returns_200(pg_clean: str, monkeypatch: pytest.MonkeyPa
             resp = client.get("/api/users/me/export")
             assert resp.status_code == 200
             data = resp.json()
-            assert data["schema_version"] == 1
+            assert data["schema_version"] == 2
             article_ids = [a["id"] for a in data["articles"]]
             assert aid in article_ids
     finally:
@@ -244,3 +255,150 @@ def test_export_endpoint_scoped_to_auth_user(
             assert aid_bob not in article_ids
     finally:
         app.dependency_overrides.pop(require_auth, None)
+
+
+# ── #778: metadata, source subscriptions, preferences ─────────────────────────
+
+
+def test_export_metadata_and_body_flag(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "meta_user")
+
+    result = assemble_user_export(uid, database_url=pg_clean)
+
+    assert result["schema_version"] == 2
+    assert result["generated_at"]
+    assert result["includes_article_bodies"] is True
+
+
+def test_export_source_subscriptions_reflect_disabled_global_source(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "sub_user")
+
+    with connect(database_url=pg_clean) as conn:
+        slug_row = conn.execute(
+            "SELECT slug FROM sources WHERE owner_user_id IS NULL ORDER BY slug LIMIT 1"
+        ).fetchone()
+        assert slug_row is not None
+        slug = slug_row["slug"]
+        conn.execute(
+            """
+            INSERT INTO user_sources(user_id, source_slug, enabled)
+            VALUES (%s, %s, FALSE)
+            ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = FALSE
+            """,
+            (uid, slug),
+        )
+
+    result = assemble_user_export(uid, database_url=pg_clean)
+
+    by_slug = {s["slug"]: s for s in result["source_subscriptions"]}
+    assert by_slug[slug]["subscribed"] is False
+    assert by_slug[slug]["private"] is False
+
+
+def test_export_includes_own_private_source_not_other_users(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid_alice = _make_user(pg_clean, "priv_alice")
+    uid_bob = _make_user(pg_clean, "priv_bob")
+
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+            VALUES (%s, %s, %s, %s, %s, 0, TRUE, %s)
+            """,
+            (
+                "alice-private-feed",
+                "Alice's Feed",
+                "https://example.com/feed",
+                "custom",
+                "rss_feed",
+                uid_alice,
+            ),
+        )
+
+    alice_export = assemble_user_export(uid_alice, database_url=pg_clean)
+    bob_export = assemble_user_export(uid_bob, database_url=pg_clean)
+
+    alice_slugs = {s["slug"] for s in alice_export["source_subscriptions"]}
+    bob_slugs = {s["slug"] for s in bob_export["source_subscriptions"]}
+
+    assert "alice-private-feed" in alice_slugs
+    assert "alice-private-feed" not in bob_slugs
+    alice_private = next(
+        s for s in alice_export["source_subscriptions"] if s["slug"] == "alice-private-feed"
+    )
+    assert alice_private["private"] is True
+    assert alice_private["subscribed"] is True
+
+
+def test_export_preferences_include_recommendations_onboarding_notifications(
+    pg_clean: str,
+) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "pref_user")
+
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_settings(user_id, category_weights, novelty_weight)
+            VALUES (%s, %s, %s)
+            ON CONFLICT(user_id) DO UPDATE SET
+              category_weights = excluded.category_weights,
+              novelty_weight = excluded.novelty_weight
+            """,
+            (uid, Jsonb({"python": 2.0}), 0.5),
+        )
+        conn.execute(
+            """
+            INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
+            VALUES (%s, %s, NOW(), NOW())
+            ON CONFLICT(user_id) DO UPDATE SET
+              interests = excluded.interests, completed_at = NOW(), updated_at = NOW()
+            """,
+            (uid, Jsonb(["python", "security"])),
+        )
+        conn.execute(
+            """
+            UPDATE users
+            SET briefing_time = '07:30', briefing_timezone = 'America/New_York',
+                briefing_push_enabled = TRUE, recap_enabled = FALSE, recap_day = 'fri'
+            WHERE id = %s
+            """,
+            (uid,),
+        )
+
+    result = assemble_user_export(uid, database_url=pg_clean)
+    prefs = result["preferences"]
+
+    assert prefs["recommendations"] == {"category_weights": {"python": 2.0}, "novelty_weight": 0.5}
+    assert prefs["onboarding"]["interests"] == ["python", "security"]
+    assert prefs["onboarding"]["completed_at"] is not None
+    assert prefs["notifications"]["briefing_time"] == "07:30"
+    assert prefs["notifications"]["briefing_timezone"] == "America/New_York"
+    assert prefs["notifications"]["push_enabled"] is True
+    assert prefs["notifications"]["recap_enabled"] is False
+    assert prefs["notifications"]["recap_day"] == "fri"
+
+
+def test_export_preferences_scoped_to_user(pg_clean: str) -> None:
+    """Alice's preferences must not leak into Bob's export."""
+    sync_sources(pg_clean)
+    uid_alice = _make_user(pg_clean, "pref_scope_alice")
+    uid_bob = _make_user(pg_clean, "pref_scope_bob")
+
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_settings(user_id, category_weights, novelty_weight)
+            VALUES (%s, %s, %s)
+            """,
+            (uid_alice, Jsonb({"security": 3.0}), 1.5),
+        )
+
+    alice_export = assemble_user_export(uid_alice, database_url=pg_clean)
+    bob_export = assemble_user_export(uid_bob, database_url=pg_clean)
+
+    assert alice_export["preferences"]["recommendations"]["category_weights"] == {"security": 3.0}
+    assert bob_export["preferences"]["recommendations"]["category_weights"] == {}

--- a/docs/user-guide/saved-history.md
+++ b/docs/user-guide/saved-history.md
@@ -81,15 +81,23 @@ Want to back up or migrate your history? Use the built-in export:
 1. Go to Settings → Advanced
 2. Click "Download my data"
 3. Receive a JSON file containing:
-   - Your article interactions (read/saved/starred/etc. timestamps)
+   - Export metadata (`schema_version`, `generated_at`, and whether cached
+     article bodies are included)
+   - Your article interactions (read/saved/starred/etc. timestamps),
+     including cached article body text where available
    - Applied tags
-   - Source subscriptions and health
-   - Briefings history
-   - Personal settings (excluding secrets)
+   - Briefings history, with cited article IDs
+   - `source_subscriptions` — your enabled/disabled state for global sources,
+     plus any private sources you own (other users' private sources are
+     never included)
+   - `preferences` — recommendation weights, onboarding
+     interests/completion state, and notification settings (briefing
+     time/timezone, push-enabled, recap, analytics opt-in)
 
-The export excludes article bodies/text (to keep the file small and focused on
-your personal state). You can re-import this data on another instance using
-the import tool (see Settings → Advanced → Import).
+The export includes cached article body text when present, so the file can be
+large. Secrets (password hash, session tokens, push subscription keys, API
+tokens) are never included. There is currently no import tool — this export
+is for backup and personal portability only.
 
 ## Auto-cleanup
 

--- a/frontend/src/components/settings/DataExportSection.tsx
+++ b/frontend/src/components/settings/DataExportSection.tsx
@@ -27,8 +27,10 @@ export function DataExportSection() {
       </div>
       <div className="rounded-lg border border-border bg-card p-4 space-y-3">
         <p className="text-xs text-muted-foreground">
-          Download a personal archive of your reading history, starred articles, workflow state, and
-          daily briefings as a JSON file.
+          Download a personal archive of your reading history, starred articles, workflow state,
+          daily briefings, source subscriptions, and preferences (recommendation weights, onboarding
+          interests, notification settings) as a JSON file. Cached article body text is included
+          when available; secrets are never included.
         </p>
         <button
           onClick={() => void handleExport()}


### PR DESCRIPTION
## Summary
- Closes #778.
- Extends `assemble_user_export()` in `backend/news_dashboard/export.py` with a `source_subscriptions` section (global source enabled/disabled state + user-owned private sources, scoped so other users' private sources never leak) and a `preferences` section (recommendation weights, onboarding interests/completion state, notification settings).
- Adds export metadata: `schema_version` (bumped 1 → 2), `generated_at`, and `includes_article_bodies` so the payload is self-describing.
- Updates `docs/user-guide/saved-history.md` and the Settings "Data Export" copy to accurately describe what's exported — cached article bodies are included (previously documented as excluded), and there's no import tool yet (previously implied one existed).
- No secrets are exported: password hashes, session tokens, OTP hashes, MCP tokens, and raw push-subscription keys are never read.

## Test plan
- [x] `pytest backend/tests/test_export.py backend/tests/test_source_subscriptions.py` — 39 passed, including new coverage for disabled global sources, owned private sources, multi-user source/preference scoping, and export metadata.
- [x] `ruff check`, `mypy`, `ty`, `pyrefly` on backend changes — clean.
- [x] `tsc -b`, `eslint`, `prettier` on frontend changes — clean.
- [x] Full pre-commit run on changed files — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)