### PR TITLE
feat: add a one-command demo quickstart (docker-compose.demo.yml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,28 @@ SQLite is supported only as a legacy import source for
 > automatically on first boot. Starting against a Postgres without the
 > extension fails fast with a clear error naming it.
 
+## Try the demo
+
+Want to try News Dashboard before self-hosting it? One command runs a
+throwaway instance seeded with sample articles and a read-only guest account
+— no AI keys, no configuration:
+
+```bash
+docker compose -f docker-compose.demo.yml up
+```
+
+Open [http://localhost:8080](http://localhost:8080) and log in with:
+
+| Field    | Value   |
+| -------- | ------- |
+| Username | `guest` |
+| Password | `demo`  |
+
+The guest account is **read-only** — write actions (saving, marking read,
+adding sources, etc.) are rejected. This compose file uses fixed demo secrets
+and is not meant for real deployments; see [Quick Start](#quick-start) below
+to self-host for real.
+
 ## Quick Start
 
 You can run News Dashboard in two ways:

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -16,6 +16,7 @@ import yaml  # type: ignore[import-untyped]
 REPO_ROOT = Path(__file__).parent.parent.parent
 COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
 COMPOSE_PROD_FILE = REPO_ROOT / "docker-compose.prod.yml"
+COMPOSE_DEMO_FILE = REPO_ROOT / "docker-compose.demo.yml"
 
 _REQUIRED_AUTH_VARS = {
     "SESSION_SECRET",
@@ -71,6 +72,28 @@ def test_compose_prod_file_exists() -> None:
     assert COMPOSE_PROD_FILE.exists(), f"docker-compose.prod.yml not found at {COMPOSE_PROD_FILE}"
 
 
+def test_compose_demo_file_exists() -> None:
+    assert COMPOSE_DEMO_FILE.exists(), f"docker-compose.demo.yml not found at {COMPOSE_DEMO_FILE}"
+
+
+def test_compose_demo_app_service_has_demo_mode_and_session_secret() -> None:
+    """The demo compose file must enable DEMO_MODE and supply SESSION_SECRET."""
+    compose = yaml.safe_load(COMPOSE_DEMO_FILE.read_text())
+    services = compose.get("services", {})
+    assert "news-dashboard" in services, "news-dashboard service missing from demo compose"
+
+    env = services["news-dashboard"].get("environment", {})
+    if isinstance(env, list):
+        env = dict(item.split("=", 1) if "=" in item else (item, "") for item in env)
+
+    assert _resolve_default(env.get("DEMO_MODE")) in ("1", "true", "yes", "on"), (
+        "DEMO_MODE must be enabled in docker-compose.demo.yml"
+    )
+    assert _resolve_default(env.get("SESSION_SECRET")), (
+        "SESSION_SECRET must have a value in docker-compose.demo.yml"
+    )
+
+
 def _assert_app_healthcheck_uses_no_extra_tools(compose_file: Path) -> None:
     """The news-dashboard service healthcheck must not rely on curl/wget.
 
@@ -111,3 +134,7 @@ def test_compose_app_healthcheck_configured() -> None:
 
 def test_compose_prod_app_healthcheck_configured() -> None:
     _assert_app_healthcheck_uses_no_extra_tools(COMPOSE_PROD_FILE)
+
+
+def test_compose_demo_app_healthcheck_configured() -> None:
+    _assert_app_healthcheck_uses_no_extra_tools(COMPOSE_DEMO_FILE)

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,47 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: news_dashboard
+      POSTGRES_USER: news_dashboard
+      POSTGRES_PASSWORD: demo-only-password
+    volumes:
+      - news-dashboard-demo-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U news_dashboard -d news_dashboard"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  news-dashboard:
+    image: ghcr.io/lihor-hub/news-dashboard:latest
+    ports:
+      - "8080:8080"
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: news_dashboard
+      POSTGRES_USER: news_dashboard
+      POSTGRES_PASSWORD: demo-only-password
+      SESSION_SECRET: demo-only-session-secret-not-for-real-deployments
+      DEMO_MODE: "1"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/api/ready', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  news-dashboard-demo-postgres:

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -1,12 +1,13 @@
 # Getting Started
 
-Welcome to **News Dashboard** — your private news platform. There are three ways
+Welcome to **News Dashboard** — your private news platform. There are four ways
 to start using the app, depending on how you want to access it.
 
 | On-ramp | Best for |
 |---------|----------|
 | [Install the Android APK](install-android-apk.md) | Reading on an Android phone or tablet |
 | [Create a web account](create-web-account.md) | Reading in a browser on any device |
+| [Try the demo](try-the-demo.md) | Trying the app locally with sample data, no setup |
 | [Self-host your own instance](https://github.com/lihor-hub/news-dashboard#quick-start) | Running News Dashboard on your own infrastructure |
 
 The public instance runs at **[news.lihor.ro](https://news.lihor.ro)**. If you

--- a/website/docs/getting-started/try-the-demo.md
+++ b/website/docs/getting-started/try-the-demo.md
@@ -1,0 +1,44 @@
+# Try the Demo
+
+The fastest way to see News Dashboard without setting up your own accounts,
+sources, or AI keys is demo mode: a throwaway instance seeded with sample
+articles and a read-only guest account.
+
+## Run it
+
+From a clone of the repository:
+
+```bash
+docker compose -f docker-compose.demo.yml up
+```
+
+This starts a bundled PostgreSQL instance and the published News Dashboard
+image with `DEMO_MODE=1`. No `.env` file, API keys, or manual configuration
+are required.
+
+Open [http://localhost:8080](http://localhost:8080) and sign in with:
+
+| Field    | Value   |
+| -------- | ------- |
+| Username | `guest` |
+| Password | `demo`  |
+
+## What's seeded
+
+On first boot, demo mode seeds deterministic, fully offline sample data —
+articles across categories like Python, AI/LLM, Rust, and cloud/infra, in a
+mix of read, unread, saved, and archived states. No network requests or LLM
+calls happen during seeding.
+
+## Guest account limitations
+
+The `guest` account is **read-only**. You can browse the Today Feed, search,
+open articles, and explore the UI, but write actions (saving, marking read,
+snoozing, adding sources, changing settings, and similar) are rejected.
+
+## Next steps
+
+Demo mode is for trying the app locally, not for a permanent or public
+instance. When you're ready to run your own instance for real, see the
+[Quick Start](https://github.com/lihor-hub/news-dashboard#quick-start) in the
+README and the [Self-Hosting guide](/docs/self-hosting).


### PR DESCRIPTION
## Summary

Closes #926.

- Adds `docker-compose.demo.yml`, modeled on `docker-compose.prod.yml`: published image, bundled `pgvector/pgvector:pg16` Postgres, `DEMO_MODE=1`, and fixed throwaway `SESSION_SECRET`/Postgres credentials (no `.env`, no AI keys required).
- Adds a "Try the demo" section to `README.md` right before Quick Start: the one command and the `guest`/`demo` login.
- Adds `website/docs/getting-started/try-the-demo.md` and links it from the Getting Started index.
- Extends `backend/tests/test_compose_auth_env.py` with coverage for the new demo compose file (file exists, `DEMO_MODE` enabled, `SESSION_SECRET` set, healthcheck configured consistently with the other compose files).

Demo seeding logic (`backend/news_dashboard/demo.py`, the `DEMO_MODE` startup hook in `main.py`, and the `reject_guest_writes` guest read-only middleware) already existed and is unchanged by this PR.

## Test plan

- [x] `pytest backend/tests/test_compose_auth_env.py backend/tests/test_demo.py -q` — 22 passed.
- [x] `ruff check` / `mypy` on the changed test file — clean.
- [x] `docker compose -f docker-compose.demo.yml config -q` — valid compose file.
- [x] `cd website && npm run build` — docs build succeeds with the new page.
- [ ] Full `docker compose -f docker-compose.demo.yml up` end-to-end run against the published `ghcr.io` image — not verified in this sandbox (outbound registry pulls were not reachable in the agent's environment). Compose config validation plus the existing, unchanged `DEMO_MODE`/guest-seeding code path give confidence this works; recommend a manual smoke test before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)