### PR TITLE
feat: thumbs up/down feedback on briefings and recommendations (#931)

### DIFF
--- a/backend/news_dashboard/ai_feedback/__init__.py
+++ b/backend/news_dashboard/ai_feedback/__init__.py
@@ -1,0 +1,1 @@
+"""Explicit thumbs up/down feedback on briefings and recommendations."""

--- a/backend/news_dashboard/ai_feedback/models.py
+++ b/backend/news_dashboard/ai_feedback/models.py
@@ -1,0 +1,18 @@
+"""Request models for the ai_feedback feature module."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+SubjectType = Literal["briefing", "recommendation"]
+Verdict = Literal[-1, 1]
+
+
+class AiFeedbackRequest(BaseModel):
+    subject_type: SubjectType
+    subject_id: int
+    article_id: int | None = None
+    verdict: Verdict
+    comment: str | None = None

--- a/backend/news_dashboard/ai_feedback/router.py
+++ b/backend/news_dashboard/ai_feedback/router.py
@@ -1,0 +1,73 @@
+"""HTTP routes for thumbs up/down feedback on briefings and recommendations.
+
+The router carries no blanket auth dependency of its own; it is mounted on
+``main``'s authenticated ``api`` router, which applies ``require_auth`` and
+blocks guest/demo writes.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from news_dashboard.ai_feedback import service
+from news_dashboard.ai_feedback.models import AiFeedbackRequest, SubjectType
+from news_dashboard.auth import require_auth
+
+router = APIRouter()
+
+
+def _validate_subject_type(subject_type: str) -> SubjectType:
+    if subject_type == "briefing":
+        return "briefing"
+    if subject_type == "recommendation":
+        return "recommendation"
+    raise HTTPException(status_code=400, detail="invalid subject_type")
+
+
+@router.post("/api/ai-feedback")
+def record_ai_feedback_endpoint(
+    payload: AiFeedbackRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    comment = (payload.comment or "").strip() or None
+    return service.record_feedback(
+        current_user["id"],
+        payload.subject_type,
+        payload.subject_id,
+        payload.verdict,
+        article_id=payload.article_id,
+        comment=comment,
+    )
+
+
+@router.delete("/api/ai-feedback")
+def delete_ai_feedback_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    subject_type: str,
+    subject_id: int,
+    article_id: int | None = None,
+) -> dict[str, Any]:
+    deleted = service.delete_feedback(
+        current_user["id"],
+        _validate_subject_type(subject_type),
+        subject_id,
+        article_id=article_id,
+    )
+    return {"deleted": deleted}
+
+
+@router.get("/api/ai-feedback")
+def list_ai_feedback_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    subject_type: str,
+    subject_ids: Annotated[str, Query(description="Comma-separated subject ids")],
+) -> dict[str, Any]:
+    ids = [int(part) for part in subject_ids.split(",") if part.strip()]
+    feedback_map = service.get_feedback_map(
+        current_user["id"],
+        _validate_subject_type(subject_type),
+        ids,
+    )
+    return {"items": feedback_map}

