### PR TITLE
feat: generate a full AI weekly reading narrative for recaps (#933)

### DIFF
--- a/backend/news_dashboard/recaps/narrative.py
+++ b/backend/news_dashboard/recaps/narrative.py
@@ -1,0 +1,77 @@
+"""AI-written weekly recap narrative (long form, for the recap page)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _fallback_narrative(recap: dict[str, Any]) -> str:
+    articles_read = int(recap.get("articles_read") or 0)
+    minutes_read = recap.get("minutes_read") or 0
+    categories: list[dict[str, Any]] = recap.get("categories") or []
+    top_category = categories[0].get("category") if categories else None
+
+    if articles_read <= 0:
+        return "You didn't read any articles this week — your next recap is a fresh start."
+    if top_category:
+        return (
+            f"You read {articles_read} articles in {minutes_read} minutes this week, "
+            f"mostly {top_category}."
+        )
+    return f"You read {articles_read} articles in {minutes_read} minutes this week."
+
+
+def generate_recap_narrative(recap: dict[str, Any]) -> str:
+    """Generate a 2-paragraph AI narrative for a weekly recap.
+
+    Takes the recap dict from ``recaps.service.assemble_weekly_recap()`` and
+    asks the chat model for a longer, second-person "week in reading" review
+    grounded strictly in the given metrics. Falls back to a deterministic
+    template sentence if the LLM is not configured or the call fails, matching
+    the graceful-degradation contract of ``push.generate_recap_push_hook``.
+    """
+    fallback = _fallback_narrative(recap)
+
+    try:
+        from news_dashboard.ai_client import free_llm_config, get_chat_client
+
+        api_key, base_url = free_llm_config()
+        if not api_key:
+            return fallback
+
+        client = get_chat_client(api_key=api_key, base_url=base_url)
+        model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
+
+        metrics = {k: v for k, v in recap.items() if k != "generated_at"}
+
+        prompt = (
+            "Write a weekly reading review in the voice of 'here's your week in "
+            "reading', addressed directly to the reader (second person). "
+            "Write exactly 2 short paragraphs, roughly 60-120 words total. "
+            "Ground everything strictly in the metrics below — do not invent "
+            "facts, activity, or numbers that are not present in the data. "
+            "If 'saved' or 'dwell' data is present, mention their reading "
+            "backlog and skim-vs-read balance.\n\n"
+            f"Recap metrics (JSON):\n{json.dumps(metrics, default=str)}\n\n"
+            "Reply with only the narrative text, as plain paragraphs separated "
+            "by a blank line."
+        )
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=300,
+            temperature=0.7,
+        )
+        narrative = (response.choices[0].message.content or "").strip()
+        if narrative:
+            return narrative
+    except Exception:
+        logger.warning("Recap narrative LLM generation failed; using default message")
+
+    return fallback

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -229,19 +229,21 @@ def _run_per_user_briefings() -> tuple[str, str | None] | None:
 def _generate_recap_for_user(user_id: int, *, push_enabled: bool = True) -> bool:
     """Assemble, persist, and (optionally) push a weekly recap for one user."""
     from news_dashboard.push import generate_recap_push_hook, send_push_for_user
+    from news_dashboard.recaps.narrative import generate_recap_narrative
     from news_dashboard.recaps.service import assemble_weekly_recap, save_weekly_recap
 
     logger.info("Weekly recap: generating for user_id=%s", user_id)
     try:
         recap = assemble_weekly_recap(user_id)
-        narrative = generate_recap_push_hook(recap) if push_enabled else None
+        narrative = generate_recap_narrative(recap)
         saved = save_weekly_recap(user_id, recap, narrative)
         logger.info("Weekly recap: complete for user_id=%s id=%s", user_id, saved.get("id"))
         if push_enabled:
             try:
+                hook = generate_recap_push_hook(recap)
                 send_push_for_user(
                     user_id,
-                    narrative or "Your weekly reading recap is ready.",
+                    hook or "Your weekly reading recap is ready.",
                     "",
                     target_url="/recap",
                 )

--- a/backend/tests/test_recap_narrative.py
+++ b/backend/tests/test_recap_narrative.py
@@ -1,0 +1,109 @@
+"""Tests for the AI weekly recap narrative generator."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.recaps.narrative import generate_recap_narrative
+
+
+def _make_recap(**overrides: object) -> dict[str, object]:
+    recap: dict[str, object] = {
+        "week_start": "2026-06-22",
+        "week_end": "2026-06-29",
+        "generated_at": "2026-06-29T09:00:00+00:00",
+        "articles_read": 12,
+        "categories": [{"category": "science", "count": 5}],
+        "sources": [{"source": "Example News", "count": 4}],
+        "minutes_read": 45.0,
+        "current_streak_days": 3,
+    }
+    recap.update(overrides)
+    return recap
+
+
+def test_generate_recap_narrative_falls_back_when_no_api_key() -> None:
+    with patch("news_dashboard.ai_client.free_llm_config", return_value=("", None)):
+        result = generate_recap_narrative(_make_recap())
+
+    assert "12" in result
+
+
+def test_generate_recap_narrative_falls_back_with_zero_articles() -> None:
+    with patch("news_dashboard.ai_client.free_llm_config", return_value=("", None)):
+        result = generate_recap_narrative(_make_recap(articles_read=0, categories=[]))
+
+    assert result
+    assert "0" not in result or "didn't read" in result
+
+
+def test_generate_recap_narrative_returns_llm_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+
+    narrative_text = (
+        "You had a strong week, reading 12 articles mostly about science.\n\n"
+        "Keep up the streak — three days running is great momentum."
+    )
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content=narrative_text))]
+    )
+
+    with (
+        patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+    ):
+        result = generate_recap_narrative(_make_recap())
+
+    assert result == narrative_text
+    mock_client.chat.completions.create.assert_called_once()
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert "12" in call_kwargs["messages"][0]["content"]
+
+
+def test_generate_recap_narrative_falls_back_on_llm_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError("LLM unavailable")
+
+    with (
+        patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+    ):
+        result = generate_recap_narrative(_make_recap())
+
+    assert "12" in result
+    mock_client.chat.completions.create.assert_called_once()
+
+
+def test_generate_recap_narrative_mentions_saved_and_dwell(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+
+    captured_prompt: list[str] = []
+
+    def fake_create(**kwargs: Any) -> MagicMock:
+        captured_prompt.append(kwargs["messages"][0]["content"])
+        return MagicMock(choices=[MagicMock(message=MagicMock(content="Narrative."))])
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = fake_create
+
+    recap = _make_recap(
+        saved={"starred_this_week": 2, "read_from_backlog": 1, "backlog_total": 8},
+        dwell={"skims": 3, "reads": 9, "average_seconds": 42.0},
+    )
+
+    with (
+        patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+    ):
+        generate_recap_narrative(recap)
+
+    prompt = captured_prompt[0]
+    assert "backlog_total" in prompt
+    assert "average_seconds" in prompt
+    assert "generated_at" not in prompt

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -203,6 +203,10 @@ def test_run_weekly_recaps_sends_push_when_enabled() -> None:
             "news_dashboard.recaps.service.save_weekly_recap",
             return_value={"id": 1, **recap},
         ) as save,
