### PR TITLE
refactor: migrate article embeddings to pgvector for SQL similarity search (#924)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - db
 
   db:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     restart: unless-stopped
     environment:
       POSTGRES_DB: news_dashboard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       (github.event_name == 'pull_request' && needs.detect-changes.outputs.backend == 'true')
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_DB: news_dashboard
           POSTGRES_USER: news_dashboard

--- a/.github/workflows/pr-timing.yml
+++ b/.github/workflows/pr-timing.yml
@@ -46,7 +46,7 @@ jobs:
             ref: ${{ github.event.pull_request.base.sha }}
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_DB: news_dashboard
           POSTGRES_USER: news_dashboard

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/github/license/lihor-hub/news-dashboard)](LICENSE)
 ![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue)
 ![Node 26](https://img.shields.io/badge/node-26-339933)
-![PostgreSQL 16+](https://img.shields.io/badge/postgresql-16%2B-4169E1)
+![PostgreSQL 16+ pgvector](https://img.shields.io/badge/postgresql-16%2B%20pgvector-4169E1)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/lihor-hub/news-dashboard)
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/lihor-hub/news-dashboard)
 
@@ -43,7 +43,7 @@ optional OpenAI features for embeddings, Ask AI, and briefings.
 
 - Python 3.14+
 - Node.js and npm compatible with `package-lock.json`
-- PostgreSQL 16+
+- PostgreSQL 16+ with the [pgvector](https://github.com/pgvector/pgvector) extension (the `pgvector/pgvector:pg16` image, or install `vector` on an external Postgres)
 - Docker and Docker Compose for the container flow
 - API key for AI features (`FREE_LLM_API_KEY` or `OPENAI_API_KEY`)
 
@@ -78,6 +78,15 @@ Runtime storage is PostgreSQL only. Set `DATABASE_URL` or the split
 SQLite is supported only as a legacy import source for
 `news-dashboard-migrate sqlite-to-postgres`.
 
+> **Upgrading an existing deployment:** article embeddings moved from an
+> opaque BLOB column to [pgvector](https://github.com/pgvector/pgvector), so
+> similarity search (Ask AI, topic map, recommendations) runs in SQL instead
+> of Python. Swap your Postgres image to `pgvector/pgvector:pg16` (or install
+> the `vector` extension on an external Postgres) before starting the new
+> version — the app backfills existing embeddings into the new column
+> automatically on first boot. Starting against a Postgres without the
+> extension fails fast with a clear error naming it.
+
 ## Quick Start
 
 You can run News Dashboard in two ways:
@@ -99,7 +108,7 @@ docker run --rm -d \
   -e POSTGRES_PASSWORD=news-dashboard-local-password \
   -v news-dashboard-postgres-data:/var/lib/postgresql/data \
   -p 5432:5432 \
-  postgres:16-alpine
+  pgvector/pgvector:pg16
 ```
 
 Then run the application:
@@ -164,7 +173,7 @@ docker run --rm -d \
   -e POSTGRES_USER=news_dashboard \
   -e POSTGRES_PASSWORD=news-dashboard-local-password \
   -p 5432:5432 \
-  postgres:16-alpine
+  pgvector/pgvector:pg16
 ```
 
 Set backend env (or copy `.env.example` to `.env` and adjust values):

--- a/backend/news_dashboard/ai_stats/service.py
+++ b/backend/news_dashboard/ai_stats/service.py
@@ -12,7 +12,7 @@ import re
 from typing import Any
 
 from news_dashboard.db import connect, init_db
-from news_dashboard.embeddings import decode_embedding
+from news_dashboard.embeddings import parse_vector
 from news_dashboard.insights import (
     greedy_cluster,
     load_recent_embedded_articles,
@@ -384,7 +384,7 @@ def _load_recent_articles(
         if user_id is None:
             rows = conn.execute(
                 """
-                SELECT id, title, summary, category, (embedding IS NOT NULL) AS embedded
+                SELECT id, title, summary, category, (embedding_vec IS NOT NULL) AS embedded
                 FROM articles
                 WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
                 ORDER BY discovered_at DESC
@@ -396,7 +396,7 @@ def _load_recent_articles(
             rows = conn.execute(
                 """
                 SELECT a.id, a.title, a.summary, a.category,
-                       (a.embedding IS NOT NULL) AS embedded
+                       (a.embedding_vec IS NOT NULL) AS embedded
                 FROM articles a
                 JOIN sources src ON src.slug = a.source_slug
                 LEFT JOIN user_sources us
@@ -500,9 +500,7 @@ def embedding_map(
             "days": days,
         }
 
-    norm_vecs = [
-        normalize_vector(decode_embedding(bytes(article["embedding"]))) for article in embedded
-    ]
+    norm_vecs = [normalize_vector(parse_vector(article["embedding_vec"])) for article in embedded]
     coords = pca_2d(norm_vecs)
     assignments = greedy_cluster(norm_vecs, _CLUSTER_THRESHOLD)
 

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -424,7 +424,7 @@ def _merge_user_recommendation(
 
 def _article_from_row(row: Any, conn: Any, article_id: int, user_id: int | None) -> dict[str, Any]:
     d = row_to_dict(row)
-    d.pop("embedding", None)
+    d.pop("embedding_vec", None)
     d.pop("fts_vector", None)
     if user_id is not None:
         _merge_user_state(d, conn, article_id, user_id)

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import struct
 import threading
 import time
 from collections.abc import Iterator, Mapping, Sequence
@@ -16,6 +17,10 @@ from psycopg import sql
 from psycopg.rows import dict_row
 
 POSTGRES_PREFIXES = ("postgres:" + "//", "postgresql:" + "//")
+
+# Dimension of the OpenAI text-embedding-3-small vectors stored in
+# articles.embedding_vec (backend/news_dashboard/embeddings.py).
+EMBEDDING_DIMENSIONS = 1536
 
 logger = logging.getLogger(__name__)
 _INIT_DB_LOCK = threading.Lock()
@@ -143,6 +148,7 @@ POSTGRES_SCHEMA = [
     """,
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS canonical_id BIGINT REFERENCES articles(id)",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA",
+    f"ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding_vec vector({EMBEDDING_DIMENSIONS})",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS body_status TEXT NOT NULL DEFAULT 'missing'",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS insights TEXT",
@@ -790,6 +796,18 @@ POSTGRES_MULTIUSER_SCHEMA = [
     " INTEGER NOT NULL DEFAULT 3",
 ]
 
+# Runs after POSTGRES_SCHEMA/POSTGRES_MULTIUSER_SCHEMA and the embedding_vec
+# backfill (see init_db): building the ANN index before backfill would make
+# every backfill UPDATE pay index-maintenance cost, and dropping the legacy
+# BLOB column before backfill would destroy the data it reads from.
+POSTGRES_POST_BACKFILL_SCHEMA = [
+    """
+    CREATE INDEX IF NOT EXISTS idx_articles_embedding_vec_hnsw
+      ON articles USING hnsw (embedding_vec vector_cosine_ops)
+    """,
+    "ALTER TABLE articles DROP COLUMN IF EXISTS embedding",
+]
+
 
 def _validate_postgres_url(url: str) -> str:
     if not url.startswith(POSTGRES_PREFIXES):
@@ -887,7 +905,11 @@ def connect(
         if isinstance(db_path, Path):
             schema = _schema_name(db_path)
             conn.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(schema)))
-            conn.execute(sql.SQL("SET search_path TO {}").format(sql.Identifier(schema)))
+            # `public` stays on the path (after the test schema) so extension
+            # types/operators pgvector installs there — e.g. `vector`,
+            # `<=>` — resolve even though tables/functions still isolate per
+            # test schema.
+            conn.execute(sql.SQL("SET search_path TO {}, public").format(sql.Identifier(schema)))
         yield conn
         conn.commit()
     except Exception:
@@ -897,12 +919,116 @@ def connect(
         conn.close()
 
 
+def _unpack_embedding_blob(blob: bytes) -> list[float]:
+    n = len(blob) // 4
+    return list(struct.unpack(f"{n}f", blob))
+
+
+def _vector_literal(vector: list[float]) -> str:
+    return "[" + ",".join(repr(float(x)) for x in vector) + "]"
+
+
+def _backfill_embedding_vectors(
+    db_path: Path | str | None,
+    database_url: str | None,
+    batch_size: int = 500,
+) -> int:
+    """Migrate pre-pgvector BLOB embeddings into the embedding_vec column.
+
+    Runs on every init_db call; a no-op once every legacy BLOB has a vector
+    (or the legacy `embedding` column has already been dropped). Batches so a
+    large existing archive doesn't hold one long-running transaction.
+    """
+    total = 0
+    while True:
+        with connect(db_path, database_url=database_url) as conn:
+            has_column = conn.execute(
+                """
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'articles' AND column_name = 'embedding'
+                """
+            ).fetchone()
+            if not has_column:
+                return total
+            rows = conn.execute(
+                """
+                SELECT id, embedding FROM articles
+                WHERE embedding IS NOT NULL AND embedding_vec IS NULL
+                LIMIT %s
+                """,
+                (batch_size,),
+            ).fetchall()
+            if not rows:
+                return total
+            for row in rows:
+                vector = _unpack_embedding_blob(bytes(row["embedding"]))
+                conn.execute(
+                    "UPDATE articles SET embedding_vec = %s::vector WHERE id = %s",
+                    (_vector_literal(vector), row["id"]),
+                )
+            total += len(rows)
+
+
+def _run_schema_statements(
+    statements: list[str],
+    db_path: Path | str | None,
+    database_url: str | None,
+) -> int:
+    """Run each schema statement in its own transaction and return the count applied.
+
+    Isolating each statement in its own transaction means one failure doesn't
+    leave later attempts in an aborted transaction.
+    """
+    applied = 0
+    for statement in statements:
+        try:
+            with connect(db_path, database_url=database_url) as conn:
+                conn.execute(statement)
+                applied += 1
+        except Exception as exc:
+            statement_preview = " ".join(statement.split())[:240]
+            logger.exception("Schema initialization failed on statement: %s", statement_preview)
+            message = f"Schema initialization failed on statement: {statement_preview}"
+            raise SchemaInitializationError(message) from exc
+    return applied
+
+
+def _ensure_vector_extension(db_path: Path | str | None, database_url: str | None) -> None:
+    """Create the pgvector `vector` extension if it isn't already installed.
+
+    Extensions are database-wide, not schema-scoped, so two concurrent
+    init_db() calls against different schemas of the same database (e.g. the
+    app Deployment and the ingest CronJob starting together) can both pass
+    the "IF NOT EXISTS" check and race to create it; the loser gets a unique
+    violation even though the extension now exists either way, so that race
+    is treated as success rather than failure.
+    """
+    try:
+        with connect(db_path, database_url=database_url) as conn:
+            # Explicit SCHEMA public: db_path-based test connections put a
+            # per-test schema first on search_path (see connect()), which
+            # would otherwise become the implicit target schema here.
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector SCHEMA public")
+    except (psycopg.errors.UniqueViolation, psycopg.errors.DuplicateObject):
+        logger.debug("pgvector extension already created by a concurrent init_db call")
+    except Exception as exc:
+        message = (
+            "PostgreSQL is missing the pgvector 'vector' extension. Use the "
+            "pgvector/pgvector:pg16 image (or install the vector extension) "
+            "instead of stock postgres:16."
+        )
+        raise SchemaInitializationError(message) from exc
+
+
 def init_db(db_path: Path | str | None = None, database_url: str | None = None) -> None:
     if isinstance(db_path, str) and db_path.startswith(POSTGRES_PREFIXES):
         database_url = db_path
         db_path = None
     schema_fingerprint = sha256(
-        "\0".join(POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA).encode("utf-8")
+        "\0".join(
+            POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA + POSTGRES_POST_BACKFILL_SCHEMA
+        ).encode("utf-8")
     ).hexdigest()
     env_key = (
         database_url
@@ -943,19 +1069,20 @@ def init_db(db_path: Path | str | None = None, database_url: str | None = None) 
             if cache_key in _INITIALIZED_DATABASES:
                 return
 
+        _ensure_vector_extension(db_path, database_url)
+
         # Each statement runs in its own transaction so one failed statement does
         # not leave later attempts in an aborted transaction.
-        applied = 0
-        for statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA:
-            try:
-                with connect(db_path, database_url=database_url) as conn:
-                    conn.execute(statement)
-                    applied += 1
-            except Exception as exc:
-                statement_preview = " ".join(statement.split())[:240]
-                logger.exception("Schema initialization failed on statement: %s", statement_preview)
-                message = f"Schema initialization failed on statement: {statement_preview}"
-                raise SchemaInitializationError(message) from exc
+        applied = _run_schema_statements(
+            POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA, db_path, database_url
+        )
+
+        # Backfill embedding_vec from any pre-migration BLOB embeddings before
+        # building the ANN index and dropping the legacy column, so no data
+        # is lost and the index is built once, over final data.
+        _backfill_embedding_vectors(db_path, database_url)
+
+        applied += _run_schema_statements(POSTGRES_POST_BACKFILL_SCHEMA, db_path, database_url)
     finally:
         if lock_conn is not None:
             if lock_context is None:

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -2,14 +2,13 @@
 
 Embedding model : text-embedding-3-small (OpenAI)
 Answer model    : gpt-4o-mini (OpenAI)
-Storage         : articles.embedding BLOB (serialized float32 numpy array)
-Retrieval       : pure-Python cosine similarity over stored vectors
+Storage         : articles.embedding_vec (pgvector, cosine ops, HNSW index)
+Retrieval       : SQL top-k via the `<=>` cosine-distance operator
 """
 
 from __future__ import annotations
 
 import os
-import struct
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -45,21 +44,20 @@ def _require_env(name: str, purpose: str) -> str:
     raise MissingAICredentialsError(message)
 
 
-# ── Embedding serialisation ────────────────────────────────────────────────
+# ── pgvector (de)serialisation ──────────────────────────────────────────────
 
 
-def _pack(vector: list[float]) -> bytes:
-    return struct.pack(f"{len(vector)}f", *vector)
+def vector_literal(vector: list[float]) -> str:
+    """Format a Python float vector as a pgvector input literal, e.g. "[0.1,0.2]"."""
+    return "[" + ",".join(repr(float(x)) for x in vector) + "]"
 
 
-def _unpack(blob: bytes) -> list[float]:
-    n = len(blob) // 4
-    return list(struct.unpack(f"{n}f", blob))
-
-
-def decode_embedding(blob: bytes) -> list[float]:
-    """Public helper: deserialize a stored embedding BLOB into a float vector."""
-    return _unpack(blob)
+def parse_vector(value: Any) -> list[float]:
+    """Parse a pgvector column value (returned as text) into a float vector."""
+    text = value.strip("[]") if isinstance(value, str) else str(value).strip("[]")
+    if not text:
+        return []
+    return [float(x) for x in text.split(",")]
 
 
 # ── Embedding source text ──────────────────────────────────────────────────
@@ -169,19 +167,18 @@ def ensure_article_embedded(article_id: int, db_path: Any = None) -> None:
     init_db(db_path)
     with connect(db_path) as conn:
         row = conn.execute(
-            "SELECT id, title, summary, reason, tags, embedding FROM articles WHERE id=%s",
+            "SELECT id, title, summary, reason, tags, embedding_vec FROM articles WHERE id=%s",
             (article_id,),
         ).fetchone()
-        if row is None or row["embedding"] is not None:
+        if row is None or row["embedding_vec"] is not None:
             return  # already embedded or gone
         text = embedding_text(row["title"], row["summary"], row["reason"], row["tags"])
         if not text:
             return
         vector = _embed(text)
-        blob = _pack(vector)
         conn.execute(
-            "UPDATE articles SET embedding=%s WHERE id=%s",
-            (blob, article_id),
+            "UPDATE articles SET embedding_vec=%s::vector WHERE id=%s",
+            (vector_literal(vector), article_id),
         )
 
 
@@ -212,7 +209,7 @@ def embed_all_eligible(
                     LEFT JOIN user_article_state uas
                         ON uas.article_id = a.id AND uas.user_id = %s
                     WHERE COALESCE(uas.state, 'today') != 'archived'
-                      AND a.embedding IS NULL
+                      AND a.embedding_vec IS NULL
                       AND (
                         (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
                         OR src.owner_user_id = %s
@@ -228,7 +225,7 @@ def embed_all_eligible(
                     JOIN user_article_state uas
                         ON uas.article_id = a.id AND uas.user_id = %s
                     WHERE (uas.state = 'done' OR uas.starred = TRUE)
-                      AND a.embedding IS NULL
+                      AND a.embedding_vec IS NULL
                       AND (
                         (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
                         OR src.owner_user_id = %s
@@ -239,7 +236,7 @@ def embed_all_eligible(
             status_filter = "status != 'archived'" if include_all else "status IN ('saved', 'read')"
             rows = conn.execute(
                 "SELECT id, title, summary, reason, tags FROM articles "
-                f"WHERE {status_filter} AND embedding IS NULL"
+                f"WHERE {status_filter} AND embedding_vec IS NULL"
             ).fetchall()
 
     count = 0
@@ -248,13 +245,12 @@ def embed_all_eligible(
         if not text:
             continue
         vector = _embed(text)
-        blob = _pack(vector)
         from news_dashboard.db import connect as _connect
 
         with _connect(db_path) as conn:
             conn.execute(
-                "UPDATE articles SET embedding=%s WHERE id=%s",
-                (blob, row["id"]),
+                "UPDATE articles SET embedding_vec=%s::vector WHERE id=%s",
+                (vector_literal(vector), row["id"]),
             )
         count += 1
     return count
@@ -289,71 +285,78 @@ def ask(
     # 1. Backfill embeddings for any eligible articles not yet embedded
     embed_all_eligible(db_path, include_all=include_all, user_id=user_id)
 
-    # 2. Load embedded articles scoped to the requesting user
+    # 2. Embed the user's question, then let Postgres rank + return the top-k
+    #    nearest articles in one query via the pgvector `<=>` cosine-distance
+    #    operator (using the embedding_vec HNSW index), with a COUNT(*) in the
+    #    same round trip for the MIN_ARTICLES eligibility check.
+    query_vec = vector_literal(_embed(query))
     init_db(db_path)
     with connect(db_path) as conn:
         if user_id is not None:
             if include_all:
                 sql = """
-                    SELECT a.id, a.title, a.url, a.summary, a.embedding
+                    SELECT a.id, a.title, a.url, a.summary,
+                      COUNT(*) OVER () AS eligible_count
                     FROM articles a
                     LEFT JOIN sources src ON src.slug = a.source_slug
                     LEFT JOIN user_sources us_src
-                        ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
+                        ON us_src.user_id = %(user_id)s AND us_src.source_slug = a.source_slug
                     LEFT JOIN user_article_state uas
-                        ON uas.article_id = a.id AND uas.user_id = %s
+                        ON uas.article_id = a.id AND uas.user_id = %(user_id)s
                     WHERE COALESCE(uas.state, 'today') != 'archived'
-                      AND a.embedding IS NOT NULL
+                      AND a.embedding_vec IS NOT NULL
                       AND (
                         (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
-                        OR src.owner_user_id = %s
+                        OR src.owner_user_id = %(user_id)s
                       )
+                    ORDER BY a.embedding_vec <=> %(query_vec)s::vector
+                    LIMIT %(top_k)s
                 """
             else:
                 sql = """
-                    SELECT a.id, a.title, a.url, a.summary, a.embedding
+                    SELECT a.id, a.title, a.url, a.summary,
+                      COUNT(*) OVER () AS eligible_count
                     FROM articles a
                     LEFT JOIN sources src ON src.slug = a.source_slug
                     LEFT JOIN user_sources us_src
-                        ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
+                        ON us_src.user_id = %(user_id)s AND us_src.source_slug = a.source_slug
                     JOIN user_article_state uas
-                        ON uas.article_id = a.id AND uas.user_id = %s
+                        ON uas.article_id = a.id AND uas.user_id = %(user_id)s
                     WHERE (uas.state = 'done' OR uas.starred = TRUE)
-                      AND a.embedding IS NOT NULL
+                      AND a.embedding_vec IS NOT NULL
                       AND (
                         (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE))
-                        OR src.owner_user_id = %s
+                        OR src.owner_user_id = %(user_id)s
                       )
+                    ORDER BY a.embedding_vec <=> %(query_vec)s::vector
+                    LIMIT %(top_k)s
                 """
-            rows = conn.execute(sql, (user_id, user_id, user_id)).fetchall()
+            rows = conn.execute(
+                sql, {"user_id": user_id, "query_vec": query_vec, "top_k": TOP_K}
+            ).fetchall()
         else:
             status_filter = "status != 'archived'" if include_all else "status IN ('saved', 'read')"
             rows = conn.execute(
-                "SELECT id, title, url, summary, embedding FROM articles "
-                f"WHERE {status_filter} AND embedding IS NOT NULL"
+                "SELECT id, title, url, summary, COUNT(*) OVER () AS eligible_count "
+                f"FROM articles WHERE {status_filter} AND embedding_vec IS NOT NULL "
+                "ORDER BY embedding_vec <=> %(query_vec)s::vector LIMIT %(top_k)s",
+                {"query_vec": query_vec, "top_k": TOP_K},
             ).fetchall()
 
-    if len(rows) < MIN_ARTICLES:
+    eligible_count = rows[0]["eligible_count"] if rows else 0
+    if eligible_count < MIN_ARTICLES:
         return {
             "answer": (
                 f"Not enough articles yet — I need at least {MIN_ARTICLES} saved or read "
-                f"articles to answer questions. You currently have {len(rows)}."
+                f"articles to answer questions. You currently have {eligible_count}."
             ),
             "sources": [],
             "trace_id": None,
         }
 
-    # 3. Embed the user's question
-    query_vec = _embed(query)
-
-    # 4. Rank by cosine similarity and pick top-k
-    scored = [(row, _cosine(query_vec, _unpack(bytes(row["embedding"])))) for row in rows]
-    scored.sort(key=lambda x: x[1], reverse=True)
-    top = scored[:TOP_K]
-
-    # 5. Build context for the prompt
+    # 3. Build context for the prompt (rows already top-k, nearest first)
     context_blocks = []
-    for i, (row, _score) in enumerate(top, 1):
+    for i, row in enumerate(rows, 1):
         context_blocks.append(
             f"[{i}] Title: {row['title']}\nURL: {row['url']}\nSummary: {row['summary']}"
         )
@@ -373,6 +376,6 @@ def ask(
         answer_text = _answer(prompt.text, user_prompt, user_id=user_id, prompt=prompt)
         trace.update_output(answer_text)
 
-    # 7. Return answer + deduplicated source list (top-k order)
-    sources = [{"id": row["id"], "title": row["title"], "url": row["url"]} for row, _ in top]
+    # 7. Return answer + source list (top-k order)
+    sources = [{"id": row["id"], "title": row["title"], "url": row["url"]} for row in rows]
     return {"answer": answer_text, "sources": sources, "trace_id": trace.trace_id}

--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -1075,7 +1075,7 @@ def ingest_all(db_path: Path | str | None = None) -> IngestResult:
     return IngestResult(results=results, run_id=run_id, total_errors=total_errors)
 
 
-_INTERNAL_ARTICLE_COLUMNS = frozenset({"embedding", "fts_vector", "search_vector"})
+_INTERNAL_ARTICLE_COLUMNS = frozenset({"embedding_vec", "fts_vector", "search_vector"})
 _ARTICLE_LIST_COLUMNS = (
     "id, url, canonical_url, canonical_id, title, source_slug, source_name,"
     " category, kind, published_at, discovered_at, status, importance_score,"
@@ -1189,9 +1189,9 @@ def _article_order_clause(*, state: str | None) -> str:
 def _article_dict(row: Any) -> dict[str, Any]:
     """Convert a DB row to a dict, stripping internal-only columns.
 
-    'embedding' (BLOB/BYTEA) contains binary float data that is not
-    UTF-8-safe and must never be sent to the frontend.  'fts_vector'
-    (Postgres GENERATED ALWAYS tsvector) is similarly internal.
+    'embedding_vec' (pgvector) is a large internal-only field that must
+    never be sent to the frontend.  'fts_vector' (Postgres GENERATED ALWAYS
+    tsvector) is similarly internal.
     """
     d = row_to_dict(row)
     for col in _INTERNAL_ARTICLE_COLUMNS:

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -13,11 +13,11 @@ import json
 import logging
 import math
 import os
-import struct
 from typing import Any
 
 from news_dashboard.body_fetch import get_article
 from news_dashboard.db import connect, init_db
+from news_dashboard.embeddings import parse_vector
 
 logger = logging.getLogger(__name__)
 
@@ -203,11 +203,6 @@ def _cluster_ai_config() -> tuple[str, str | None, str]:
     return api_key, base_url, model
 
 
-def _unpack_embedding(blob: bytes) -> list[float]:
-    n = len(blob) // 4
-    return list(struct.unpack(f"{n}f", blob))
-
-
 def _cosine_sim(a: list[float], b: list[float]) -> float:
     dot = sum(x * y for x, y in zip(a, b, strict=False))
     norm_a = math.sqrt(sum(x * x for x in a))
@@ -316,7 +311,6 @@ def _greedy_cluster(normalized_vecs: list[list[float]], threshold: float) -> lis
 pca_2d = _pca_2d
 greedy_cluster = _greedy_cluster
 normalize_vector = _normalize
-unpack_embedding = _unpack_embedding
 
 
 def _generate_cluster_label(
@@ -374,7 +368,7 @@ def load_recent_embedded_articles(
 ) -> list[dict[str, Any]]:
     """Load recent articles that have an embedding, scoped to the user's visible sources.
 
-    Returns dicts with keys: id, title, url, summary, category, embedding.
+    Returns dicts with keys: id, title, url, summary, category, embedding_vec.
     """
     init_db(database_url=database_url)
 
@@ -382,10 +376,10 @@ def load_recent_embedded_articles(
         if user_id is None:
             rows = conn.execute(
                 """
-                SELECT id, title, url, summary, category, embedding
+                SELECT id, title, url, summary, category, embedding_vec
                 FROM articles
                 WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
-                  AND embedding IS NOT NULL
+                  AND embedding_vec IS NOT NULL
                 ORDER BY discovered_at DESC
                 LIMIT %s
                 """,
@@ -394,7 +388,7 @@ def load_recent_embedded_articles(
         else:
             rows = conn.execute(
                 """
-                SELECT a.id, a.title, a.url, a.summary, a.category, a.embedding
+                SELECT a.id, a.title, a.url, a.summary, a.category, a.embedding_vec
                 FROM articles a
                 JOIN sources src ON src.slug = a.source_slug
                 LEFT JOIN user_sources us
@@ -402,7 +396,7 @@ def load_recent_embedded_articles(
                 LEFT JOIN user_article_state uas
                   ON uas.article_id = a.id AND uas.user_id = %s
                 WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
-                  AND a.embedding IS NOT NULL
+                  AND a.embedding_vec IS NOT NULL
                   AND COALESCE(uas.state, 'today') != 'archived'
                   AND (
                     (
@@ -445,7 +439,7 @@ def cluster_recent_articles(
     article_data: list[dict[str, Any]] = []
     norm_vecs: list[list[float]] = []
     for row in rows:
-        vec = _unpack_embedding(bytes(row["embedding"]))
+        vec = parse_vector(row["embedding_vec"])
         norm_vec = _normalize(vec)
         article_data.append(
             {

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -534,24 +534,24 @@ def _load_user_history_vectors(conn: Any, user_id: int) -> list[list[float]]:
     Articles without an embedding are skipped, so an empty list means "no
     embedded history" and semantic scoring stays disabled for this user.
     """
-    from news_dashboard.embeddings import decode_embedding
+    from news_dashboard.embeddings import parse_vector
 
     rows = conn.execute(
         """
-        SELECT a.embedding
+        SELECT a.embedding_vec
         FROM user_article_state uas
         JOIN articles a ON a.id = uas.article_id
         WHERE uas.user_id = %s
-          AND a.embedding IS NOT NULL
+          AND a.embedding_vec IS NOT NULL
           AND (uas.starred IS TRUE OR uas.state = 'done')
         """,
         (user_id,),
     ).fetchall()
     vectors: list[list[float]] = []
     for row in rows:
-        blob = row_to_dict(row).get("embedding")
-        if blob is not None:
-            vectors.append(decode_embedding(bytes(blob)))
+        value = row_to_dict(row).get("embedding_vec")
+        if value is not None:
+            vectors.append(parse_vector(value))
     return vectors
 
 
@@ -565,7 +565,7 @@ def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]
 
     rows = conn.execute(
         f"""
-        SELECT a.id, a.title, a.source_slug, a.category, a.tags, a.embedding,
+        SELECT a.id, a.title, a.source_slug, a.category, a.tags, a.embedding_vec,
           a.importance_score,
           EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - a.discovered_at::timestamptz))
             / 3600.0 AS age_hours,
@@ -639,7 +639,7 @@ def recompute_user_recommendations(
         adjustment = profile.adjustment(source_slug, category, tags)
         category_factor = preferences.category_weights.get(str(category).lower(), 1.0)
         manual_category = (category_factor - 1.0) * CATEGORY_AFFINITY_WEIGHT * AFFINITY_SCORE_SPAN
-        candidate_vector = _decode_candidate_embedding(candidate.get("embedding"))
+        candidate_vector = _decode_candidate_embedding(candidate.get("embedding_vec"))
         semantic = semantic_adjustment(candidate_vector, semantic_profile)
         freshness = freshness_adjustment(age_hours, importance)
         novelty = (
@@ -709,10 +709,10 @@ def _opt_float(value: Any) -> float | None:
     return float(value)
 
 
-def _decode_candidate_embedding(blob: Any) -> list[float] | None:
+def _decode_candidate_embedding(value: Any) -> list[float] | None:
     """Best-effort decode of a candidate's stored embedding, ``None`` if absent."""
-    if blob is None:
+    if value is None:
         return None
-    from news_dashboard.embeddings import decode_embedding
+    from news_dashboard.embeddings import parse_vector
 
-    return decode_embedding(bytes(blob))
+    return parse_vector(value)

--- a/backend/news_dashboard/shares.py
+++ b/backend/news_dashboard/shares.py
@@ -201,7 +201,7 @@ def get_shared_article(share_id: int, user_id: int) -> dict[str, Any] | None:
     if row is None:
         return None
     article = row_to_dict(row)
-    article.pop("embedding", None)
+    article.pop("embedding_vec", None)
     article.pop("fts_vector", None)
     return article
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -208,9 +208,11 @@ def pg_url() -> Generator[str]:
             )
             conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(worker_schema)))
 
-        # Append connection options to set search_path
+        # Append connection options to set search_path. `public` stays on the
+        # path (after the worker schema) so pgvector's extension types/
+        # operators — installed into `public` — stay resolvable.
         separator = "&" if "?" in original_url else "?"
-        service_url = f"{original_url}{separator}options=-csearch_path%3D{worker_schema}"
+        service_url = f"{original_url}{separator}options=-csearch_path%3D{worker_schema}%2Cpublic"
 
     orig_db_url = os.environ.get("DATABASE_URL")
     if service_url:

--- a/backend/tests/test_ai_stats.py
+++ b/backend/tests/test_ai_stats.py
@@ -6,16 +6,20 @@ including per-user visibility scoping (global vs private vs disabled sources).
 
 from __future__ import annotations
 
-import struct
-
 from news_dashboard.ai_stats.service import _tokenize, embedding_map, word_cloud
-from news_dashboard.db import connect
+from news_dashboard.db import EMBEDDING_DIMENSIONS, connect
+from news_dashboard.embeddings import vector_literal
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
-def _pack_vec(vec: list[float]) -> bytes:
-    return struct.pack(f"{len(vec)}f", *vec)
+def _padded_vec(vec: list[float]) -> str:
+    """A pgvector literal padded to the real embedding_vec(1536) width.
+
+    Trailing zeros don't change cosine similarity/ordering, so tests can keep
+    seeding short, readable vectors.
+    """
+    return vector_literal(vec + [0.0] * (EMBEDDING_DIMENSIONS - len(vec)))
 
 
 def _seed_source(
@@ -46,15 +50,15 @@ def _seed_article(
     embedding: list[float] | None = None,
 ) -> int:
     _seed_source(pg_url, slug)
-    blob = _pack_vec(embedding) if embedding is not None else None
+    vec = _padded_vec(embedding) if embedding is not None else None
     with connect(database_url=pg_url) as conn:
         row = conn.execute(
             """
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, summary, embedding, discovered_at
+              category, kind, summary, embedding_vec, discovered_at
             )
-            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', %s, %s, NOW())
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', %s, %s::vector, NOW())
             RETURNING id
             """,
             (
@@ -65,7 +69,7 @@ def _seed_article(
                 slug,
                 category,
                 summary,
-                blob,
+                vec,
             ),
         ).fetchone()
     assert row is not None

--- a/backend/tests/test_ask_scope.py
+++ b/backend/tests/test_ask_scope.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import struct
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,11 +10,18 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-from news_dashboard.db import connect, init_db
+from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
+from news_dashboard.embeddings import vector_literal
 
 
-def _pack(vector: list[float]) -> bytes:
-    return struct.pack(f"{len(vector)}f", *vector)
+def _test_vector(value: float = 0.1, dims: int = 10) -> str:
+    """A pgvector literal padded to the real embedding_vec(1536) width.
+
+    Trailing zeros don't change cosine similarity/ordering, so tests can keep
+    seeding short, readable vectors.
+    """
+    vec = [value] * dims + [0.0] * (EMBEDDING_DIMENSIONS - dims)
+    return vector_literal(vec)
 
 
 def _seed_source(db_path: Path, slug: str = "test-source", name: str = "TestSource") -> None:
@@ -34,7 +40,7 @@ def _seed_articles(db_path: Path) -> None:
     """Insert one article per legacy status with a pre-set embedding."""
     init_db(db_path)
     _seed_source(db_path)
-    embedding = _pack([0.1] * 10)
+    embedding = _test_vector()
     statuses = ["new", "saved", "read", "skipped", "archived"]
     with connect(db_path) as conn:
         for i, status in enumerate(statuses, start=1):
@@ -43,8 +49,8 @@ def _seed_articles(db_path: Path) -> None:
                 INSERT INTO articles(
                     id, url, canonical_url, title, source_slug, source_name,
                     category, kind, status, importance_score, summary, reason,
-                    tags, embedding
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    tags, embedding_vec
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::vector)
                 """,
                 (
                     i,
@@ -86,7 +92,7 @@ def _make_openai_stub(monkeypatch: pytest.MonkeyPatch, answer: str = "ok") -> No
 
     class FakeEmbeddingData:
         def __init__(self) -> None:
-            self.embedding = [0.1] * 10
+            self.embedding = [0.1] * 10 + [0.0] * (EMBEDDING_DIMENSIONS - 10)
 
     class FakeEmbeddingResponse:
         def __init__(self) -> None:
@@ -110,7 +116,7 @@ def _ids_in_pool(db_path: Path, include_all: bool) -> set[int]:
     status_filter = "status != 'archived'" if include_all else "status IN ('saved', 'read')"
     with connect(db_path) as conn:
         rows = conn.execute(
-            f"SELECT id FROM articles WHERE {status_filter} AND embedding IS NOT NULL"
+            f"SELECT id FROM articles WHERE {status_filter} AND embedding_vec IS NOT NULL"
         ).fetchall()
     return {row["id"] for row in rows}
 
@@ -144,7 +150,7 @@ def test_ask_default_scope_returns_answer(tmp_path: Path, monkeypatch: pytest.Mo
     db_path = tmp_path / "ask.db"
     init_db(db_path)
     _seed_source(db_path, "s", "S")
-    embedding = _pack([0.1] * 10)
+    embedding = _test_vector()
     with connect(db_path) as conn:
         for i in range(1, 8):  # 7 saved/read articles — above MIN_ARTICLES=5
             conn.execute(
@@ -152,8 +158,8 @@ def test_ask_default_scope_returns_answer(tmp_path: Path, monkeypatch: pytest.Mo
                 INSERT INTO articles(
                     id, url, canonical_url, title, source_slug, source_name,
                     category, kind, status, importance_score, summary, reason,
-                    tags, embedding
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    tags, embedding_vec
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::vector)
                 """,
                 (
                     i,
@@ -201,7 +207,7 @@ def test_ask_include_all_widens_corpus(tmp_path: Path, monkeypatch: pytest.Monke
     db_path = tmp_path / "ask.db"
     init_db(db_path)
     _seed_source(db_path, "s", "S")
-    embedding = _pack([0.1] * 10)
+    embedding = _test_vector()
     # Insert 6 articles with status 'new' — not picked up by default scope
     with connect(db_path) as conn:
         for i in range(1, 7):
@@ -210,8 +216,8 @@ def test_ask_include_all_widens_corpus(tmp_path: Path, monkeypatch: pytest.Monke
                 INSERT INTO articles(
                     id, url, canonical_url, title, source_slug, source_name,
                     category, kind, status, importance_score, summary, reason,
-                    tags, embedding
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    tags, embedding_vec
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::vector)
                 """,
                 (
                     i,
@@ -263,15 +269,15 @@ def _seed_article_with_embedding(
     source_name: str = "TestSource",
     legacy_status: str = "new",
 ) -> None:
-    embedding = _pack([0.1] * 10)
+    embedding = _test_vector()
     with connect(db_path) as conn:
         conn.execute(
             """
             INSERT INTO articles(
                 id, url, canonical_url, title, source_slug, source_name,
                 category, kind, status, importance_score, summary, reason,
-                tags, embedding
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                tags, embedding_vec
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::vector)
             """,
             (
                 article_id,

--- a/backend/tests/test_behavioral_affinity.py
+++ b/backend/tests/test_behavioral_affinity.py
@@ -337,21 +337,23 @@ def test_manual_category_preferences_change_user_scores(
 def test_manual_novelty_weight_changes_novel_article_score(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:
-    import struct
+    from news_dashboard.db import EMBEDDING_DIMENSIONS
+    from news_dashboard.embeddings import vector_literal
 
     db_path = _setup_db(monkeypatch, pg_clean)
     _insert_source(db_path, "src", category="ai")
     user_id = _make_user(db_path, "alice")
     history = _insert_article(db_path, "src", "history", category="ai")
     candidate = _insert_article(db_path, "src", "candidate", category="ai", importance=100)
+    pad = [0.0] * (EMBEDDING_DIMENSIONS - 2)
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE articles SET embedding = %s WHERE id = %s",
-            (struct.pack("2f", 1.0, 0.0), history),
+            "UPDATE articles SET embedding_vec = %s::vector WHERE id = %s",
+            (vector_literal([1.0, 0.0, *pad]), history),
         )
         conn.execute(
-            "UPDATE articles SET embedding = %s WHERE id = %s",
-            (struct.pack("2f", -1.0, 0.0), candidate),
+            "UPDATE articles SET embedding_vec = %s::vector WHERE id = %s",
+            (vector_literal([-1.0, 0.0, *pad]), candidate),
         )
     _set_state(db_path, user_id, history, state="done")
 

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -213,7 +213,7 @@ def test_get_article_returns_article(tmp_path: Path) -> None:
     assert result is not None
     assert result["id"] == article_id
     assert result["title"] == "Test Article"
-    assert "embedding" not in result
+    assert "embedding_vec" not in result
 
 
 def test_get_article_returns_none_for_missing(tmp_path: Path) -> None:

--- a/backend/tests/test_database_config.py
+++ b/backend/tests/test_database_config.py
@@ -26,8 +26,11 @@ def test_postgres_url_is_reported_without_password() -> None:
 def test_postgres_articles_schema_includes_embedding_column() -> None:
     postgres_schema = "\n".join(POSTGRES_SCHEMA).lower()
 
+    # Legacy BLOB column, kept only so pre-pgvector installs have something to
+    # backfill from (see db._backfill_embedding_vectors); dropped after backfill.
     assert "embedding bytea" in postgres_schema
     assert "alter table articles add column if not exists embedding bytea" in postgres_schema
+    assert "embedding_vec vector(1536)" in postgres_schema
 
 
 def test_postgres_schema_includes_user_article_recommendations() -> None:

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -35,6 +35,9 @@ def test_init_db_postgres_applies_all_statements(tmp_path: Any) -> None:
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+        patch("news_dashboard.db.POSTGRES_POST_BACKFILL_SCHEMA", []),
+        patch("news_dashboard.db._ensure_vector_extension", lambda *_a, **_k: None),
+        patch("news_dashboard.db._backfill_embedding_vectors", lambda *_a, **_k: 0),
     ):
         from news_dashboard.db import init_db
 
@@ -67,6 +70,9 @@ def test_init_db_postgres_failure_surfaces_and_is_not_cached(
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+        patch("news_dashboard.db.POSTGRES_POST_BACKFILL_SCHEMA", []),
+        patch("news_dashboard.db._ensure_vector_extension", lambda *_a, **_k: None),
+        patch("news_dashboard.db._backfill_embedding_vectors", lambda *_a, **_k: 0),
     ):
         from news_dashboard.db import SchemaInitializationError, init_db
 
@@ -106,6 +112,9 @@ def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> N
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+        patch("news_dashboard.db.POSTGRES_POST_BACKFILL_SCHEMA", []),
+        patch("news_dashboard.db._ensure_vector_extension", lambda *_a, **_k: None),
+        patch("news_dashboard.db._backfill_embedding_vectors", lambda *_a, **_k: 0),
     ):
         from news_dashboard.db import init_db
 
@@ -136,6 +145,9 @@ def test_init_db_postgres_caches_successful_schema_runs(tmp_path: Any) -> None:
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
+        patch("news_dashboard.db.POSTGRES_POST_BACKFILL_SCHEMA", []),
+        patch("news_dashboard.db._ensure_vector_extension", lambda *_a, **_k: None),
+        patch("news_dashboard.db._backfill_embedding_vectors", lambda *_a, **_k: 0),
     ):
         from news_dashboard.db import init_db
 

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -7,7 +7,6 @@ DB-touching tests use the pg_clean fixture (live Postgres).
 from __future__ import annotations
 
 import json
-import struct
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -503,8 +502,12 @@ def test_get_or_generate_insights_endpoint_returns_404_for_unauthorized_cached(
 # ── clustering unit tests (no DB, no AI) ─────────────────────────────────────
 
 
-def _pack_vec(vec: list[float]) -> bytes:
-    return struct.pack(f"{len(vec)}f", *vec)
+def _pack_vec(vec: list[float]) -> str:
+    """A pgvector literal padded to the real embedding_vec(1536) width."""
+    from news_dashboard.db import EMBEDDING_DIMENSIONS
+    from news_dashboard.embeddings import vector_literal
+
+    return vector_literal(vec + [0.0] * (EMBEDDING_DIMENSIONS - len(vec)))
 
 
 def _unit_vec(dim: int, idx: int) -> list[float]:
@@ -605,12 +608,12 @@ def _seed_articles_with_embeddings(pg_url: str, groups: list[list[list[float]]])
                     """
                     INSERT INTO articles(
                       url, canonical_url, title, source_slug, source_name,
-                      category, kind, summary, embedding,
+                      category, kind, summary, embedding_vec,
                       discovered_at
                     )
                     VALUES (
                       %s, %s, %s, 'test-src2', 'Test2', 'tech', 'rss_feed',
-                      %s, %s,
+                      %s, %s::vector,
                       NOW()
                     )
                     RETURNING id
@@ -634,17 +637,17 @@ def _seed_topic_map_article(
     source_slug: str,
     title: str,
     url_slug: str,
-    embedding: bytes,
+    embedding: str,
 ) -> int:
     with connect(database_url=pg_url) as conn:
         row = conn.execute(
             """
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, summary, embedding, discovered_at
+              category, kind, summary, embedding_vec, discovered_at
             )
             VALUES (
-              %s, %s, %s, %s, %s, 'tech', 'rss_feed', %s, %s, NOW()
+              %s, %s, %s, %s, %s, 'tech', 'rss_feed', %s, %s::vector, NOW()
             )
             RETURNING id
             """,
@@ -867,5 +870,5 @@ def test_load_recent_embedded_articles_returns_only_embedded_rows(pg_clean: str)
 
     assert len(rows) == 2
     for row in rows:
-        assert set(row) >= {"id", "title", "url", "summary", "category", "embedding"}
-        assert row["embedding"] is not None
+        assert set(row) >= {"id", "title", "url", "summary", "category", "embedding_vec"}
+        assert row["embedding_vec"] is not None

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import struct
 import sys
 from collections.abc import Generator
 from types import SimpleNamespace
@@ -241,8 +240,12 @@ def test_list_briefings_tool_is_scoped_per_user(pg_clean: str) -> None:
     assert bob_result["briefings"] == []
 
 
-def _pack(vector: list[float]) -> bytes:
-    return struct.pack(f"{len(vector)}f", *vector)
+def _pack(vector: list[float]) -> str:
+    """A pgvector literal padded to the real embedding_vec(1536) width."""
+    from news_dashboard.db import EMBEDDING_DIMENSIONS
+    from news_dashboard.embeddings import vector_literal
+
+    return vector_literal(vector + [0.0] * (EMBEDDING_DIMENSIONS - len(vector)))
 
 
 def _make_openai_stub(monkeypatch: pytest.MonkeyPatch, answer: str = "ok") -> None:
@@ -264,7 +267,9 @@ def _make_openai_stub(monkeypatch: pytest.MonkeyPatch, answer: str = "ok") -> No
 
     class FakeEmbeddingData:
         def __init__(self) -> None:
-            self.embedding = [0.1] * 10
+            from news_dashboard.db import EMBEDDING_DIMENSIONS
+
+            self.embedding = [0.1] * 10 + [0.0] * (EMBEDDING_DIMENSIONS - 10)
 
     class FakeEmbeddingResponse:
         def __init__(self) -> None:
@@ -304,8 +309,8 @@ def test_ask_tool_answers_over_users_corpus(pg_clean: str, monkeypatch: pytest.M
                 INSERT INTO articles(
                     id, url, canonical_url, title, source_slug, source_name,
                     category, kind, status, importance_score, summary, reason,
-                    tags, embedding
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    tags, embedding_vec
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::vector)
                 """,
                 (
                     i,

--- a/backend/tests/test_novelty_freshness.py
+++ b/backend/tests/test_novelty_freshness.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import struct
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from news_dashboard.db import connect, init_db
+from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
+from news_dashboard.embeddings import vector_literal
 from news_dashboard.recommendations import (
     FRESHNESS_SCORE_SPAN,
     NOVELTY_SCORE_SPAN,
@@ -17,6 +17,11 @@ from news_dashboard.recommendations import (
 )
 
 pytestmark = pytest.mark.postgres
+
+
+def _padded(vec: list[float]) -> list[float]:
+    """Right-pad a toy test vector with zeros to the real embedding_vec(1536) width."""
+    return vec + [0.0] * (EMBEDDING_DIMENSIONS - len(vec))
 
 
 # ── Pure freshness/novelty logic (no database) ────────────────────────────────
@@ -104,15 +109,15 @@ def _insert_article(
     discovered_at: str = "2026-06-21T10:00:00+00:00",
     embedding: list[float] | None = None,
 ) -> int:
-    blob = struct.pack(f"{len(embedding)}f", *embedding) if embedding is not None else None
+    vec = vector_literal(_padded(embedding)) if embedding is not None else None
     with connect(db_path) as conn:
         row = conn.execute(
             """
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, state, importance_score, discovered_at, embedding
+              category, kind, state, importance_score, discovered_at, embedding_vec
             )
-            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, %s, %s::vector)
             RETURNING id
             """,
             (
@@ -124,7 +129,7 @@ def _insert_article(
                 category,
                 importance,
                 discovered_at,
-                blob,
+                vec,
             ),
         ).fetchone()
     assert row is not None

--- a/backend/tests/test_pgvector_migration.py
+++ b/backend/tests/test_pgvector_migration.py
@@ -1,0 +1,165 @@
+"""pgvector migration (issue #924): extension setup, BLOB backfill, SQL top-k."""
+
+from __future__ import annotations
+
+import math
+import struct
+from pathlib import Path
+
+import pytest
+
+from news_dashboard.db import EMBEDDING_DIMENSIONS, _backfill_embedding_vectors, connect, init_db
+from news_dashboard.embeddings import parse_vector, vector_literal
+
+pytestmark = pytest.mark.postgres
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    return dot / (norm_a * norm_b)
+
+
+def _padded(vec: list[float]) -> list[float]:
+    return vec + [0.0] * (EMBEDDING_DIMENSIONS - len(vec))
+
+
+def _seed_source(db_path: Path, slug: str = "src") -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, 'tech', 'rss_feed', 50, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug.title(), f"https://example.com/{slug}.xml"),
+        )
+
+
+def test_vector_extension_is_available(tmp_path: Path) -> None:
+    """init_db's `CREATE EXTENSION IF NOT EXISTS vector` statement succeeded."""
+    db_path = tmp_path / "ext.db"
+    init_db(db_path)
+    with connect(db_path) as conn:
+        row = conn.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'").fetchone()
+    assert row is not None
+
+
+def test_embedding_vec_has_hnsw_cosine_index(tmp_path: Path) -> None:
+    db_path = tmp_path / "idx.db"
+    init_db(db_path)
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename = 'articles' AND indexname = 'idx_articles_embedding_vec_hnsw'
+            """
+        ).fetchone()
+    assert row is not None
+
+
+def test_legacy_blob_column_is_dropped_after_migration(tmp_path: Path) -> None:
+    """init_db drops the pre-pgvector BLOB column once backfilled."""
+    db_path = tmp_path / "dropped.db"
+    init_db(db_path)
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'articles' AND column_name = 'embedding'
+            """
+        ).fetchone()
+    assert row is None
+
+
+def test_backfill_migrates_legacy_blob_embeddings_losslessly(tmp_path: Path) -> None:
+    """Upgrading a pre-pgvector database backfills BLOB embeddings into
+    embedding_vec with the same nearest-neighbor ordering as before, and the
+    backfill is idempotent (a second pass has nothing left to do).
+    """
+    db_path = tmp_path / "backfill.db"
+    init_db(db_path)
+    _seed_source(db_path)
+
+    # Reproduce a not-yet-migrated database: re-add the legacy BLOB column
+    # init_db already dropped, and seed it directly (bypassing embedding_vec).
+    with connect(db_path) as conn:
+        conn.execute("ALTER TABLE articles ADD COLUMN IF NOT EXISTS embedding BYTEA")
+
+    vectors = {1: [1.0, 0.0, 0.0], 2: [0.9, 0.1, 0.0], 3: [0.0, 1.0, 0.0]}
+    with connect(db_path) as conn:
+        for article_id, vec in vectors.items():
+            blob = struct.pack(f"{EMBEDDING_DIMENSIONS}f", *_padded(vec))
+            conn.execute(
+                """
+                INSERT INTO articles(
+                  id, url, canonical_url, title, source_slug, source_name,
+                  category, kind, importance_score, discovered_at, embedding
+                ) VALUES (%s, %s, %s, %s, 'src', 'Src', 'tech', 'rss_feed', 50,
+                  '2026-06-21T10:00:00+00:00', %s)
+                """,
+                (
+                    article_id,
+                    f"https://example.com/{article_id}",
+                    f"https://example.com/{article_id}",
+                    f"Article {article_id}",
+                    blob,
+                ),
+            )
+
+    backfilled = _backfill_embedding_vectors(db_path, None)
+    assert backfilled == len(vectors)
+
+    with connect(db_path) as conn:
+        rows = conn.execute("SELECT id, embedding_vec FROM articles ORDER BY id").fetchall()
+    got = {row["id"]: parse_vector(row["embedding_vec"]) for row in rows}
+
+    for article_id, original in vectors.items():
+        assert _cosine(got[article_id], _padded(original)) == pytest.approx(1.0, abs=1e-4)
+
+    # Nearest-neighbor ordering is preserved: article 2 is closer to 1 than 3 is.
+    assert _cosine(got[1], got[2]) > _cosine(got[1], got[3])
+
+    # Nothing left to backfill on a second pass.
+    assert _backfill_embedding_vectors(db_path, None) == 0
+
+
+def test_sql_topk_orders_candidates_by_cosine_distance(tmp_path: Path) -> None:
+    """The pgvector `<=>` operator ranks nearest-first directly in SQL —
+    the retrieval path embeddings.ask() relies on for top-k, with no
+    full-table Python cosine loop.
+    """
+    db_path = tmp_path / "topk.db"
+    init_db(db_path)
+    _seed_source(db_path)
+
+    vectors = {1: [1.0, 0.0], 2: [0.9, 0.1], 3: [0.0, 1.0]}
+    with connect(db_path) as conn:
+        for article_id, vec in vectors.items():
+            conn.execute(
+                """
+                INSERT INTO articles(
+                  id, url, canonical_url, title, source_slug, source_name,
+                  category, kind, importance_score, discovered_at, embedding_vec
+                ) VALUES (%s, %s, %s, %s, 'src', 'Src', 'tech', 'rss_feed', 50,
+                  '2026-06-21T10:00:00+00:00', %s::vector)
+                """,
+                (
+                    article_id,
+                    f"https://example.com/{article_id}",
+                    f"https://example.com/{article_id}",
+                    f"Article {article_id}",
+                    vector_literal(_padded(vec)),
+                ),
+            )
+
+        query_vec = vector_literal(_padded([1.0, 0.0]))
+        rows = conn.execute(
+            "SELECT id FROM articles ORDER BY embedding_vec <=> %s::vector LIMIT 2",
+            (query_vec,),
+        ).fetchall()
+
+    assert [row["id"] for row in rows] == [1, 2]

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -16,7 +16,6 @@ user survive the whole ingest → score → serve pipeline:
 
 from __future__ import annotations
 
-import struct
 from pathlib import Path
 from typing import Any
 
@@ -24,7 +23,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from news_dashboard.auth import require_auth
-from news_dashboard.db import connect, init_db
+from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
+from news_dashboard.embeddings import vector_literal
 from news_dashboard.main import app
 from news_dashboard.recommendations import upsert_recommendation_score
 
@@ -77,9 +77,9 @@ def _insert_article(
             """
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, state, importance_score, tags, discovered_at, embedding
+              category, kind, state, importance_score, tags, discovered_at, embedding_vec
             )
-            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, '', %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, '', %s, %s::vector)
             RETURNING id
             """,
             (
@@ -91,7 +91,9 @@ def _insert_article(
                 category,
                 importance,
                 discovered_at,
-                struct.pack(f"{len(embedding)}f", *embedding) if embedding else None,
+                vector_literal(embedding + [0.0] * (EMBEDDING_DIMENSIONS - len(embedding)))
+                if embedding
+                else None,
             ),
         ).fetchone()
     assert row is not None

--- a/backend/tests/test_semantic_similarity.py
+++ b/backend/tests/test_semantic_similarity.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import struct
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 import news_dashboard.embeddings as embeddings_mod
-from news_dashboard.db import connect, init_db
-from news_dashboard.embeddings import embedding_text, ensure_article_embedded
+from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
+from news_dashboard.embeddings import embedding_text, ensure_article_embedded, vector_literal
 from news_dashboard.recommendations import (
     SEMANTIC_SCORE_SPAN,
     build_semantic_profile,
@@ -17,6 +16,16 @@ from news_dashboard.recommendations import (
 )
 
 pytestmark = pytest.mark.postgres
+
+
+def _padded(vec: list[float]) -> list[float]:
+    """Right-pad a toy test vector with zeros to the real embedding_vec(1536) width.
+
+    Trailing zeros in the same positions on both sides of a cosine comparison
+    leave the similarity unchanged, so tests can keep using small, readable
+    vectors like [1.0, 0.0].
+    """
+    return vec + [0.0] * (EMBEDDING_DIMENSIONS - len(vec))
 
 
 # ── Pure semantic logic (no database) ─────────────────────────────────────────
@@ -97,15 +106,15 @@ def _insert_article(
     importance: int = 50,
     embedding: list[float] | None = None,
 ) -> int:
-    blob = struct.pack(f"{len(embedding)}f", *embedding) if embedding is not None else None
+    vec = vector_literal(_padded(embedding)) if embedding is not None else None
     with connect(db_path) as conn:
         row = conn.execute(
             """
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, state, importance_score, discovered_at, embedding
+              category, kind, state, importance_score, discovered_at, embedding_vec
             )
-            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', 'today', %s, %s, %s::vector)
             RETURNING id
             """,
             (
@@ -117,7 +126,7 @@ def _insert_article(
                 category,
                 importance,
                 "2026-06-21T10:00:00+00:00",
-                blob,
+                vec,
             ),
         ).fetchone()
     assert row is not None

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: news_dashboard
       POSTGRES_USER: news_dashboard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: news_dashboard
       POSTGRES_USER: news_dashboard

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -176,7 +176,7 @@ ingestCronJob:
 
 postgresql:
   enabled: true
-  image: postgres:16-alpine
+  image: pgvector/pgvector:pg16
   podSecurityContext:
     fsGroup: 999
     seccompProfile:

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -17,6 +17,7 @@ PostgreSQL is the application database. Runtime code should be written directly 
 - Do not add SQLite fallbacks, database-type sniffing, placeholder translation, or generic multi-database SQL.
 - Configure the app with `DATABASE_URL` or `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.
 - SQLite is allowed only as an input format for legacy migration tooling that imports old local data into PostgreSQL.
+- PostgreSQL must have the [pgvector](https://github.com/pgvector/pgvector) extension available (the `pgvector/pgvector:pg16` image, or `CREATE EXTENSION vector` on an external instance): article embeddings live in `articles.embedding_vec`, with similarity search (Ask AI, topic map, recommendations) running as SQL `<=>` queries over an HNSW index instead of a Python cosine loop.
 
 ## Runtime Topology
 
@@ -41,7 +42,7 @@ flowchart TB
     Deployment["news-dashboard Deployment<br/>replicas: 1"]
     CronJob["K8s CronJob<br/>news-dashboard ingest<br/>every 6 hours"]
     PostgresSvc["Postgres Service"]
-    Postgres["Postgres StatefulSet<br/>postgres:16-alpine"]
+    Postgres["Postgres StatefulSet<br/>pgvector/pgvector:pg16"]
     PVC["HostPath / PVC storage"]
   end
 

--- a/website/docs/configuration/postgres-backup.md
+++ b/website/docs/configuration/postgres-backup.md
@@ -105,7 +105,7 @@ kubectl -n news-dashboard scale deployment news-dashboard --replicas=1
 pg_restore --list news_dashboard_20260628T020001Z.dump | head -40
 
 # Restore into a throwaway local container:
-docker run --rm -e POSTGRES_PASSWORD=test -p 5433:5432 -d --name pg-verify postgres:16-alpine
+docker run --rm -e POSTGRES_PASSWORD=test -p 5433:5432 -d --name pg-verify pgvector/pgvector:pg16
 sleep 3
 pg_restore -h 127.0.0.1 -p 5433 -U postgres -d postgres \
   --create news_dashboard_20260628T020001Z.dump

--- a/website/docs/contributing/index.md
+++ b/website/docs/contributing/index.md
@@ -7,7 +7,8 @@ News Dashboard.
 
 - Python 3.14+
 - Node.js LTS
-- PostgreSQL 16+
+- PostgreSQL 16+ with the [pgvector](https://github.com/pgvector/pgvector) extension
+  (use the `pgvector/pgvector:pg16` image)
 - A running PostgreSQL instance for backend tests and local development
 
 Start with the root


### PR DESCRIPTION
## Summary

Closes #924.

Migrates article embeddings from an opaque BLOB column to [pgvector](https://github.com/pgvector/pgvector), so similarity search (Ask AI retrieval, topic clustering, recommendations, ai-stats) runs in SQL over an HNSW index instead of fetching every candidate row into Python and computing cosine similarity in a loop.

- Add `articles.embedding_vec vector(1536)`. PostgreSQL now requires the pgvector extension — the app fails startup with a clear, actionable error if it's missing.
- On startup, existing BLOB embeddings are automatically backfilled into `embedding_vec` in batches, then the legacy BLOB column is dropped — a single-release migration, no manual steps for self-hosters beyond swapping the Postgres image.
- Rewrite `embeddings.ask()`'s top-k retrieval to a single SQL query using the `<=>` cosine-distance operator (no more full-table Python cosine loop). `insights.py`, `recommendations.py`, and `ai_stats/service.py` read from `embedding_vec` instead of unpacking BYTEA.
- Swap the Postgres image to `pgvector/pgvector:pg16` across `docker-compose.yml`, `docker-compose.prod.yml`, `.github/workflows/ci.yml`, `.github/workflows/pr-timing.yml`, the devcontainer, and the Helm chart's bundled Postgres.
- Fixed a real concurrency bug surfaced while testing this: two concurrent `init_db()` calls (e.g. the app Deployment and the ingest CronJob starting together) could both pass `CREATE EXTENSION IF NOT EXISTS vector`'s existence check and race to create it, since extensions are database-wide, not schema-scoped — the loser previously got an unhandled unique-violation. Now treated as success.
- Docs updated (README, architecture, contributing, postgres-backup) for the new PostgreSQL 16+ with pgvector requirement, including an upgrade note for existing deployments.

Out of scope (per the issue): changing the embedding model/dimension, re-embedding content, quantization. `recommendations.py`'s multi-signal scoring (cold-start + affinity + freshness + novelty, not pure similarity ranking) keeps its Python-side blend, just reading vectors from `embedding_vec` instead of BYTEA — only genuinely pure top-k similarity retrieval (Ask AI) and clustering candidate loading moved fully to SQL.

## Test plan

- [x] New `backend/tests/test_pgvector_migration.py`: extension creation, HNSW index presence, legacy-BLOB backfill losslessness + idempotency, SQL top-k cosine ordering.
- [x] Updated all existing tests that seeded raw BLOB embeddings (`test_ask_scope.py`, `test_semantic_similarity.py`, `test_novelty_freshness.py`, `test_behavioral_affinity.py`, `test_insights.py`, `test_ai_stats.py`, `test_recommendation_contracts.py`, `test_mcp.py`, `test_db_init.py`) to seed `embedding_vec` instead.
- [x] Full backend suite: `1723 passed` against a local `pgvector/pgvector:pg16` container.
- [x] `ruff check`, `ruff format --check`, `mypy`: clean.
- [x] `test_chart_render.py` / `test_compose_auth_env.py`: 19 passed (Helm/compose config unaffected structurally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)