### PR TITLE
fix: cap AI fallback body-fetch downloads (#785)

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -27,11 +27,43 @@ from news_dashboard.url_safety import (
 logger = logging.getLogger(__name__)
 
 _AI_HTML_LIMIT = 15_000
+# Raw bytes downloaded from the network before decoding, well above _AI_HTML_LIMIT
+# to tolerate multi-byte charsets while still bounding worst-case memory/network use.
+_AI_FETCH_BYTE_CAP = 200_000
 _AI_MODEL = "gpt-4o-mini"
 _AI_PROMPT = (
     "Extract the main article text from this HTML. "
     "Return only the article body as plain text, no HTML tags."
 )
+
+
+def _fetch_capped_html(url: str, *, byte_cap: int) -> str:
+    """Stream ``url`` and decode at most ``byte_cap`` bytes of the response body.
+
+    Stops reading as soon as the cap is reached instead of downloading the
+    full response before truncating, so a large HTML page can't be pulled
+    entirely into memory just to be sliced down afterward.
+    """
+    import httpx  # lazy import — optional at module load time
+
+    chunks: list[bytes] = []
+    total = 0
+    with httpx.stream(
+        "GET",
+        url,
+        timeout=15,
+        headers={"User-Agent": USER_AGENT},
+        follow_redirects=False,
+    ) as resp:
+        resp.raise_for_status()
+        encoding = resp.encoding or "utf-8"
+        for chunk in resp.iter_bytes():
+            chunks.append(chunk)
+            total += len(chunk)
+            if total >= byte_cap:
+                break
+    raw = b"".join(chunks)[:byte_cap]
+    return raw.decode(encoding, errors="replace")
 
 
 def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]:
@@ -50,15 +82,7 @@ def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]
 
     try:
         validate_server_fetch_url(url)
-        import httpx  # lazy import — optional at module load time
-
-        resp = httpx.get(
-            url,
-            timeout=15,
-            headers={"User-Agent": USER_AGENT},
-            follow_redirects=False,
-        )
-        html = resp.text[:_AI_HTML_LIMIT]
+        html = _fetch_capped_html(url, byte_cap=_AI_FETCH_BYTE_CAP)[:_AI_HTML_LIMIT]
     except UnsafeUrlError as exc:
         logger.warning("ai_body_fetch: unsafe URL %r: %s", url, exc)
         return "", "error"

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import http.server
 import threading
 import urllib.request
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -444,6 +444,42 @@ def test_prefetch_article_bodies_skips_already_ok(tmp_path: Path) -> None:
 # ── _ai_extract_body ──────────────────────────────────────────────────────────
 
 
+class _FakeStreamResponse:
+    """Minimal stand-in for the ``httpx.stream(...)`` context manager."""
+
+    def __init__(
+        self,
+        text: str,
+        *,
+        status_code: int = 200,
+        encoding: str = "utf-8",
+        chunk_size: int = 65_536,
+        on_chunk: Callable[[], None] | None = None,
+    ) -> None:
+        self._data = text.encode(encoding)
+        self.status_code = status_code
+        self.encoding = encoding
+        self._chunk_size = chunk_size
+        self._on_chunk = on_chunk
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            msg = f"HTTP {self.status_code}"
+            raise RuntimeError(msg)
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        for i in range(0, len(self._data), self._chunk_size):
+            if self._on_chunk is not None:
+                self._on_chunk()
+            yield self._data[i : i + self._chunk_size]
+
+    def __enter__(self) -> _FakeStreamResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
 def test_ai_extract_body_skipped_without_api_key(tmp_path: Path) -> None:
     from news_dashboard.body_fetch import _ai_extract_body
 
@@ -482,13 +518,13 @@ def test_ai_extract_body_rejects_private_network_url_before_fetch() -> None:
 
     called = False
 
-    def fake_get(*_: object, **__: object) -> None:
+    def fake_stream(*_: object, **__: object) -> None:
         nonlocal called
         called = True
 
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
-        patch("httpx.get", side_effect=fake_get),
+        patch("httpx.stream", side_effect=fake_stream),
     ):
         body, status = _ai_extract_body("http://169.254.169.254/latest/meta-data")
 
@@ -502,8 +538,7 @@ def test_ai_extract_body_calls_openai_on_html(tmp_path: Path) -> None:
 
     from news_dashboard.body_fetch import _ai_extract_body
 
-    mock_resp = MagicMock()
-    mock_resp.text = "<html><body>Hello world</body></html>"
+    fake_stream = _FakeStreamResponse("<html><body>Hello world</body></html>")
 
     mock_completion = MagicMock()
     mock_completion.choices[0].message.content = "Hello world"
