### PR TITLE
feat: include reading list items in briefings (#905)

### DIFF
--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from news_dashboard import briefing_agent
 from news_dashboard.db import connect, row_to_dict
+from news_dashboard.reading_list import service as reading_list_service
 
 CANDIDATE_LIMIT = 40
 DEFAULT_BRIEFING_MODEL = "gpt-4o-mini"
@@ -270,6 +271,35 @@ def _validate_content(raw: dict[str, Any], candidate_ids: set[int]) -> dict[str,
     return content
 
 
+_READING_LIST_FIELDS = ("id", "url", "title", "site_name", "image_url")
+
+
+def _reading_list_section(
+    user_id: int | None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return the opted-in "saved for later" items for a briefing, or [] if disabled.
+
+    Marking an item done stays a manual, separate action — surfacing it here
+    never mutates reading_list_items.status.
+    """
+    if user_id is None:
+        return []
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT briefing_include_reading_list, briefing_reading_list_limit"
+            " FROM users WHERE id = %s",
+            (user_id,),
+        ).fetchone()
+    if row is None or not row["briefing_include_reading_list"]:
+        return []
+    limit = int(row["briefing_reading_list_limit"] or 0)
+    if limit <= 0:
+        return []
+    items = reading_list_service.list_items(user_id, status="unread", database_url=database_url)
+    return [{field: item.get(field) for field in _READING_LIST_FIELDS} for item in items[:limit]]
+
+
 def _save_briefing(  # noqa: PLR0913
     since_at: datetime,
     until_at: datetime,
@@ -279,6 +309,7 @@ def _save_briefing(  # noqa: PLR0913
     database_url: str | None = None,
     user_id: int | None = None,
     focus_prompt: str | None = None,
+    reading_list_items: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Insert briefing + article links; return the full briefing dict."""
     title = content.get("title") or ""
@@ -287,6 +318,8 @@ def _save_briefing(  # noqa: PLR0913
         "sections": content.get("sections", []),
         "worth_opening": content.get("worth_opening", []),
     }
+    if reading_list_items:
+        content_blob["reading_list"] = reading_list_items
 
     with connect(database_url=database_url) as conn:
         row = conn.execute(
@@ -657,6 +690,7 @@ def generate_briefing(  # noqa: PLR0913, PLR0915
     _record(briefing_agent.STAGE_CITATION_VERIFICATION, "complete")
 
     # Stage 5: assembly (persistence).
+    reading_list_items = _reading_list_section(user_id, database_url=database_url)
     try:
         result = _save_briefing(
             since_at,
@@ -667,6 +701,7 @@ def generate_briefing(  # noqa: PLR0913, PLR0915
             database_url,
             user_id=user_id,
             focus_prompt=focus_prompt,
+            reading_list_items=reading_list_items,
         )
     except Exception as exc:
         _record(briefing_agent.STAGE_ASSEMBLY, "failed", error=str(exc))

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -784,6 +784,10 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "ALTER TABLE article_shares ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ",
     "CREATE INDEX IF NOT EXISTS idx_article_shares_sender"
     " ON article_shares(from_user_id, created_at DESC)",
+    "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_include_reading_list"
+    " BOOLEAN NOT NULL DEFAULT FALSE",
+    "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_reading_list_limit"
+    " INTEGER NOT NULL DEFAULT 3",
 ]
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2700,9 +2700,11 @@ def briefings_chat(
 
 _BRIEFING_TIME_RE = __import__("re").compile(r"^([01]\d|2[0-3]):[0-5]\d$")
 _NOTIFICATION_COLS = (
-    "briefing_time, briefing_push_enabled, briefing_timezone, recap_enabled, recap_day"
+    "briefing_time, briefing_push_enabled, briefing_timezone, recap_enabled, recap_day, "
+    "briefing_include_reading_list, briefing_reading_list_limit"
 )
 _RECAP_DAYS = frozenset({"mon", "tue", "wed", "thu", "fri", "sat", "sun"})
+_READING_LIST_LIMIT_MAX = 20
 
 
 class NotificationSettingsUpdate(BaseModel):
@@ -2711,6 +2713,8 @@ class NotificationSettingsUpdate(BaseModel):
     briefing_timezone: str | None = None
     recap_enabled: bool | None = None
     recap_day: str | None = None
+    briefing_include_reading_list: bool | None = None
+    briefing_reading_list_limit: int | None = None
 
 
 class PushSubscribeRequest(BaseModel):
@@ -2823,8 +2827,22 @@ def get_notification_settings(
         "push_enabled": bool(row["briefing_push_enabled"]),
         "recap_enabled": bool(row["recap_enabled"]),
         "recap_day": row["recap_day"] or "mon",
+        "briefing_include_reading_list": bool(row["briefing_include_reading_list"]),
+        "briefing_reading_list_limit": row["briefing_reading_list_limit"] or 3,
         "vapid_public_key": get_vapid_public_key(),
     }
+
+
+def _reading_list_updates(payload: NotificationSettingsUpdate) -> dict[str, Any]:
+    updates: dict[str, Any] = {}
+    if payload.briefing_include_reading_list is not None:
+        updates["briefing_include_reading_list"] = payload.briefing_include_reading_list
+    if payload.briefing_reading_list_limit is not None:
+        if not 1 <= payload.briefing_reading_list_limit <= _READING_LIST_LIMIT_MAX:
+            detail = f"briefing_reading_list_limit must be between 1 and {_READING_LIST_LIMIT_MAX}"
+            raise HTTPException(status_code=422, detail=detail)
+        updates["briefing_reading_list_limit"] = payload.briefing_reading_list_limit
+    return updates
 
 
 @api.put("/api/settings/notifications")
@@ -2855,6 +2873,7 @@ def update_notification_settings(
             detail = "recap_day must be one of: " + ", ".join(sorted(_RECAP_DAYS))
             raise HTTPException(status_code=422, detail=detail)
         updates["recap_day"] = payload.recap_day
+    updates.update(_reading_list_updates(payload))
     if updates:
         set_clauses = ", ".join(f"{k} = %s" for k in updates)
         with connect() as conn:
@@ -2875,6 +2894,8 @@ def update_notification_settings(
         "push_enabled": bool(row["briefing_push_enabled"]),
         "recap_enabled": bool(row["recap_enabled"]),
         "recap_day": row["recap_day"] or "mon",
+        "briefing_include_reading_list": bool(row["briefing_include_reading_list"]),
+        "briefing_reading_list_limit": row["briefing_reading_list_limit"] or 3,
     }
 
 

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -35,6 +35,7 @@ from news_dashboard.briefings import (
     select_candidates,
 )
 from news_dashboard.db import connect, row_to_dict
+from news_dashboard.reading_list.service import add_item as add_reading_list_item
 
 # ── Seeding helpers ───────────────────────────────────────────────────────────
 
@@ -1336,3 +1337,78 @@ def test_generate_briefing_records_no_run_row_for_no_candidates(pg_clean: str) -
     run = row_to_dict(row)
     assert run["status"] == "complete"
     assert run["briefing_id"] is None
+
+
+# ── reading-list "saved for later" section ────────────────────────────────────
+
+
+def _set_reading_list_opt_in(
+    pg_url: str, user_id: int, *, enabled: bool, limit: int | None = None
+) -> None:
+    with connect(database_url=pg_url) as conn:
+        if limit is None:
+            conn.execute(
+                "UPDATE users SET briefing_include_reading_list = %s WHERE id = %s",
+                (enabled, user_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE users SET briefing_include_reading_list = %s,"
+                " briefing_reading_list_limit = %s WHERE id = %s",
+                (enabled, limit, user_id),
+            )
+
+
+def test_generate_briefing_omits_reading_list_by_default(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/rl1", title="Article 1", state="today")
+    user_id = _seed_user(pg_clean, username="rl-default-user")
+    add_reading_list_item(user_id, "https://example.com/saved", database_url=pg_clean)
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai, user_id=user_id)
+
+    assert "reading_list" not in result["content"]
+
+
+def test_generate_briefing_includes_unread_reading_list_items_when_opted_in(
+    pg_clean: str,
+) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/rl2", title="Article 1", state="today")
+    user_id = _seed_user(pg_clean, username="rl-opt-in-user")
+    _set_reading_list_opt_in(pg_clean, user_id, enabled=True)
+    saved = add_reading_list_item(user_id, "https://example.com/saved-1", database_url=pg_clean)
+    add_reading_list_item(user_id, "https://example.com/saved-2", database_url=pg_clean)
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai, user_id=user_id)
+
+    reading_list = result["content"]["reading_list"]
+    assert len(reading_list) == 2
+    assert {item["id"] for item in reading_list} == {saved["id"], saved["id"] + 1}
+
+
+def test_generate_briefing_respects_reading_list_limit(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/rl3", title="Article 1", state="today")
+    user_id = _seed_user(pg_clean, username="rl-limit-user")
+    _set_reading_list_opt_in(pg_clean, user_id, enabled=True, limit=1)
+    add_reading_list_item(user_id, "https://example.com/saved-a", database_url=pg_clean)
+    add_reading_list_item(user_id, "https://example.com/saved-b", database_url=pg_clean)
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai, user_id=user_id)
+
+    assert len(result["content"]["reading_list"]) == 1
+
+
+def test_generate_briefing_excludes_done_reading_list_items(pg_clean: str) -> None:
+    _seed_source(pg_clean)
+    _seed_article(pg_clean, url="https://example.com/rl4", title="Article 1", state="today")
+    user_id = _seed_user(pg_clean, username="rl-done-user")
+    _set_reading_list_opt_in(pg_clean, user_id, enabled=True)
+    add_reading_list_item(user_id, "https://example.com/saved-done", database_url=pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute("UPDATE reading_list_items SET status = 'done' WHERE user_id = %s", (user_id,))
+
+    result = generate_briefing(database_url=pg_clean, ai_fn=_fake_ai, user_id=user_id)
+
+    assert result["content"].get("reading_list", []) == []

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -353,6 +353,8 @@ def test_get_notification_settings_returns_defaults(
         "briefing_timezone": "UTC",
         "recap_enabled": True,
         "recap_day": "mon",
+        "briefing_include_reading_list": False,
+        "briefing_reading_list_limit": 3,
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -383,6 +385,8 @@ def test_get_notification_settings_utc_fallback(
         "briefing_timezone": None,
         "recap_enabled": True,
         "recap_day": "mon",
+        "briefing_include_reading_list": False,
+        "briefing_reading_list_limit": 3,
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -402,6 +406,8 @@ def test_put_notification_settings_valid_time(client: TestClient) -> None:
         "briefing_timezone": "UTC",
         "recap_enabled": True,
         "recap_day": "mon",
+        "briefing_include_reading_list": False,
+        "briefing_reading_list_limit": 3,
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -426,6 +432,8 @@ def test_put_notification_settings_valid_timezone(client: TestClient) -> None:
         "briefing_timezone": "Europe/Bucharest",
         "recap_enabled": True,
         "recap_day": "mon",
+        "briefing_include_reading_list": False,
+        "briefing_reading_list_limit": 3,
     }
 
     with patch("news_dashboard.main.connect") as mock_connect:
@@ -439,6 +447,40 @@ def test_put_notification_settings_valid_timezone(client: TestClient) -> None:
 
     assert resp.status_code == 200
     assert resp.json()["briefing_timezone"] == "Europe/Bucharest"
+
+
+def test_put_notification_settings_valid_reading_list_opt_in(client: TestClient) -> None:
+    fake_row: dict[str, Any] = {
+        "briefing_time": "09:00",
+        "briefing_push_enabled": False,
+        "briefing_timezone": "UTC",
+        "recap_enabled": True,
+        "recap_day": "mon",
+        "briefing_include_reading_list": True,
+        "briefing_reading_list_limit": 5,
+    }
+
+    with patch("news_dashboard.main.connect") as mock_connect:
+        ctx = mock_connect.return_value.__enter__.return_value
+        ctx.execute.return_value.fetchone.return_value = fake_row
+
+        resp = client.put(
+            "/api/settings/notifications",
+            json={"briefing_include_reading_list": True, "briefing_reading_list_limit": 5},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["briefing_include_reading_list"] is True
+    assert data["briefing_reading_list_limit"] == 5
+
+
+def test_put_notification_settings_invalid_reading_list_limit(client: TestClient) -> None:
+    resp = client.put("/api/settings/notifications", json={"briefing_reading_list_limit": 0})
+    assert resp.status_code == 422
+
+    resp = client.put("/api/settings/notifications", json={"briefing_reading_list_limit": 21})
+    assert resp.status_code == 422
 
 
 def test_put_notification_settings_invalid_timezone(client: TestClient) -> None:


### PR DESCRIPTION
Closes #905

## Design note

The briefing content pipeline (`generate_briefing` in [backend/news_dashboard/briefings.py](backend/news_dashboard/briefings.py)) assembles and persists a `content` JSONB blob in `_save_briefing` (Stage 5, "assembly"). That's the natural hook-in point: it's where `sections`/`worth_opening` are already frozen into a stable historical snapshot at generation time, so a `content["reading_list"]` key added there behaves the same way (it survives read-time exactly as generated, rather than being re-queried live on every `GET /api/briefings/{id}`).

A new `_reading_list_section(user_id, database_url)` helper:
- Reads the two new opt-in columns off `users` (`briefing_include_reading_list`, `briefing_reading_list_limit`), mirroring the existing `recap_enabled`/`recap_day` pattern exactly (additive `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` in `POSTGRES_SCHEMA`, no migrations directory in this repo).
- If enabled, calls `reading_list.service.list_items(user_id, status="unread")` (reused as-is, per the issue) and takes the first N — `list_items` already orders by `priority ASC, created_at ASC, id ASC`, so "N highest-priority unread items" falls out for free from the existing drag-and-drop reorder feature (#903), no new ordering concept needed.
- Returns `[]` when disabled/no user context, so `content_blob["reading_list"]` is only set (and thus only appears in the persisted/returned content) when there's something to show.

Both settings are exposed through the existing `/api/settings/notifications` GET/PUT pair (`briefing_include_reading_list`, `briefing_reading_list_limit`), the same endpoint recap settings use.

Marking an item done stays entirely manual — including it in a briefing never mutates `reading_list_items.status`, matching how `worth_opening` articles are never auto-marked read either.

## Changes
- `backend/news_dashboard/db.py`: two new additive `users` columns (`briefing_include_reading_list` bool default false, `briefing_reading_list_limit` int default 3).
- `backend/news_dashboard/briefings.py`: `_reading_list_section` helper + wiring into `generate_briefing`/`_save_briefing`.
- `backend/news_dashboard/main.py`: extend `NotificationSettingsUpdate` + the notification settings GET/PUT handlers with validation (limit must be 1–20).
- Tests: `backend/tests/test_briefings_db.py` (opt-out by default, opted-in inclusion, limit enforcement, excludes done items) and `backend/tests/test_push_notifications.py` (settings endpoint round-trip + limit validation).

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `source .env && make test` — 1711 backend tests + 802 frontend tests pass