--- a/backend/news_dashboard/ai_feedback/service.py
+++ b/backend/news_dashboard/ai_feedback/service.py
@@ -1,0 +1,148 @@
+"""Persist explicit thumbs up/down feedback on briefings and recommendations.
+
+Recommendation feedback keys ``subject_id`` on the article id (there is no
+separate recommendation entity — see ``user_article_recommendations``'s
+``(user_id, article_id)`` primary key). Briefing feedback keys ``subject_id``
+on the briefing id, optionally scoped to one cited ``article_id`` within it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.ai_feedback.models import SubjectType
+from news_dashboard.db import connect, init_db, row_to_dict
+
+
+def _upsert_sql(article_id: int | None) -> str:
+    # Two different partial unique indexes back this table (see db.py) depending
+    # on whether article_id is NULL, so the ON CONFLICT target must match.
+    if article_id is None:
+        conflict = "(user_id, subject_type, subject_id) WHERE article_id IS NULL"
+    else:
+        conflict = "(user_id, subject_type, subject_id, article_id) WHERE article_id IS NOT NULL"
+    return f"""
+        INSERT INTO ai_feedback (user_id, subject_type, subject_id, article_id, verdict, comment)
+        VALUES (%(user_id)s, %(subject_type)s, %(subject_id)s, %(article_id)s,
+                %(verdict)s, %(comment)s)
+        ON CONFLICT {conflict}
+        DO UPDATE SET verdict = EXCLUDED.verdict, comment = EXCLUDED.comment,
+                       updated_at = NOW()
+        RETURNING id, user_id, subject_type, subject_id, article_id, verdict, comment, created_at
+    """
+
+
+def record_feedback(  # noqa: PLR0913
+    user_id: int,
+    subject_type: SubjectType,
+    subject_id: int,
+    verdict: int,
+    *,
+    article_id: int | None = None,
+    comment: str | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Record or replace the user's verdict; returns the saved row.
+
+    Also attaches the verdict as a Langfuse score to the briefing's generation
+    trace when one was captured and Langfuse is configured; a no-op otherwise.
+    """
+    init_db(db_path, database_url=database_url)
+    params = {
+        "user_id": user_id,
+        "subject_type": subject_type,
+        "subject_id": subject_id,
+        "article_id": article_id,
+        "verdict": verdict,
+        "comment": comment,
+    }
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(_upsert_sql(article_id), params).fetchone()
+    saved = dict(row_to_dict(row))
+
+    if subject_type == "briefing":
+        _score_briefing_trace(
+            subject_id, verdict, comment, db_path=db_path, database_url=database_url
+        )
+    return saved
+
+
+def delete_feedback(
+    user_id: int,
+    subject_type: SubjectType,
+    subject_id: int,
+    *,
+    article_id: int | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> bool:
+    """Retract a previously recorded verdict. Returns whether a row was deleted."""
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        if article_id is None:
+            result = conn.execute(
+                "DELETE FROM ai_feedback WHERE user_id = %s AND subject_type = %s"
+                " AND subject_id = %s AND article_id IS NULL",
+                (user_id, subject_type, subject_id),
+            )
+        else:
+            result = conn.execute(
+                "DELETE FROM ai_feedback WHERE user_id = %s AND subject_type = %s"
+                " AND subject_id = %s AND article_id = %s",
+                (user_id, subject_type, subject_id, article_id),
+            )
+        return bool(result.rowcount > 0)
+
+
+def get_feedback_map(
+    user_id: int,
+    subject_type: SubjectType,
+    subject_ids: list[int],
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, int]:
+    """Return ``{"<subject_id>:<article_id or ''>": verdict}`` for the given subjects."""
+    if not subject_ids:
+        return {}
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            "SELECT subject_id, article_id, verdict FROM ai_feedback"
+            " WHERE user_id = %s AND subject_type = %s AND subject_id = ANY(%s)",
+            (user_id, subject_type, subject_ids),
+        ).fetchall()
+    result: dict[str, int] = {}
+    for row in rows:
+        d = row_to_dict(row)
+        key = f"{d['subject_id']}:{d['article_id'] if d['article_id'] is not None else ''}"
+        result[key] = int(d["verdict"])
+    return result
+
+
+def _score_briefing_trace(
+    briefing_id: int,
+    verdict: int,
+    comment: str | None,
+    *,
+    db_path: Path | str | None,
+    database_url: str | None,
+) -> None:
+    from news_dashboard.ai_client import create_score
+
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT trace_id FROM briefings WHERE id = %s",
+            (briefing_id,),
+        ).fetchone()
+    trace_id = row_to_dict(row).get("trace_id") if row else None
+    if not trace_id:
+        return
+    create_score(
+        trace_id,
+        name="user-thumbs",
+        value=verdict,
+        data_type="NUMERIC",
+        comment=comment,
+    )