@@ -512,7 +547,7 @@ def test_ai_extract_body_calls_openai_on_html(tmp_path: Path) -> None:
 
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
-        patch("httpx.get", return_value=mock_resp),
+        patch("httpx.stream", return_value=fake_stream),
         patch("openai.OpenAI", return_value=mock_client),
     ):
         body, status = _ai_extract_body("https://example.com/article")
@@ -527,9 +562,24 @@ def test_ai_extract_body_returns_error_on_http_failure(tmp_path: Path) -> None:
 
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
-        patch("httpx.get", side_effect=RuntimeError("connection refused")),
+        patch("httpx.stream", side_effect=RuntimeError("connection refused")),
     ):
         body, status = _ai_extract_body("https://example.com/article")
+
+    assert status == "error"
+    assert body == ""
+
+
+def test_ai_extract_body_returns_error_on_non_2xx_status(tmp_path: Path) -> None:
+    from news_dashboard.body_fetch import _ai_extract_body
+
+    fake_stream = _FakeStreamResponse("<html>not found</html>", status_code=404)
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("httpx.stream", return_value=fake_stream),
+    ):
+        body, status = _ai_extract_body("https://example.com/missing")
 
     assert status == "error"
     assert body == ""
@@ -540,8 +590,7 @@ def test_ai_extract_body_returns_error_when_openai_returns_empty(tmp_path: Path)
 
     from news_dashboard.body_fetch import _ai_extract_body
 
-    mock_resp = MagicMock()
-    mock_resp.text = "<html><body>some html</body></html>"
+    fake_stream = _FakeStreamResponse("<html><body>some html</body></html>")
 
     mock_completion = MagicMock()
     mock_completion.choices[0].message.content = "   "
@@ -550,7 +599,7 @@ def test_ai_extract_body_returns_error_when_openai_returns_empty(tmp_path: Path)
 
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
-        patch("httpx.get", return_value=mock_resp),
+        patch("httpx.stream", return_value=fake_stream),
         patch("openai.OpenAI", return_value=mock_client),
     ):
         body, status = _ai_extract_body("https://example.com/article")
@@ -566,8 +615,7 @@ def test_ai_extract_body_truncates_html_to_limit(tmp_path: Path) -> None:
 
     # 'A' * limit + 'B' * limit — 'B' must never appear in the OpenAI call
     long_html = "A" * _AI_HTML_LIMIT + "B" * _AI_HTML_LIMIT
-    mock_resp = MagicMock()
-    mock_resp.text = long_html
+    fake_stream = _FakeStreamResponse(long_html)
 
     mock_completion = MagicMock()
     mock_completion.choices[0].message.content = "extracted"
@@ -576,7 +624,7 @@ def test_ai_extract_body_truncates_html_to_limit(tmp_path: Path) -> None:
 
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
-        patch("httpx.get", return_value=mock_resp),
+        patch("httpx.stream", return_value=fake_stream),
         patch("openai.OpenAI", return_value=mock_client),
     ):
         _ai_extract_body("https://example.com/article")
@@ -594,6 +642,27 @@ def test_ai_extract_body_truncates_html_to_limit(tmp_path: Path) -> None:
     assert "A" * 10 in prompt_msg
     # Exact length: prompt + '\n\n' + truncated html
     assert len(prompt_msg) == len(_AI_PROMPT) + 2 + _AI_HTML_LIMIT
+
+
+def test_ai_extract_body_stops_streaming_once_byte_cap_reached() -> None:
+    """A response far larger than the byte cap must not be fully consumed."""
+    from news_dashboard.body_fetch import _AI_FETCH_BYTE_CAP, _fetch_capped_html
+
+    huge_html = "X" * (_AI_FETCH_BYTE_CAP * 10)
+    consumed_chunks = 0
+
+    def count_chunk() -> None:
+        nonlocal consumed_chunks
+        consumed_chunks += 1
+
+    fake_stream = _FakeStreamResponse(huge_html, chunk_size=4096, on_chunk=count_chunk)
+
+    with patch("httpx.stream", return_value=fake_stream):
+        text = _fetch_capped_html("https://example.com/huge", byte_cap=_AI_FETCH_BYTE_CAP)
+
+    assert len(text) == _AI_FETCH_BYTE_CAP
+    # Only enough chunks to cross the cap should have been pulled, not all of them.
+    assert consumed_chunks < len(huge_html) // 4096
 
 
 # ── fetch_and_cache_body with AI fallback ─────────────────────────────────────

--- a/backend/tests/test_user_attribution.py
+++ b/backend/tests/test_user_attribution.py
@@ -215,14 +215,14 @@ def test_ai_extract_body_threads_user_id_to_chat_create() -> None:
     from news_dashboard.body_fetch import _ai_extract_body
 
     mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
