### PR TITLE
fix: prevent duplicate default source definitions (#842)

### DIFF
--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -225,15 +225,6 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         80,
         interest_tags=("model-releases", "evals", "infra", "product-news"),
     ),
-    # ── AI research ──────────────────────────────────────────────────────────
-    SourceDefinition(
-        "arxiv-ai-ml",
-        "arXiv AI/ML",
-        "https://rss.arxiv.org/rss/cs.AI",
-        "ai-research",
-        priority=70,
-        interest_tags=("evals", "model-releases", "research"),
-    ),
     SourceDefinition(
         "google-research-blog",
         "Google Research Blog",

--- a/backend/tests/test_default_sources.py
+++ b/backend/tests/test_default_sources.py
@@ -1,0 +1,20 @@
+"""Regression test: DEFAULT_SOURCES must not contain duplicate slugs (issue #842)."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from news_dashboard.sources import DEFAULT_SOURCES
+
+
+def test_default_sources_have_unique_slugs() -> None:
+    """Every DEFAULT_SOURCES slug appears exactly once.
+
+    A duplicate slug lets ingest_all() fetch the same built-in source twice
+    in one run and lets onboarding recommendations offer duplicate candidates,
+    even though PostgreSQL upserts converge on a single sources row.
+    """
+    slugs = [source.slug for source in DEFAULT_SOURCES]
+    counts = Counter(slugs)
+    duplicates = {slug: count for slug, count in counts.items() if count > 1}
+    assert not duplicates, f"duplicate DEFAULT_SOURCES slugs: {duplicates}"


### PR DESCRIPTION
Fixes #842

## Summary
- `DEFAULT_SOURCES` in `backend/news_dashboard/sources.py` defined the `arxiv-ai-ml` source twice (identical `SourceDefinition` blocks). Removed the duplicate.
- `sync_sources()` upserts into PostgreSQL so the duplicate converged to one DB row, but `ingest_all()` and the onboarding recommendation helper iterate `DEFAULT_SOURCES` directly, so the duplicate could still cause double-fetching during an ingest run and duplicate recommendation candidates.
- Added `backend/tests/test_default_sources.py` with a regression test (`Counter`-based) that fails if any `DEFAULT_SOURCES` slug repeats, guarding against future duplicates.

## Test plan
- [x] `pytest backend/tests/test_default_sources.py backend/tests/test_arxiv_ai_ml_source.py backend/tests/test_new_feeds.py -q` — 12 passed
- [x] `pytest backend/tests/test_onboarding_interests.py -q` — 9 passed
- [x] `ruff check` clean on changed files
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)