### PR TITLE
fix: podcast feed URL always uses localhost:8000 instead of actual host (#963)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2466,6 +2466,7 @@ def briefings_list(
 
 @api.get("/api/briefings/podcast-feed-token")
 def get_podcast_feed_token_endpoint(
+    request: Request,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, str]:
     """Return the user's current (revocable) podcast feed token and subscribe URL."""
@@ -2476,11 +2477,12 @@ def get_podcast_feed_token_endpoint(
     if version is None:
         raise HTTPException(status_code=404, detail="user not found")
     token = make_feed_token(current_user["id"], version)
-    return {"token": token, "url": feed_url(token)}
+    return {"token": token, "url": feed_url(token, _request_base_origin(request))}
 
 
 @api.post("/api/briefings/podcast-feed-token/regenerate")
 def regenerate_podcast_feed_token_endpoint(
+    request: Request,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, str]:
     """Revoke the user's current podcast feed token and issue a new one."""
@@ -2489,11 +2491,11 @@ def regenerate_podcast_feed_token_endpoint(
 
     version = bump_podcast_feed_token_version(current_user["id"])
     token = make_feed_token(current_user["id"], version)
-    return {"token": token, "url": feed_url(token)}
+    return {"token": token, "url": feed_url(token, _request_base_origin(request))}
 
 
 @api.get("/api/briefings/podcast.rss")
-def podcast_rss_feed_endpoint(token: Annotated[str, Query()]) -> Response:
+def podcast_rss_feed_endpoint(request: Request, token: Annotated[str, Query()]) -> Response:
     """Serve the authenticated user's podcast feed of previously-generated briefs.
 
     Authenticated via a revocable per-user token (not the session cookie), since
@@ -2526,7 +2528,7 @@ def podcast_rss_feed_endpoint(token: Annotated[str, Query()]) -> Response:
         briefing["audio_bytes"] = audio_path.stat().st_size
         episodes.append(briefing)
 
-    xml = build_feed_xml(token=token, briefings=episodes)
+    xml = build_feed_xml(token=token, briefings=episodes, base_url=_request_base_origin(request))
     return Response(content=xml, media_type="application/rss+xml")
 
 

--- a/backend/news_dashboard/podcast_feed.py
+++ b/backend/news_dashboard/podcast_feed.py
@@ -72,16 +72,28 @@ def verify_feed_token(token: str) -> int | None:
     return user_id
 
 
-def _base_url() -> str:
-    return os.getenv("APP_BASE_URL", "http://localhost:8000")
+def _base_url(base_url: str | None = None) -> str:
+    """Return the feed's base URL.
+
+    ``APP_BASE_URL`` always wins when set (needed for worker contexts that have
+    no live request, e.g. digest emails). Otherwise prefer the caller-supplied
+    ``base_url`` (derived from the inbound request's Host/X-Forwarded-* headers)
+    and fall back to localhost only when neither is available.
+    """
+    override = os.getenv("APP_BASE_URL")
+    if override:
+        return override
+    if base_url:
+        return base_url
+    return "http://localhost:8000"
 
 
-def feed_url(token: str) -> str:
-    return f"{_base_url()}/api/briefings/podcast.rss?token={token}"
+def feed_url(token: str, base_url: str | None = None) -> str:
+    return f"{_base_url(base_url)}/api/briefings/podcast.rss?token={token}"
 
 
-def audio_url(briefing_id: int, token: str) -> str:
-    return f"{_base_url()}/api/briefings/{briefing_id}/podcast-audio?token={token}"
+def audio_url(briefing_id: int, token: str, base_url: str | None = None) -> str:
+    return f"{_base_url(base_url)}/api/briefings/{briefing_id}/podcast-audio?token={token}"
 
 
 def _rfc2822(value: Any) -> str | None:
@@ -97,14 +109,16 @@ def _rfc2822(value: Any) -> str | None:
     return None
 
 
-def build_feed_xml(*, token: str, briefings: list[dict[str, Any]]) -> str:
+def build_feed_xml(
+    *, token: str, briefings: list[dict[str, Any]], base_url: str | None = None
+) -> str:
     """Build a podcast RSS 2.0 (+ iTunes tags) document for the given briefings.
 
     Each entry in ``briefings`` must have ``id``, ``created_at``, ``title``,
     ``summary``, and ``audio_bytes`` (size in bytes of the already-generated
     MP3 for that briefing).
     """
-    base = _base_url()
+    base = _base_url(base_url)
     itunes_ns = "http://www.itunes.org/dtds/podcast-1.0.dtd"
     atom_ns = "http://www.w3.org/2005/Atom"
     ET.register_namespace("itunes", itunes_ns)
@@ -121,7 +135,7 @@ def build_feed_xml(*, token: str, briefings: list[dict[str, Any]]) -> str:
     ET.SubElement(channel, f"{{{itunes_ns}}}author").text = "News Dashboard"
     ET.SubElement(channel, f"{{{itunes_ns}}}explicit").text = "false"
     atom_link = ET.SubElement(channel, f"{{{atom_ns}}}link")
-    atom_link.set("href", feed_url(token))
+    atom_link.set("href", feed_url(token, base_url))
     atom_link.set("rel", "self")
     atom_link.set("type", "application/rss+xml")
 
@@ -137,7 +151,7 @@ def build_feed_xml(*, token: str, briefings: list[dict[str, Any]]) -> str:
         guid.set("isPermaLink", "false")
         guid.text = f"briefing-{briefing_id}"
         enclosure = ET.SubElement(item, "enclosure")
-        enclosure.set("url", audio_url(briefing_id, token))
+        enclosure.set("url", audio_url(briefing_id, token, base_url))
         enclosure.set("length", str(briefing.get("audio_bytes") or 0))
         enclosure.set("type", "audio/mpeg")
 

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -17,6 +17,7 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
+from urllib.parse import urlsplit
 
 import pytest
 from fastapi.testclient import TestClient
@@ -398,8 +399,8 @@ def test_get_podcast_feed_token_endpoint_uses_request_host(monkeypatch: Any) -> 
         resp = c.get("/api/briefings/podcast-feed-token")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["url"].startswith("https://example.com")
-    assert "localhost" not in data["url"]
+    parsed = urlsplit(data["url"])
+    assert (parsed.scheme, parsed.netloc) == ("https", "example.com")
 
 
 def test_get_podcast_feed_token_endpoint_app_base_url_takes_precedence(
@@ -410,7 +411,8 @@ def test_get_podcast_feed_token_endpoint_app_base_url_takes_precedence(
     monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
     resp = client.get("/api/briefings/podcast-feed-token")
     assert resp.status_code == 200
-    assert resp.json()["url"].startswith("https://pinned.example.org")
+    parsed = urlsplit(resp.json()["url"])
+    assert (parsed.scheme, parsed.netloc) == ("https", "pinned.example.org")
 
 
 def test_regenerate_podcast_feed_token_endpoint_issues_new_token(

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -390,6 +390,29 @@ def test_get_podcast_feed_token_endpoint_returns_token_and_url(
     assert data["url"].endswith(f"/api/briefings/podcast.rss?token={data['token']}")
 
 
+def test_get_podcast_feed_token_endpoint_uses_request_host(monkeypatch: Any) -> None:
+    """Without APP_BASE_URL, the returned url matches the request's host, not localhost."""
+    monkeypatch.delenv("APP_BASE_URL", raising=False)
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    with TestClient(app, base_url="https://example.com", raise_server_exceptions=True) as c:
+        resp = c.get("/api/briefings/podcast-feed-token")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["url"].startswith("https://example.com")
+    assert "localhost" not in data["url"]
+
+
+def test_get_podcast_feed_token_endpoint_app_base_url_takes_precedence(
+    client: TestClient, monkeypatch: Any
+) -> None:
+    """APP_BASE_URL still overrides the request-derived host when explicitly set."""
+    monkeypatch.setenv("APP_BASE_URL", "https://pinned.example.org")
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    resp = client.get("/api/briefings/podcast-feed-token")
+    assert resp.status_code == 200
+    assert resp.json()["url"].startswith("https://pinned.example.org")
+
+
 def test_regenerate_podcast_feed_token_endpoint_issues_new_token(
     client: TestClient, monkeypatch: Any
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #963. **Copy feed URL** on the Brief History page (and the RSS `<atom:link>`/enclosure URLs) always used `http://localhost:8000` as the base host unless the `APP_BASE_URL` env var was explicitly set, breaking podcast subscription for any deployment not accessed directly at `localhost:8000`.

- `podcast_feed.py`: `_base_url()`, `feed_url()`, `audio_url()`, and `build_feed_xml()` now accept an optional `base_url` override. Precedence: `APP_BASE_URL` env var (explicit pin, still needed for worker contexts with no live request) → caller-supplied `base_url` (derived from the request) → `http://localhost:8000` fallback.
- `main.py`: `get_podcast_feed_token_endpoint`, `regenerate_podcast_feed_token_endpoint`, and `podcast_rss_feed_endpoint` now take a `Request` parameter and pass `_request_base_origin(request)` — the existing helper that already honors `X-Forwarded-Host`/`X-Forwarded-Proto` for proxy deployments — through to `feed_url()`/`build_feed_xml()`.
- `digest.py` (email mark-read links) is unchanged/out of scope, as specified in the issue — it has no live request to derive a host from.

## Test plan

- [x] Added `test_get_podcast_feed_token_endpoint_uses_request_host`: with `APP_BASE_URL` unset and a `TestClient(app, base_url="https://example.com")`, the returned `url` starts with `https://example.com`, not `localhost:8000`.
- [x] Added `test_get_podcast_feed_token_endpoint_app_base_url_takes_precedence`: confirms `APP_BASE_URL` still overrides the request-derived host when explicitly set (no regression for pinned deployments).
- [x] Existing tests in `backend/tests/test_briefings_api.py` and `backend/tests/test_podcast_feed.py` pass unchanged (56 passed).
- [x] `make lint` — clean.
- [x] `make typecheck` (mypy, ty, pyrefly) — clean.
- [x] Full backend suite: `1794 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)