-    mock_http_response = MagicMock()
-    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
-
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
         patch("news_dashboard.ai_client.get_openai_client"),
         patch("news_dashboard.ai_client.chat_create", new=mock_cc),
-        patch("httpx.get", return_value=mock_http_response),
+        patch(
+            "news_dashboard.body_fetch._fetch_capped_html",
+            return_value="<html><body><p>article content here</p></body></html>",
+        ),
     ):
         _ai_extract_body("https://example.com/article", user_id=55)
 
@@ -233,14 +233,14 @@ def test_ai_extract_body_passes_none_user_id_by_default() -> None:
     from news_dashboard.body_fetch import _ai_extract_body
 
     mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
-    mock_http_response = MagicMock()
-    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
-
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
         patch("news_dashboard.ai_client.get_openai_client"),
         patch("news_dashboard.ai_client.chat_create", new=mock_cc),
-        patch("httpx.get", return_value=mock_http_response),
+        patch(
+            "news_dashboard.body_fetch._fetch_capped_html",
+            return_value="<html><body><p>article content here</p></body></html>",
+        ),
     ):
         _ai_extract_body("https://example.com/article")
 
@@ -251,9 +251,6 @@ def test_ai_extract_body_uses_free_llm_gateway_config() -> None:
     from news_dashboard.body_fetch import _ai_extract_body
 
     mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
-    mock_http_response = MagicMock()
-    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
-
     with (
         patch.dict(
             "os.environ",
@@ -265,7 +262,10 @@ def test_ai_extract_body_uses_free_llm_gateway_config() -> None:
         ),
         patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
         patch("news_dashboard.ai_client.chat_create", new=mock_cc),
-        patch("httpx.get", return_value=mock_http_response),
+        patch(
+            "news_dashboard.body_fetch._fetch_capped_html",
+            return_value="<html><body><p>article content here</p></body></html>",
+        ),
     ):
         _ai_extract_body("https://example.com/article")
 
@@ -279,14 +279,14 @@ def test_ai_extract_body_falls_back_to_openai_when_gateway_unset() -> None:
     from news_dashboard.body_fetch import _ai_extract_body
 
     mock_cc = MagicMock(return_value=_mock_completion("Article body text."))
-    mock_http_response = MagicMock()
-    mock_http_response.text = "<html><body><p>article content here</p></body></html>"
-
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-openai"}, clear=True),
         patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
         patch("news_dashboard.ai_client.chat_create", new=mock_cc),
-        patch("httpx.get", return_value=mock_http_response),
+        patch(
+            "news_dashboard.body_fetch._fetch_capped_html",
+            return_value="<html><body><p>article content here</p></body></html>",
+        ),
     ):
         _ai_extract_body("https://example.com/article")
 


### PR DESCRIPTION
## Summary
- Fixes #785
- `_ai_extract_body()` in `backend/news_dashboard/body_fetch.py` previously called `httpx.get(...).text[:_AI_HTML_LIMIT]`, which fully downloads and decodes the response before truncating — a large HTML page from a subscribed feed or private source could be pulled entirely into memory just to be sliced down for the AI prompt.
- Added `_fetch_capped_html()`, which streams the response via `httpx.stream(...)` and stops reading chunks once a byte cap (`_AI_FETCH_BYTE_CAP = 200_000`, well above `_AI_HTML_LIMIT = 15_000` to tolerate multi-byte charsets) is reached, decoding only the capped buffer.
- `resp.raise_for_status()` is called inside the stream so non-2xx responses degrade to `("", "error")` the same as network failures, with no user-visible crash.
- Unsafe URLs are still rejected by `validate_server_fetch_url()` before any network I/O, `follow_redirects=False` and the existing timeout/user agent are preserved, and normal-sized HTML fallback behavior is unchanged.

## Test plan
- [x] Added `test_ai_extract_body_stops_streaming_once_byte_cap_reached`, which asserts the streamed response is cut off at the byte cap and that not all chunks of a response far larger than the cap are consumed.
- [x] Added `test_ai_extract_body_returns_error_on_non_2xx_status` for the non-2xx-degrades-gracefully case.
- [x] Updated existing `_ai_extract_body` tests (unsafe URL, HTTP failure, empty AI response, HTML truncation) to mock `httpx.stream` instead of `httpx.get` via a small `_FakeStreamResponse` context-manager stand-in.
- [x] `pytest backend/tests/test_body_fetch.py` — 52 passed
- [x] `ruff check` / `ruff format --check` / `mypy` / `ty check` on touched files — all pass
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly) pass on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)