### PR TITLE
fix: derive title from post body for Mastodon feed entries (#940)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -566,9 +566,36 @@ def _fetch_lobsters_feed(source: SourceDefinition) -> list[dict[str, Any]]:
     return _parse_feed_url(source.url)
 
 
+def _mastodon_title(entry: Any) -> str:
+    """Derive a title from the post body for Mastodon entries, which have no <title>."""
+    raw = entry.get("summary") or entry.get("description") or ""
+    text = clean_html(raw)
+    if not text:
+        return "Untitled"
+    return text[:80].rstrip() + ("…" if len(text) > 80 else "")
+
+
 def _fetch_mastodon_feed(source: SourceDefinition) -> list[dict[str, Any]]:
-    """Fetch a Mastodon user or hashtag RSS feed."""
-    return _parse_feed_url(source.url)
+    """Fetch a Mastodon user or hashtag RSS feed.
+
+    Mastodon hashtag/user RSS entries have no <title> element, so the generic
+    "Untitled" fallback in _parse_feed_url always fires; derive one from the body.
+    """
+    content = _fetch_feed_content(source.url)
+    parsed = feedparser.parse(content)
+    if parsed.bozo and not parsed.entries:
+        exc = getattr(parsed, "bozo_exception", None)
+        msg = f"Feed parse failed: {exc or 'no entries, bozo=True'}"
+        raise FeedFetchError(msg)
+    return [
+        {
+            "url": e.get("link") or e.get("id") or "",
+            "title": e.get("title") or _mastodon_title(e),
+            "description": e.get("summary") or e.get("description") or "",
+            "date": parse_date(e),
+        }
+        for e in parsed.entries
+    ]
 
 
 def _fetch_media_feed(source: SourceDefinition) -> list[dict[str, Any]]:

--- a/backend/tests/test_new_feeds.py
+++ b/backend/tests/test_new_feeds.py
@@ -54,13 +54,32 @@ def test_fetch_lobsters_feed_passthrough() -> None:
         mock_parse.assert_called_once_with("https://lobste.rs/rss")
 
 
-def test_fetch_mastodon_feed_passthrough() -> None:
-    """Test that Mastodon URL is passed through unchanged."""
-    source = _make_source("mastodon_feed", "https://mastodon.social/tags/tech.rss")
-    with patch("news_dashboard.ingest._parse_feed_url") as mock_parse:
-        mock_parse.return_value = [{"url": "test", "title": "Test", "description": ""}]
-        _fetch_mastodon_feed(source)
-        mock_parse.assert_called_once_with("https://mastodon.social/tags/tech.rss")
+def test_mastodon_feed_derives_title_from_summary() -> None:
+    """Title should be derived from entry summary when entry.title is absent."""
+    source = _make_source("mastodon_feed", "https://mastodon.social/tags/technology.rss")
+    body_html = "<p>This is a Mastodon post about open-source software and distributed nets.</p>"
+    fake_entry = {"link": "https://mastodon.social/@user/1", "title": "", "summary": body_html}
+    with (
+        patch("news_dashboard.ingest._fetch_feed_content", return_value=b""),
+        patch("news_dashboard.ingest.feedparser") as mock_fp,
+    ):
+        mock_fp.parse.return_value = Mock(bozo=False, entries=[fake_entry])
+        entries = _fetch_mastodon_feed(source)
+    assert entries[0]["title"] != "Untitled"
+    assert "Mastodon post" in entries[0]["title"]
+
+
+def test_mastodon_feed_falls_back_to_untitled_when_no_body() -> None:
+    """Falls back to 'Untitled' only when summary and description are also absent."""
+    source = _make_source("mastodon_feed", "https://mastodon.social/tags/technology.rss")
+    fake_entry = {"link": "https://mastodon.social/@user/2", "title": "", "summary": ""}
+    with (
+        patch("news_dashboard.ingest._fetch_feed_content", return_value=b""),
+        patch("news_dashboard.ingest.feedparser") as mock_fp,
+    ):
+        mock_fp.parse.return_value = Mock(bozo=False, entries=[fake_entry])
+        entries = _fetch_mastodon_feed(source)
+    assert entries[0]["title"] == "Untitled"
 
 
 def test_ingest_source_routes_to_correct_function() -> None:


### PR DESCRIPTION
## Summary
- Fixes #940: Mastodon hashtag/user RSS entries have no `<title>` element, so every ingested Mastodon article was stored as `"Untitled"`.
- `_fetch_mastodon_feed` now builds its own entry list instead of delegating to `_parse_feed_url`, deriving the title from `entry.summary`/`entry.description` (HTML-stripped via `clean_html`, truncated to ~80 chars with a trailing `…`), falling back to `"Untitled"` only when the body is also empty.

## Test plan
- [x] Added `test_mastodon_feed_derives_title_from_summary` — asserts a plain-text snippet is derived when `entry.title` is absent but `entry.summary` has body text.
- [x] Added `test_mastodon_feed_falls_back_to_untitled_when_no_body` — asserts `"Untitled"` fallback when both `title` and `summary` are empty.
- [x] `pytest backend/tests/test_new_feeds.py` — 6 passed
- [x] `ruff check`, `ruff format --check`, `mypy` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)