### PR TITLE
feat: add sent-share history and revoke controls (#784)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -781,6 +781,9 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_mcp_tokens_user ON mcp_tokens(user_id, created_at DESC)",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS analytics_enabled BOOLEAN NOT NULL DEFAULT TRUE",
+    "ALTER TABLE article_shares ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ",
+    "CREATE INDEX IF NOT EXISTS idx_article_shares_sender"
+    " ON article_shares(from_user_id, created_at DESC)",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1351,6 +1351,28 @@ def list_shares(
     }
 
 
+@api.get("/api/shares/sent")
+def list_sent_shares_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import list_sent_shares
+
+    return {"items": list_sent_shares(current_user["id"])}
+
+
+@api.post("/api/shares/{share_id}/revoke")
+def revoke_share_endpoint(
+    share_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    from news_dashboard.shares import revoke_share
+
+    share = revoke_share(share_id, current_user["id"])
+    if share is None:
+        raise HTTPException(status_code=404, detail="Share not found")
+    return share
+
+
 @api.get("/api/shares/unread_count")
 def shares_unread_count(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -73,19 +73,23 @@ def share_article(
 
 
 def list_received_shares(user_id: int, *, limit: int = 100) -> list[dict[str, Any]]:
-    """Return shares received by a user, newest first, with article + sender info."""
+    """Return shares received by a user, newest first, with article + sender info.
+
+    Revoked shares are excluded — a revoked share should not appear in the
+    recipient's inbox or count toward their unread total.
+    """
     with connect() as conn:
         rows = conn.execute(
             """
             SELECT s.id, s.note, s.context_summary, s.created_at, s.read_at,
-                   s.from_user_id, u.username AS from_username,
+                   s.revoked_at, s.from_user_id, u.username AS from_username,
                    a.id AS article_id, a.title AS article_title,
                    a.url AS article_url, a.source_name AS article_source_name,
                    a.summary AS article_summary
             FROM article_shares s
             JOIN users u ON u.id = s.from_user_id
             JOIN articles a ON a.id = s.article_id
-            WHERE s.to_user_id = %s
+            WHERE s.to_user_id = %s AND s.revoked_at IS NULL
             ORDER BY s.created_at DESC
             LIMIT %s
             """,
@@ -98,20 +102,74 @@ def list_received_shares(user_id: int, *, limit: int = 100) -> list[dict[str, An
     return shares
 
 
+def list_sent_shares(user_id: int, *, limit: int = 100) -> list[dict[str, Any]]:
+    """Return shares sent by a user, newest first, with article + recipient info.
+
+    Unlike ``list_received_shares``, revoked shares are included here so the
+    sender retains a full audit trail of what they sent.
+    """
+    with connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT s.id, s.note, s.context_summary, s.created_at, s.read_at,
+                   s.revoked_at, s.to_user_id, u.username AS to_username,
+                   a.id AS article_id, a.title AS article_title,
+                   a.url AS article_url, a.source_name AS article_source_name,
+                   a.summary AS article_summary
+            FROM article_shares s
+            JOIN users u ON u.id = s.to_user_id
+            JOIN articles a ON a.id = s.article_id
+            WHERE s.from_user_id = %s
+            ORDER BY s.created_at DESC
+            LIMIT %s
+            """,
+            (user_id, limit),
+        ).fetchall()
+        shares = [row_to_dict(r) for r in rows]
+    for share in shares:
+        share["annotations"] = list_annotations(int(share["id"]))
+        share["messages"] = list_messages(int(share["id"]))
+    return shares
+
+
+def revoke_share(share_id: int, user_id: int) -> dict[str, Any] | None:
+    """Revoke a share sent by user_id. Idempotent.
+
+    Returns the updated share row, or None if no share with that id is owned
+    by user_id (already-revoked shares are returned unchanged, not re-raised).
+    """
+    with connect() as conn:
+        row = conn.execute(
+            """
+            UPDATE article_shares
+            SET revoked_at = COALESCE(revoked_at, NOW())
+            WHERE id = %s AND from_user_id = %s
+            RETURNING id, revoked_at
+            """,
+            (share_id, user_id),
+        ).fetchone()
+    return row_to_dict(row) if row is not None else None
+
+
 def get_share(share_id: int, user_id: int) -> dict[str, Any] | None:
-    """Return a single share visible to user_id (sender or recipient), with full detail."""
+    """Return a single share visible to user_id (sender or recipient), with full detail.
+
+    A revoked share is only visible to its sender (with a populated
+    ``revoked_at``); the recipient gets None as if the share never existed.
+    """
     with connect() as conn:
         row = conn.execute(
             """
             SELECT s.id, s.note, s.context_summary, s.created_at, s.read_at,
-                   s.from_user_id, u.username AS from_username,
+                   s.revoked_at, s.from_user_id, u.username AS from_username,
                    a.id AS article_id, a.title AS article_title,
                    a.url AS article_url, a.source_name AS article_source_name,
                    a.summary AS article_summary
             FROM article_shares s
             JOIN users u ON u.id = s.from_user_id
             JOIN articles a ON a.id = s.article_id
-            WHERE s.id = %s AND (s.to_user_id = %s OR s.from_user_id = %s)
+            WHERE s.id = %s
+              AND ((s.to_user_id = %s AND s.revoked_at IS NULL) OR s.from_user_id = %s)
             """,
             (share_id, user_id, user_id),
         ).fetchone()
@@ -124,14 +182,19 @@ def get_share(share_id: int, user_id: int) -> dict[str, Any] | None:
 
 
 def get_shared_article(share_id: int, user_id: int) -> dict[str, Any] | None:
-    """Return a share's article when user_id is the sender or recipient."""
+    """Return a share's article when user_id is the sender or recipient.
+
+    A revoked share's article is no longer reachable through the recipient's
+    share access; the sender retains access for their own audit trail.
+    """
     with connect() as conn:
         row = conn.execute(
             """
             SELECT a.*
             FROM article_shares s
             JOIN articles a ON a.id = s.article_id
-            WHERE s.id = %s AND (s.to_user_id = %s OR s.from_user_id = %s)
+            WHERE s.id = %s
+              AND ((s.to_user_id = %s AND s.revoked_at IS NULL) OR s.from_user_id = %s)
             """,
             (share_id, user_id, user_id),
         ).fetchone()
@@ -158,7 +221,7 @@ def mark_share_read(share_id: int, user_id: int) -> bool:
             """
             UPDATE article_shares
             SET read_at = NOW()
-            WHERE id = %s AND to_user_id = %s AND read_at IS NULL
+            WHERE id = %s AND to_user_id = %s AND read_at IS NULL AND revoked_at IS NULL
             """,
             (share_id, user_id),
         )
@@ -166,10 +229,13 @@ def mark_share_read(share_id: int, user_id: int) -> bool:
 
 
 def unread_share_count(user_id: int) -> int:
-    """Return the number of unread shares for a user."""
+    """Return the number of unread, non-revoked shares for a user."""
     with connect() as conn:
         row = conn.execute(
-            "SELECT COUNT(*) AS n FROM article_shares WHERE to_user_id = %s AND read_at IS NULL",
+            """
+            SELECT COUNT(*) AS n FROM article_shares
+            WHERE to_user_id = %s AND read_at IS NULL AND revoked_at IS NULL
+            """,
             (user_id,),
         ).fetchone()
         return int(row_to_dict(row)["n"])

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -23,7 +23,9 @@ from news_dashboard.shares import (
     list_annotations,
     list_messages,
     list_received_shares,
+    list_sent_shares,
     mark_share_read,
+    revoke_share,
     share_article,
     shareable_users,
     unread_share_count,
@@ -354,6 +356,158 @@ def test_get_share_returns_none_for_unauthorized(db: str) -> None:
     share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
 
     assert get_share(int(share["id"]), charlie) is None
+
+
+# ── Sent shares & revoke tests (#784) ──────────────────────────────────────────
+
+
+def test_list_sent_shares(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share_article(article_id=article_id, from_user_id=alice, to_user_id=bob, note="check this")
+
+    sent = list_sent_shares(alice)
+    assert len(sent) == 1
+    assert sent[0]["to_username"] == "bob"
+    assert sent[0]["article_title"] == "Article 1"
+    assert sent[0]["note"] == "check this"
+    assert sent[0]["revoked_at"] is None
+    # Recipient has nothing in their own sent history.
+    assert list_sent_shares(bob) == []
+
+
+def test_revoke_share_by_owner(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    result = revoke_share(share_id, alice)
+    assert result is not None
+    assert result["revoked_at"] is not None
+
+    # Revoked shares still show up in sender history, marked revoked.
+    sent = list_sent_shares(alice)
+    assert sent[0]["revoked_at"] is not None
+
+
+def test_revoke_share_rejects_non_owner(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    charlie = _make_user(db, "charlie")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    # Neither the recipient nor an unrelated user can revoke.
+    assert revoke_share(share_id, bob) is None
+    assert revoke_share(share_id, charlie) is None
+
+
+def test_revoke_share_is_idempotent(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    first = revoke_share(share_id, alice)
+    second = revoke_share(share_id, alice)
+    assert first is not None
+    assert second is not None
+    assert first["revoked_at"] == second["revoked_at"]
+
+
+def test_revoked_share_disappears_from_recipient_inbox_and_unread_count(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+
+    assert unread_share_count(bob) == 1
+    revoke_share(share_id, alice)
+
+    assert list_received_shares(bob) == []
+    assert unread_share_count(bob) == 0
+
+
+def test_revoked_share_returns_404_for_recipient_detail_and_article(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+    revoke_share(share_id, alice)
+
+    assert get_share(share_id, bob) is None
+    assert get_shared_article(share_id, bob) is None
+    assert fetch_shared_article_body(share_id, bob) is None
+
+    # Sender still has full access to their revoked share.
+    sender_detail = get_share(share_id, alice)
+    assert sender_detail is not None
+    assert sender_detail["revoked_at"] is not None
+    assert get_shared_article(share_id, alice) is not None
+
+
+def test_mark_share_read_rejects_revoked_share(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    share_id = int(share["id"])
+    revoke_share(share_id, alice)
+
+    assert mark_share_read(share_id, bob) is False
+
+
+def test_sent_shares_endpoint(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    client = _authed_client(alice)
+
+    try:
+        response = client.get("/api/shares/sent")
+        assert response.status_code == 200
+        items = response.json()["items"]
+        assert len(items) == 1
+        assert items[0]["to_username"] == "bob"
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def test_revoke_share_endpoint(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    client = _authed_client(alice)
+
+    try:
+        response = client.post(f"/api/shares/{share['id']}/revoke")
+        assert response.status_code == 200
+        assert response.json()["revoked_at"] is not None
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def test_revoke_share_endpoint_rejects_non_owner(db: str) -> None:
+    alice = _make_user(db, "alice")
+    bob = _make_user(db, "bob")
+    article_id = _insert_article(db)
+    share = share_article(article_id=article_id, from_user_id=alice, to_user_id=bob)
+    client = _authed_client(bob)
+
+    try:
+        response = client.post(f"/api/shares/{share['id']}/revoke")
+        assert response.status_code == 404
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
 
 
 # ── AI context generation tests ───────────────────────────────────────────────

--- a/docs/user-guide/sharing.md
+++ b/docs/user-guide/sharing.md
@@ -1,112 +1,86 @@
 # Sharing articles
 
 Share interesting articles with other users on your News Dashboard instance
-using the built-in **Sharing** feature. This lets you send a link to an
-article that, when opened by the recipient, shows the article in their own
-interface with their own triage state.
+using the built-in **Sharing** feature. Sharing is authenticated and
+in-app: you pick a recipient by username, and the article shows up directly
+in their **Shared** inbox — there's no public link or token involved.
 
 ## How sharing works
 
 When you share an article:
-1. The system generates a **single-use, time-limited token** for that article
-2. It creates a share record linking you (the sender), the recipient, and the
-   article
-3. You give the recipient a URL like: `https://your-instance.com/article/123?share=abc123`
-4. When the recipient opens that link:
-   - The app validates the token (ensures it's unused and not expired)
-   - The article loads in their interface
-   - They can read, triage, star, etc. — just like any other article
-   - Their actions are recorded under their own user account
-   - The share token is marked as used and cannot be reused
+1. The system creates a share record linking you (the sender), the
+   recipient, and the article
+2. The recipient sees it appear in their **Shared → Received** tab
+3. The recipient can read the article, leave messages back and forth with
+   you, and see any highlights you attached to the share
+4. You can revoke the share at any time from your **Shared → Sent** tab
 
-Sharing is **not** forwarding the article text or URL — it's granting access
-to the article within the app, respecting permissions and personal state.
+Sharing is **not** forwarding the article text or URL — it grants the
+recipient access to the article within the app, scoped to that specific
+share (this matters for private-source articles the recipient wouldn't
+otherwise be able to see).
 
 ## Sharing from the article view
 
 To share an article you're viewing:
 
-1. Open the article (tap/click on it in any feed)
-2. In the article header, tap the **Share** icon (usually three dots connected
-   by lines, or a paper airplane)
+1. Open the article
+2. Use the **Share** action in the article view
 3. In the share dialog:
-   - Enter the recipient's username (must exist on your instance)
+   - Pick the recipient from the list of other users on your instance
    - Optionally add a note explaining why you're sharing
-   - Tap "Send share"
-4. The recipient receives a notification (in-app bell, and optionally email
-   or push if configured) with your note and a link to accept the share
-
-## Sharing from feeds
-
-You can also share directly from any article list (Today Feed, Saved, etc.):
-
-1. Hover over or long-press an article card
-2. Look for the **Share** action in the article menu
-3. Follow the same steps as above
+   - Send the share
+4. The recipient gets a push notification (if enabled) and sees the share in
+   their **Shared** inbox
 
 ## Receiving shares
 
 When someone shares an article with you:
-- You'll see a notification in the app (bell icon in the header)
-- Optionally, you may receive an email or push notification (if enabled)
-- The notification shows:
-  - Who shared it
-  - Their note (if any)
-  - The article title and source
-- Tap the notification to go straight to the article
-- Alternatively, visit the **Shares** tab (in your user menu) to see all
-  incoming and outgoing shares
+- It appears under **Shared → Received**, with an unread indicator until you
+  open it
+- You'll see who shared it, their note (if any), any highlighted passages,
+  and an AI-generated note on why it's relevant to you
+- Opening the share view marks it read and clears the unread badge
+- You can reply in the share's message thread — this is a two-way
+  conversation between you and the sender, not a public comment section
 
-## What the recipient sees
+## Sent shares and revoking
 
-When the recipient opens the shared article:
-- The article loads normally (title, summary, body, metadata)
-- They see any tags you've applied (tags are visible to all users)
-- They do **not** see:
-  - Your personal triage state (your Done/Skip/Star/etc.)
-  - Your personal notes (if notes feature is enabled)
-  - Your read/save timestamps
-- They interact with the article as if they discovered it themselves:
-  - Their triage actions are recorded under their username
-  - They can star, save, skip, or mark as done
-  - Their own tags can be added (separate from yours)
-
-## Share expiration and limits
-
-Shares are designed to be private and temporary:
-- **Single-use**: once the recipient opens the link, it cannot be reused
-- **Time-limited**: shares expire after 7 days if not opened
-- **Revokable**: you can delete a sent share from the Shares tab before it's
-  opened
-- **Auditable**: both sender and recipient can see the share in their
-  Shares history (who, when, article, note)
+Under **Shared → Sent**, you can see every article you've sent to other
+users:
+- Recipient username, when it was sent, and whether they've read it yet
+- **Revoke** removes the recipient's access — a revoked share disappears
+  from their received list and no longer counts toward their unread total,
+  and they can no longer open the shared article or its detail view
+- Revoking does not delete the record: it still appears in your own Sent
+  history, marked **Revoked**, so you keep a full audit trail of what you
+  sent
 
 ## Privacy
 
 Sharing respects the app's privacy model:
 - No article content leaves your server
-- No personal notes or private state are shared
-- The recipient cannot see your tags unless the tags feature is enabled for
-  all users (tags are always visible if the feature is on)
-- Share tokens are cryptographically random and unguessable
-- Expired shares are automatically cleaned up by a daily job
+- The recipient does not see your personal triage state, notes, or reading
+  history — only the article, your note, and anything you explicitly
+  highlighted for that share
+- Access to a shared article is scoped to the share itself: it doesn't
+  change what the recipient can see anywhere else in the app, and revoking
+  the share removes that access
 
 ## Requirements
 
 Sharing requires:
-- A working instance (single-user or multi-user)
-- Recipient must have an account on the same instance
+- A multi-user instance with at least one other account to share with
 - No additional configuration needed — sharing is enabled by default
 
 ## Troubleshooting
 
 If sharing doesn't work:
-- **"Invalid or expired share"**: the link was already used or too old; ask
-  the sender to resend
-- **"User not found"**: double-check the recipient's username
-- **"Sharing not available"**: contact your admin — on private instances,
-  sharing can be disabled site-wide (though this is not the default)
-- No notifications?: check your notification settings (bell icon → Settings)
+- **"Recipient user not found"**: the recipient's account may have been
+  removed; refresh the recipient list and try again
+- **A shared article returns "not found"**: the sender may have revoked the
+  share, or you're not the sender or recipient of that share
+- No push notifications?: check your notification settings (bell icon →
+  Settings)
 
-Sharing works the same whether you're on desktop, tablet or mobile — the share dialog
-and notifications adapt to the screen size.
+Sharing works the same whether you're on desktop, tablet, or mobile.

--- a/frontend/src/__tests__/shared.test.tsx
+++ b/frontend/src/__tests__/shared.test.tsx
@@ -8,6 +8,8 @@ import type { ReactElement } from 'react';
 // ── API mock ─────────────────────────────────────────────────────────────────
 const apiMock = vi.hoisted(() => ({
   fetchReceivedShares: vi.fn(),
+  fetchSentShares: vi.fn(),
+  revokeShare: vi.fn(),
   markShareRead: vi.fn(),
   fetchShareDetail: vi.fn(),
   fetchShareMessages: vi.fn(),
@@ -35,6 +37,7 @@ function makeShare(overrides = {}) {
     context_summary: null,
     created_at: new Date(Date.now() - 60_000).toISOString(),
     read_at: null,
+    revoked_at: null,
     from_user_id: 2,
     from_username: 'bob',
     article_id: 99,
@@ -44,6 +47,25 @@ function makeShare(overrides = {}) {
     article_summary: null,
     annotations: [],
     messages: [],
+    ...overrides,
+  };
+}
+
+function makeSentShare(overrides = {}) {
+  return {
+    id: 43,
+    note: 'Check this out',
+    context_summary: null,
+    created_at: new Date(Date.now() - 60_000).toISOString(),
+    read_at: null,
+    revoked_at: null,
+    to_user_id: 3,
+    to_username: 'charlie',
+    article_id: 100,
+    article_title: 'Rust vs Go in 2026',
+    article_url: 'https://example.com/rust-go',
+    article_source_name: 'Tech Blog',
+    article_summary: null,
     ...overrides,
   };
 }
@@ -66,6 +88,8 @@ function renderWithRouter(ui: ReactElement, { path = '/', route = '/' } = {}) {
 describe('SharedPage', () => {
   beforeEach(() => {
     apiMock.markShareRead.mockResolvedValue(true);
+    apiMock.fetchSentShares.mockResolvedValue({ items: [] });
+    apiMock.revokeShare.mockResolvedValue(undefined);
   });
 
   it('shows empty state when no shares', async () => {
@@ -92,6 +116,46 @@ describe('SharedPage', () => {
     await waitFor(() => expect(screen.getByText('The Future of TypeScript')).toBeTruthy());
     const original = screen.getByRole('link', { name: /Original/ });
     expect(original.getAttribute('href')).toBe('https://example.com/ts');
+  });
+
+  it('switches to the Sent tab and shows sent shares', async () => {
+    apiMock.fetchReceivedShares.mockResolvedValue({ items: [] });
+    apiMock.fetchSentShares.mockResolvedValue({ items: [makeSentShare()] });
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+    await waitFor(() => expect(screen.getByText('Nothing shared yet')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sent' }));
+
+    await waitFor(() => expect(screen.getByText('Rust vs Go in 2026')).toBeTruthy());
+    expect(screen.getByText('charlie')).toBeTruthy();
+  });
+
+  it('revokes a sent share', async () => {
+    apiMock.fetchReceivedShares.mockResolvedValue({ items: [] });
+    apiMock.fetchSentShares.mockResolvedValue({ items: [makeSentShare()] });
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+    await waitFor(() => expect(screen.getByText('Nothing shared yet')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sent' }));
+    await waitFor(() => expect(screen.getByText('Rust vs Go in 2026')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: /Revoke/ }));
+    await waitFor(() => expect(apiMock.revokeShare).toHaveBeenCalledWith(43));
+  });
+
+  it('shows a revoked badge and hides the revoke action for revoked sent shares', async () => {
+    apiMock.fetchReceivedShares.mockResolvedValue({ items: [] });
+    apiMock.fetchSentShares.mockResolvedValue({
+      items: [makeSentShare({ revoked_at: new Date().toISOString() })],
+    });
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+    await waitFor(() => expect(screen.getByText('Nothing shared yet')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sent' }));
+    await waitFor(() => expect(screen.getByText('Rust vs Go in 2026')).toBeTruthy());
+
+    expect(screen.getByText('Revoked')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Revoke/ })).toBeNull();
   });
 });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,6 +39,7 @@ import type {
   ReadingStreak,
   RecommendationPreferences,
   ReceivedShare,
+  SentShare,
   ShareDetail,
   ShareAnnotation,
   ShareMessage,
@@ -795,6 +796,14 @@ export async function fetchReceivedShares(): Promise<{
 export async function fetchSharesUnreadCount(): Promise<number> {
   const data = await requestJson<{ unread: number }>('/api/shares/unread_count');
   return data.unread;
+}
+
+export async function fetchSentShares(): Promise<{ items: SentShare[] }> {
+  return requestJson('/api/shares/sent');
+}
+
+export async function revokeShare(shareId: number): Promise<void> {
+  await requestJson(`/api/shares/${shareId}/revoke`, { method: 'POST' });
 }
 
 // ── Reading Goals & Quizzes ───────────────────────────────────────────────────

--- a/frontend/src/pages/SharedPage.tsx
+++ b/frontend/src/pages/SharedPage.tsx
@@ -1,15 +1,19 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Send, ExternalLink } from 'lucide-react';
+import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
+import { Send, ExternalLink, Ban } from 'lucide-react';
 import { EmptyState } from '@/components/EmptyState';
-import { fetchReceivedShares, markShareRead } from '@/api';
+import { fetchReceivedShares, fetchSentShares, markShareRead, revokeShare } from '@/api';
 import { relativeTime } from '@/lib/format';
 import { cn } from '@/lib/utils';
+import type { ReceivedShare, SentShare } from '@/types';
 
 const SHARES_KEY = ['shares'];
+const SENT_SHARES_KEY = ['shares-sent'];
 
-export function SharedPage() {
+type Tab = 'received' | 'sent';
+
+function ReceivedTab() {
   const queryClient = useQueryClient();
   const { data, isLoading } = useQuery({
     queryKey: SHARES_KEY,
@@ -17,7 +21,7 @@ export function SharedPage() {
     staleTime: 15_000,
   });
 
-  const shares = data?.items ?? [];
+  const shares: ReceivedShare[] = data?.items ?? [];
 
   // Opening the page clears the unread badge: mark every unread share as read
   // once, then refresh the badge query other surfaces rely on.
@@ -36,68 +40,191 @@ export function SharedPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shares.map((s) => (s.read_at ? '' : s.id)).join(',')]);
 
+  if (!isLoading && shares.length === 0) {
+    return (
+      <EmptyState
+        icon={Send}
+        title="Nothing shared yet"
+        subtitle="When someone sends you an article, it shows up here."
+      />
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {shares.map((s) => (
+        <li
+          key={s.id}
+          className={cn('rounded-lg border border-border p-3', !s.read_at && 'bg-surface')}
+        >
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {!s.read_at && (
+              <span className="size-2 shrink-0 rounded-full bg-signal-high" aria-hidden />
+            )}
+            <span className="font-medium text-foreground">{s.from_username}</span>
+            <span>shared · {relativeTime(s.created_at)}</span>
+          </div>
+
+          <Link
+            to={`/shared/${s.id}`}
+            className="mt-1 block font-medium text-foreground hover:underline"
+          >
+            {s.article_title}
+          </Link>
+          <div className="mt-0.5 text-xs text-muted-foreground">{s.article_source_name}</div>
+
+          {s.note ? (
+            <div className="mt-2 rounded-md bg-surface-2 px-2.5 py-1.5 text-sm text-foreground">
+              "{s.note}"
+            </div>
+          ) : null}
+
+          <div className="mt-2 flex items-center gap-3 text-xs">
+            <Link to={`/shared/${s.id}`} className="text-accent-foreground hover:underline">
+              View
+            </Link>
+            <a
+              href={s.article_url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+            >
+              Original <ExternalLink className="size-3" />
+            </a>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function SentTab() {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: SENT_SHARES_KEY,
+    queryFn: fetchSentShares,
+    staleTime: 15_000,
+  });
+
+  const shares: SentShare[] = data?.items ?? [];
+
+  const revokeMutation = useMutation({
+    mutationFn: (shareId: number) => revokeShare(shareId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: SENT_SHARES_KEY });
+    },
+  });
+
+  if (!isLoading && shares.length === 0) {
+    return (
+      <EmptyState
+        icon={Send}
+        title="Nothing sent yet"
+        subtitle="Articles you share with other people show up here."
+      />
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {shares.map((s) => {
+        const revoked = Boolean(s.revoked_at);
+        return (
+          <li
+            key={s.id}
+            className={cn('rounded-lg border border-border p-3', revoked && 'opacity-60')}
+          >
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>
+                To <span className="font-medium text-foreground">{s.to_username}</span>
+              </span>
+              <span>· {relativeTime(s.created_at)}</span>
+              {revoked ? (
+                <span className="rounded-full bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+                  Revoked
+                </span>
+              ) : s.read_at ? (
+                <span className="text-[10px] uppercase text-muted-foreground">Read</span>
+              ) : (
+                <span className="text-[10px] uppercase text-muted-foreground">Unread</span>
+              )}
+            </div>
+
+            <div className="mt-1 block font-medium text-foreground">{s.article_title}</div>
+            <div className="mt-0.5 text-xs text-muted-foreground">{s.article_source_name}</div>
+
+            {s.note ? (
+              <div className="mt-2 rounded-md bg-surface-2 px-2.5 py-1.5 text-sm text-foreground">
+                "{s.note}"
+              </div>
+            ) : null}
+
+            <div className="mt-2 flex items-center gap-3 text-xs">
+              <a
+                href={s.article_url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+              >
+                Original <ExternalLink className="size-3" />
+              </a>
+              {!revoked ? (
+                <button
+                  type="button"
+                  onClick={() => revokeMutation.mutate(s.id)}
+                  disabled={revokeMutation.isPending}
+                  className="inline-flex items-center gap-1 text-destructive hover:underline disabled:opacity-50"
+                >
+                  <Ban className="size-3" />
+                  Revoke
+                </button>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function SharedPage() {
+  const [tab, setTab] = useState<Tab>('received');
+
   return (
     <div className="mx-auto max-w-2xl px-4 py-6">
       <div className="mb-4">
-        <h1 className="text-lg font-semibold text-foreground">Shared with me</h1>
-        <p className="text-sm text-muted-foreground">
-          {isLoading ? '…' : `${shares.length} article${shares.length === 1 ? '' : 's'}`} sent to
-          you by other people
-        </p>
+        <h1 className="text-lg font-semibold text-foreground">Shared</h1>
+        <p className="text-sm text-muted-foreground">Articles you've sent and received</p>
       </div>
 
-      {!isLoading && shares.length === 0 ? (
-        <EmptyState
-          icon={Send}
-          title="Nothing shared yet"
-          subtitle="When someone sends you an article, it shows up here."
-        />
-      ) : (
-        <ul className="flex flex-col gap-2">
-          {shares.map((s) => (
-            <li
-              key={s.id}
-              className={cn('rounded-lg border border-border p-3', !s.read_at && 'bg-surface')}
-            >
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                {!s.read_at && (
-                  <span className="size-2 shrink-0 rounded-full bg-signal-high" aria-hidden />
-                )}
-                <span className="font-medium text-foreground">{s.from_username}</span>
-                <span>shared · {relativeTime(s.created_at)}</span>
-              </div>
+      <div className="mb-4 flex items-center gap-1 border-b border-border text-sm">
+        <button
+          type="button"
+          onClick={() => setTab('received')}
+          className={cn(
+            'px-3 py-2 font-medium transition-colors',
+            tab === 'received'
+              ? 'border-b-2 border-accent-foreground text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          Received
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('sent')}
+          className={cn(
+            'px-3 py-2 font-medium transition-colors',
+            tab === 'sent'
+              ? 'border-b-2 border-accent-foreground text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          Sent
+        </button>
+      </div>
 
-              <Link
-                to={`/shared/${s.id}`}
-                className="mt-1 block font-medium text-foreground hover:underline"
-              >
-                {s.article_title}
-              </Link>
-              <div className="mt-0.5 text-xs text-muted-foreground">{s.article_source_name}</div>
-
-              {s.note ? (
-                <div className="mt-2 rounded-md bg-surface-2 px-2.5 py-1.5 text-sm text-foreground">
-                  "{s.note}"
-                </div>
-              ) : null}
-
-              <div className="mt-2 flex items-center gap-3 text-xs">
-                <Link to={`/shared/${s.id}`} className="text-accent-foreground hover:underline">
-                  View
-                </Link>
-                <a
-                  href={s.article_url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
-                >
-                  Original <ExternalLink className="size-3" />
-                </a>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
+      {tab === 'received' ? <ReceivedTab /> : <SentTab />}
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -66,8 +66,25 @@ export interface ReceivedShare {
   context_summary?: string | null;
   created_at: string;
   read_at?: string | null;
+  revoked_at?: string | null;
   from_user_id: number;
   from_username: string;
+  article_id: number;
+  article_title: string;
+  article_url: string;
+  article_source_name: string;
+  article_summary?: string | null;
+}
+
+export interface SentShare {
+  id: number;
+  note?: string | null;
+  context_summary?: string | null;
+  created_at: string;
+  read_at?: string | null;
+  revoked_at?: string | null;
+  to_user_id: number;
+  to_username: string;
   article_id: number;
   article_title: string;
   article_url: string;


### PR DESCRIPTION
## Summary

Closes #784.

- Adds `GET /api/shares/sent`, returning shares sent by the current user (recipient username, article metadata, created/read/revoked timestamps, note, annotations, messages) — including revoked shares, so the sender keeps a full audit trail.
- Adds `POST /api/shares/{share_id}/revoke`, idempotent and restricted to the share's sender (404 for anyone else, including the recipient).
- Revoked shares are excluded from the recipient's `list_received_shares` and `unread_share_count`, and `get_share` / `get_shared_article` / `fetch_shared_article_body` return `None` (→ 404) for the recipient once revoked. The sender retains full access with `revoked_at` populated.
- `article_shares` gains a `revoked_at TIMESTAMPTZ` column plus an index on `(from_user_id, created_at DESC)` for the new sent-shares query.
- Frontend: `SharedPage` now has **Received** / **Sent** tabs; the Sent tab shows read/unread/revoked status and a Revoke action (hidden once already revoked).
- Rewrote `docs/user-guide/sharing.md` to describe the actual authenticated in-app share model (it previously described single-use public tokens that were never implemented).

## Test plan

- [x] Backend: `pytest backend/tests/test_article_shares.py` — 34 passed (new tests cover sent-share listing, revoke ownership/idempotency, revoked-share visibility for recipient vs sender, unread-count/read-endpoint behavior, and the two new API endpoints)
- [x] Backend: `pytest -k share` across the suite — 47 passed
- [x] Frontend: `vitest run src/__tests__/shared.test.tsx` — 12 passed (new tests for the Sent tab, revoke action, and revoked badge)
- [x] Frontend: full `vitest run` — 787 passed
- [x] `ruff`, `mypy`, `tsc --noEmit`, `eslint` all clean on touched files (also verified via pre-commit hooks on the commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)