### PR TITLE
docs: correct search guide for current filters and query semantics (#786)

### DIFF
--- a/docs/user-guide/search.md
+++ b/docs/user-guide/search.md
@@ -1,7 +1,7 @@
 # Search
 
 News Dashboard includes full-text search across your article corpus so you can
-find articles by keyword, topic, or phrase.
+find articles by keyword or topic, then narrow the results with filters.
 
 ## What you can search
 
@@ -12,42 +12,57 @@ The search index includes:
 - **Reason** — the contextual blurb (e.g., "New release vX.Y.Z from source.")
 - **Tags** — any tags you've applied to articles
 - **Source name** — the human-readable name of the source (e.g., "Hugging Face Blog")
-- **Body** — the full article text (if the full-text extraction feature is enabled; see note below)
-
-By default, search operates on title, summary, reason, tags, and source name.
-If you have enabled full-text extraction (via the `FULL_TEXT_ENABLED` setting or
-equivalent), the article body is also indexed.
+- **Body** — the cached full article text, when it has been fetched for that
+  article (there is no separate setting to turn this on or off — the body
+  is indexed whenever it's already been captured through the app's normal
+  body-fetch path)
 
 ## How search works
 
 Behind the scenes, News Dashboard uses PostgreSQL's built-in full-text search
 (`tsvector` column and `GIN` index). When you type a query:
 
-1. The app parses your input into search terms
-2. It constructs a `tsquery` using the `&` (AND) operator by default — meaning
-   all terms must appear in the document
-3. The database returns matching articles ranked by relevance (ts_rank)
-4. The UI displays results with the matching terms highlighted
+1. The app splits your input into alphanumeric tokens (at least 2 characters,
+   and not a bare number) and lowercases them
+2. It builds a query that requires every token to match as a **prefix**,
+   combined with **AND** — e.g. `postgres index` matches articles containing
+   both a word starting with "postgres" and a word starting with "index"
+3. The database returns matching articles ranked by relevance (`ts_rank_cd`)
 
-You can refine your search with:
-- **Exact phrases**: `"exact phrase"` (requires full-text to be enabled)
-- **Wildcards**: `prefix*` (matches any word starting with prefix)
-- **OR logic**: `term1 | term2` (matches articles with either term)
+Search does not currently support quoted exact phrases, explicit wildcard
+characters, or `OR` logic — every word you type narrows the results further.
 
 ## Where to search
 
-Click the search icon in the top navigation bar or press `/` anywhere in the
-app to focus the search box. As you type, results appear instantly below the
-input.
+Click **Search** in the navigation sidebar to open the full Search page, or
+press `⌘K` / `Ctrl+K` anywhere in the app to open the command palette, which
+includes a quick inline search (showing up to 6 matching articles) alongside
+jump-to-view and action shortcuts. Press `?` to see all keyboard shortcuts.
 
-Results show:
+On the Search page, results show:
 - Article title
-- Summary snippet with matches highlighted
+- Summary snippet
 - Source name and category
-- Article status (new/read/saved/skipped/archived)
+- Article status (today/later/done/skipped/archived)
 - Publication date
 
 Click any result to open the article in the main view.
+
+## Filters
+
+The Search page filters are backed by the URL, so a search with filters
+applied can be bookmarked or shared:
+
+- **Starred** — only starred articles
+- **Include archived** — archived articles are **excluded by default**;
+  toggle this on to include them, or pick "Archived" directly under **State**
+- **State** — multi-select across today, later, done, skipped, and archived
+- **Category** — multi-select by category
+- **Source** — multi-select by source
+- **Date** — any time, today, past week, or past month
+- **Tag** — a single tag
+
+Results load 100 at a time; use **Load more** to fetch additional pages.
 
 ## Saved Views
 
@@ -61,46 +76,27 @@ notifications, or email digests.
 
 ## Search scope
 
-Search looks across **all articles in your database**, regardless of:
-- Workflow state (new, read, saved, skipped, archived, starred, snoozed)
-- Category or source
-- Date (unless you include date-specific terms in your query)
-
-If you want to limit results to a specific state, use the filters in conjunction
-with search (e.g., open the Saved tab, then search within saved articles).
+Search looks across **all articles in your database** by default, regardless
+of workflow state, category, or source — narrow the results using the filters
+above (e.g. select "Saved" as a state, or a specific source).
 
 ## Keeping search relevant
 
-Because the search index is built from the article metadata you already have:
+Because the search index is built from article data you already have:
 
 - No extra ingestion steps are required — search works on existing articles
 - The index updates automatically when:
   - New articles are ingested
   - You add or remove tags
   - An article's status changes
+  - An article's body is fetched and cached
 - No external services are needed; everything runs inside your PostgreSQL
   instance
 
-## Full-text extraction (optional)
-
-For deeper search, you can enable full-text extraction:
-
-1. Set `FULL_TEXT_ENABLED=true` in your environment
-2. The app will download and extract the full article body for saved/read
-   articles (using Trafilatura or goose3 under the hood)
-3. Extracted text is indexed alongside title/summary/reason/tags/source
-4. This enables searching within the article body — useful for finding
-   specific mentions inside long-form content
-
-> **Note**: Full-text extraction increases:
-> - Database storage (one extra `text` column per article)
-> - Ingestion time (HTTP fetch + parsing per article)
-> - Index size (larger `tsvector`)
-
-It is off by default to keep the app lightweight and privacy-respecting (no
-extra network calls during ingest unless enabled).
-
 ## Privacy
 
-Search is 100% local — your query text and article contents never leave your
-instance. No telemetry is sent when you search.
+Search queries execute locally in your own PostgreSQL database — your query
+text and article contents are never sent to an external service. If you've
+opted in to in-app analytics, using search records lightweight usage events
+(such as which route or feature was used) to help understand app usage; these
+events never include your query text or article contents.


### PR DESCRIPTION
## Summary

Fixes #786. Rewrites `docs/user-guide/search.md` so it matches the current implementation instead of describing a search UX that never shipped.

- Replaces the claimed exact-phrase / wildcard / OR query syntax with the actual tokenized prefix-AND semantics from `_search_tsquery()` in `backend/news_dashboard/ingest.py`.
- Removes the reference to a nonexistent `FULL_TEXT_ENABLED` setting; the generated `search_vector` column (`backend/news_dashboard/db.py`) always includes `body` when it's already cached, with no separate toggle.
- Documents the current filter chips in `frontend/src/pages/SearchPage.tsx`: Starred, Include archived, State, Category, Source, Date, Tag — and that archived articles are excluded by default.
- Documents Load-more pagination (100 results per page) instead of implying infinite/instant results.
- Corrects the entry point: there's no `/` keyboard shortcut for the Search page; it's reached via the nav sidebar, or `⌘K`/`Ctrl+K` for the command palette's inline quick search.
- Narrows the privacy claim: search itself runs entirely in the local Postgres instance, but if a user has opted into in-app analytics, lightweight feature/route usage events may be recorded — never query text or article contents.

Scoped to `docs/user-guide/search.md` only, per the issue's suggested implementation notes (the separate `website/docs` Docusaurus copy is stale for unrelated reasons tracked by #824).

## Test plan

- [x] Manually diffed the new guide against `SearchPage.tsx`, `workflowApi.ts`, `_search_tsquery()`, and the `search_vector` generated column definition.
- [x] `npm run test:frontend -- frontend/src/__tests__/search.test.tsx` — 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)