### PR TITLE
feat: add reading-list save option to PWA share target (#906)

### DIFF
--- a/frontend/src/__tests__/shareTarget.test.tsx
+++ b/frontend/src/__tests__/shareTarget.test.tsx
@@ -1,33 +1,42 @@
 // @vitest-environment happy-dom
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as api from '../api';
+import * as readingListApi from '../api/readingListApi';
 import { ShareTargetPage } from '../pages/ShareTargetPage';
 
 const testRoutes = [
   { path: '/share-target', element: <ShareTargetPage /> },
   { path: '/a/:id', element: <div>Reader</div> },
+  { path: '/reading-list', element: <div>Reading list</div> },
 ];
+
+function renderPage(initialEntry: string) {
+  const router = createMemoryRouter(testRoutes, { initialEntries: [initialEntry] });
+  const client = new QueryClient();
+  render(
+    <QueryClientProvider client={client}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+  return router;
+}
 
 describe('ShareTargetPage', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('saves the shared URL and navigates to the article reader', async () => {
+  it('saves the shared URL as an article and navigates to the reader', async () => {
     vi.spyOn(api, 'saveSharedUrl').mockResolvedValue({ id: 42 } as never);
-    const router = createMemoryRouter(testRoutes, {
-      initialEntries: ['/share-target?title=Post&text=Note&url=https%3A%2F%2Fexample.com%2Fpost'],
-    });
-    const client = new QueryClient();
-
-    render(
-      <QueryClientProvider client={client}>
-        <RouterProvider router={router} />
-      </QueryClientProvider>
+    const router = renderPage(
+      '/share-target?title=Post&text=Note&url=https%3A%2F%2Fexample.com%2Fpost'
     );
+
+    await userEvent.click(await screen.findByRole('button', { name: /save as article/i }));
 
     await waitFor(() =>
       expect(api.saveSharedUrl).toHaveBeenCalledWith({
@@ -39,18 +48,21 @@ describe('ShareTargetPage', () => {
     await waitFor(() => expect(router.state.location.pathname).toBe('/a/42'));
   });
 
+  it('saves the shared URL to the reading list and navigates there', async () => {
+    const addSpy = vi
+      .spyOn(readingListApi, 'addReadingListItem')
+      .mockResolvedValue({ id: 7 } as never);
+    const router = renderPage('/share-target?url=https%3A%2F%2Fexample.com%2Fvideo');
+
+    await userEvent.click(await screen.findByRole('button', { name: /save to reading list/i }));
+
+    await waitFor(() => expect(addSpy).toHaveBeenCalledWith('https://example.com/video'));
+    await waitFor(() => expect(router.state.location.pathname).toBe('/reading-list'));
+  });
+
   it('shows a graceful error when the share payload has no URL', async () => {
     const saveSpy = vi.spyOn(api, 'saveSharedUrl');
-    const router = createMemoryRouter(testRoutes, {
-      initialEntries: ['/share-target?text=just+words'],
-    });
-    const client = new QueryClient();
-
-    render(
-      <QueryClientProvider client={client}>
-        <RouterProvider router={router} />
-      </QueryClientProvider>
-    );
+    renderPage('/share-target?text=just+words');
 
     expect(await screen.findByText('Could not save link')).toBeTruthy();
     expect(saveSpy).not.toHaveBeenCalled();

--- a/frontend/src/pages/ShareTargetPage.tsx
+++ b/frontend/src/pages/ShareTargetPage.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Loader2, TriangleAlert } from 'lucide-react';
+import { Bookmark, Loader2, Newspaper, TriangleAlert } from 'lucide-react';
 import { saveSharedUrl } from '@/api';
+import { addReadingListItem } from '@/api/readingListApi';
+import { Button } from '@/components/ui/button';
 
 function extractSharedUrl(params: URLSearchParams): string {
   const directUrl = params.get('url')?.trim();
@@ -10,50 +12,79 @@ function extractSharedUrl(params: URLSearchParams): string {
   return /https?:\/\/\S+/.exec(text)?.[0] ?? '';
 }
 
+type PendingAction = 'article' | 'reading-list' | null;
+
 export function ShareTargetPage() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
+  const [pending, setPending] = useState<PendingAction>(null);
   const [error, setError] = useState<string | null>(null);
   const sharedUrl = useMemo(() => extractSharedUrl(params), [params]);
+  const title = params.get('title');
+  const text = params.get('text');
 
-  useEffect(() => {
-    if (!sharedUrl) {
-      setError('No link was shared.');
-      return;
+  async function handleSaveAsArticle() {
+    setPending('article');
+    setError(null);
+    try {
+      const article = await saveSharedUrl({ url: sharedUrl, title, text });
+      void navigate(`/a/${article.id}`, { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save link.');
+      setPending(null);
     }
-    let cancelled = false;
-    saveSharedUrl({
-      url: sharedUrl,
-      title: params.get('title'),
-      text: params.get('text'),
-    })
-      .then((article) => {
-        if (!cancelled) void navigate(`/a/${article.id}`, { replace: true });
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Could not save link.');
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [navigate, params, sharedUrl]);
+  }
 
-  if (error) {
+  async function handleSaveToReadingList() {
+    setPending('reading-list');
+    setError(null);
+    try {
+      await addReadingListItem(sharedUrl);
+      void navigate('/reading-list', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save link.');
+      setPending(null);
+    }
+  }
+
+  if (!sharedUrl) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center px-4">
         <div className="max-w-sm text-center">
           <TriangleAlert className="mx-auto mb-3 size-8 text-destructive" />
           <h1 className="text-lg font-semibold text-foreground">Could not save link</h1>
-          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+          <p className="mt-2 text-sm text-muted-foreground">No link was shared.</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-[60vh] items-center justify-center gap-2 text-sm text-muted-foreground">
-      <Loader2 className="size-4 animate-spin" />
-      Saving link...
+    <div className="flex min-h-[60vh] items-center justify-center px-4">
+      <div className="w-full max-w-sm text-center">
+        <h1 className="text-lg font-semibold text-foreground">Save shared link</h1>
+        <p className="mt-2 truncate text-sm text-muted-foreground">{title ?? sharedUrl}</p>
+        {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+        <div className="mt-6 flex flex-col gap-2">
+          <Button
+            type="button"
+            onClick={() => void handleSaveAsArticle()}
+            disabled={pending !== null}
+          >
+            {pending === 'article' ? <Loader2 className="animate-spin" /> : <Newspaper />}
+            Save as article
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void handleSaveToReadingList()}
+            disabled={pending !== null}
+          >
+            {pending === 'reading-list' ? <Loader2 className="animate-spin" /> : <Bookmark />}
+            Save to reading list
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #906

## Summary
- `ShareTargetPage` now presents a choice after a link is shared from the OS share sheet: **Save as article** (existing behavior, unchanged API call/navigation) or **Save to reading list** (calls `addReadingListItem`, navigates to `/reading-list`).
- This lets links that aren't well-suited to the article import flow (e.g. a shared YouTube video) go straight into the reading list instead.
- Dedup for reading-list saves is already handled server-side via the `normalize_url` unique constraint (`ON CONFLICT ... DO NOTHING`), so no backend changes were needed.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:frontend` (803 tests passed, including updated/added `shareTarget.test.tsx` cases for both save paths and the existing no-URL error case)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)