+        patch(
+            "news_dashboard.recaps.narrative.generate_recap_narrative",
+            return_value="Your week in review...",
+        ) as narrative,
         patch("news_dashboard.push.generate_recap_push_hook", return_value="Nice week!") as hook,
         patch("news_dashboard.push.send_push_for_user") as send_push,
     ):
@@ -211,8 +215,9 @@ def test_run_weekly_recaps_sends_push_when_enabled() -> None:
 
     assert "recap_enabled" in fake_conn.sql
     assemble.assert_called_once_with(42)
+    narrative.assert_called_once_with(recap)
     hook.assert_called_once_with(recap)
-    save.assert_called_once_with(42, recap, "Nice week!")
+    save.assert_called_once_with(42, recap, "Your week in review...")
     send_push.assert_called_once_with(42, "Nice week!", "", target_url="/recap")
 
 
@@ -239,13 +244,18 @@ def test_run_weekly_recaps_generates_but_skips_push_when_disabled() -> None:
             "news_dashboard.recaps.service.save_weekly_recap",
             return_value={"id": 1, **recap},
         ) as save,
+        patch(
+            "news_dashboard.recaps.narrative.generate_recap_narrative",
+            return_value="Your week in review...",
+        ) as narrative,
         patch("news_dashboard.push.generate_recap_push_hook") as hook,
         patch("news_dashboard.push.send_push_for_user") as send_push,
     ):
         mock_dt.now.return_value = now
         _run_weekly_recaps()
 
