### PR TITLE
fix: finish onboarding source-choice narrowing (#823)

### DIFF
--- a/backend/tests/test_onboarding_interests.py
+++ b/backend/tests/test_onboarding_interests.py
@@ -214,6 +214,45 @@ def test_save_onboarding_interests_persists_profile_and_source_choices(
     }
 
 
+def test_onboarding_disabled_source_excluded_from_articles(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with connect(pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+              category, kind, state)
+            VALUES (%s, %s, 'Disabled source article', 'openai-blog', 'openai-blog',
+              'tech', 'rss_feed', 'today')
+            """,
+            (
+                "https://example.com/onboarding-disabled",
+                "https://example.com/onboarding-disabled",
+            ),
+        )
+
+    with _api_client(user_id) as client:
+        response = client.post(
+            "/api/onboarding/interests",
+            json={
+                "interests": ["agents"],
+                "enabled_source_slugs": ["langgraph-releases"],
+                "disabled_source_slugs": ["openai-blog"],
+            },
+        )
+        assert response.status_code == 200
+
+        articles_response = client.get("/api/articles", params={"limit": 500})
+
+    assert articles_response.status_code == 200
+    titles = {item["title"] for item in articles_response.json()["items"]}
+    assert "Disabled source article" not in titles
+
+
 def test_new_user_has_no_explicit_global_source_subscriptions(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/frontend/src/__tests__/onboardingWizard.test.tsx
+++ b/frontend/src/__tests__/onboardingWizard.test.tsx
@@ -263,8 +263,32 @@ describe('OnboardingWizard', () => {
     await waitFor(() => expect(save).toHaveBeenCalled());
     const payload = save.mock.calls[0][0];
     // Both recommended sources should be in the enabled list
-    expect(payload.enabled_slugs).toContain('hn');
-    expect(payload.enabled_slugs).toContain('arxiv');
+    expect(payload.enabled_source_slugs).toContain('hn');
+    expect(payload.enabled_source_slugs).toContain('arxiv');
+    expect(payload.disabled_source_slugs).toEqual([]);
+  });
+
+  it('sends unselected recommendations as disabled_source_slugs on Apply', async () => {
+    vi.spyOn(api, 'fetchOnboardingInterests').mockResolvedValue(MOCK_INTERESTS);
+    vi.spyOn(api, 'fetchOnboardingSourceRecommendations').mockResolvedValue(MOCK_RECOMMENDATIONS);
+    const save = vi.spyOn(api, 'saveOnboardingInterests').mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <OnboardingWizard {...makeProps({ onClose })} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(screen.getByText('Technology')).toBeTruthy());
+    fireEvent.click(screen.getByText('Technology'));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => expect(screen.getByText('Hacker News')).toBeTruthy());
+    // Deselect arXiv, leaving only Hacker News selected
+    fireEvent.click(screen.getByText('arXiv'));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+    await waitFor(() => expect(save).toHaveBeenCalled());
+    const payload = save.mock.calls[0][0];
+    expect(payload.enabled_source_slugs).toEqual(['hn']);
+    expect(payload.disabled_source_slugs).toEqual(['arxiv']);
   });
 });
 
@@ -314,7 +338,7 @@ describe('onboarding API functions', () => {
     expect(body.interest_ids).toEqual(['tech', 'science']);
   });
 
-  it('saveOnboardingInterests POSTs to /api/onboarding/profile', async () => {
+  it('saveOnboardingInterests POSTs to /api/onboarding/interests', async () => {
     const calls: { url: string; init?: RequestInit }[] = [];
     vi.stubGlobal(
       'fetch',
@@ -323,14 +347,20 @@ describe('onboarding API functions', () => {
         return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
       })
     );
-    await api.saveOnboardingInterests({ interest_ids: ['tech'], enabled_slugs: ['hn'] });
-    expect(calls[0].url).toBe('/api/onboarding/profile');
+    await api.saveOnboardingInterests({
+      interests: ['tech'],
+      enabled_source_slugs: ['hn'],
+      disabled_source_slugs: ['arxiv'],
+    });
+    expect(calls[0].url).toBe('/api/onboarding/interests');
     expect(calls[0].init?.method).toBe('POST');
     const body = JSON.parse(calls[0].init?.body as string) as {
-      interest_ids: string[];
-      enabled_slugs: string[];
+      interests: string[];
+      enabled_source_slugs: string[];
+      disabled_source_slugs: string[];
     };
-    expect(body.interest_ids).toEqual(['tech']);
-    expect(body.enabled_slugs).toEqual(['hn']);
+    expect(body.interests).toEqual(['tech']);
+    expect(body.enabled_source_slugs).toEqual(['hn']);
+    expect(body.disabled_source_slugs).toEqual(['arxiv']);
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -43,7 +43,7 @@ import type {
   ShareDetail,
   ShareAnnotation,
   ShareMessage,
-  SaveOnboardingProfileRequest,
+  SaveOnboardingInterestsRequest,
   ShareableUser,
   Source,
   SourceCleanupSuggestion,
@@ -907,9 +907,9 @@ export async function fetchOnboardingSourceRecommendations(
 }
 
 export async function saveOnboardingInterests(
-  payload: SaveOnboardingProfileRequest
+  payload: SaveOnboardingInterestsRequest
 ): Promise<void> {
-  await requestJson('/api/onboarding/profile', {
+  await requestJson('/api/onboarding/interests', {
     method: 'POST',
     body: JSON.stringify(payload),
   });

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -79,9 +79,13 @@ export function OnboardingWizard({ open, onClose }: Props) {
   }
 
   function handleApply() {
+    const disabledSlugs = recommendations
+      .map((rec) => rec.slug)
+      .filter((slug) => !selectedSlugs.has(slug));
     saveMutation.mutate({
-      interest_ids: [...selectedInterests],
-      enabled_slugs: [...selectedSlugs],
+      interests: [...selectedInterests],
+      enabled_source_slugs: [...selectedSlugs],
+      disabled_source_slugs: disabledSlugs,
     });
   }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -761,9 +761,10 @@ export interface OnboardingStatus {
   completed: boolean;
 }
 
-export interface SaveOnboardingProfileRequest {
-  interest_ids: string[];
-  enabled_slugs: string[];
+export interface SaveOnboardingInterestsRequest {
+  interests: string[];
+  enabled_source_slugs: string[];
+  disabled_source_slugs: string[];
 }
 
 export interface OpmlImportResult {


### PR DESCRIPTION
## Summary

Closes #823.

The onboarding wizard preselected recommended sources and let the user
uncheck some, but `handleApply` only sent `enabled_slugs` to
`/api/onboarding/profile`. Unselected recommendation sources were never
persisted as disabled, so they kept their implicit default-enabled
state — the wizard looked like it narrowed the feed but didn't.

- `frontend/src/components/OnboardingWizard.tsx`: `handleApply` now computes
  `disabled_source_slugs` from recommendation slugs the user left unchecked,
  alongside `enabled_source_slugs` for the ones they kept.
- `frontend/src/api.ts` / `frontend/src/types.ts`: `saveOnboardingInterests`
  now posts to `/api/onboarding/interests` (which already accepts both
  `enabled_source_slugs` and `disabled_source_slugs`) instead of the older
  `/api/onboarding/profile` endpoint, which only accepted an enabled list.
- No backend change was needed — `/api/onboarding/interests` and its
  `user_sources` upsert logic already supported writing both enabled and
  disabled rows; the gap was purely on the frontend payload/endpoint.
- Added a backend regression test asserting that a source disabled during
  onboarding is excluded from `/api/articles` (existing `user_sources`
  filtering, exercised through the onboarding path end-to-end).
- Updated/added frontend wizard tests to assert `disabled_source_slugs` is
  sent for unselected recommendations, and to hit the new endpoint.

`Skip for now` remains session-only (no API call), unchanged.

## Test plan
- [x] `python -m pytest backend/tests/test_onboarding_interests.py` — 9 passed
- [x] `python -m pytest backend/tests -q` (full suite) — 1704 passed
- [x] `npx vitest run` (full frontend suite) — 788 passed, 78 files
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, eslint, prettier, tsc) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)