--- a/backend/news_dashboard/briefings.py
+++ b/backend/news_dashboard/briefings.py
@@ -212,7 +212,7 @@ def _call_openai(
 
     from openai import OpenAIError  # lazy import — optional dep at import time
 
-    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt, observe
     from news_dashboard.ai_memory.service import format_memories_for_prompt
 
     prompt = get_prompt("briefing-system", fallback=_BRIEFING_SYSTEM_PROMPT)
@@ -227,36 +227,42 @@ def _call_openai(
     user = "Articles:\n\n" + "\n\n".join(article_lines)
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
-    try:
-        response = chat_create(
-            client,
-            name="briefing-generation",
-            tags=["briefing"],
-            user_id=user_id,
-            prompt=prompt,
-            model=model,
-            messages=[
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
-            response_format={"type": "json_object"},
-            max_tokens=2048,
-        )
-    except OpenAIError as exc:
-        # Connection refused, auth failure, or the model/gateway rejecting the
-        # request (e.g. an endpoint that does not support JSON response_format).
-        # Surface the upstream reason instead of an opaque 500.
-        endpoint = base_url or "the default OpenAI endpoint"
-        msg = f"Briefing AI request to {endpoint} failed: {exc}"
-        raise BriefingGenerationError(msg) from exc
-    from news_dashboard.ai_client import strip_markdown_fence
+    # Grouped under one Langfuse trace so its id can carry user thumbs feedback
+    # (see the ``ai_feedback`` module) even though this helper only returns JSON.
+    with observe("briefing-generation", input={"model": model}) as trace:
+        try:
+            response = chat_create(
+                client,
+                name="briefing-generation",
+                tags=["briefing"],
+                user_id=user_id,
+                prompt=prompt,
+                model=model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                response_format={"type": "json_object"},
+                max_tokens=2048,
+            )
+        except OpenAIError as exc:
+            # Connection refused, auth failure, or the model/gateway rejecting the
+            # request (e.g. an endpoint that does not support JSON response_format).
+            # Surface the upstream reason instead of an opaque 500.
+            endpoint = base_url or "the default OpenAI endpoint"
+            msg = f"Briefing AI request to {endpoint} failed: {exc}"
+            raise BriefingGenerationError(msg) from exc
+        from news_dashboard.ai_client import strip_markdown_fence
 
-    text = strip_markdown_fence(response.choices[0].message.content or "{}")
-    try:
-        return json.loads(text)  # type: ignore[no-any-return]
-    except json.JSONDecodeError as exc:
-        msg = f"AI returned invalid JSON: {exc}"
-        raise BriefingGenerationError(msg) from exc
+        text = strip_markdown_fence(response.choices[0].message.content or "{}")
+        try:
+            parsed: dict[str, Any] = json.loads(text)
+        except json.JSONDecodeError as exc:
+            msg = f"AI returned invalid JSON: {exc}"
+            raise BriefingGenerationError(msg) from exc
+        trace.update_output(parsed)
+    parsed["_trace_id"] = trace.trace_id
+    return parsed
 
 
 def _validate_content(raw: dict[str, Any], candidate_ids: set[int]) -> dict[str, Any]:
@@ -312,6 +318,7 @@ def _save_briefing(  # noqa: PLR0913
     user_id: int | None = None,
     focus_prompt: str | None = None,
     reading_list_items: list[dict[str, Any]] | None = None,
+    trace_id: str | None = None,
 ) -> dict[str, Any]:
     """Insert briefing + article links; return the full briefing dict."""
     title = content.get("title") or ""
@@ -328,9 +335,9 @@ def _save_briefing(  # noqa: PLR0913
             """
             INSERT INTO briefings(
                 scope, since_at, until_at, status,
-                title, summary, content, model, user_id, focus_prompt
+                title, summary, content, model, user_id, focus_prompt, trace_id
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -344,6 +351,7 @@ def _save_briefing(  # noqa: PLR0913
                 model,
                 user_id,
                 focus_prompt,
+                trace_id,
             ),
         ).fetchone()
         if row is None:
@@ -673,6 +681,8 @@ def generate_briefing(  # noqa: PLR0913, PLR0915
         latency_ms=int((time.monotonic() - t0) * 1000),
     )
 
+    trace_id = raw_content.pop("_trace_id", None)
+
     # Stage 4: citation verification.
     try:
         content = _validate_content(raw_content, candidate_ids)
@@ -704,6 +714,7 @@ def generate_briefing(  # noqa: PLR0913, PLR0915
             user_id=user_id,
             focus_prompt=focus_prompt,
             reading_list_items=reading_list_items,
+            trace_id=trace_id,
         )
     except Exception as exc:
         _record(briefing_agent.STAGE_ASSEMBLY, "failed", error=str(exc))

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -813,6 +813,30 @@ POSTGRES_MULTIUSER_SCHEMA = [
         "CREATE INDEX IF NOT EXISTS idx_greader_tokens_user"
         " ON greader_tokens(user_id, created_at DESC)"
     ),
+    "ALTER TABLE briefings ADD COLUMN IF NOT EXISTS trace_id TEXT",
+    """
+    CREATE TABLE IF NOT EXISTS ai_feedback (
+      id           BIGSERIAL PRIMARY KEY,
+      user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      subject_type TEXT NOT NULL CHECK (subject_type IN ('briefing', 'recommendation')),
+      subject_id   BIGINT NOT NULL,
+      article_id   BIGINT REFERENCES articles(id) ON DELETE SET NULL,
+      verdict      SMALLINT NOT NULL CHECK (verdict IN (-1, 1)),
+      comment      TEXT,
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ai_feedback_subject ON ai_feedback(subject_type, subject_id)",
+    # Two partial unique indexes instead of one plain UNIQUE constraint: Postgres
+    # treats NULLs as distinct in a unique constraint, so a plain
+    # UNIQUE(user_id, subject_type, subject_id, article_id) would let a user
+    # insert unlimited duplicate whole-briefing rows (article_id IS NULL).
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_feedback_unique_item"
+    " ON ai_feedback(user_id, subject_type, subject_id, article_id)"
+    " WHERE article_id IS NOT NULL",
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_feedback_unique_subject"
+    " ON ai_feedback(user_id, subject_type, subject_id) WHERE article_id IS NULL",
 ]
 
 # Runs after POSTGRES_SCHEMA/POSTGRES_MULTIUSER_SCHEMA and the embedding_vec

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -3375,6 +3375,7 @@ def admin_delete_user(
 
 # Feature-module routers mount onto ``api`` so they inherit its ``require_auth``
 # gate. Add each new domain's router here as it is extracted from main.py.
+from news_dashboard.ai_feedback.router import router as ai_feedback_router  # noqa: E402
 from news_dashboard.ai_memory.router import router as ai_memory_router  # noqa: E402
 from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E402
 from news_dashboard.greader import public_greader_router  # noqa: E402
@@ -3387,6 +3388,7 @@ from news_dashboard.reading_progress.router import router as reading_progress_ro
 from news_dashboard.recaps.router import router as recaps_router  # noqa: E402
 from news_dashboard.saved_searches.router import router as saved_searches_router  # noqa: E402
 
+api.include_router(ai_feedback_router)
 api.include_router(ai_stats_router)
 api.include_router(ai_memory_router)
 api.include_router(greader_router)

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -36,6 +36,10 @@ STATE_SIGNAL_WEIGHTS: dict[str, float] = {
 # Starred is the strongest positive signal; it stacks on top of the state weight.
 STAR_WEIGHT = 2.0
 
+# Explicit thumbs feedback on a recommendation is a stronger, deliberate signal
+# than any implicit workflow action, so it must outweigh a single star/click.
+EXPLICIT_FEEDBACK_WEIGHT = 3.0
+
 # Laplace-style smoothing: shrinks affinity toward neutral when only a handful of
 # interactions exist for a feature, so a single click can't dominate scoring.
 AFFINITY_SMOOTHING = 2.0
@@ -100,13 +104,15 @@ class ArticleSignal:
     source_slug: str
     category: str | None = None
     tags: tuple[str, ...] = ()
+    explicit_verdict: int = 0
 
     @property
     def weight(self) -> float:
-        """Signed strength of this interaction as an implicit-feedback signal."""
+        """Signed strength of this interaction as an affinity-learning signal."""
         base = STATE_SIGNAL_WEIGHTS.get(self.state, 0.0)
         if self.starred:
             base += STAR_WEIGHT
+        base += self.explicit_verdict * EXPLICIT_FEEDBACK_WEIGHT
         return base
 
 
@@ -519,6 +525,28 @@ def _load_user_signals(conn: Any, user_id: int) -> list[ArticleSignal]:
                 source_slug=str(d["source_slug"]),
                 category=d.get("category"),
                 tags=parse_tags(d.get("tags")),
+            )
+        )
+
+    feedback_rows = conn.execute(
+        """
+        SELECT f.verdict, a.source_slug, a.category, a.tags
+        FROM ai_feedback f
+        JOIN articles a ON a.id = f.subject_id
+        WHERE f.user_id = %s AND f.subject_type = 'recommendation'
+        """,
+        (user_id,),
+    ).fetchall()
+    for row in feedback_rows:
+        d = row_to_dict(row)
+        signals.append(
+            ArticleSignal(
+                state="today",
+                starred=False,
+                source_slug=str(d["source_slug"]),
+                category=d.get("category"),
+                tags=parse_tags(d.get("tags")),
+                explicit_verdict=int(d["verdict"]),
             )
         )
     return signals

--- a/backend/tests/test_ai_feedback.py
+++ b/backend/tests/test_ai_feedback.py
@@ -1,0 +1,290 @@
+"""Tests for thumbs up/down feedback on briefings and recommendations (#931)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.ai_feedback import service
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+from news_dashboard.recommendations import (
+    ArticleSignal,
+    _load_user_signals,
+    build_affinity_profile,
+)
+
+# ── Seeding helpers ───────────────────────────────────────────────────────────
+
+
+def _setup_db(monkeypatch: pytest.MonkeyPatch, pg_url: str) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    init_db(database_url=pg_url)
+    return pg_url
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_source(pg_url: str, slug: str = "test-source") -> None:
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, "Test Source", f"https://example.com/{slug}", "tech", "rss_feed"),
+        )
+
+
+def _seed_article(
+    pg_url: str,
+    *,
+    url: str,
+    title: str = "Test Article",
+    source_slug: str = "test-source",
+) -> int:
+    _seed_source(pg_url, source_slug)
+    ts = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name,
+              category, kind, importance_score, state, discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (url, url, title, source_slug, "Test Source", "tech", "rss_feed", 50, "new", ts),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_briefing(pg_url: str, *, user_id: int, trace_id: str | None = None) -> int:
+    now = datetime.now(timezone.utc)
+    with connect(database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO briefings(
+                scope, since_at, until_at, status, title, summary, content,
+                model, user_id, trace_id
+            )
+            VALUES ('day', %s, %s, 'complete', 'Title', 'Summary', '{}'::jsonb,
+                    'gpt-4o-mini', %s, %s)
+            RETURNING id
+            """,
+            (now - timedelta(hours=1), now, user_id, trace_id),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ── Service: upsert / retract semantics ──────────────────────────────────────
+
+
+def test_record_feedback_upserts_on_second_call(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    briefing_id = _seed_briefing(database_url, user_id=user_id)
+
+    first = service.record_feedback(user_id, "briefing", briefing_id, 1, database_url=database_url)
+    second = service.record_feedback(
+        user_id, "briefing", briefing_id, -1, comment="changed my mind", database_url=database_url
+    )
+
+    assert first["verdict"] == 1
+    assert second["id"] == first["id"]
+    assert second["verdict"] == -1
+    assert second["comment"] == "changed my mind"
+
+    with connect(database_url=database_url) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM ai_feedback WHERE user_id = %s", (user_id,)
+        ).fetchone()["count"]
+    assert count == 1
+
+
+def test_record_feedback_allows_per_article_and_whole_briefing_rows(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    briefing_id = _seed_briefing(database_url, user_id=user_id)
+    article_id = _seed_article(database_url, url="https://example.com/a")
+
+    whole = service.record_feedback(user_id, "briefing", briefing_id, 1, database_url=database_url)
+    per_article = service.record_feedback(
+        user_id, "briefing", briefing_id, -1, article_id=article_id, database_url=database_url
+    )
+    # Retracting the whole-briefing verdict twice must not create duplicates.
+    service.record_feedback(user_id, "briefing", briefing_id, 1, database_url=database_url)
+
+    assert whole["id"] != per_article["id"]
+    with connect(database_url=database_url) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM ai_feedback WHERE user_id = %s", (user_id,)
+        ).fetchone()["count"]
+    assert count == 2
+
+
+def test_delete_feedback_retracts_verdict(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    briefing_id = _seed_briefing(database_url, user_id=user_id)
+    service.record_feedback(user_id, "briefing", briefing_id, 1, database_url=database_url)
+
+    deleted = service.delete_feedback(user_id, "briefing", briefing_id, database_url=database_url)
+    deleted_again = service.delete_feedback(
+        user_id, "briefing", briefing_id, database_url=database_url
+    )
+
+    assert deleted is True
+    assert deleted_again is False
+
+
+def test_get_feedback_map_keys_by_subject_and_article(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    briefing_id = _seed_briefing(database_url, user_id=user_id)
+    article_id = _seed_article(database_url, url="https://example.com/a")
+
+    service.record_feedback(user_id, "briefing", briefing_id, 1, database_url=database_url)
+    service.record_feedback(
+        user_id, "briefing", briefing_id, -1, article_id=article_id, database_url=database_url
+    )
+
+    feedback_map = service.get_feedback_map(
+        user_id, "briefing", [briefing_id], database_url=database_url
+    )
+    assert feedback_map[f"{briefing_id}:"] == 1
+    assert feedback_map[f"{briefing_id}:{article_id}"] == -1
+
+
+# ── Langfuse trace scoring ────────────────────────────────────────────────────
+
+
+def test_record_feedback_scores_briefing_trace_when_present(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    briefing_id = _seed_briefing(database_url, user_id=user_id, trace_id="trace-abc")
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_create_score(trace_id: str, **kwargs: object) -> bool:
+        calls.append({"trace_id": trace_id, **kwargs})
+        return True
+
+    monkeypatch.setattr("news_dashboard.ai_client.create_score", _fake_create_score)
+
+    service.record_feedback(user_id, "briefing", briefing_id, -1, database_url=database_url)
+
+    assert len(calls) == 1
+    assert calls[0]["trace_id"] == "trace-abc"
+    assert calls[0]["value"] == -1
+
+
+def test_record_feedback_skips_scoring_without_trace(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    briefing_id = _seed_briefing(database_url, user_id=user_id, trace_id=None)
+
+    def _fail(*_args: object, **_kwargs: object) -> bool:
+        pytest.fail("create_score should not be called without a trace_id")
+
+    monkeypatch.setattr("news_dashboard.ai_client.create_score", _fail)
+
+    service.record_feedback(user_id, "briefing", briefing_id, 1, database_url=database_url)
+
+
+# ── API endpoints ─────────────────────────────────────────────────────────────
+
+
+def test_post_and_delete_ai_feedback_endpoints(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    briefing_id = _seed_briefing(database_url, user_id=user_id)
+
+    try:
+        with _client_for(user_id) as client:
+            posted = client.post(
+                "/api/ai-feedback",
+                json={"subject_type": "briefing", "subject_id": briefing_id, "verdict": 1},
+            )
+            listed = client.get(
+                "/api/ai-feedback",
+                params={"subject_type": "briefing", "subject_ids": str(briefing_id)},
+            )
+            deleted = client.request(
+                "DELETE",
+                "/api/ai-feedback",
+                params={"subject_type": "briefing", "subject_id": briefing_id},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert posted.status_code == 200
+    assert posted.json()["verdict"] == 1
+    assert listed.json()["items"][f"{briefing_id}:"] == 1
+    assert deleted.status_code == 200
+    assert deleted.json()["deleted"] is True
+
+
+# ── Recommendation scoring integration ────────────────────────────────────────
+
+
+def test_score_article_thumbs_down_outweighs_implicit_click(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    article_id = _seed_article(
+        database_url, url="https://example.com/a", source_slug="disliked-source"
+    )
+    service.record_feedback(user_id, "recommendation", article_id, -1, database_url=database_url)
+
+    with connect(database_url=database_url) as conn:
+        signals = _load_user_signals(conn, user_id)
+
+    assert len(signals) == 1
+    profile = build_affinity_profile(signals)
+    assert profile.sources["disliked-source"] < 0
+
+    # A single implicit "today" click carries zero weight, so even one explicit
+    # thumbs-down must pull the source affinity meaningfully negative.
+    implicit_only = build_affinity_profile(
+        [ArticleSignal(state="today", starred=False, source_slug="disliked-source")]
+    )
+    assert profile.sources["disliked-source"] < implicit_only.sources.get("disliked-source", 0.0)

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -750,7 +750,7 @@ def test_call_openai_parses_valid_json(monkeypatch: pytest.MonkeyPatch) -> None:
         [{"id": 1, "title": "A", "summary": "s", "source_name": "S", "category": "c"}],
         model="gpt-x",
     )
-    assert result == {"title": "T", "sections": []}
+    assert result == {"title": "T", "sections": [], "_trace_id": None}
 
 
 def test_call_openai_raises_on_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/frontend/src/__tests__/aiFeedbackThumbs.test.tsx
+++ b/frontend/src/__tests__/aiFeedbackThumbs.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AiFeedbackThumbs } from '../components/AiFeedbackThumbs';
+import * as api from '../api';
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AiFeedbackThumbs', () => {
+  it('renders unselected when no prior feedback exists', async () => {
+    vi.spyOn(api, 'fetchAiFeedback').mockResolvedValue({});
+
+    render(<AiFeedbackThumbs subjectType="briefing" subjectId={7} />);
+
+    await waitFor(() => expect(api.fetchAiFeedback).toHaveBeenCalledWith('briefing', [7]));
+    expect(screen.getByLabelText('Thumbs up').getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByLabelText('Thumbs down').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('preselects the persisted verdict on mount', async () => {
+    vi.spyOn(api, 'fetchAiFeedback').mockResolvedValue({ '7:': 1 });
+
+    render(<AiFeedbackThumbs subjectType="briefing" subjectId={7} />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Thumbs up').getAttribute('aria-pressed')).toBe('true')
+    );
+  });
+
+  it('optimistically selects thumbs up and posts feedback', async () => {
+    vi.spyOn(api, 'fetchAiFeedback').mockResolvedValue({});
+    const post = vi.spyOn(api, 'postAiFeedback').mockResolvedValue({
+      id: 1,
+      user_id: 1,
+      subject_type: 'briefing',
+      subject_id: 7,
+      article_id: null,
+      verdict: 1,
+      comment: null,
+      created_at: '2026-01-01T00:00:00Z',
+    });
+
+    render(<AiFeedbackThumbs subjectType="briefing" subjectId={7} />);
+    await userEvent.click(screen.getByLabelText('Thumbs up'));
+
+    expect(screen.getByLabelText('Thumbs up').getAttribute('aria-pressed')).toBe('true');
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('briefing', 7, 1, { articleId: undefined })
+    );
+  });
+
+  it('clicking the selected verdict again retracts it', async () => {
+    vi.spyOn(api, 'fetchAiFeedback').mockResolvedValue({ '7:': 1 });
+    const del = vi.spyOn(api, 'deleteAiFeedback').mockResolvedValue({ deleted: true });
+
+    render(<AiFeedbackThumbs subjectType="briefing" subjectId={7} />);
+    await waitFor(() =>
+      expect(screen.getByLabelText('Thumbs up').getAttribute('aria-pressed')).toBe('true')
+    );
+
+    await userEvent.click(screen.getByLabelText('Thumbs up'));
+
+    expect(screen.getByLabelText('Thumbs up').getAttribute('aria-pressed')).toBe('false');
+    await waitFor(() => expect(del).toHaveBeenCalledWith('briefing', 7, { articleId: undefined }));
+  });
+
+  it('reverts the optimistic update when the request fails', async () => {
+    vi.spyOn(api, 'fetchAiFeedback').mockResolvedValue({});
+    vi.spyOn(api, 'postAiFeedback').mockRejectedValue(new Error('network error'));
+
+    render(<AiFeedbackThumbs subjectType="briefing" subjectId={7} />);
+    await userEvent.click(screen.getByLabelText('Thumbs up'));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Thumbs up').getAttribute('aria-pressed')).toBe('false')
+    );
+  });
+});

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -23,6 +23,7 @@ vi.spyOn(console, 'error').mockImplementation(() => undefined);
 beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(api, 'fetchArticleHighlights').mockResolvedValue([]);
+  vi.spyOn(api, 'fetchAiFeedback').mockResolvedValue({});
 });
 
 function makeArticle(overrides: Partial<Article> = {}): Article {

--- a/frontend/src/api/aiFeedback.ts
+++ b/frontend/src/api/aiFeedback.ts
@@ -1,0 +1,65 @@
+import { requestJson } from './core';
+
+export type AiFeedbackSubjectType = 'briefing' | 'recommendation';
+export type AiFeedbackVerdict = -1 | 1;
+
+export interface AiFeedback {
+  id: number;
+  user_id: number;
+  subject_type: AiFeedbackSubjectType;
+  subject_id: number;
+  article_id: number | null;
+  verdict: AiFeedbackVerdict;
+  comment: string | null;
+  created_at: string;
+}
+
+export async function postAiFeedback(
+  subjectType: AiFeedbackSubjectType,
+  subjectId: number,
+  verdict: AiFeedbackVerdict,
+  options?: { articleId?: number; comment?: string }
+): Promise<AiFeedback> {
+  return requestJson<AiFeedback>('/api/ai-feedback', {
+    method: 'POST',
+    body: JSON.stringify({
+      subject_type: subjectType,
+      subject_id: subjectId,
+      article_id: options?.articleId ?? null,
+      verdict,
+      comment: options?.comment ?? null,
+    }),
+  });
+}
+
+export async function deleteAiFeedback(
+  subjectType: AiFeedbackSubjectType,
+  subjectId: number,
+  options?: { articleId?: number }
+): Promise<{ deleted: boolean }> {
+  const params = new URLSearchParams({
+    subject_type: subjectType,
+    subject_id: String(subjectId),
+  });
+  if (options?.articleId != null) {
+    params.set('article_id', String(options.articleId));
+  }
+  return requestJson<{ deleted: boolean }>(`/api/ai-feedback?${params}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function fetchAiFeedback(
+  subjectType: AiFeedbackSubjectType,
+  subjectIds: number[]
+): Promise<Record<string, AiFeedbackVerdict>> {
+  if (subjectIds.length === 0) return {};
+  const params = new URLSearchParams({
+    subject_type: subjectType,
+    subject_ids: subjectIds.join(','),
+  });
+  const response = await requestJson<{ items: Record<string, AiFeedbackVerdict> }>(
+    `/api/ai-feedback?${params}`
+  );
+  return response.items;
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from './core';
 export * from './admin';
+export * from './aiFeedback';
 export * from './ask';
 export * from './articles';
 export * from './auth';

--- a/frontend/src/components/AiFeedbackThumbs.tsx
+++ b/frontend/src/components/AiFeedbackThumbs.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import {
+  deleteAiFeedback,
+  fetchAiFeedback,
+  postAiFeedback,
+  type AiFeedbackSubjectType,
+  type AiFeedbackVerdict,
+} from '@/api';
+
+/** Thumbs up/down feedback control for a briefing or recommendation. */
+export function AiFeedbackThumbs({
+  subjectType,
+  subjectId,
+  articleId,
+  className,
+}: {
+  subjectType: AiFeedbackSubjectType;
+  subjectId: number;
+  articleId?: number;
+  className?: string;
+}) {
+  const [verdict, setVerdict] = useState<AiFeedbackVerdict | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAiFeedback(subjectType, [subjectId])
+      .then((items) => {
+        if (cancelled) return;
+        const key = `${subjectId}:${articleId ?? ''}`;
+        setVerdict(items[key] ?? null);
+      })
+      .catch(() => {
+        // Non-critical: thumbs simply render unselected if the lookup fails.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [subjectType, subjectId, articleId]);
+
+  async function handleClick(next: AiFeedbackVerdict) {
+    if (pending) return;
+    setPending(true);
+    const previous = verdict;
+    const nextVerdict = previous === next ? null : next;
+    setVerdict(nextVerdict);
+    try {
+      if (nextVerdict === null) {
+        await deleteAiFeedback(subjectType, subjectId, { articleId });
+      } else {
+        await postAiFeedback(subjectType, subjectId, nextVerdict, { articleId });
+      }
+    } catch {
+      setVerdict(previous);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className={`inline-flex items-center gap-1 ${className ?? ''}`}>
+      <button
+        type="button"
+        aria-label="Thumbs up"
+        aria-pressed={verdict === 1}
+        disabled={pending}
+        onClick={() => void handleClick(1)}
+        className={`rounded-md p-1 transition-colors ${
+          verdict === 1
+            ? 'text-primary bg-primary/10'
+            : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+        }`}
+      >
+        <ThumbsUp className="size-3.5" strokeWidth={1.75} />
+      </button>
+      <button
+        type="button"
+        aria-label="Thumbs down"
+        aria-pressed={verdict === -1}
+        disabled={pending}
+        onClick={() => void handleClick(-1)}
+        className={`rounded-md p-1 transition-colors ${
+          verdict === -1
+            ? 'text-destructive bg-destructive/10'
+            : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+        }`}
+      >
+        <ThumbsDown className="size-3.5" strokeWidth={1.75} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/BriefingView.tsx
+++ b/frontend/src/components/BriefingView.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { RefreshCw, Headphones, ChevronDown, ChevronUp, Sparkles, AlertCircle } from 'lucide-react';
+import { AiFeedbackThumbs } from '@/components/AiFeedbackThumbs';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { formatDate, formatWindow } from '@/lib/briefingUtils';
@@ -146,10 +147,16 @@ export function BriefingView({
           <h2 className="text-[22px] font-semibold tracking-tight leading-tight break-words">
             {briefing.title}
           </h2>
-          <p className="text-xs text-muted-foreground mt-1">
-            {formatDate(briefing.created_at)} · {formatWindow(briefing.since_at, briefing.until_at)}{' '}
-            · {articleCount} {articleCount === 1 ? 'article' : 'articles'}
-          </p>
+          <div className="text-xs text-muted-foreground mt-1 flex items-center gap-2">
+            <span>
+              {formatDate(briefing.created_at)} ·{' '}
+              {formatWindow(briefing.since_at, briefing.until_at)} · {articleCount}{' '}
+              {articleCount === 1 ? 'article' : 'articles'}
+            </span>
+            {briefing.status === 'complete' && (
+              <AiFeedbackThumbs subjectType="briefing" subjectId={briefing.id} />
+            )}
+          </div>
           {afterMeta}
         </div>
         {onGenerate && (

--- a/frontend/src/components/article/ArticleWhyRecommended.tsx
+++ b/frontend/src/components/article/ArticleWhyRecommended.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
 import { Lightbulb } from 'lucide-react';
+import { AiFeedbackThumbs } from '@/components/AiFeedbackThumbs';
 import { recommendationExplanation } from '@/lib/recommendation';
 import type { RecommendationSignals } from '@/lib/workflowTypes';
 
 export function ArticleWhyRecommended({
+  articleId,
   aiExplanation,
   score,
   signals,
 }: {
+  articleId: number;
   aiExplanation: string | null | undefined;
   score: number | null | undefined;
   signals: RecommendationSignals | null | undefined;
@@ -16,15 +19,18 @@ export function ArticleWhyRecommended({
 
   return (
     <div className="mt-3">
-      <button
-        onClick={() => setShowWhyRecommended((v) => !v)}
-        data-testid="why-recommended-button"
-        aria-expanded={showWhyRecommended}
-        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface/40 px-3 py-1.5 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-surface transition-colors"
-      >
-        <Lightbulb className="size-3.5" strokeWidth={1.75} />
-        {showWhyRecommended ? 'Hide why recommended' : 'Why recommended?'}
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setShowWhyRecommended((v) => !v)}
+          data-testid="why-recommended-button"
+          aria-expanded={showWhyRecommended}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface/40 px-3 py-1.5 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-surface transition-colors"
+        >
+          <Lightbulb className="size-3.5" strokeWidth={1.75} />
+          {showWhyRecommended ? 'Hide why recommended' : 'Why recommended?'}
+        </button>
+        <AiFeedbackThumbs subjectType="recommendation" subjectId={articleId} />
+      </div>
       {showWhyRecommended &&
         (() => {
           const explanation = recommendationExplanation({ score, signals });

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -244,6 +244,7 @@ export function ArticlePage() {
 
             {/* Why recommended — on-demand explanation of the personalized ranking */}
             <ArticleWhyRecommended
+              articleId={Number(article.id)}
               aiExplanation={article.recommendationExplanation}
               score={article.recommendationScore}
               signals={article.recommendationSignals}


### PR DESCRIPTION
## Summary
- Adds an `ai_feedback` table (upsert/retract semantics, keyed on `user_id` + `subject_type` + `subject_id` + optional `article_id`) and a small `ai_feedback` feature-module router/service (`POST`/`GET`/`DELETE /api/ai-feedback`), mounted on `main`'s authenticated `api` router.
- Adds thumbs up/down UI: on `BriefingView` (whole-briefing feedback) and on the article page's "Why recommended" card (per-recommendation feedback), with optimistic updates and persisted state across reloads.
- Recommendation feedback folds into `recommendations.py`'s affinity scoring as a new `ArticleSignal.explicit_verdict` weighted at `EXPLICIT_FEEDBACK_WEIGHT = 3.0` — stronger than an implicit star/click, so a thumbs-down meaningfully outweighs a click.
- Briefing feedback attaches as a Langfuse `user-thumbs` score to the briefing's generation trace: `briefings.py`'s `_call_openai` now wraps its chat call in `ai_client.observe(...)` and persists the resulting `trace_id` on the `briefings` row (new nullable column); scoring is a no-op when Langfuse isn't configured or no trace was captured.

Closes #931.

## Test plan
- [x] Backend: `backend/tests/test_ai_feedback.py` — upsert/retract semantics (including the whole-briefing vs. per-article partial-unique-index distinction), the `GET` feedback map, Langfuse trace scoring (present/absent trace), and a `score_article`/`_load_user_signals` test proving thumbs-down outweighs an implicit click.
- [x] Frontend: `frontend/src/__tests__/aiFeedbackThumbs.test.tsx` — initial state, optimistic select/retract, and rollback on request failure.
- [x] Full backend suite: `pytest backend/tests` — 1723 passed.
- [x] Full frontend suite: `vitest run` — 808 passed.
- [x] `ruff check`, `ruff format --check`, `mypy`, `ty`, `pyrefly`, `vulture`, `eslint`, `prettier`, `knip`, `tsc` all pass (pre-commit hook run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)