### PR TITLE
feat: enrich weekly recap with saved-backlog, dwell profile, and nudges (#932)

### DIFF
--- a/backend/news_dashboard/recaps/service.py
+++ b/backend/news_dashboard/recaps/service.py
@@ -20,6 +20,7 @@ from news_dashboard.reading_progress.service import get_streak
 logger = logging.getLogger(__name__)
 
 RECAP_WINDOW_DAYS = 7
+SKIM_THRESHOLD_MS = 30_000
 
 
 def assemble_weekly_recap(
@@ -33,6 +34,9 @@ def assemble_weekly_recap(
     now = now or datetime.now(timezone.utc)
     start = now - timedelta(days=RECAP_WINDOW_DAYS)
     streak = get_streak(user_id, now=now, database_url=database_url)
+
+    from news_dashboard.personalization_nudges import generate_nudges
+
     with connect(db_path, database_url=database_url) as conn:
         return {
             "week_start": start.date().isoformat(),
@@ -43,6 +47,11 @@ def assemble_weekly_recap(
             "sources": _top_field(conn, user_id, start, "a.source_name", "source"),
             "minutes_read": _minutes_read(conn, user_id, start),
             "current_streak_days": streak["current_streak_days"],
+            "saved": _saved_backlog(conn, user_id, start),
+            "dwell": _dwell_profile(conn, user_id, start),
+            "nudges": generate_nudges(
+                user_id, database_url=database_url, db_path=db_path, max_results=2
+            ),
         }
 
 
@@ -149,3 +158,50 @@ def _minutes_read(conn: Any, user_id: int, start: datetime) -> float:
     if row is None or row["minutes"] is None:
         return 0.0
     return float(row["minutes"])
+
+
+def _saved_backlog(conn: Any, user_id: int, start: datetime) -> dict[str, int]:
+    row = conn.execute(
+        """
+        SELECT
+          COUNT(*) FILTER (WHERE starred_at >= %(start)s) AS starred_this_week,
+          COUNT(*) FILTER (
+            WHERE state = 'done' AND done_at >= %(start)s AND starred = TRUE
+          ) AS read_from_backlog,
+          COUNT(*) FILTER (
+            WHERE starred = TRUE AND state NOT IN ('done', 'archived')
+          ) AS backlog_total
+        FROM user_article_state
+        WHERE user_id = %(user_id)s
+        """,
+        {"user_id": user_id, "start": start},
+    ).fetchone()
+    return {
+        "starred_this_week": int(row["starred_this_week"]) if row else 0,
+        "read_from_backlog": int(row["read_from_backlog"]) if row else 0,
+        "backlog_total": int(row["backlog_total"]) if row else 0,
+    }
+
+
+def _dwell_profile(conn: Any, user_id: int, start: datetime) -> dict[str, Any]:
+    row = conn.execute(
+        """
+        SELECT
+          COUNT(*) FILTER (WHERE duration_ms < %(threshold)s) AS skims,
+          COUNT(*) FILTER (WHERE duration_ms >= %(threshold)s) AS reads,
+          ROUND(AVG(duration_ms) / 1000.0, 1) AS average_seconds
+        FROM user_events
+        WHERE user_id = %(user_id)s
+          AND event_type = 'article_close'
+          AND duration_ms IS NOT NULL
+          AND created_at >= %(start)s
+        """,
+        {"user_id": user_id, "start": start, "threshold": SKIM_THRESHOLD_MS},
+    ).fetchone()
+    return {
+        "skims": int(row["skims"]) if row else 0,
+        "reads": int(row["reads"]) if row else 0,
+        "average_seconds": float(row["average_seconds"])
+        if row and row["average_seconds"] is not None
+        else 0.0,
+    }

--- a/backend/tests/test_recaps.py
+++ b/backend/tests/test_recaps.py
@@ -105,6 +105,103 @@ def test_assemble_weekly_recap_aggregates_trailing_week(monkeypatch: Any, pg_cle
     assert recap["categories"][0]["count"] == 1
     assert recap["minutes_read"] == 2.0
     assert recap["current_streak_days"] == 1
+    assert recap["saved"] == {"starred_this_week": 0, "read_from_backlog": 0, "backlog_total": 0}
+    assert recap["dwell"] == {"skims": 0, "reads": 0, "average_seconds": 0.0}
+    assert recap["nudges"] == []
+
+
+def test_assemble_weekly_recap_saved_backlog_counts(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(days=7)
+
+    starred_and_read = _insert_article(db_path, "starred-and-read", "science")
+    starred_only = _insert_article(db_path, "starred-only", "science")
+    archived_starred = _insert_article(db_path, "archived-starred", "science")
+    stale_starred = _insert_article(db_path, "stale-starred", "science")
+
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state, starred, starred_at,"
+            " done_at) VALUES (%s, %s, 'done', TRUE, %s, %s)",
+            (user_id, starred_and_read, now, now),
+        )
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state, starred, starred_at)"
+            " VALUES (%s, %s, 'today', TRUE, %s)",
+            (user_id, starred_only, now),
+        )
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state, starred, starred_at)"
+            " VALUES (%s, %s, 'archived', TRUE, %s)",
+            (user_id, archived_starred, now),
+        )
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state, starred, starred_at)"
+            " VALUES (%s, %s, 'today', TRUE, %s)",
+            (user_id, stale_starred, start - timedelta(days=10)),
+        )
+
+    recap = assemble_weekly_recap(user_id, now=now, database_url=db_path)
+
+    assert recap["saved"]["starred_this_week"] == 3
+    assert recap["saved"]["read_from_backlog"] == 1
+    # backlog_total is all-time and excludes done/archived states.
+    assert recap["saved"]["backlog_total"] == 2
+
+
+def test_assemble_weekly_recap_dwell_profile_buckets_by_threshold(
+    monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    now = datetime.now(timezone.utc)
+
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO user_events(user_id, event_type, duration_ms, created_at)"
+            " VALUES (%s, 'article_close', %s, %s)",
+            (user_id, 10_000, now),
+        )
+        conn.execute(
+            "INSERT INTO user_events(user_id, event_type, duration_ms, created_at)"
+            " VALUES (%s, 'article_close', %s, %s)",
+            (user_id, 60_000, now),
+        )
+
+    recap = assemble_weekly_recap(user_id, now=now, database_url=db_path)
+
+    assert recap["dwell"] == {"skims": 1, "reads": 1, "average_seconds": 35.0}
+
+
+def test_assemble_weekly_recap_includes_nudges(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    now = datetime.now(timezone.utc)
+
+    fake_nudges = [
+        {
+            "id": "source:noise-feed",
+            "kind": "source",
+            "title": "Noisy source: Noise Feed",
+            "message": "You've skipped 90% of recent articles from 'Noise Feed'.",
+            "reason": "low_signal",
+            "skip_rate": 0.9,
+            "articles_last_30_days": 50,
+            "action": "disable_source",
+            "target": "noise-feed",
+            "target_label": "Noise Feed",
+        }
+    ]
+    monkeypatch.setattr(
+        "news_dashboard.personalization_nudges.generate_nudges",
+        lambda *_args, **_kwargs: fake_nudges,
+    )
+
+    recap = assemble_weekly_recap(user_id, now=now, database_url=db_path)
+
+    assert recap["nudges"] == fake_nudges
 
 
 def test_save_and_list_recaps_upserts_by_week(monkeypatch: Any, pg_clean: str) -> None:

--- a/frontend/src/__tests__/weeklyRecapPage.test.tsx
+++ b/frontend/src/__tests__/weeklyRecapPage.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import * as api from '../api';
+import { WeeklyRecapPage } from '../pages/WeeklyRecapPage';
+import type { WeeklyRecap } from '../types';
+
+vi.mock('../api', () => ({
+  fetchRecaps: vi.fn(),
+  fetchPersonalizationNudges: vi.fn(),
+  applyPersonalizationNudge: vi.fn(),
+  dismissPersonalizationNudge: vi.fn(),
+}));
+
+function makeQc() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={makeQc()}>{children}</QueryClientProvider>;
+}
+
+const ENRICHED_RECAP: WeeklyRecap = {
+  id: 1,
+  user_id: 1,
+  week_start: '2026-06-29',
+  created_at: '2026-07-06T00:00:00+00:00',
+  narrative: null,
+  data: {
+    week_start: '2026-06-29',
+    week_end: '2026-07-06',
+    generated_at: '2026-07-06T00:00:00+00:00',
+    articles_read: 4,
+    categories: [],
+    sources: [],
+    minutes_read: 15.0,
+    current_streak_days: 3,
+    saved: { starred_this_week: 2, read_from_backlog: 1, backlog_total: 5 },
+    dwell: { skims: 3, reads: 2, average_seconds: 22.5 },
+    nudges: [
+      {
+        id: 'source:noise-feed',
+        kind: 'source',
+        title: 'Noisy source: Noise Feed',
+        message: "You've skipped 90% of recent articles from 'Noise Feed'.",
+        reason: 'low_signal',
+        skip_rate: 0.9,
+        articles_last_30_days: 50,
+        action: 'disable_source',
+        target: 'noise-feed',
+        target_label: 'Noise Feed',
+      },
+    ],
+  },
+};
+
+const LEGACY_RECAP: WeeklyRecap = {
+  id: 2,
+  user_id: 1,
+  week_start: '2026-06-22',
+  created_at: '2026-06-29T00:00:00+00:00',
+  narrative: 'Nice reading week',
+  data: {
+    week_start: '2026-06-22',
+    week_end: '2026-06-29',
+    generated_at: '2026-06-29T00:00:00+00:00',
+    articles_read: 4,
+    categories: [],
+    sources: [],
+    minutes_read: 15.0,
+    current_streak_days: 3,
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('WeeklyRecapPage', () => {
+  it('renders saved backlog, dwell profile, and nudges for an enriched recap', async () => {
+    vi.mocked(api.fetchRecaps).mockResolvedValue([ENRICHED_RECAP]);
+    render(<WeeklyRecapPage />, { wrapper: Wrapper });
+
+    await screen.findByText('Saved backlog');
+    expect(screen.getByText('Skim vs deep read')).toBeInTheDocument();
+    expect(screen.getByText('Suggested changes')).toBeInTheDocument();
+    expect(screen.getByText('Noisy source: Noise Feed')).toBeInTheDocument();
+    expect(screen.getByText('22.5s')).toBeInTheDocument();
+  });
+
+  it('renders a legacy recap without the enriched fields without crashing', async () => {
+    vi.mocked(api.fetchRecaps).mockResolvedValue([LEGACY_RECAP]);
+    render(<WeeklyRecapPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('4')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Saved backlog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Skim vs deep read')).not.toBeInTheDocument();
+    expect(screen.queryByText('Suggested changes')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/FeedNudgeBanner.tsx
+++ b/frontend/src/components/FeedNudgeBanner.tsx
@@ -10,7 +10,7 @@ import type { PersonalizationNudge } from '@/types';
 
 const NUDGES_KEY = 'personalization-nudges';
 
-function NudgeCard({ nudge }: { nudge: PersonalizationNudge }) {
+export function NudgeCard({ nudge }: { nudge: PersonalizationNudge }) {
   const qc = useQueryClient();
 
   const applyMutation = useMutation({

--- a/frontend/src/pages/WeeklyRecapPage.tsx
+++ b/frontend/src/pages/WeeklyRecapPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Flame, Loader2 } from 'lucide-react';
 import { fetchRecaps } from '../api';
+import { NudgeCard } from '../components/FeedNudgeBanner';
 import type { WeeklyRecap, WeeklyRecapField } from '../types';
 
 interface PageState {
@@ -92,6 +93,36 @@ export function WeeklyRecapPage() {
               <FieldBars items={latest.data.sources} labelKey="source" />
             </Panel>
           </section>
+
+          {latest.data.saved && (
+            <Panel title="Saved backlog">
+              <div className="grid grid-cols-3 gap-3 text-center">
+                <SavedStat label="Saved this week" value={latest.data.saved.starred_this_week} />
+                <SavedStat label="Read from backlog" value={latest.data.saved.read_from_backlog} />
+                <SavedStat label="Backlog" value={latest.data.saved.backlog_total} />
+              </div>
+            </Panel>
+          )}
+
+          {latest.data.dwell && (
+            <Panel title="Skim vs deep read">
+              <div className="grid grid-cols-3 gap-3 text-center">
+                <SavedStat label="Skims" value={latest.data.dwell.skims} />
+                <SavedStat label="Deep reads" value={latest.data.dwell.reads} />
+                <SavedStat label="Avg. dwell" value={`${latest.data.dwell.average_seconds}s`} />
+              </div>
+            </Panel>
+          )}
+
+          {latest.data.nudges && latest.data.nudges.length > 0 && (
+            <Panel title="Suggested changes">
+              <div className="-mx-3 space-y-2">
+                {latest.data.nudges.map((nudge) => (
+                  <NudgeCard key={nudge.id} nudge={nudge} />
+                ))}
+              </div>
+            </Panel>
+          )}
         </>
       )}
 
@@ -122,6 +153,15 @@ function Metric({ label, value }: { label: string; value: string }) {
     <div className="rounded-md border border-border bg-surface px-3 py-2">
       <div className="text-[11px] text-muted-foreground">{label}</div>
       <div className="mt-1 text-xl font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function SavedStat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div>
+      <div className="text-lg font-semibold tabular-nums">{value}</div>
+      <div className="text-[11px] text-muted-foreground">{label}</div>
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -429,6 +429,18 @@ export interface WeeklyRecapField {
   count: number;
 }
 
+export interface WeeklyRecapSaved {
+  starred_this_week: number;
+  read_from_backlog: number;
+  backlog_total: number;
+}
+
+export interface WeeklyRecapDwell {
+  skims: number;
+  reads: number;
+  average_seconds: number;
+}
+
 export interface WeeklyRecapData {
   week_start: string;
   week_end: string;
@@ -438,6 +450,9 @@ export interface WeeklyRecapData {
   sources: WeeklyRecapField[];
   minutes_read: number;
   current_streak_days: number;
+  saved?: WeeklyRecapSaved;
+  dwell?: WeeklyRecapDwell;
+  nudges?: PersonalizationNudge[];
 }
 
 export interface WeeklyRecap {


### PR DESCRIPTION
## Summary

Closes #932.

- `assemble_weekly_recap` (`backend/news_dashboard/recaps/service.py`) now returns three new payload keys, computed by private helpers in the existing `_articles_read`/`_top_field` style:
  - `saved`: `starred_this_week` (windowed), `read_from_backlog` (windowed, starred+done), `backlog_total` (all-time, starred and not done/archived).
  - `dwell`: skim/deep-read counts from `article_close` events bucketed around a new `SKIM_THRESHOLD_MS = 30_000` constant, plus average dwell seconds.
  - `nudges`: up to 2 active personalization nudges via `generate_nudges(user_id, max_results=2)` (lazy import, matching the `scheduler.py` convention).
- No migration needed — the recap payload is stored as jsonb.
- `WeeklyRecapData` (`frontend/src/types.ts`) gets the three new fields as optional, so historical recaps without them still type-check.
- `WeeklyRecapPage.tsx` renders new "Saved backlog" and "Skim vs deep read" panels, and a "Suggested changes" panel that reuses `FeedNudgeBanner`'s `NudgeCard` (now exported) so apply/dismiss hit the existing `/api/personalization/nudges/apply|dismiss` endpoints. All three sections are guarded for recaps that predate these fields.

## Test plan

- [x] `backend/tests/test_recaps.py` — added cases for saved-backlog counting (starred this week, read from backlog, archived excluded from backlog total), skim/read bucketing around the 30s threshold with empty-telemetry zeros, and nudges embedded in the payload (monkeypatched `generate_nudges`). All 7 tests pass against Postgres.
- [x] `frontend/src/__tests__/weeklyRecapPage.test.tsx` (new) — renders an enriched recap (saved/dwell/nudges sections + nudge card) and a legacy recap without the new keys (sections absent, no crash). Both pass.
- [x] `npx tsc --noEmit`, `npx eslint`, `ruff check`, `mypy` all clean on touched files.
- [x] Full pre-commit hook suite passes on the commit (ruff, mypy, ty, pyrefly, vulture, eslint, prettier, knip, tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)