### PR TITLE
chore: install vulture and add dead-code scan to the Python quality gate (#835)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,12 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: vulture
+        name: vulture (dead code)
+        entry: vulture backend backend/vulture_whitelist.py --min-confidence 80
+        language: system
+        types: [python]
+        pass_filenames: false
       - id: eslint
         name: eslint
         entry: npm run lint --silent

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install ci-install lint format typecheck \
+.PHONY: install ci-install lint format typecheck dead-code \
         test test-smoke test-backend test-frontend test-e2e test-a11y test-nightly test-full \
         helm-validate check build
 
@@ -18,8 +18,13 @@ ci-install:
 lint:
 	ruff check backend
 	ruff format --check backend
+	vulture backend backend/vulture_whitelist.py --min-confidence 80
 	npm run lint --silent
 	npm run format:check --silent
+
+## dead-code: scan Python source for unused symbols (vulture)
+dead-code:
+	vulture backend backend/vulture_whitelist.py --min-confidence 80
 
 ## format: auto-format backend and frontend code
 format:

--- a/backend/vulture_whitelist.py
+++ b/backend/vulture_whitelist.py
@@ -1,0 +1,7 @@
+# vulture whitelist — symbols that appear unused but are kept intentionally.
+#
+# Nothing needs to be listed here today: the pytest-fixture and fake-signature
+# false positives found so far are handled via `ignore_names` in
+# `[tool.vulture]` (pyproject.toml), since vulture's whitelist mechanism only
+# covers module-level symbols, not local variables/parameters. This file
+# exists so `make dead-code` has a stable whitelist target to grow into.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "testcontainers[postgres]>=4.14.2",
   "pytest-xdist>=3.0.0",
   "types-defusedxml>=0.7.0",
+  "vulture>=2.14",
 ]
 
 [project.scripts]
@@ -222,3 +223,10 @@ include = ["backend", "backend/tests"]
 python-version = "3.14"
 project-includes = ["backend"]
 search-path = ["backend", "backend/tests"]
+
+# ── vulture (dead code) ──────────────────────────────────────────────────────
+[tool.vulture]
+# Pytest fixture parameters that are only used for their setup/teardown side
+# effects (e.g. seeding the test DB, patching env vars) and a fake-connect
+# shim parameter kept to match psycopg's real signature.
+ignore_names = ["tmp_db", "clean_throttle", "row_factory"]

--- a/scripts/test_repo_metadata.py
+++ b/scripts/test_repo_metadata.py
@@ -48,6 +48,19 @@ class TestReadmeVersionBadge(unittest.TestCase):
         )
 
 
+class TestVultureWhitelistExists(unittest.TestCase):
+    """`make lint` / `make dead-code` pass `backend/vulture_whitelist.py` on the
+    vulture command line; if the file is deleted those commands break silently
+    (vulture just sees fewer paths) instead of failing loudly.
+    """
+
+    def test_vulture_whitelist_file_exists(self) -> None:
+        whitelist = ROOT / "backend" / "vulture_whitelist.py"
+        assert whitelist.is_file(), (
+            "backend/vulture_whitelist.py must exist for `make lint`/`make dead-code`"
+        )
+
+
 class TestNoPrivatePersonalPhrases(unittest.TestCase):
     _FORBIDDEN: ClassVar[list[str]] = ["private personal", "for Ioachim"]
     _EXTENSIONS: ClassVar[set[str]] = {".py", ".md", ".toml", ".ts", ".tsx", ".txt", ".rst"}

--- a/uv.lock
+++ b/uv.lock
@@ -915,6 +915,7 @@ dev = [
     { name = "testcontainers" },
     { name = "ty" },
     { name = "types-defusedxml" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -949,6 +950,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.26.8" },
     { name = "types-defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.49.0" },
+    { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
     { name = "webdriver-manager", specifier = ">=4.0.0" },
 ]
 provides-extras = ["dev"]
@@ -1879,6 +1881,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/0e/933bacb37b57ae7928b0030eef205a3dbb3e37afdbdde5be2e113318958f/virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce", size = 4577424, upload-time = "2026-06-13T20:36:45.066Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e", size = 4557937, upload-time = "2026-06-13T20:36:42.967Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `vulture>=2.14` to the `dev` optional-dependency group and hand-patches `uv.lock` to add just that one entry (kept the opt-in `crawl4ai` extra's large tree out of the committed lock, matching how the lock already excludes it today).
- Wires vulture into `make lint` and adds a standalone `make dead-code` target: `vulture backend backend/vulture_whitelist.py --min-confidence 80`.
- Adds a `vulture` local pre-commit hook (system language, Python file types), placed after `pyrefly` and before `eslint`.
- Creates `backend/vulture_whitelist.py` as the whitelist target file (empty today — see below).
- Adds `[tool.vulture]` `ignore_names` in `pyproject.toml` for `tmp_db`, `clean_throttle`, `row_factory` — these are pytest fixture parameters (and one fake-`psycopg.connect` shim parameter) used only for setup side effects / signature compatibility, not genuinely dead code. Vulture's whitelist mechanism only covers module-level symbols it can statically reference, not local variables/parameters, so `ignore_names` is the correct tool for these.
- Adds a guard test in `scripts/test_repo_metadata.py` asserting `backend/vulture_whitelist.py` exists.

At `--min-confidence 80`, vulture found zero unused module-level symbols in `backend/` (only the three fixture-argument false positives above), so no whitelist entries were needed this round.

Closes #835

## Test plan

- [x] `vulture backend backend/vulture_whitelist.py --min-confidence 80` exits 0
- [x] `make lint` exits 0 (ruff, vulture, npm lint/format all pass)
- [x] `make typecheck` exits 0 (mypy, ty, pyrefly, tsc)
- [x] `pytest -q` — 1799 passed
- [x] `python3 -m unittest scripts/test_repo_metadata.py` — 5 passed (including new whitelist-existence test)
- [x] pre-commit hooks (including new `vulture` hook) pass on the commit