### PR TITLE
fix: strip markdown code fences from AI response before JSON parsing in _call_openai and tts (#937)

### DIFF
--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -151,6 +151,22 @@ def chat_create(
     return cast("ChatCompletion", completion)
 
 
+def strip_markdown_fence(text: str) -> str:
+    """Strip a wrapping ```json ... ``` or ``` ... ``` code fence, if present.
+
+    Some model/gateway combinations ignore ``response_format={"type": "json_object"}``
+    and wrap the JSON payload in a markdown code fence, which breaks a direct
+    ``json.loads`` on the raw content. Only strips when the text actually starts
+    with a fence, so already-clean JSON passes through unchanged.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text
+    lines = stripped.splitlines()
+    lines = lines[1:-1] if lines and lines[-1].strip() == "```" else lines[1:]
+    return "\n".join(lines)
+
+
 def openai_config() -> tuple[str, str | None]:
     """Return (api_key, base_url) for real-OpenAI-only features (TTS audio, body extraction).
 

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -249,7 +249,9 @@ def _call_openai(
         endpoint = base_url or "the default OpenAI endpoint"
         msg = f"Briefing AI request to {endpoint} failed: {exc}"
         raise BriefingGenerationError(msg) from exc
-    text = response.choices[0].message.content or "{}"
+    from news_dashboard.ai_client import strip_markdown_fence
+
+    text = strip_markdown_fence(response.choices[0].message.content or "{}")
     try:
         return json.loads(text)  # type: ignore[no-any-return]
     except json.JSONDecodeError as exc:

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -206,7 +206,7 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
     """Generate a conversational podcast script from briefing content using LLM."""
     api_key, base_url = _script_ai_config()
 
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, strip_markdown_fence
 
     model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
     client = get_chat_client(api_key=api_key, base_url=base_url)
@@ -237,7 +237,7 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
         max_tokens=2048,
     )
 
-    text = response.choices[0].message.content or "{}"
+    text = strip_markdown_fence(response.choices[0].message.content or "{}")
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -759,6 +759,22 @@ def test_call_openai_raises_on_invalid_json(monkeypatch: pytest.MonkeyPatch) -> 
         _call_openai([{"id": 1, "title": "A"}], model="gpt-x")
 
 
+def test_call_openai_strips_markdown_fence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Response wrapped in ```json ... ``` is parsed correctly."""
+    payload = '{"title": "T", "sections": []}'
+    _patch_openai(monkeypatch, f"```json\n{payload}\n```")
+    result = _call_openai([{"id": 1, "title": "A"}], model="gpt-x")
+    assert result["title"] == "T"
+
+
+def test_call_openai_strips_plain_fence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Response wrapped in ``` ... ``` (no language tag) is also handled."""
+    payload = '{"title": "T", "sections": []}'
+    _patch_openai(monkeypatch, f"```\n{payload}\n```")
+    result = _call_openai([{"id": 1, "title": "A"}], model="gpt-x")
+    assert result["title"] == "T"
+
+
 def test_call_openai_wraps_upstream_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """An error from the gateway surfaces as BriefingGenerationError, not a bare 500."""
     from openai import OpenAIError

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -309,6 +309,35 @@ def test_generate_podcast_script() -> None:
     assert script[1]["text"] == "Hi Alex!"
 
 
+def test_generate_podcast_script_strips_markdown_fence() -> None:
+    """Response wrapped in ```json ... ``` is parsed correctly."""
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(
+                content=(
+                    "```json\n"
+                    '{"script": [{"speaker": "Alex", "voice": "alloy", "text": "Hello!"}]}\n'
+                    "```"
+                )
+            )
+        )
+    ]
+    with (
+        patch.dict("os.environ", {"FREE_LLM_API_KEY": "sk-free-llm"}),
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
+    ):
+        script = generate_podcast_script(
+            {
+                "title": "Briefing",
+                "summary": "Briefing Summary",
+                "sections": [{"title": "S1", "body": "Body 1"}],
+            }
+        )
+    assert len(script) == 1
+    assert script[0]["text"] == "Hello!"
+
+
 def test_generate_podcast_script_raises_when_no_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #937.

- `_call_openai` in `backend/news_dashboard/briefings.py` and `generate_podcast_script` in `backend/news_dashboard/tts.py` both call `json.loads` directly on the raw model response, even though `response_format={"type": "json_object"}` doesn't guarantee a fence-free payload on every gateway/model combination. A markdown-fenced response (` ```json\n{...}\n``` `) raised `JSONDecodeError` → `BriefingGenerationError`/`ValueError`, burning the retry budget with the same structural failure every attempt (observed in production for `user_id=4`).
- Added a shared `strip_markdown_fence` helper in `backend/news_dashboard/ai_client.py` that strips a wrapping ` ``` ` / ` ```json ` fence only when the text actually starts with one, leaving clean JSON untouched.
- Wired the helper into both call sites. No changes to retry logic, `response_format`, or the scheduler (out of scope per the issue).

## Test plan

- [x] `test_call_openai_strips_markdown_fence` / `test_call_openai_strips_plain_fence` added to `backend/tests/test_briefings_db.py`
- [x] `test_generate_podcast_script_strips_markdown_fence` added to `backend/tests/test_tts.py`
- [x] Existing `test_call_openai_raises_on_invalid_json` and other briefings/tts tests still pass (141 passed across `test_briefings_db.py`, `test_briefings_api.py`, `test_tts.py`)
- [x] `ruff check`, `mypy` clean on changed files
- [x] Full pre-commit hook suite passed on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)