-    save.assert_called_once_with(42, recap, None)
+    narrative.assert_called_once_with(recap)
+    save.assert_called_once_with(42, recap, "Your week in review...")
     hook.assert_not_called()
     send_push.assert_not_called()
 

--- a/frontend/src/__tests__/weeklyRecapPage.test.tsx
+++ b/frontend/src/__tests__/weeklyRecapPage.test.tsx
@@ -100,4 +100,19 @@ describe('WeeklyRecapPage', () => {
     expect(screen.queryByText('Skim vs deep read')).not.toBeInTheDocument();
     expect(screen.queryByText('Suggested changes')).not.toBeInTheDocument();
   });
+
+  it('renders a multi-paragraph narrative as separate paragraph elements', async () => {
+    const first = 'You read 4 articles in 15 minutes this week.';
+    const second = 'Keep up the great momentum with your 3 day streak.';
+    vi.mocked(api.fetchRecaps).mockResolvedValue([
+      { ...LEGACY_RECAP, narrative: `${first}\n\n${second}` },
+    ]);
+    render(<WeeklyRecapPage />, { wrapper: Wrapper });
+
+    const firstParagraph = await screen.findByText(first);
+    const secondParagraph = await screen.findByText(second);
+    expect(firstParagraph.tagName).toBe('P');
+    expect(secondParagraph.tagName).toBe('P');
+    expect(firstParagraph).not.toBe(secondParagraph);
+  });
 });

--- a/frontend/src/pages/WeeklyRecapPage.tsx
+++ b/frontend/src/pages/WeeklyRecapPage.tsx
@@ -80,7 +80,15 @@ export function WeeklyRecapPage() {
                 <div className="flex size-10 shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
                   <Flame className="size-5" />
                 </div>
-                <p className="text-sm">{latest.narrative}</p>
+                <div className="space-y-2 text-sm">
+                  {latest.narrative
+                    .split(/\n\s*\n/)
+                    .map((paragraph) => paragraph.trim())
+                    .filter(Boolean)
+                    .map((paragraph, index) => (
+                      <p key={index}>{paragraph}</p>
+                    ))}
+                </div>
               </div>
             </Panel>
           )}


### PR DESCRIPTION
## Summary
- Adds `generate_recap_narrative()` in a new `backend/news_dashboard/recaps/narrative.py`, producing a 2-paragraph, second-person "week in reading" review grounded strictly in the recap metrics (mirrors the free-LLM-first, deterministic-fallback pattern of `generate_recap_push_hook`).
- `scheduler._generate_recap_for_user` now always computes and persists the long narrative (fixing the previous quirk where push-disabled users got no narrative at all), while the push notification body still uses the short `generate_recap_push_hook` hook.
- `WeeklyRecapPage.tsx` renders the narrative as multiple `<p>` paragraphs (split on blank lines) instead of a single paragraph.

Closes #933

## Test plan
- [x] `backend/tests/test_recap_narrative.py` (new): fallback-without-key, fallback-with-zero-articles, mocked-LLM success, LLM-error fallback, saved/dwell metrics included in prompt (and `generated_at` excluded)
- [x] `backend/tests/test_scheduler.py`: updated to assert `generate_recap_narrative` is always called and persisted, independent of push-enabled state, and that the push hook remains separate
- [x] `frontend/src/__tests__/weeklyRecapPage.test.tsx`: added a case asserting a multi-paragraph narrative renders as separate `<p>` elements
- [x] `pytest backend/tests/test_recap_narrative.py backend/tests/test_scheduler.py backend/tests/test_recaps.py backend/tests/test_push_notifications.py` → 142 passed
- [x] `vitest run frontend/src/__tests__/weeklyRecapPage.test.tsx` → 3 passed
- [x] `mypy`, `ruff`, `tsc --noEmit`, `eslint` all clean
- [x] pre-commit hooks passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)