### PR TITLE
refactor: extract shared NavLink component and useLogout hook (#831)

### DIFF
--- a/frontend/src/__tests__/navLink.test.tsx
+++ b/frontend/src/__tests__/navLink.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Home } from 'lucide-react';
+import { NavLink } from '../components/NavLink';
+
+function renderNavLink(props: Partial<React.ComponentProps<typeof NavLink>> = {}) {
+  return render(
+    <MemoryRouter>
+      <NavLink to="/today" label="Today" icon={Home} isActive={false} variant="rail" {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('NavLink', () => {
+  it('applies the active class when isActive is true', () => {
+    renderNavLink({ isActive: true });
+    const link = screen.getByText('Today').closest('a');
+    expect(link?.className).toContain('bg-surface-2');
+  });
+
+  it('does not apply the active class when isActive is false', () => {
+    renderNavLink({ isActive: false });
+    const link = screen.getByText('Today').closest('a');
+    expect(link?.className).not.toContain('bg-surface-2');
+  });
+
+  it('shows the count badge when count is positive', () => {
+    renderNavLink({ count: 5 });
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('does not render a count badge when count is 0', () => {
+    renderNavLink({ count: 0 });
+    expect(screen.queryByText('0')).toBeNull();
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -9,11 +9,13 @@ import { ShortcutOverlay } from './ShortcutOverlay';
 import { WhatsNewDialog } from './WhatsNewDialog';
 import { OnboardingWizard } from './OnboardingWizard';
 import { ListenQueuePlayer } from './ListenQueuePlayer';
+import { NavLink } from './NavLink';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
 import { useOnboardingWizard } from '@/hooks/useOnboardingWizard';
 import { useElectronBriefNotifier } from '@/hooks/useElectronBriefNotifier';
+import { useLogout } from '@/hooks/useLogout';
 import { cn } from '@/lib/utils';
-import { fetchSummary, fetchSharesUnreadCount, fetchAnalyticsSettings, logoutUser } from '@/api';
+import { fetchSummary, fetchSharesUnreadCount, fetchAnalyticsSettings } from '@/api';
 import { startAnalytics, stopAnalytics, trackRoute, setAnalyticsAllowed } from '@/lib/analytics';
 import { useAuth } from '@/contexts/auth';
 import {
@@ -64,8 +66,8 @@ function useOnlineStatus() {
 
 function DesktopRail({ pathname }: { pathname: string }) {
   const counts = useNavCounts();
-  const { user, setUser } = useAuth();
-  const navigate = useNavigate();
+  const { user } = useAuth();
+  const handleLogout = useLogout();
   const countFor = (item: NavigationItem): number | null =>
     item.to === '/today'
       ? counts.today
@@ -75,62 +77,33 @@ function DesktopRail({ pathname }: { pathname: string }) {
           ? counts.shared
           : null;
 
-  async function handleLogout() {
-    await logoutUser();
-    setUser(null);
-    void navigate('/login', { replace: true });
-  }
-
   return (
     <aside className="hidden md:flex md:flex-col md:w-[200px] md:shrink-0 md:border-r md:border-border md:min-h-[calc(100vh-3rem)] md:sticky md:top-12 md:self-start">
       <nav className="flex flex-col p-2 gap-0.5">
-        {primaryNavigationItems.map((n) => {
-          const Icon = n.icon;
-          const active = isNavigationItemActive(n.to, pathname);
-          const count = countFor(n);
-          return (
-            <Link
-              key={n.to}
-              to={n.to}
-              className={cn(
-                'flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm',
-                active
-                  ? 'bg-surface-2 text-foreground font-medium'
-                  : 'text-muted-foreground hover:bg-surface hover:text-foreground'
-              )}
-            >
-              <Icon className="size-4" />
-              <span className="flex-1">{n.label}</span>
-              {count != null && count > 0 && (
-                <span className="text-[10px] font-medium tabular-nums text-muted-foreground">
-                  {count}
-                </span>
-              )}
-            </Link>
-          );
-        })}
+        {primaryNavigationItems.map((n) => (
+          <NavLink
+            key={n.to}
+            to={n.to}
+            label={n.label}
+            icon={n.icon}
+            isActive={isNavigationItemActive(n.to, pathname)}
+            count={countFor(n)}
+            variant="rail"
+          />
+        ))}
       </nav>
       <div className="mx-2 my-2 h-px bg-border" />
       <nav className="flex flex-col p-2 gap-0.5">
-        {secondaryNavigationItemsFor(Boolean(user?.is_admin)).map((m) => {
-          const Icon = m.icon;
-          const active = isNavigationItemActive(m.to, pathname);
-          return (
-            <Link
-              key={m.to}
-              to={m.to}
-              className={cn(
-                'flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm',
-                active
-                  ? 'bg-surface-2 text-foreground font-medium'
-                  : 'text-muted-foreground hover:bg-surface hover:text-foreground'
-              )}
-            >
-              <Icon className="size-4" />
-              {m.label}
-            </Link>
-          );
-        })}
+        {secondaryNavigationItemsFor(Boolean(user?.is_admin)).map((m) => (
+          <NavLink
+            key={m.to}
+            to={m.to}
+            label={m.label}
+            icon={m.icon}
+            isActive={isNavigationItemActive(m.to, pathname)}
+            variant="rail"
+          />
+        ))}
       </nav>
       <div className="mt-auto mx-2 mb-2 pt-2 border-t border-border">
         {user && (
@@ -151,7 +124,8 @@ function DesktopRail({ pathname }: { pathname: string }) {
 export function AppShell() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
-  const { user, setUser } = useAuth();
+  const { user } = useAuth();
+  const handleLogout = useLogout();
   const [moreOpen, setMoreOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
@@ -159,12 +133,6 @@ export function AppShell() {
   const onboarding = useOnboardingWizard();
   const online = useOnlineStatus();
   useElectronBriefNotifier((path) => void navigate(path));
-
-  async function handleLogout() {
-    await logoutUser();
-    setUser(null);
-    void navigate('/login', { replace: true });
-  }
 
   useEffect(() => {
     let cancelled = false;
@@ -279,49 +247,31 @@ export function AppShell() {
                   )}
                 </SheetHeader>
                 <nav className="p-2">
-                  {mobilePrimaryOverflowItems.map((m) => {
-                    const Icon = m.icon;
-                    const active = isNavigationItemActive(m.to, pathname);
-                    return (
-                      <Link
-                        key={m.to}
-                        to={m.to}
-                        onClick={() => setMoreOpen(false)}
-                        className={cn(
-                          'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm',
-                          active
-                            ? 'bg-surface-2 text-foreground'
-                            : 'text-muted-foreground hover:bg-surface hover:text-foreground'
-                        )}
-                      >
-                        <Icon className="size-4" />
-                        {m.label}
-                      </Link>
-                    );
-                  })}
+                  {mobilePrimaryOverflowItems.map((m) => (
+                    <NavLink
+                      key={m.to}
+                      to={m.to}
+                      label={m.label}
+                      icon={m.icon}
+                      isActive={isNavigationItemActive(m.to, pathname)}
+                      variant="sheet"
+                      onClick={() => setMoreOpen(false)}
+                    />
+                  ))}
                   {mobilePrimaryOverflowItems.length > 0 && (
                     <div className="mx-1 my-1 h-px bg-border" />
                   )}
-                  {secondaryNavigationItemsFor(Boolean(user?.is_admin)).map((m) => {
-                    const Icon = m.icon;
-                    const active = isNavigationItemActive(m.to, pathname);
-                    return (
-                      <Link
-                        key={m.to}
-                        to={m.to}
-                        onClick={() => setMoreOpen(false)}
-                        className={cn(
-                          'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm',
-                          active
-                            ? 'bg-surface-2 text-foreground'
-                            : 'text-muted-foreground hover:bg-surface hover:text-foreground'
-                        )}
-                      >
-                        <Icon className="size-4" />
-                        {m.label}
-                      </Link>
-                    );
-                  })}
+                  {secondaryNavigationItemsFor(Boolean(user?.is_admin)).map((m) => (
+                    <NavLink
+                      key={m.to}
+                      to={m.to}
+                      label={m.label}
+                      icon={m.icon}
+                      isActive={isNavigationItemActive(m.to, pathname)}
+                      variant="sheet"
+                      onClick={() => setMoreOpen(false)}
+                    />
+                  ))}
                   <button
                     onClick={() => void handleLogout()}
                     className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-sm text-muted-foreground hover:bg-surface hover:text-foreground"

--- a/frontend/src/components/NavLink.tsx
+++ b/frontend/src/components/NavLink.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface NavLinkProps {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  isActive: boolean;
+  variant: 'rail' | 'sheet';
+  count?: number | null;
+  onClick?: () => void;
+}
+
+const variantClasses: Record<NavLinkProps['variant'], { base: string; active: string }> = {
+  rail: {
+    base: 'flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm',
+    active: 'bg-surface-2 text-foreground font-medium',
+  },
+  sheet: {
+    base: 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm',
+    active: 'bg-surface-2 text-foreground',
+  },
+};
+
+const inactiveClasses = 'text-muted-foreground hover:bg-surface hover:text-foreground';
+
+export function NavLink({
+  to,
+  label,
+  icon: Icon,
+  isActive,
+  variant,
+  count,
+  onClick,
+}: NavLinkProps) {
+  const { base, active } = variantClasses[variant];
+  return (
+    <Link to={to} onClick={onClick} className={cn(base, isActive ? active : inactiveClasses)}>
+      <Icon className="size-4" />
+      <span className={variant === 'rail' ? 'flex-1' : undefined}>{label}</span>
+      {count != null && count > 0 && (
+        <span className="text-[10px] font-medium tabular-nums text-muted-foreground">{count}</span>
+      )}
+    </Link>
+  );
+}

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router-dom';
+import { logoutUser } from '@/api';
+import { useAuth } from '@/contexts/auth';
+
+export function useLogout() {
+  const navigate = useNavigate();
+  const { setUser } = useAuth();
+
+  return async function handleLogout() {
+    await logoutUser();
+    setUser(null);
+    void navigate('/login', { replace: true });
+  };
+}


### PR DESCRIPTION
## Summary

Closes #831.

`AppShell.tsx` had three near-identical navigation link rendering loops (desktop rail primary, desktop rail secondary, mobile sheet menu) that each independently computed active/inactive styling and rendered a `<Link>` + icon, plus a duplicated `handleLogout` in both `DesktopRail` and `AppShell`.

- Added `frontend/src/components/NavLink.tsx`: wraps `react-router-dom`'s `<Link>` with `isActive`, `icon`, optional `count` (notification badge), and `variant` (`'rail' | 'sheet'`) props; centralizes the active/inactive class strings.
- Added `frontend/src/hooks/useLogout.ts`: encapsulates `logoutUser()` + `setUser(null)` + `navigate('/login', { replace: true })`.
- Replaced all three nav loops in `AppShell.tsx` with `<NavLink>`.
- Removed the duplicate `handleLogout`; both `DesktopRail` and `AppShell` now call `useLogout()`.
- The mobile bottom nav (5-column grid, different vertical icon+label layout) was intentionally left untouched — out of scope per the issue (it's a distinct visual pattern, not one of the three loops called out).

Note: the issue's line-count target (`AppShell.tsx <= 270 lines`, "currently 349") appears to reference an older snapshot of the file — the file was 386 lines on `main` at the time this PR was branched. This change reduces it to 336 lines (-50 lines, -13%).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint -- --max-warnings 0` passes
- [x] Added `frontend/src/__tests__/navLink.test.tsx`: active/inactive class, count badge shown when >0, hidden when 0
- [x] Full frontend suite: `npx vitest run` — 76 files / 779 tests passed (includes `appShellStickyNav.test.ts` and `routing.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)