### PR TITLE
ops: expose optional runtime env in Helm chart (#822)

### DIFF
--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -207,6 +207,41 @@ def test_helm_template_app_and_ingest_receive_sentry_env() -> None:
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_app_config_defaults_off() -> None:
+    output = _render_chart()
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert "METRICS_ENABLED" not in deployment_env
+    assert "ENABLE_API_DOCS" not in deployment_env
+    assert "ANALYTICS_RETENTION_DAYS" not in deployment_env
+    assert "CORS_ORIGINS" not in deployment_env
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_app_config_optional_runtime_env() -> None:
+    output = _render_chart(
+        "app.config.metricsEnabled=true",
+        "app.config.enableApiDocs=true",
+        "app.config.analyticsRetentionDays=90",
+        "app.config.corsOrigins=https://example.com",
+    )
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert _env_entry(deployment_env, "METRICS_ENABLED") == (
+        '- name: METRICS_ENABLED\n  value: "true"'
+    )
+    assert _env_entry(deployment_env, "ENABLE_API_DOCS") == (
+        '- name: ENABLE_API_DOCS\n  value: "true"'
+    )
+    assert _env_entry(deployment_env, "ANALYTICS_RETENTION_DAYS") == (
+        '- name: ANALYTICS_RETENTION_DAYS\n  value: "90"'
+    )
+    assert _env_entry(deployment_env, "CORS_ORIGINS") == (
+        '- name: CORS_ORIGINS\n  value: "https://example.com"'
+    )
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
 def test_helm_template_external_postgres() -> None:
     output = _render_chart(
         "postgresql.enabled=false",

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -395,6 +395,16 @@ helm upgrade news-dashboard ./helm/news-dashboard \
 kubectl -n news-dashboard rollout status deployment/news-dashboard
 ```
 
+The `app.config` values in `helm/news-dashboard/values.yaml` expose the
+optional runtime env vars above as structured chart values instead of a
+manifest overlay: `app.config.metricsEnabled` (`METRICS_ENABLED`),
+`app.config.enableApiDocs` (`ENABLE_API_DOCS`),
+`app.config.analyticsRetentionDays` (`ANALYTICS_RETENTION_DAYS`), and
+`app.config.corsOrigins` (`CORS_ORIGINS`). All default to off/unset, matching
+the app's own defaults. Sentry DSNs and other secret-bearing values are
+supplied via `app.sentry.existingSecret` (a pre-existing Secret), never
+committed to `values.yaml`.
+
 ### Migration / Schema Updates
 
 The app calls `init_db()` on every startup, which creates missing tables and

--- a/helm/news-dashboard/templates/_helpers.tpl
+++ b/helm/news-dashboard/templates/_helpers.tpl
@@ -73,3 +73,22 @@
   value: {{ .Values.app.sentry.release | quote }}
 {{- end }}
 {{- end -}}
+
+{{- define "news-dashboard.configEnv" -}}
+{{- if .Values.app.config.metricsEnabled }}
+- name: METRICS_ENABLED
+  value: "true"
+{{- end }}
+{{- if .Values.app.config.enableApiDocs }}
+- name: ENABLE_API_DOCS
+  value: "true"
+{{- end }}
+{{- if .Values.app.config.analyticsRetentionDays }}
+- name: ANALYTICS_RETENTION_DAYS
+  value: {{ .Values.app.config.analyticsRetentionDays | quote }}
+{{- end }}
+{{- if .Values.app.config.corsOrigins }}
+- name: CORS_ORIGINS
+  value: {{ .Values.app.config.corsOrigins | quote }}
+{{- end }}
+{{- end -}}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -157,6 +157,7 @@ spec:
                   name: {{ include "news-dashboard.fullname" . }}-auth
                   key: TOKEN_SECRET
 {{- end }}
+{{- include "news-dashboard.configEnv" . | indent 12 }}
           ports:
             - containerPort: 8080
               name: http

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -124,6 +124,18 @@ app:
     environment: ""
     # Optional release identifier, usually set by CI to the deployed commit SHA.
     release: ""
+  config:
+    # Serves GET /metrics in Prometheus exposition format. Off by default.
+    metricsEnabled: false
+    # Serves the interactive API docs (/docs, /redoc, /openapi.json). Off by
+    # default so a public deployment doesn't leak its full API surface.
+    enableApiDocs: false
+    # Days to retain user_events before the daily cleanup job prunes them.
+    # Leave empty to use the app's built-in default (180).
+    analyticsRetentionDays: ""
+    # Comma-separated browser origins allowed by CORS. Leave empty to use the
+    # app's built-in default.
+    corsOrigins: ""
 
 ingestCronJob:
   enabled: true


### PR DESCRIPTION
## Summary
Closes #822.

- Adds an `app.config` values section to `helm/news-dashboard/values.yaml` (`metricsEnabled`, `enableApiDocs`, `analyticsRetentionDays`, `corsOrigins`), documented inline.
- Adds a `news-dashboard.configEnv` helper in `_helpers.tpl` and renders it into the app Deployment (only the settings relevant to the long-running app process; the ingest CronJob only runs `scheduled-ingest` and doesn't need these).
- Sentry backend/frontend DSN support (`app.sentry.*`) was already fully implemented in the chart via the existing `sentryEnv` helper, rendered into both the Deployment and the CronJob — no changes needed there.
- Documents the new values in `docs/SELF_HOSTING.md` under the Kubernetes (Helm) section.
- All new values default to off/unset, matching the app's own built-in defaults, so existing deployments are unaffected.

## Test plan
- [x] `helm lint ./helm/news-dashboard`
- [x] `helm template news-dashboard ./helm/news-dashboard --set app.auth.sessionSecret=dummy --set-string postgresql.password=dummy` — confirms defaults render with none of the new env vars present.
- [x] `helm template ... --set app.config.metricsEnabled=true --set app.config.enableApiDocs=true --set app.config.analyticsRetentionDays=90 --set app.config.corsOrigins=https://example.com` — confirms all four values render correctly into the Deployment.
- [x] `pytest backend/tests/test_chart_render.py -q` — 14 passed (2 new tests added: defaults-off and optional-values-render, plus all pre-existing chart render tests still pass).
- [x] `ruff check` / `ruff format --check` on the modified test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)