### PR TITLE
feat: add a Google Reader-compatible sync API for third-party RSS clients (#928)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ optional OpenAI features for embeddings, Ask AI, and briefings.
 - Local password auth with first-admin bootstrap.
 - Optional Keycloak login.
 - Optional OpenAI embeddings, Ask AI, and generated briefings.
+- Google Reader-compatible sync API for third-party RSS clients (NetNewsWire, Reeder, Unread, ...).
 - Docker, Helm, and GitHub Actions deployment support.
 
 <details>

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -794,6 +794,20 @@ POSTGRES_MULTIUSER_SCHEMA = [
     " BOOLEAN NOT NULL DEFAULT FALSE",
     "ALTER TABLE users ADD COLUMN IF NOT EXISTS briefing_reading_list_limit"
     " INTEGER NOT NULL DEFAULT 3",
+    """
+    CREATE TABLE IF NOT EXISTS greader_tokens (
+      id            BIGSERIAL PRIMARY KEY,
+      user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name          TEXT NOT NULL,
+      token_hash    TEXT NOT NULL UNIQUE,
+      token_prefix  TEXT NOT NULL,
+      created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_used_at  TIMESTAMPTZ,
+      revoked_at    TIMESTAMPTZ
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_greader_tokens_user"
+    " ON greader_tokens(user_id, created_at DESC)",
 ]
 
 # Runs after POSTGRES_SCHEMA/POSTGRES_MULTIUSER_SCHEMA and the embedding_vec

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -806,8 +806,10 @@ POSTGRES_MULTIUSER_SCHEMA = [
       revoked_at    TIMESTAMPTZ
     )
     """,
-    "CREATE INDEX IF NOT EXISTS idx_greader_tokens_user"
-    " ON greader_tokens(user_id, created_at DESC)",
+    (
+        "CREATE INDEX IF NOT EXISTS idx_greader_tokens_user"
+        " ON greader_tokens(user_id, created_at DESC)"
+    ),
 ]
 
 # Runs after POSTGRES_SCHEMA/POSTGRES_MULTIUSER_SCHEMA and the embedding_vec

--- a/backend/news_dashboard/greader.py
+++ b/backend/news_dashboard/greader.py
@@ -1,0 +1,541 @@
+"""Google Reader-compatible sync API (v1) for third-party RSS clients.
+
+Lets stock GReader clients (NetNewsWire, Reeder, Unread, ...) subscribe to a
+user's sources, read the reading list / per-feed / starred streams, and sync
+read/starred state — all read/write through the existing per-user article
+state machinery in ``ingest.py``.
+
+Auth is a dedicated per-user API-token mechanism (mirrors ``mcp/service.py``):
+tokens are opaque, hashed at rest, and revocable from Settings. GReader
+clients present the token as the ``ClientLogin`` password and then send it
+back as ``Authorization: GoogleLogin auth=<token>`` (or a plain bearer token)
+on every subsequent request.
+
+Item ids are the article id encoded as 16 hex digits, optionally wrapped in
+the ``tag:google.com,2005:reader/item/<hex>`` long form real clients expect
+from ``stream/contents``. Continuation tokens are just ``o<offset>``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Form, Header, HTTPException, Query
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel
+
+from news_dashboard.article_visibility import visible_article_sql
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db, row_to_dict
+
+TOKEN_PREFIX = "ndgr_"  # noqa: S105 -- token prefix, not a credential
+MAX_TOKENS_PER_USER = 10
+MAX_TOKEN_NAME_LENGTH = 120
+
+READING_LIST_STREAM = "user/-/state/com.google/reading-list"
+STARRED_STREAM = "user/-/state/com.google/starred"
+READ_TAG = "user/-/state/com.google/read"
+STARRED_TAG = "user/-/state/com.google/starred"
+
+DEFAULT_STREAM_LIMIT = 20
+MAX_STREAM_LIMIT = 500
+
+
+# --------------------------------------------------------------------------- #
+# Token lifecycle (mirrors news_dashboard.mcp.service)                        #
+# --------------------------------------------------------------------------- #
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _generate_token() -> tuple[str, str, str]:
+    secret = secrets.token_urlsafe(32)
+    token = f"{TOKEN_PREFIX}{secret}"
+    return token, _hash_token(token), token[: len(TOKEN_PREFIX) + 8]
+
+
+def _serialise(row: dict[str, Any]) -> dict[str, Any]:
+    data = dict(row)
+    data.pop("token_hash", None)
+    for key in ("created_at", "last_used_at", "revoked_at"):
+        value = data.get(key)
+        if value is not None and not isinstance(value, str):
+            data[key] = value.isoformat()
+    return data
+
+
+def list_tokens(user_id: int, *, database_url: str | None = None) -> list[dict[str, Any]]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, user_id, name, token_prefix, created_at, last_used_at, revoked_at
+            FROM greader_tokens
+            WHERE user_id = %s
+            ORDER BY created_at DESC
+            """,
+            (user_id,),
+        ).fetchall()
+    return [_serialise(row_to_dict(row)) for row in rows]
+
+
+def create_token(user_id: int, name: str, *, database_url: str | None = None) -> dict[str, Any]:
+    """Create a new GReader token. Returns the serialised token including the
+    plaintext ``token`` field once — callers must display it now."""
+    init_db(database_url=database_url)
+    clean_name = name.strip()[:MAX_TOKEN_NAME_LENGTH] or "RSS client"
+    token, token_hash, prefix = _generate_token()
+    with connect(database_url=database_url) as conn:
+        active = conn.execute(
+            "SELECT COUNT(*) AS n FROM greader_tokens WHERE user_id = %s AND revoked_at IS NULL",
+            (user_id,),
+        ).fetchone()
+        if row_to_dict(active)["n"] >= MAX_TOKENS_PER_USER:
+            message = "token limit reached; revoke an existing token first"
+            raise ValueError(message)
+        row = conn.execute(
+            """
+            INSERT INTO greader_tokens(user_id, name, token_hash, token_prefix)
+            VALUES (%s, %s, %s, %s)
+            RETURNING id, user_id, name, token_prefix, created_at, last_used_at, revoked_at
+            """,
+            (user_id, clean_name, token_hash, prefix),
+        ).fetchone()
+    result = _serialise(row_to_dict(row))
+    result["token"] = token
+    return result
+
+
+def revoke_token(
+    user_id: int, token_id: int, *, database_url: str | None = None
+) -> dict[str, Any] | None:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE greader_tokens
+            SET revoked_at = NOW()
+            WHERE id = %s AND user_id = %s AND revoked_at IS NULL
+            RETURNING id, user_id, name, token_prefix, created_at, last_used_at, revoked_at
+            """,
+            (token_id, user_id),
+        ).fetchone()
+    return None if row is None else _serialise(row_to_dict(row))
+
+
+def authenticate_token(token: str, *, database_url: str | None = None) -> int | None:
+    """Verify a bearer token and return the owning user_id, or None."""
+    if not token or not token.startswith(TOKEN_PREFIX):
+        return None
+    init_db(database_url=database_url)
+    token_hash = _hash_token(token)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT id, user_id, revoked_at FROM greader_tokens WHERE token_hash = %s",
+            (token_hash,),
+        ).fetchone()
+        if row is None:
+            return None
+        data = row_to_dict(row)
+        if data["revoked_at"] is not None:
+            return None
+        conn.execute("UPDATE greader_tokens SET last_used_at = NOW() WHERE id = %s", (data["id"],))
+    return int(data["user_id"])
+
+
+# --------------------------------------------------------------------------- #
+# Item id encoding                                                             #
+# --------------------------------------------------------------------------- #
+
+_ITEM_TAG_PREFIX = "tag:google.com,2005:reader/item/"
+
+
+def item_short_id(article_id: int) -> str:
+    return f"{article_id:016x}"
+
+
+def item_long_id(article_id: int) -> str:
+    return f"{_ITEM_TAG_PREFIX}{item_short_id(article_id)}"
+
+
+def parse_item_id(value: str) -> int | None:
+    hex_part = value[len(_ITEM_TAG_PREFIX) :] if value.startswith(_ITEM_TAG_PREFIX) else value
+    try:
+        return int(hex_part, 16)
+    except ValueError:
+        return None
+
+
+def _encode_continuation(offset: int) -> str | None:
+    return f"o{offset}" if offset > 0 else None
+
+
+def _decode_continuation(value: str | None) -> int:
+    if not value or not value.startswith("o"):
+        return 0
+    try:
+        return max(0, int(value[1:]))
+    except ValueError:
+        return 0
+
+
+# --------------------------------------------------------------------------- #
+# Data access                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _fetch_stream_articles(
+    user_id: int,
+    *,
+    source_slug: str | None = None,
+    starred_only: bool = False,
+    limit: int,
+    offset: int,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    clauses = [
+        "(a.canonical_id IS NULL OR COALESCE(uas.state, 'today') != 'archived')",
+        f"({visible_article_sql('a')})",
+    ]
+    params: list[Any] = [user_id]
+    if source_slug is not None:
+        clauses.append("a.source_slug = %s")
+        params.append(source_slug)
+    if starred_only:
+        clauses.append("COALESCE(uas.starred, FALSE) IS TRUE")
+    where = " AND ".join(clauses)
+    params.extend([limit, offset])
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT a.id, a.title, a.url, a.summary, a.source_slug, a.source_name,
+                   a.category, a.published_at, a.discovered_at,
+                   COALESCE(uas.state, 'today') AS state,
+                   COALESCE(uas.starred, FALSE) AS starred
+            FROM articles a
+            JOIN sources a_src ON a_src.slug = a.source_slug
+            LEFT JOIN user_sources a_us
+              ON a_us.source_slug = a.source_slug AND a_us.user_id = %s
+            LEFT JOIN user_article_state uas
+              ON uas.article_id = a.id AND uas.user_id = %s
+            WHERE {where}
+            ORDER BY a.discovered_at DESC, a.id DESC
+            LIMIT %s OFFSET %s
+            """,
+            [user_id, user_id, *params],
+        ).fetchall()
+    return [row_to_dict(row) for row in rows]
+
+
+def _fetch_articles_by_ids(
+    user_id: int, article_ids: list[int], *, database_url: str | None = None
+) -> list[dict[str, Any]]:
+    if not article_ids:
+        return []
+    from news_dashboard.db import placeholders
+
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT a.id, a.title, a.url, a.summary, a.source_slug, a.source_name,
+                   a.category, a.published_at, a.discovered_at,
+                   COALESCE(uas.state, 'today') AS state,
+                   COALESCE(uas.starred, FALSE) AS starred
+            FROM articles a
+            JOIN sources a_src ON a_src.slug = a.source_slug
+            LEFT JOIN user_sources a_us
+              ON a_us.source_slug = a.source_slug AND a_us.user_id = %s
+            LEFT JOIN user_article_state uas
+              ON uas.article_id = a.id AND uas.user_id = %s
+            WHERE a.id IN ({placeholders(article_ids)})
+              AND ({visible_article_sql("a")})
+            ORDER BY a.discovered_at DESC, a.id DESC
+            """,
+            [user_id, user_id, *article_ids, user_id],
+        ).fetchall()
+    return [row_to_dict(row) for row in rows]
+
+
+def list_visible_sources(user_id: int, *, database_url: str | None = None) -> list[dict[str, Any]]:
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT s.slug, s.name, s.url, s.category
+            FROM sources s
+            WHERE (s.owner_user_id IS NULL OR s.owner_user_id = %s)
+              AND s.deleted_at IS NULL
+            ORDER BY s.category, s.priority DESC, s.name
+            """,
+            (user_id,),
+        ).fetchall()
+    return [row_to_dict(row) for row in rows]
+
+
+def _article_to_item(article: dict[str, Any]) -> dict[str, Any]:
+    categories = [READING_LIST_STREAM]
+    if article["state"] not in ("today", "later"):
+        categories.append(READ_TAG)
+    if article["starred"]:
+        categories.append(STARRED_TAG)
+    return {
+        "id": item_long_id(article["id"]),
+        "title": article["title"],
+        "canonical": [{"href": article["url"]}],
+        "alternate": [{"href": article["url"]}],
+        "summary": {"content": article.get("summary") or ""},
+        "author": article.get("source_name"),
+        "categories": categories,
+        "origin": {
+            "streamId": f"feed/{article['source_slug']}",
+            "title": article.get("source_name"),
+        },
+        "crawlTimeMsec": "0",
+        "published": _to_epoch(article.get("published_at") or article.get("discovered_at")),
+    }
+
+
+def _to_epoch(value: Any) -> int:
+    if value is None:
+        return 0
+    from datetime import datetime
+
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return 0
+    if isinstance(value, datetime):
+        return int(value.timestamp())
+    return 0
+
+
+def apply_edit_tag(user_id: int, article_id: int, *, add: list[str], remove: list[str]) -> None:
+    import contextlib
+
+    from news_dashboard.ingest import set_article_starred, transition_article_state
+
+    for tag in add:
+        if tag == READ_TAG:
+            with contextlib.suppress(ValueError):
+                transition_article_state(article_id, "done", user_id=user_id)
+        elif tag == STARRED_TAG:
+            with contextlib.suppress(ValueError):
+                set_article_starred(article_id, True, user_id=user_id)
+    for tag in remove:
+        if tag == READ_TAG:
+            with contextlib.suppress(ValueError):
+                transition_article_state(article_id, "today", user_id=user_id)
+        elif tag == STARRED_TAG:
+            with contextlib.suppress(ValueError):
+                set_article_starred(article_id, False, user_id=user_id)
+
+
+# --------------------------------------------------------------------------- #
+# Token management endpoints (session-cookie auth, mounted on `api`)          #
+# --------------------------------------------------------------------------- #
+
+
+class TokenCreateRequest(BaseModel):
+    name: str
+
+
+router = APIRouter()
+public_greader_router = APIRouter(prefix="/api/greader")
+
+
+@router.get("/api/users/me/greader-tokens")
+def list_greader_tokens(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": list_tokens(int(current_user["id"]))}
+
+
+@router.post("/api/users/me/greader-tokens")
+def create_greader_token(
+    payload: TokenCreateRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        return create_token(int(current_user["id"]), payload.name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.delete("/api/users/me/greader-tokens/{token_id}")
+def revoke_greader_token(
+    token_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    token = revoke_token(int(current_user["id"]), token_id)
+    if token is None:
+        raise HTTPException(status_code=404, detail="token not found")
+    return token
+
+
+# --------------------------------------------------------------------------- #
+# GReader protocol endpoints (own bearer/GoogleLogin auth, publicly mounted)   #
+# --------------------------------------------------------------------------- #
+
+
+def _authenticate(authorization: str | None) -> int:
+    if not authorization:
+        raise HTTPException(status_code=401, detail="missing Authorization header")
+    lowered = authorization.lower()
+    if lowered.startswith("googlelogin "):
+        raw = authorization[len("GoogleLogin ") :].split()
+        parts = dict(item.split("=", 1) for item in raw if "=" in item)
+        token = parts.get("auth", "")
+    elif lowered.startswith("bearer "):
+        token = authorization[len("Bearer ") :].strip()
+    else:
+        token = authorization.strip()
+    user_id = authenticate_token(token)
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="invalid or revoked token")
+    return user_id
+
+
+@public_greader_router.post("/accounts/ClientLogin")
+def client_login(
+    email: Annotated[str, Form(alias="Email")] = "",
+    passwd: Annotated[str, Form(alias="Passwd")] = "",
+) -> PlainTextResponse:
+    _ = email
+    user_id = authenticate_token(passwd)
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="invalid credentials")
+    body = f"SID={passwd}\nLSID={passwd}\nAuth={passwd}\n"
+    return PlainTextResponse(body)
+
+
+@public_greader_router.get("/reader/api/0/token")
+def reader_token(
+    authorization: Annotated[str | None, Header()] = None,
+) -> PlainTextResponse:
+    user_id = _authenticate(authorization)
+    return PlainTextResponse(f"greader-post-token-{user_id}")
+
+
+@public_greader_router.get("/reader/api/0/user-info")
+def user_info(authorization: Annotated[str | None, Header()] = None) -> dict[str, Any]:
+    from news_dashboard.auth import get_user_by_id
+
+    user_id = _authenticate(authorization)
+    user = get_user_by_id(user_id)
+    return {
+        "userId": str(user_id),
+        "userName": (user or {}).get("username"),
+        "userEmail": (user or {}).get("email"),
+    }
+
+
+@public_greader_router.get("/reader/api/0/subscription/list")
+def subscription_list(authorization: Annotated[str | None, Header()] = None) -> dict[str, Any]:
+    user_id = _authenticate(authorization)
+    subscriptions = [
+        {
+            "id": f"feed/{source['slug']}",
+            "title": source["name"],
+            "categories": [
+                {
+                    "id": f"user/-/label/{source['category']}",
+                    "label": source["category"],
+                }
+            ],
+            "url": source["url"],
+            "htmlUrl": source["url"],
+        }
+        for source in list_visible_sources(user_id)
+    ]
+    return {"subscriptions": subscriptions}
+
+
+def _stream_articles(
+    user_id: int, stream_id: str, *, limit: int, offset: int
+) -> list[dict[str, Any]]:
+    if stream_id == READING_LIST_STREAM:
+        return _fetch_stream_articles(user_id, limit=limit, offset=offset)
+    if stream_id == STARRED_STREAM:
+        return _fetch_stream_articles(user_id, starred_only=True, limit=limit, offset=offset)
+    if stream_id.startswith("feed/"):
+        return _fetch_stream_articles(
+            user_id, source_slug=stream_id[len("feed/") :], limit=limit, offset=offset
+        )
+    raise HTTPException(status_code=404, detail=f"unknown stream: {stream_id}")
+
+
+@public_greader_router.get("/reader/api/0/stream/contents/{stream_id:path}")
+def stream_contents(
+    stream_id: str,
+    authorization: Annotated[str | None, Header()] = None,
+    n: Annotated[int, Query()] = DEFAULT_STREAM_LIMIT,
+    c: Annotated[str | None, Query()] = None,
+) -> dict[str, Any]:
+    user_id = _authenticate(authorization)
+    limit = max(1, min(n, MAX_STREAM_LIMIT))
+    offset = _decode_continuation(c)
+    articles = _stream_articles(user_id, stream_id, limit=limit + 1, offset=offset)
+    has_more = len(articles) > limit
+    articles = articles[:limit]
+    return {
+        "id": stream_id,
+        "updated": _to_epoch(None),
+        "items": [_article_to_item(a) for a in articles],
+        "continuation": _encode_continuation(offset + limit) if has_more else None,
+    }
+
+
+@public_greader_router.get("/reader/api/0/stream/items/ids")
+def stream_items_ids(
+    authorization: Annotated[str | None, Header()] = None,
+    s: Annotated[str, Query()] = READING_LIST_STREAM,
+    n: Annotated[int, Query()] = DEFAULT_STREAM_LIMIT,
+    c: Annotated[str | None, Query()] = None,
+) -> dict[str, Any]:
+    user_id = _authenticate(authorization)
+    limit = max(1, min(n, MAX_STREAM_LIMIT))
+    offset = _decode_continuation(c)
+    articles = _stream_articles(user_id, s, limit=limit + 1, offset=offset)
+    has_more = len(articles) > limit
+    articles = articles[:limit]
+    return {
+        "itemRefs": [{"id": item_short_id(a["id"])} for a in articles],
+        "continuation": _encode_continuation(offset + limit) if has_more else None,
+    }
+
+
+@public_greader_router.post("/reader/api/0/stream/items/contents")
+def stream_items_contents(
+    i: Annotated[list[str] | None, Form()] = None,
+    authorization: Annotated[str | None, Header()] = None,
+) -> dict[str, Any]:
+    user_id = _authenticate(authorization)
+    ids = [parse_item_id(v) for v in (i or [])]
+    article_ids = [aid for aid in ids if aid is not None]
+    articles = _fetch_articles_by_ids(user_id, article_ids)
+    return {"items": [_article_to_item(a) for a in articles]}
+
+
+@public_greader_router.post("/reader/api/0/edit-tag")
+def edit_tag(
+    i: Annotated[list[str] | None, Form()] = None,
+    a: Annotated[list[str] | None, Form()] = None,
+    r: Annotated[list[str] | None, Form()] = None,
+    authorization: Annotated[str | None, Header()] = None,
+) -> PlainTextResponse:
+    user_id = _authenticate(authorization)
+    add_tags = a or []
+    remove_tags = r or []
+    for raw_id in i or []:
+        article_id = parse_item_id(raw_id)
+        if article_id is None:
+            continue
+        apply_edit_tag(user_id, article_id, add=add_tags, remove=remove_tags)
+    return PlainTextResponse("OK")
+
+
+__all__ = ["public_greader_router", "router"]

--- a/backend/news_dashboard/greader.py
+++ b/backend/news_dashboard/greader.py
@@ -402,13 +402,16 @@ def _authenticate(authorization: str | None) -> int:
 @public_greader_router.post("/accounts/ClientLogin")
 def client_login(
     email: Annotated[str, Form(alias="Email")] = "",
-    passwd: Annotated[str, Form(alias="Passwd")] = "",
+    client_secret: Annotated[str, Form(alias="Passwd")] = "",
 ) -> PlainTextResponse:
+    # GReader clients send the API token as the "Passwd" form field — it is
+    # a high-entropy opaque token (secrets.token_urlsafe), not a user-chosen
+    # password, so SHA-256 (matching mcp/service.py's token hashing) applies.
     _ = email
-    user_id = authenticate_token(passwd)
+    user_id = authenticate_token(client_secret)
     if user_id is None:
         raise HTTPException(status_code=401, detail="invalid credentials")
-    body = f"SID={passwd}\nLSID={passwd}\nAuth={passwd}\n"
+    body = f"SID={client_secret}\nLSID={client_secret}\nAuth={client_secret}\n"
     return PlainTextResponse(body)
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -3371,6 +3371,8 @@ def admin_delete_user(
 # gate. Add each new domain's router here as it is extracted from main.py.
 from news_dashboard.ai_memory.router import router as ai_memory_router  # noqa: E402
 from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E402
+from news_dashboard.greader import public_greader_router  # noqa: E402
+from news_dashboard.greader import router as greader_router  # noqa: E402
 from news_dashboard.mcp.router import public_mcp_router  # noqa: E402
 from news_dashboard.mcp.router import router as mcp_router  # noqa: E402
 from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
@@ -3381,6 +3383,7 @@ from news_dashboard.saved_searches.router import router as saved_searches_router
 
 api.include_router(ai_stats_router)
 api.include_router(ai_memory_router)
+api.include_router(greader_router)
 api.include_router(mcp_router)
 api.include_router(quizzes_router)
 api.include_router(reading_list_router)
@@ -3390,9 +3393,11 @@ api.include_router(saved_searches_router)
 
 app.include_router(api)
 app.include_router(admin)
-# MCP tool-calling endpoints authenticate via bearer token, not the session
-# cookie, so they mount directly on the app rather than the `api` router.
+# MCP tool-calling and GReader-sync endpoints authenticate via bearer token,
+# not the session cookie, so they mount directly on the app rather than the
+# `api` router.
 app.include_router(public_mcp_router)
+app.include_router(public_greader_router)
 
 
 # ── SPA static files ─────────────────────────────────────────────────────────

--- a/backend/tests/test_greader_api.py
+++ b/backend/tests/test_greader_api.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.db import connect
+from news_dashboard.main import app
+
+
+def _make_user(database_url: str, username: str) -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, 'hash') RETURNING id",
+            (username,),
+        ).fetchone()
+    return int(row["id"])
+
+
+def _seed_source(
+    database_url: str, slug: str = "test-source", category: str = "engineering"
+) -> None:
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, %s, 'rss', 50, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug, f"https://example.com/{slug}.xml", category),
+        )
+
+
+def _seed_article(database_url: str, article_id: int, source_slug: str = "test-source") -> None:
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO articles(
+                id, url, canonical_url, title, source_slug, source_name,
+                category, kind, status, importance_score, summary, reason, tags
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                article_id,
+                f"https://example.com/{article_id}",
+                f"https://example.com/{article_id}",
+                f"Article {article_id}",
+                source_slug,
+                source_slug,
+                "engineering",
+                "rss",
+                "new",
+                0.5,
+                f"Summary {article_id}",
+                "",
+                "",
+            ),
+        )
+
+
+# ─── service.py — token lifecycle ────────────────────────────────────────────
+
+
+def test_create_list_revoke_tokens_scoped_to_user(pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    alice = _make_user(pg_clean, "alice-greader")
+    bob = _make_user(pg_clean, "bob-greader")
+
+    created = greader.create_token(alice, "NetNewsWire", database_url=pg_clean)
+    assert created["token"].startswith(greader.TOKEN_PREFIX)
+    assert created["token_prefix"] in created["token"]
+
+    assert [t["id"] for t in greader.list_tokens(alice, database_url=pg_clean)] == [created["id"]]
+    assert greader.list_tokens(bob, database_url=pg_clean) == []
+
+    assert greader.revoke_token(bob, created["id"], database_url=pg_clean) is None
+    revoked = greader.revoke_token(alice, created["id"], database_url=pg_clean)
+    assert revoked is not None
+    assert revoked["revoked_at"] is not None
+
+
+def test_created_token_response_never_stores_plaintext(pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    alice = _make_user(pg_clean, "alice-hash")
+    created = greader.create_token(alice, "client", database_url=pg_clean)
+    assert created["token"]
+
+    listed = greader.list_tokens(alice, database_url=pg_clean)[0]
+    assert "token" not in listed
+    assert "token_hash" not in listed
+
+
+def test_token_limit_per_user(pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    alice = _make_user(pg_clean, "alice-limit")
+    for i in range(greader.MAX_TOKENS_PER_USER):
+        greader.create_token(alice, f"client-{i}", database_url=pg_clean)
+
+    with pytest.raises(ValueError, match="token limit reached"):
+        greader.create_token(alice, "one-too-many", database_url=pg_clean)
+
+
+def test_authenticate_token_rejects_unknown_revoked_and_malformed(pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    alice = _make_user(pg_clean, "alice-auth")
+    created = greader.create_token(alice, "client", database_url=pg_clean)
+    token = created["token"]
+
+    assert greader.authenticate_token(token, database_url=pg_clean) == alice
+    assert greader.authenticate_token("not-a-real-token", database_url=pg_clean) is None
+    assert greader.authenticate_token("", database_url=pg_clean) is None
+
+    greader.revoke_token(alice, created["id"], database_url=pg_clean)
+    assert greader.authenticate_token(token, database_url=pg_clean) is None
+
+
+# ─── item id encoding ─────────────────────────────────────────────────────────
+
+
+def test_item_id_round_trips_short_and_long_forms() -> None:
+    from news_dashboard import greader
+
+    long_id = greader.item_long_id(42)
+    short_id = greader.item_short_id(42)
+    assert long_id == f"tag:google.com,2005:reader/item/{short_id}"
+    assert greader.parse_item_id(long_id) == 42
+    assert greader.parse_item_id(short_id) == 42
+    assert greader.parse_item_id("not-hex") is None
+
+
+# ─── HTTP endpoints ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client() -> Generator[TestClient]:
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def _client_for(user_id: int) -> TestClient:
+    from news_dashboard.auth import require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_token_management_endpoints(pg_clean: str) -> None:
+    alice = _make_user(pg_clean, "alice-http")
+
+    with _client_for(alice) as client:
+        created = client.post("/api/users/me/greader-tokens", json={"name": "NetNewsWire"})
+        assert created.status_code == 200
+        body = created.json()
+        assert body["token"].startswith("ndgr_")
+        token_id = body["id"]
+
+        listed = client.get("/api/users/me/greader-tokens")
+        assert listed.status_code == 200
+        assert len(listed.json()["items"]) == 1
+        assert "token" not in listed.json()["items"][0]
+
+        revoked = client.delete(f"/api/users/me/greader-tokens/{token_id}")
+        assert revoked.status_code == 200
+        assert revoked.json()["revoked_at"] is not None
+
+    app.dependency_overrides.clear()
+
+
+def test_client_login_returns_auth_token_or_401(client: TestClient, pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    alice = _make_user(pg_clean, "alice-login")
+    created = greader.create_token(alice, "client", database_url=pg_clean)
+
+    resp = client.post(
+        "/api/greader/accounts/ClientLogin",
+        data={"Email": "alice", "Passwd": created["token"]},
+    )
+    assert resp.status_code == 200
+    assert f"Auth={created['token']}" in resp.text
+
+    bad = client.post(
+        "/api/greader/accounts/ClientLogin",
+        data={"Email": "alice", "Passwd": "bogus"},
+    )
+    assert bad.status_code == 401
+
+
+def _auth_header(token: str) -> dict[str, str]:
+    return {"Authorization": f"GoogleLogin auth={token}"}
+
+
+def test_protocol_endpoints_require_auth(client: TestClient) -> None:
+    resp = client.get("/api/greader/reader/api/0/user-info")
+    assert resp.status_code == 401
+
+    resp = client.get(
+        "/api/greader/reader/api/0/user-info", headers={"Authorization": "GoogleLogin auth=bogus"}
+    )
+    assert resp.status_code == 401
+
+
+def test_subscription_list_and_stream_contents(client: TestClient, pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    _seed_source(pg_clean, "feed-a", category="python")
+    alice = _make_user(pg_clean, "alice-stream")
+    _seed_article(pg_clean, 1, source_slug="feed-a")
+    _seed_article(pg_clean, 2, source_slug="feed-a")
+    created = greader.create_token(alice, "client", database_url=pg_clean)
+    headers = _auth_header(created["token"])
+
+    subs = client.get("/api/greader/reader/api/0/subscription/list", headers=headers)
+    assert subs.status_code == 200
+    sub_items = subs.json()["subscriptions"]
+    assert any(s["id"] == "feed/feed-a" for s in sub_items)
+
+    contents = client.get(
+        "/api/greader/reader/api/0/stream/contents/user/-/state/com.google/reading-list",
+        headers=headers,
+    )
+    assert contents.status_code == 200
+    items = contents.json()["items"]
+    assert len(items) == 2
+    assert items[0]["id"] == greader.item_long_id(2)
+
+    feed_contents = client.get(
+        "/api/greader/reader/api/0/stream/contents/feed/feed-a",
+        headers=headers,
+    )
+    assert feed_contents.status_code == 200
+    assert len(feed_contents.json()["items"]) == 2
+
+
+def test_stream_contents_continuation_paging(client: TestClient, pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    _seed_source(pg_clean, "feed-b")
+    alice = _make_user(pg_clean, "alice-paging")
+    for i in range(1, 6):
+        _seed_article(pg_clean, i, source_slug="feed-b")
+    created = greader.create_token(alice, "client", database_url=pg_clean)
+    headers = _auth_header(created["token"])
+
+    first_page = client.get(
+        "/api/greader/reader/api/0/stream/contents/user/-/state/com.google/reading-list",
+        params={"n": 2},
+        headers=headers,
+    )
+    assert first_page.status_code == 200
+    first_body = first_page.json()
+    assert len(first_body["items"]) == 2
+    assert first_body["continuation"]
+
+    second_page = client.get(
+        "/api/greader/reader/api/0/stream/contents/user/-/state/com.google/reading-list",
+        params={"n": 2, "c": first_body["continuation"]},
+        headers=headers,
+    )
+    assert second_page.status_code == 200
+    second_body = second_page.json()
+    assert len(second_body["items"]) == 2
+    assert {item["id"] for item in first_body["items"]}.isdisjoint(
+        {item["id"] for item in second_body["items"]}
+    )
+
+
+def test_visibility_isolation_between_users(client: TestClient, pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    _seed_source(pg_clean, "private-source")
+    alice = _make_user(pg_clean, "alice-owner")
+    bob = _make_user(pg_clean, "bob-visitor")
+    _seed_article(pg_clean, 42, source_slug="private-source")
+
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "UPDATE sources SET owner_user_id = %s, enabled = TRUE WHERE slug = %s",
+            (alice, "private-source"),
+        )
+
+    alice_token = greader.create_token(alice, "client", database_url=pg_clean)
+    bob_token = greader.create_token(bob, "client", database_url=pg_clean)
+
+    alice_contents = client.get(
+        "/api/greader/reader/api/0/stream/contents/user/-/state/com.google/reading-list",
+        headers=_auth_header(alice_token["token"]),
+    )
+    bob_contents = client.get(
+        "/api/greader/reader/api/0/stream/contents/user/-/state/com.google/reading-list",
+        headers=_auth_header(bob_token["token"]),
+    )
+    assert any(item["id"] == greader.item_long_id(42) for item in alice_contents.json()["items"])
+    assert not any(item["id"] == greader.item_long_id(42) for item in bob_contents.json()["items"])
+
+
+def test_edit_tag_marks_read_and_starred_round_trip(client: TestClient, pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    _seed_source(pg_clean, "feed-c")
+    alice = _make_user(pg_clean, "alice-edit")
+    _seed_article(pg_clean, 99, source_slug="feed-c")
+    created = greader.create_token(alice, "client", database_url=pg_clean)
+    headers = _auth_header(created["token"])
+    item_id = greader.item_long_id(99)
+
+    mark_read = client.post(
+        "/api/greader/reader/api/0/edit-tag",
+        data={"i": item_id, "a": greader.READ_TAG},
+        headers=headers,
+    )
+    assert mark_read.status_code == 200
+
+    star = client.post(
+        "/api/greader/reader/api/0/edit-tag",
+        data={"i": item_id, "a": greader.STARRED_TAG},
+        headers=headers,
+    )
+    assert star.status_code == 200
+
+    starred_stream = client.get(
+        "/api/greader/reader/api/0/stream/contents/user/-/state/com.google/starred",
+        headers=headers,
+    )
+    assert any(item["id"] == item_id for item in starred_stream.json()["items"])
+
+    unread = client.post(
+        "/api/greader/reader/api/0/edit-tag",
+        data={"i": item_id, "r": greader.READ_TAG},
+        headers=headers,
+    )
+    assert unread.status_code == 200
+
+    unstar = client.post(
+        "/api/greader/reader/api/0/edit-tag",
+        data={"i": item_id, "r": greader.STARRED_TAG},
+        headers=headers,
+    )
+    assert unstar.status_code == 200
+
+    starred_stream_after = client.get(
+        "/api/greader/reader/api/0/stream/contents/user/-/state/com.google/starred",
+        headers=headers,
+    )
+    assert not any(item["id"] == item_id for item in starred_stream_after.json()["items"])
+
+
+def test_stream_items_ids_and_contents_round_trip(client: TestClient, pg_clean: str) -> None:
+    from news_dashboard import greader
+
+    _seed_source(pg_clean, "feed-d")
+    alice = _make_user(pg_clean, "alice-ids")
+    _seed_article(pg_clean, 7, source_slug="feed-d")
+    created = greader.create_token(alice, "client", database_url=pg_clean)
+    headers = _auth_header(created["token"])
+
+    ids_resp = client.get("/api/greader/reader/api/0/stream/items/ids", headers=headers)
+    assert ids_resp.status_code == 200
+    refs = ids_resp.json()["itemRefs"]
+    assert refs == [{"id": greader.item_short_id(7)}]
+
+    contents_resp = client.post(
+        "/api/greader/reader/api/0/stream/items/contents",
+        data={"i": greader.item_long_id(7)},
+        headers=headers,
+    )
+    assert contents_resp.status_code == 200
+    assert contents_resp.json()["items"][0]["id"] == greader.item_long_id(7)

--- a/frontend/src/__tests__/greaderTokensSettings.test.tsx
+++ b/frontend/src/__tests__/greaderTokensSettings.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { mockFetchGreaderTokens, mockCreateGreaderToken, mockRevokeGreaderToken } = vi.hoisted(
+  () => ({
+    mockFetchGreaderTokens: vi.fn(),
+    mockCreateGreaderToken: vi.fn(),
+    mockRevokeGreaderToken: vi.fn(),
+  })
+);
+
+vi.mock('@/api', () => ({
+  fetchGreaderTokens: mockFetchGreaderTokens,
+  createGreaderToken: mockCreateGreaderToken,
+  revokeGreaderToken: mockRevokeGreaderToken,
+}));
+
+import { GreaderTokensSection } from '../components/settings/GreaderTokensSection';
+
+beforeEach(() => {
+  mockFetchGreaderTokens.mockResolvedValue({ items: [] });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GreaderTokensSection', () => {
+  it('renders the section heading', async () => {
+    render(<GreaderTokensSection />);
+    await waitFor(() =>
+      expect(screen.getByText('RSS Client Sync (Google Reader API)')).toBeInTheDocument()
+    );
+  });
+
+  it('shows existing tokens', async () => {
+    mockFetchGreaderTokens.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          name: 'NetNewsWire',
+          token_prefix: 'ndgr_abcd1234',
+          created_at: '2026-01-01T00:00:00Z',
+          last_used_at: null,
+          revoked_at: null,
+        },
+      ],
+    });
+    render(<GreaderTokensSection />);
+    expect(await screen.findByText('NetNewsWire')).toBeInTheDocument();
+  });
+
+  it('creates a token and shows the minted secret once', async () => {
+    const user = userEvent.setup();
+    mockCreateGreaderToken.mockResolvedValue({
+      id: 2,
+      name: 'Reeder',
+      token_prefix: 'ndgr_efgh5678',
+      created_at: '2026-01-02T00:00:00Z',
+      last_used_at: null,
+      revoked_at: null,
+      token: 'ndgr_efgh5678secret',
+    });
+    render(<GreaderTokensSection />);
+
+    const input = await screen.findByLabelText('New RSS sync token name');
+    await user.type(input, 'Reeder');
+    await user.click(screen.getByRole('button', { name: 'Create token' }));
+
+    await waitFor(() => expect(mockCreateGreaderToken).toHaveBeenCalledWith('Reeder'));
+    expect(await screen.findByText('ndgr_efgh5678secret')).toBeInTheDocument();
+  });
+
+  it('revokes a token', async () => {
+    const user = userEvent.setup();
+    mockFetchGreaderTokens.mockResolvedValue({
+      items: [
+        {
+          id: 3,
+          name: 'Unread',
+          token_prefix: 'ndgr_ijkl9012',
+          created_at: '2026-01-03T00:00:00Z',
+          last_used_at: null,
+          revoked_at: null,
+        },
+      ],
+    });
+    mockRevokeGreaderToken.mockResolvedValue({
+      id: 3,
+      name: 'Unread',
+      token_prefix: 'ndgr_ijkl9012',
+      created_at: '2026-01-03T00:00:00Z',
+      last_used_at: null,
+      revoked_at: '2026-01-04T00:00:00Z',
+    });
+    render(<GreaderTokensSection />);
+
+    const revokeBtn = await screen.findByRole('button', { name: 'Revoke RSS sync token' });
+    await user.click(revokeBtn);
+
+    await waitFor(() => expect(mockRevokeGreaderToken).toHaveBeenCalledWith(3));
+    expect(await screen.findByText(/revoked/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,6 +1,7 @@
 import type {
   Achievement,
   AiMemory,
+  GreaderToken,
   McpToken,
   ReadingDna,
   ReadingGoal,
@@ -95,6 +96,23 @@ export async function createMcpToken(name: string): Promise<McpToken> {
 
 export async function revokeMcpToken(tokenId: number): Promise<McpToken> {
   return requestJson<McpToken>(`/api/users/me/mcp-tokens/${tokenId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function fetchGreaderTokens(): Promise<{ items: GreaderToken[] }> {
+  return requestJson('/api/users/me/greader-tokens');
+}
+
+export async function createGreaderToken(name: string): Promise<GreaderToken> {
+  return requestJson<GreaderToken>('/api/users/me/greader-tokens', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function revokeGreaderToken(tokenId: number): Promise<GreaderToken> {
+  return requestJson<GreaderToken>(`/api/users/me/greader-tokens/${tokenId}`, {
     method: 'DELETE',
   });
 }

--- a/frontend/src/components/settings/GreaderTokensSection.tsx
+++ b/frontend/src/components/settings/GreaderTokensSection.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { RefreshCw, Trash2 } from 'lucide-react';
+import { createGreaderToken, fetchGreaderTokens, revokeGreaderToken } from '@/api';
+import type { GreaderToken } from '@/types';
+
+type GreaderTokenState = 'idle' | 'loading' | 'creating' | 'error';
+
+export function GreaderTokensSection() {
+  const [tokens, setTokens] = useState<GreaderToken[]>([]);
+  const [newName, setNewName] = useState('');
+  const [mintedToken, setMintedToken] = useState<string | null>(null);
+  const [state, setState] = useState<GreaderTokenState>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const data = await fetchGreaderTokens();
+        if (!cancelled) {
+          setTokens(data.items);
+          setState('idle');
+        }
+      } catch {
+        if (!cancelled) setState('error');
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const create = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    setState('creating');
+    try {
+      const token = await createGreaderToken(name);
+      setTokens((current) => [token, ...current]);
+      setMintedToken(token.token ?? null);
+      setNewName('');
+      setState('idle');
+    } catch {
+      setState('error');
+    }
+  };
+
+  const revoke = async (tokenId: number) => {
+    setState('creating');
+    try {
+      const updated = await revokeGreaderToken(tokenId);
+      setTokens((current) => current.map((t) => (t.id === tokenId ? updated : t)));
+      setState('idle');
+    } catch {
+      setState('error');
+    }
+  };
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        RSS Client Sync (Google Reader API)
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+        <p className="text-xs text-muted-foreground">
+          Create a token to subscribe with a third-party RSS reader (NetNewsWire, Reeder, Unread,
+          ...). Enter your username as the email and this token as the password when adding the
+          account.
+        </p>
+
+        {mintedToken && (
+          <div className="rounded-md border border-border bg-surface p-3 space-y-1">
+            <p className="text-xs font-medium text-foreground">
+              Copy this token now — it will not be shown again:
+            </p>
+            <code className="block break-all text-xs text-foreground">{mintedToken}</code>
+            <button
+              onClick={() => setMintedToken(null)}
+              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <input
+            value={newName}
+            onChange={(event) => setNewName(event.target.value)}
+            placeholder="Token name (e.g. NetNewsWire)"
+            aria-label="New RSS sync token name"
+            className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <button
+            onClick={() => void create()}
+            disabled={state === 'creating' || !newName.trim()}
+            className="flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-60"
+          >
+            {state === 'creating' ? <RefreshCw className="size-3 animate-spin" /> : null}
+            Create token
+          </button>
+        </div>
+
+        {state === 'error' && (
+          <p className="text-xs text-destructive" role="alert">
+            Could not update RSS sync tokens.
+          </p>
+        )}
+
+        <div className="space-y-2">
+          {tokens.map((token) => (
+            <div
+              key={token.id}
+              className="flex items-center justify-between gap-3 rounded-md border border-border bg-surface p-3"
+            >
+              <div className="min-w-0 space-y-1">
+                <p className="truncate text-sm text-foreground">{token.name}</p>
+                <p className="text-[11px] text-muted-foreground">
+                  {token.token_prefix}…{token.revoked_at ? ' · revoked' : ''}
+                  {token.last_used_at ? ` · last used ${token.last_used_at}` : ' · never used'}
+                </p>
+              </div>
+              {!token.revoked_at && (
+                <button
+                  onClick={() => void revoke(token.id)}
+                  aria-label="Revoke RSS sync token"
+                  className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-card hover:text-destructive"
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              )}
+            </div>
+          ))}
+          {state !== 'loading' && tokens.length === 0 && (
+            <p className="text-xs text-muted-foreground">No RSS sync tokens yet.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { PersonalizationSection } from '@/components/settings/PersonalizationSec
 import { WatchlistsSection } from '@/components/settings/WatchlistsSection';
 import { AiMemorySection } from '@/components/settings/AiMemorySection';
 import { McpTokensSection } from '@/components/settings/McpTokensSection';
+import { GreaderTokensSection } from '@/components/settings/GreaderTokensSection';
 import { DataExportSection } from '@/components/settings/DataExportSection';
 import { DailyBriefSection } from '@/components/settings/DailyBriefSection';
 import { WeeklyRecapSection } from '@/components/settings/WeeklyRecapSection';
@@ -22,6 +23,7 @@ export function SettingsPage() {
       <WatchlistsSection />
       <AiMemorySection />
       <McpTokensSection />
+      <GreaderTokensSection />
       <DataExportSection />
       <DailyBriefSection />
       <WeeklyRecapSection />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -487,6 +487,16 @@ export interface McpToken {
   token?: string;
 }
 
+export interface GreaderToken {
+  id: number;
+  name: string;
+  token_prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  token?: string;
+}
+
 export interface PersonalizationNudge {
   id: string;
   kind: 'source' | 'topic';

--- a/website/docs/configuration/greader-sync.md
+++ b/website/docs/configuration/greader-sync.md
@@ -1,0 +1,55 @@
+---
+title: RSS client sync (Google Reader API)
+sidebar_position: 6
+---
+
+# RSS client sync (Google Reader API)
+
+News Dashboard exposes a v1 [Google Reader-compatible](https://en.wikipedia.org/wiki/Google_Reader) sync API so third-party RSS readers (NetNewsWire, Reeder, Unread, FeedMe, ...) can subscribe with their favorite native client while News Dashboard stays the backend. It is read-only for subscriptions plus read/star sync — clients cannot add, edit, or delete subscriptions through this API.
+
+## Creating a token
+
+Any signed-in user can create a sync token from **Settings → RSS Client Sync (Google Reader API)**, or via:
+
+```bash
+curl -X POST https://your-instance/api/users/me/greader-tokens \
+  -H 'Content-Type: application/json' \
+  --cookie "nd_session=$SESSION_COOKIE" \
+  -d '{"name": "NetNewsWire"}'
+```
+
+The response includes the plaintext token (prefixed `ndgr_`) exactly once — only its hash is stored, alongside a short prefix, creation time, and last-used time. Tokens can be revoked at any time from the same Settings section; revoking sets `revoked_at` and immediately invalidates the token. Each user may hold up to 10 active tokens.
+
+## Connecting a client
+
+In your RSS reader's "Google Reader" or "FreshRSS/Miniflux-compatible" account setup:
+
+- **Server URL**: `https://your-instance/api/greader`
+- **Username / Email**: your News Dashboard username (any non-empty value is accepted; only the token is checked)
+- **Password**: the token you created above
+
+The client performs `POST /api/greader/accounts/ClientLogin` with your username and the token as the password, receives an `Auth=` value (the same token), and sends it back as `Authorization: GoogleLogin auth=<token>` (or a plain bearer token) on every subsequent request.
+
+## Endpoints (v1)
+
+All endpoints below live under `/api/greader/reader/api/0/` and require the `Authorization` header described above:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `token` | GET | Returns a POST token for client compatibility. |
+| `user-info` | GET | Returns the authenticated user's id/username/email. |
+| `subscription/list` | GET | Lists visible sources as subscriptions, with `category` mapped to a folder label. |
+| `stream/contents/user/-/state/com.google/reading-list` | GET | All articles visible to the user. |
+| `stream/contents/user/-/state/com.google/starred` | GET | Starred articles only. |
+| `stream/contents/feed/<slug>` | GET | Articles from a single source. |
+| `stream/items/ids` | GET | Item id listing for a stream, for clients that page ids separately from content. |
+| `stream/items/contents` | POST | Full item bodies for a set of `i=` item ids. |
+| `edit-tag` | POST | Add/remove `user/-/state/com.google/read` or `.../starred` tags — delegates to the same article state machine as the web UI. |
+
+Streams and item bodies page via a `c` continuation token returned alongside `items`/`itemRefs` when more results are available; pass it back as `c` on the next request.
+
+## Visibility and security
+
+- Only sources the token owner can see (global subscribed sources plus their own private sources) are ever returned — the same rule the browser API enforces.
+- State changes made via `edit-tag` (read/starred) are immediately visible in the web UI, and vice versa, since both paths write through `user_article_state`.
+- Tokens are bearer secrets: treat them like passwords, transmit only over HTTPS, and revoke immediately if a client is decommissioned or compromised.


### PR DESCRIPTION
Closes #928.

## Summary

- Adds a v1 Google Reader-compatible sync API under `/api/greader/*` so third-party RSS clients (NetNewsWire, Reeder, Unread, FeedMe, ...) can subscribe with News Dashboard as the backend, read the reading-list/per-feed/starred streams, and sync read/starred state.
- Auth is a dedicated per-user API-token mechanism (`backend/news_dashboard/greader.py`), hashed at rest and revocable from Settings, mirroring the existing MCP token pattern (`mcp/service.py`). Clients present the token via `ClientLogin` and then send it back as `Authorization: GoogleLogin auth=<token>` (or a plain bearer token).
- Endpoints: `accounts/ClientLogin`, `reader/api/0/token`, `reader/api/0/user-info`, `reader/api/0/subscription/list`, `reader/api/0/stream/contents/...` (reading-list, starred, per-feed), `reader/api/0/stream/items/ids` + `stream/items/contents`, and `reader/api/0/edit-tag` (read/starred), all offset-continuation-paged.
- All streams/subscriptions respect the existing per-user source-visibility rules (global subscribed sources + the caller's own private sources), and `edit-tag` delegates to the existing `transition_article_state` / `set_article_starred` article state machine — GReader state changes show up in the web UI and vice versa.
- New `greader_tokens` table (mirrors `mcp_tokens`).
- New Settings → "RSS Client Sync (Google Reader API)" section for creating/listing/revoking tokens (mirrors the MCP tokens section).
- Docs: `website/docs/configuration/greader-sync.md` plus a README feature bullet.

Out of scope (per issue): subscription add/edit/delete via the API, OPML endpoints, Fever API, and unread-count optimizations beyond what the streams need.

## Test plan

- [x] `backend/tests/test_greader_api.py` (13 new tests): token lifecycle (create/list/revoke, plaintext never stored, per-user limit), item-id short/long-form round trip, `ClientLogin` success/failure, protocol auth rejection, `subscription/list` + `stream/contents` (reading-list/per-feed/starred), continuation paging, cross-user visibility isolation, and `edit-tag` read/starred round trip.
- [x] Full backend suite: `1769 passed` (no regressions).
- [x] `frontend/src/__tests__/greaderTokensSettings.test.tsx` (4 new tests) + full frontend suite: `807 passed`.
- [x] `ruff`, `mypy`, `eslint`, `tsc`, and the full pre-commit hook set all pass on the changed files.
- [ ] Manual verification against a real GReader client (e.g. NetNewsWire) was not performed in this automated run — the acceptance criterion "verified with NetNewsWire against a local instance" should be confirmed by a human before treating this as fully done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)