### PR TITLE
fix: replace medium.com substring check with exact hostname match in _try_amp_url

### DIFF
--- a/backend/news_dashboard/selenium_client.py
+++ b/backend/news_dashboard/selenium_client.py
@@ -225,7 +225,7 @@ def _try_amp_url(url: str) -> str | None:
     """Return an AMP variant of *url* for domains that support it, or None."""
     parsed = urllib.parse.urlparse(url)
     hostname = parsed.hostname or ""
-    if "medium.com" in hostname:
+    if hostname == "medium.com" or hostname.endswith(".medium.com"):
         path = parsed.path
         if not path.startswith("/amp"):
             return urllib.parse.urlunparse(parsed._replace(path=f"/amp{path}"))

--- a/backend/tests/test_selenium_client.py
+++ b/backend/tests/test_selenium_client.py
@@ -171,6 +171,20 @@ def test_try_amp_url_non_medium_returns_none() -> None:
     assert _try_amp_url("https://example.com/article") is None
 
 
+def test_try_amp_url_medium_subdomain() -> None:
+    amp = _try_amp_url("https://blog.medium.com/post")
+    assert amp is not None
+    assert "/amp/" in amp
+
+
+def test_try_amp_url_medium_lookalike_suffix_returns_none() -> None:
+    assert _try_amp_url("https://medium.com.evil.example/post") is None
+
+
+def test_try_amp_url_medium_lookalike_prefix_returns_none() -> None:
+    assert _try_amp_url("https://notmedium.com/post") is None
+
+
 # ── Fetch timeout handling ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- `_try_amp_url()` in `backend/news_dashboard/selenium_client.py` used `"medium.com" in hostname`, which also matches lookalike hostnames like `medium.com.evil.example` or `notmedium.com` (CodeQL alert #8, `py/incomplete-url-substring-sanitization`).
- Replaced with an exact-or-subdomain match: `hostname == "medium.com" or hostname.endswith(".medium.com")`.
- No behavior change for genuine `medium.com` / `*.medium.com` URLs.

Closes #971

## Test plan
- [x] Added TDD-first tests: `test_try_amp_url_medium_subdomain`, `test_try_amp_url_medium_lookalike_suffix_returns_none`, `test_try_amp_url_medium_lookalike_prefix_returns_none` — verified the two lookalike-hostname tests fail against the old substring check before applying the fix.
- [x] `pytest backend/tests/test_selenium_client.py -q` — 24 passed
- [x] `ruff check` — all checks passed
- [x] `mypy backend/news_dashboard/selenium_client.py` — no issues
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)