### PR TITLE
feat: drag-and-drop reorder for reading list (#903)

### DIFF
--- a/frontend/src/__tests__/readingList.test.tsx
+++ b/frontend/src/__tests__/readingList.test.tsx
@@ -1,14 +1,35 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { DragEndEvent } from '@dnd-kit/core';
 import { ReadingListPage } from '../pages/ReadingListPage';
 import * as readingListApi from '../api/readingListApi';
 import type { ReadingListItem } from '../api/readingListApi';
 
 vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+let capturedOnDragEnd: ((event: DragEndEvent) => void) | undefined;
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: ReactNode;
+      onDragEnd: (event: DragEndEvent) => void;
+    }) => {
+      capturedOnDragEnd = onDragEnd;
+      return children;
+    },
+  };
+});
 
 function makeItem(overrides: Partial<ReadingListItem> = {}): ReadingListItem {
   return {
@@ -118,6 +139,39 @@ describe('ReadingListPage', () => {
     await screen.findByText('First');
     const [moveFirstDown] = screen.getAllByRole('button', { name: 'Move down' });
     await userEvent.click(moveFirstDown);
+
+    await waitFor(() => {
+      expect(reorderSpy).toHaveBeenCalledWith([2, 1]);
+    });
+  });
+
+  it('renders a drag handle for each item to support drag-and-drop reordering', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([
+      makeItem({ id: 1, title: 'First' }),
+      makeItem({ id: 2, title: 'Second', priority: 2 }),
+    ]);
+
+    renderPage();
+    await screen.findByText('First');
+
+    expect(screen.getAllByRole('button', { name: 'Drag to reorder' })).toHaveLength(2);
+  });
+
+  it('reorders items when a drag-and-drop gesture completes', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([
+      makeItem({ id: 1, title: 'First' }),
+      makeItem({ id: 2, title: 'Second', priority: 2 }),
+    ]);
+    const reorderSpy = vi.spyOn(readingListApi, 'reorderReadingList').mockResolvedValue([]);
+
+    renderPage();
+    await screen.findByText('First');
+
+    expect(capturedOnDragEnd).toBeDefined();
+    capturedOnDragEnd?.({
+      active: { id: 1 },
+      over: { id: 2 },
+    } as DragEndEvent);
 
     await waitFor(() => {
       expect(reorderSpy).toHaveBeenCalledWith([2, 1]);

--- a/frontend/src/pages/ReadingListPage.tsx
+++ b/frontend/src/pages/ReadingListPage.tsx
@@ -5,6 +5,7 @@ import {
   BookmarkPlus,
   Check,
   ExternalLink,
+  GripVertical,
   Loader2,
   MonitorPlay,
   Newspaper,
@@ -15,6 +16,23 @@ import {
   Users,
 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   addReadingListItem,
   deleteReadingListItem,
@@ -60,9 +78,30 @@ function ItemCard({
 }) {
   const pending = item.fetch_status === 'pending';
   const { label: kindLabel, Icon: KindIcon } = KIND_META[item.kind];
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
 
   return (
-    <div className="flex items-start gap-3 px-4 md:px-5 py-3 hover:bg-surface">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-start gap-3 px-4 md:px-5 py-3 hover:bg-surface"
+    >
+      <button
+        type="button"
+        aria-label="Drag to reorder"
+        className="mt-4 shrink-0 cursor-grab touch-none rounded-sm p-1 text-muted-foreground hover:text-foreground active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-4" strokeWidth={1.75} />
+      </button>
       {item.image_url ? (
         <img
           src={item.image_url}
@@ -165,6 +204,10 @@ export function ReadingListPage() {
   const [importSource, setImportSource] = useState<ReadingListImportSource>('pocket');
   const [importResult, setImportResult] = useState<ReadingListImportResult | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
 
   const { data: items = [], isLoading } = useQuery({
     queryKey: ['reading-list', filter],
@@ -226,6 +269,16 @@ export function ReadingListPage() {
     if (index < 0 || target < 0 || target >= ids.length) return;
     [ids[index], ids[target]] = [ids[target], ids[index]];
     reorderMutation.mutate(ids);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const ids = items.map((item) => item.id);
+    const oldIndex = ids.indexOf(Number(active.id));
+    const newIndex = ids.indexOf(Number(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    reorderMutation.mutate(arrayMove(ids, oldIndex, newIndex));
   }
 
   function handleToggleDone(item: ReadingListItem) {
@@ -351,19 +404,26 @@ export function ReadingListPage() {
           }
         />
       ) : (
-        <div className="divide-y divide-border border-t border-border">
-          {items.map((item, index) => (
-            <ItemCard
-              key={item.id}
-              item={item}
-              isFirst={index === 0}
-              isLast={index === items.length - 1}
-              onMove={handleMove}
-              onToggleDone={handleToggleDone}
-              onDelete={(id) => deleteMutation.mutate(id)}
-            />
-          ))}
-        </div>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={items.map((item) => item.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="divide-y divide-border border-t border-border">
+              {items.map((item, index) => (
+                <ItemCard
+                  key={item.id}
+                  item={item}
+                  isFirst={index === 0}
+                  isLast={index === items.length - 1}
+                  onMove={handleMove}
+                  onToggleDone={handleToggleDone}
+                  onDelete={(id) => deleteMutation.mutate(id)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
       )}
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "news-dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.16",
         "@radix-ui/react-slot": "^1.3.0",
         "@radix-ui/react-switch": "^1.3.2",
@@ -1863,6 +1866,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "dead-code": "knip"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.16",
     "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/react-switch": "^1.3.2",


### PR DESCRIPTION
## Summary
- Closes #903
- Adds `@dnd-kit/core` + `@dnd-kit/sortable` drag-and-drop reordering to `ReadingListPage.tsx`, with a dedicated grip handle per item
- Keeps the existing up/down buttons as a keyboard-accessible fallback (drag-only reordering is not accessible)
- Reuses the existing `POST /api/reading-list/reorder` endpoint via `reorderReadingList` — no backend changes

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:frontend` (790 tests passed, including new drag-handle-rendering and drag-end-reorder tests)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)