### PR TITLE
chore: dead-code sweep for note/warning-level CodeQL findings (#972)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import re
@@ -441,15 +442,15 @@ def _fetch_feed_content(url: str) -> bytes:
         with open_server_fetch_url(req, timeout=FEED_FETCH_TIMEOUT_SECS) as resp:
             content_length = resp.headers.get("Content-Length")
             if content_length is not None:
-                try:
+                # Content-Length is attacker-controlled and may be non-numeric;
+                # ignore malformed values rather than failing the fetch on them.
+                with contextlib.suppress(ValueError):
                     if int(content_length) > FEED_FETCH_MAX_BYTES:
                         msg = (
                             f"Feed response too large ({content_length} bytes, "
                             f"max {FEED_FETCH_MAX_BYTES}): {url}"
                         )
                         raise FeedFetchError(msg)
-                except ValueError:
-                    pass
             content: bytes = resp.read(FEED_FETCH_MAX_BYTES + 1)
     except TimeoutError as exc:
         msg = f"Feed fetch timed out after {FEED_FETCH_TIMEOUT_SECS}s: {url}"
@@ -669,7 +670,6 @@ def detect_and_translate_article(
 ) -> tuple[str, str, str, str | None]:
     """Detect language and translate title and summary to English if needed."""
     import json
-    import re
 
     from news_dashboard.ai_client import chat_create, get_chat_client
 
@@ -1131,20 +1131,6 @@ def _search_tsquery(value: str) -> str | None:
         return None
     return " & ".join(f"{token}:*" for token in tokens)
 
-
-# UAS columns that override article-level state when a user_id is provided
-_UAS_STATE_COLUMNS = frozenset(
-    {
-        "state",
-        "starred",
-        "done_at",
-        "starred_at",
-        "skipped_at",
-        "archived_at",
-        "later_until",
-        "restored_at",
-    }
-)
 
 _COLD_START_RECOMMENDATION_SCORE_SQL = """
     (

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -497,10 +497,6 @@ def upsert_recommendation_score(  # noqa: PLR0913
         )
 
 
-# States that constitute an explicit interaction worth learning from.
-_INTERACTION_STATES = ("done", "skipped", "archived", "later")
-
-
 def _load_user_signals(conn: Any, user_id: int) -> list[ArticleSignal]:
     """Read the user's live workflow state + starred metadata into signals."""
     rows = conn.execute(

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -254,7 +254,6 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
         if not isinstance(item, dict):
             continue
         speaker = str(item.get("speaker") or "")
-        voice = str(item.get("voice") or "")
         txt = str(item.get("text") or "")
 
         if speaker.lower() == "alex":

--- a/backend/tests/test_ingest_route_auth.py
+++ b/backend/tests/test_ingest_route_auth.py
@@ -18,14 +18,6 @@ def client() -> Generator[TestClient]:
         yield c
 
 
-_FAKE_ADMIN = {
-    "id": 1,
-    "username": "adminuser",
-    "email": None,
-    "is_admin": True,
-}
-
-
 def test_ingest_requires_admin(client: TestClient) -> None:
     from news_dashboard.auth import require_admin, require_auth
 

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -17,6 +17,7 @@ from news_dashboard.push import (
     get_user_push_subscriptions,
     save_push_subscription,
     send_push_for_user,
+    send_push_notification,
     validate_push_subscription,
 )
 
@@ -139,8 +140,6 @@ def test_delete_push_subscription_by_endpoint(
 
 
 def test_send_push_notification_calls_webpush(monkeypatch: pytest.MonkeyPatch) -> None:
-    import news_dashboard.push as push_mod
-
     monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
     monkeypatch.setenv("VAPID_EMAIL", "test@example.com")
 
@@ -154,7 +153,7 @@ def test_send_push_notification_calls_webpush(monkeypatch: pytest.MonkeyPatch) -
         "WebPushException": _FakeWebPushError,
     }
     with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
-        push_mod.send_push_notification(
+        send_push_notification(
             endpoint="https://ep.example.com",
             p256dh="abc",
             auth="xyz",
@@ -171,8 +170,6 @@ def test_send_push_notification_calls_webpush(monkeypatch: pytest.MonkeyPatch) -
 def test_send_push_notification_payload_without_url(monkeypatch: pytest.MonkeyPatch) -> None:
     import json
 
-    import news_dashboard.push as push_mod
-
     monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
 
     mock_webpush = MagicMock()
@@ -185,7 +182,7 @@ def test_send_push_notification_payload_without_url(monkeypatch: pytest.MonkeyPa
         "WebPushException": _FakeWebPushError,
     }
     with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
-        push_mod.send_push_notification(
+        send_push_notification(
             endpoint="https://ep.example.com",
             p256dh="abc",
             auth="xyz",
@@ -201,8 +198,6 @@ def test_send_push_notification_payload_without_url(monkeypatch: pytest.MonkeyPa
 def test_send_push_notification_payload_with_url(monkeypatch: pytest.MonkeyPatch) -> None:
     import json
 
-    import news_dashboard.push as push_mod
-
     monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
 
     mock_webpush = MagicMock()
@@ -215,7 +210,7 @@ def test_send_push_notification_payload_with_url(monkeypatch: pytest.MonkeyPatch
         "WebPushException": _FakeWebPushError,
     }
     with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
-        push_mod.send_push_notification(
+        send_push_notification(
             endpoint="https://ep.example.com",
             p256dh="abc",
             auth="xyz",
@@ -231,8 +226,6 @@ def test_send_push_notification_payload_with_url(monkeypatch: pytest.MonkeyPatch
 def test_send_push_notification_payload_with_tag(monkeypatch: pytest.MonkeyPatch) -> None:
     import json
 
-    import news_dashboard.push as push_mod
-
     monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
 
     mock_webpush = MagicMock()
@@ -245,7 +238,7 @@ def test_send_push_notification_payload_with_tag(monkeypatch: pytest.MonkeyPatch
         "WebPushException": _FakeWebPushError,
     }
     with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
-        push_mod.send_push_notification(
+        send_push_notification(
             endpoint="https://ep.example.com",
             p256dh="abc",
             auth="xyz",
@@ -262,8 +255,6 @@ def test_send_push_notification_payload_with_tag(monkeypatch: pytest.MonkeyPatch
 def test_send_push_notification_logs_on_webpush_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import news_dashboard.push as push_mod
-
     monkeypatch.setenv("VAPID_PRIVATE_KEY", "fake-private-key")
 
     class _FakeWebPushError(Exception):
@@ -275,7 +266,7 @@ def test_send_push_notification_logs_on_webpush_exception(
         "WebPushException": _FakeWebPushError,
     }
     with patch.dict("sys.modules", {"pywebpush": MagicMock(**fake_module)}):
-        push_mod.send_push_notification(
+        send_push_notification(
             endpoint="https://ep.example.com",
             p256dh="abc",
             auth="xyz",

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -387,8 +387,6 @@ def test_submit_quiz_partial_score(tmp_path: Path) -> None:
     user_id, article_id = _seed(db_path)
     _seed_done_article(db_path, user_id, article_id)
 
-    import json
-
     mock_response = MagicMock()
     mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
 
@@ -416,8 +414,6 @@ def test_submit_quiz_not_found(tmp_path: Path) -> None:
 
 
 def _generate_quiz_with_mock(user_id: int, db_path: Path) -> dict[str, Any]:
-    import json
-
     mock_response = MagicMock()
     mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
     with (

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -948,7 +948,6 @@ def test_scheduler_status_reports_external_ingest_authority(
 # connect/row_to_dict/generate_briefing/push helpers are lazily imported inside
 # _run_per_user_briefings, so they must be patched at their source modules.
 _CONNECT_PATH = "news_dashboard.db.connect"
-_ROW_TO_DICT_PATH = "news_dashboard.db.row_to_dict"
 _PER_USER_GEN_PATH = "news_dashboard.briefings.generate_briefing"
 _SEND_PUSH_PATH = "news_dashboard.push.send_push_for_user"
 _GEN_PUSH_HOOK_PATH = "news_dashboard.push.generate_push_hook"

--- a/design/radar-source/src/routes/__root.tsx
+++ b/design/radar-source/src/routes/__root.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
-  Outlet,
   Link,
   createRootRouteWithContext,
   useRouter,

--- a/design/radar-source/src/routes/a.$id.tsx
+++ b/design/radar-source/src/routes/a.$id.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, useNavigate, useRouter } from "@tanstack/react-r
 import { useEffect, useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, ChevronLeft as PrevIcon, Star, Check, Clock, X as XIcon, Archive, ExternalLink, AlertCircle, Loader2 } from "lucide-react";
 import { useApp } from "@/lib/store";
-import { relativeTime, formatDate, signalLabel } from "@/lib/format";
+import { formatDate, signalLabel } from "@/lib/format";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 

--- a/desktop/src/url-helper.test.js
+++ b/desktop/src/url-helper.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assert = require('assert');
 const { isAppUrl } = require('./url-helper');
 
 const cases = [

--- a/frontend/src/pages/FeedsRunsPage.tsx
+++ b/frontend/src/pages/FeedsRunsPage.tsx
@@ -218,7 +218,7 @@ export function FeedsRunsPage() {
                 variant="outline"
                 size="sm"
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={loading || page === 1}
+                disabled={page === 1}
               >
                 ‹
               </Button>
@@ -226,7 +226,7 @@ export function FeedsRunsPage() {
                 variant="outline"
                 size="sm"
                 onClick={() => setPage((p) => p + 1)}
-                disabled={loading || !hasMore}
+                disabled={!hasMore}
               >
                 ›
               </Button>


### PR DESCRIPTION
## Summary

Closes #972. Cleans up ~25 note/warning-level CodeQL findings that were confirmed genuine dead code (no behavior changes):

- Unused globals: `test_scheduler.py` `_ROW_TO_DICT_PATH`, `test_ingest_route_auth.py` `_FAKE_ADMIN`, `recommendations.py` `_INTERACTION_STATES`, `ingest.py` `_UAS_STATE_COLUMNS`
- Unused imports: `desktop/src/url-helper.test.js` `assert`, `design/radar-source/.../a.$id.tsx` `relativeTime`, `design/radar-source/.../__root.tsx` `Outlet`
- Redundant local `import re` / `import json` shadowing existing module-level imports in `ingest.py` and `test_quiz.py`
- Consolidated `test_push_notifications.py`'s five per-test `import news_dashboard.push as push_mod` into the existing top-level `from news_dashboard.push import (...)`
- `tts.py`: removed a dead `voice = ...` initial assignment (every branch of the following if/elif/else reassigns it)
- `ingest.py`: replaced a bare `except ValueError: pass` around Content-Length parsing with `contextlib.suppress(ValueError)` plus an explanatory comment
- `FeedsRunsPage.tsx`: dropped redundant `loading ||` on two pagination buttons that only render in the `!loading` branch

### Findings left alone (false positives, would break the gate)

- `error_tracking.py:11` and `test_error_tracking.py:5,10` — the `Any`/`Event` imports are referenced only inside `cast("...")` string forward-refs. Ruff already recognizes these as used; removing them makes `mypy` fail with `Name "Any" is not defined` (verified locally). CodeQL doesn't resolve string-literal type casts, hence the false flag.
- The `import X as Y` + `from X import ...` pattern in `test_semantic_similarity.py`, `test_recommendation_recalc.py`, `test_ingest_runs.py`, `test_hf_blog_ingest.py`, `test_briefings_db.py`, `test_briefings_api.py` — the module aliases (`embeddings_mod`, `jobs`, `ingest_module`, `body_fetch_module`, `briefings_mod`, `main_mod`) are all used for `monkeypatch.setattr(...)` to patch functions in place; they're not duplicate imports of the same names.

## Test plan

- [x] `ruff check backend/` — clean
- [x] `mypy` over `backend/news_dashboard/` and `backend/tests/` — clean
- [x] Targeted backend pytest: touched files (`test_scheduler.py`, `test_ingest_route_auth.py`, `test_error_tracking.py`, `test_quiz.py`, `test_push_notifications.py`, `test_recommendation_contracts.py`, `test_today_recommendations.py`, `test_ingest*.py`, `test_tts.py`, `test_semantic_similarity.py`, `test_recommendation_recalc.py`, `test_hf_blog_ingest.py`, `test_briefings_db.py`, `test_briefings_api.py`) — 398 passed
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:frontend` — 812 passed
- [x] Full backend `pytest` gate deferred to CI — the local full-suite run hit a known local-only issue with the shared test Postgres (see repo notes on `/dev/shm` exhaustion under full parallel runs) and hung; targeted runs above give confidence and CI runs the full suite in a clean environment.
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly, vulture, eslint, prettier, knip, tsc) all passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)