### PR TITLE
fix: embedding calls crash with 429 — no retry/backoff (#1011)

### DIFF
--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -8,16 +8,24 @@ Retrieval       : SQL top-k via the `<=>` cosine-distance operator
 
 from __future__ import annotations
 
+import logging
 import os
+import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from news_dashboard.ai_client import ManagedPrompt
 
+logger = logging.getLogger(__name__)
+
 MIN_ARTICLES = 5  # refuse to answer if fewer than this many articles are embedded
 TOP_K = 8  # articles to include as context
 DEFAULT_ANSWER_MODEL = "gpt-4o-mini"
 DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+
+# Retry budget for transient (e.g. 429 rate-limit) embedding failures.
+EMBED_MAX_ATTEMPTS = 4
+EMBED_BACKOFF_SECONDS = 1.0
 
 # Local fallback for the Ask AI system prompt. The live prompt is managed in
 # Langfuse (name "ask-system", label "production"); this string is used verbatim
@@ -34,6 +42,10 @@ ASK_SYSTEM_PROMPT = (
 
 class MissingAICredentialsError(RuntimeError):
     """Raised when Ask AI is used without the required provider credentials."""
+
+
+class EmbeddingUnavailableError(RuntimeError):
+    """Raised when the embedding provider stays unavailable after retries (e.g. persistent 429s)."""
 
 
 def _require_env(name: str, purpose: str) -> str:
@@ -96,18 +108,52 @@ def _embeddings_ai_config() -> tuple[str, str | None, str]:
     return api_key, base_url, model
 
 
+def _is_retryable_embedding_error(exc: Exception) -> bool:
+    """True for transient upstream errors (429 rate limits) worth retrying."""
+    from openai import APIStatusError, RateLimitError
+
+    if isinstance(exc, RateLimitError):
+        return True
+    return isinstance(exc, APIStatusError) and exc.status_code == 429
+
+
 def _embed(text: str) -> list[float]:
-    """Embed *text* via the configured OpenAI-compatible endpoint."""
+    """Embed *text* via the configured OpenAI-compatible endpoint.
+
+    Retries transient rate-limit (429) errors with exponential backoff. Once
+    the retry budget is exhausted, raises EmbeddingUnavailableError instead of
+    the raw provider exception so callers can distinguish "provider is
+    rate-limiting us" from other failures (e.g. bad credentials).
+    """
     from news_dashboard.ai_client import get_chat_client, trace_params
 
     api_key, base_url, model = _embeddings_ai_config()
     client = get_chat_client(api_key=api_key, base_url=base_url)
-    response = client.embeddings.create(
-        model=model,
-        input=text,
-        **trace_params("article-embedding", tags=["embedding"], user_id="system"),
-    )
-    return list(response.data[0].embedding)
+
+    attempt = 0
+    while True:
+        try:
+            response = client.embeddings.create(
+                model=model,
+                input=text,
+                **trace_params("article-embedding", tags=["embedding"], user_id="system"),
+            )
+            return list(response.data[0].embedding)
+        except Exception as exc:
+            if not _is_retryable_embedding_error(exc):
+                raise
+            attempt += 1
+            if attempt >= EMBED_MAX_ATTEMPTS:
+                message = f"embedding provider rate-limited after {attempt} attempts: {exc}"
+                raise EmbeddingUnavailableError(message) from exc
+            wait = EMBED_BACKOFF_SECONDS * (2 ** (attempt - 1))
+            logger.warning(
+                "embedding request rate-limited (attempt %d/%d); retrying in %.1fs",
+                attempt,
+                EMBED_MAX_ATTEMPTS,
+                wait,
+            )
+            time.sleep(wait)
 
 
 def _answer(
@@ -192,6 +238,8 @@ def embed_all_eligible(
 
     Called lazily on the first /api/ask request to backfill existing articles.
     When user_id is provided, only backfills articles visible to that user.
+    A single article's embedding failure (e.g. exhausted rate-limit retries)
+    is logged and skipped rather than aborting the rest of the backfill.
     Returns the number of articles newly embedded.
     """
     from news_dashboard.db import connect, init_db
@@ -244,7 +292,13 @@ def embed_all_eligible(
         text = embedding_text(row["title"], row["summary"], row["reason"], row["tags"])
         if not text:
             continue
-        vector = _embed(text)
+        try:
+            vector = _embed(text)
+        except Exception:
+            logger.warning(
+                "failed to embed article %s during backfill; skipping", row["id"], exc_info=True
+            )
+            continue
         from news_dashboard.db import connect as _connect
 
         with _connect(db_path) as conn:

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2978,13 +2978,17 @@ def ask_ai(
     payload: AskRequest,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
 ) -> dict[str, Any]:
-    from news_dashboard.embeddings import ask
+    from news_dashboard.embeddings import EmbeddingUnavailableError, ask
 
     q = payload.query.strip()
     if not q:
         raise HTTPException(status_code=400, detail="query must not be empty")
     try:
         return ask(q, include_all=payload.include_all, user_id=current_user["id"])
+    except EmbeddingUnavailableError as exc:
+        raise HTTPException(
+            status_code=503, detail="Ask AI is temporarily unavailable, try again shortly."
+        ) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,0 +1,234 @@
+"""Tests for embedding retry/backoff and per-article backfill isolation (#1011)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import openai
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard import embeddings as embeddings_mod
+from news_dashboard.auth import require_auth
+from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
+from news_dashboard.embeddings import (
+    EmbeddingUnavailableError,
+    _embed,
+    embed_all_eligible,
+)
+from news_dashboard.main import app
+
+
+def _rate_limit_error() -> openai.RateLimitError:
+    response = httpx.Response(
+        429, request=httpx.Request("POST", "https://api.openai.com/v1/embeddings")
+    )
+    return openai.RateLimitError("rate limited", response=response, body=None)
+
+
+class _FakeEmbeddingData:
+    def __init__(self, value: float = 0.1) -> None:
+        self.embedding = [value] * 10 + [0.0] * (EMBEDDING_DIMENSIONS - 10)
+
+
+class _FakeEmbeddingResponse:
+    def __init__(self, value: float = 0.1) -> None:
+        self.data = [_FakeEmbeddingData(value)]
+
+
+class _FlakyEmbeddings:
+    """Raises RateLimitError *fail_times* times, then succeeds."""
+
+    def __init__(self, fail_times: int) -> None:
+        self.fail_times = fail_times
+        self.calls = 0
+
+    def create(self, **_: Any) -> _FakeEmbeddingResponse:
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise _rate_limit_error()
+        return _FakeEmbeddingResponse()
+
+
+class _AlwaysRateLimitedEmbeddings:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def create(self, **_: Any) -> _FakeEmbeddingResponse:
+        self.calls += 1
+        raise _rate_limit_error()
+
+
+class _FakeClient:
+    def __init__(self, embeddings: Any) -> None:
+        self.embeddings = embeddings
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retries should not actually slow down the test suite."""
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+
+@pytest.fixture(autouse=True)
+def _embed_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+
+# ── _embed retry/backoff ────────────────────────────────────────────────────
+
+
+def test_embed_retries_transient_rate_limit_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flaky = _FlakyEmbeddings(fail_times=2)
+    monkeypatch.setattr(
+        embeddings_mod, "_embeddings_ai_config", lambda: ("key", None, "text-embedding-3-small")
+    )
+    monkeypatch.setattr("news_dashboard.ai_client.get_chat_client", lambda **_: _FakeClient(flaky))
+    vector = _embed("hello world")
+    assert vector[0] == pytest.approx(0.1)
+    assert flaky.calls == 3  # 2 failures + 1 success
+
+
+def test_embed_raises_unavailable_after_exhausting_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    always_limited = _AlwaysRateLimitedEmbeddings()
+    monkeypatch.setattr(
+        embeddings_mod, "_embeddings_ai_config", lambda: ("key", None, "text-embedding-3-small")
+    )
+    monkeypatch.setattr(
+        "news_dashboard.ai_client.get_chat_client", lambda **_: _FakeClient(always_limited)
+    )
+    with pytest.raises(EmbeddingUnavailableError):
+        _embed("hello world")
+    assert always_limited.calls == embeddings_mod.EMBED_MAX_ATTEMPTS
+
+
+def test_embed_does_not_retry_non_rate_limit_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _BoomEmbeddings:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def create(self, **_: Any) -> _FakeEmbeddingResponse:
+            self.calls += 1
+            message = "boom"
+            raise RuntimeError(message)
+
+    boom = _BoomEmbeddings()
+    monkeypatch.setattr(
+        embeddings_mod, "_embeddings_ai_config", lambda: ("key", None, "text-embedding-3-small")
+    )
+    monkeypatch.setattr("news_dashboard.ai_client.get_chat_client", lambda **_: _FakeClient(boom))
+    with pytest.raises(RuntimeError, match="boom"):
+        _embed("hello world")
+    assert boom.calls == 1
+
+
+# ── embed_all_eligible per-article isolation ────────────────────────────────
+
+
+def _seed_source(db_path: Path, slug: str = "test-source") -> None:
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+            VALUES (%s, %s, %s, 'engineering', 'rss', 50, TRUE)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, "TestSource", f"https://example.com/{slug}.xml"),
+        )
+
+
+def _seed_unembedded_articles(db_path: Path, count: int) -> list[int]:
+    init_db(db_path)
+    _seed_source(db_path)
+    ids = []
+    with connect(db_path) as conn:
+        for i in range(1, count + 1):
+            row = conn.execute(
+                """
+                INSERT INTO articles(
+                    url, canonical_url, title, source_slug, source_name,
+                    category, kind, status, importance_score, summary, reason, tags
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'saved', %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    f"https://example.com/{i}",
+                    f"https://example.com/{i}",
+                    f"Article {i}",
+                    "test-source",
+                    "TestSource",
+                    "engineering",
+                    "rss",
+                    0.5,
+                    f"Summary {i}",
+                    "",
+                    "",
+                ),
+            ).fetchone()
+            ids.append(row["id"])
+    return ids
+
+
+def test_embed_all_eligible_skips_failing_article_and_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "embed.db"
+    ids = _seed_unembedded_articles(db_path, count=3)
+    failing_id = ids[1]
+
+    def _fake_embed(text: str) -> list[float]:
+        if f"Article {ids.index(failing_id) + 1}" in text:
+            message = "embedding provider rate-limited after 4 attempts"
+            raise EmbeddingUnavailableError(message)
+        return [0.1] * 10 + [0.0] * (EMBEDDING_DIMENSIONS - 10)
+
+    monkeypatch.setattr(embeddings_mod, "_embed", _fake_embed)
+
+    count = embed_all_eligible(db_path)
+    assert count == 2  # the failing article is skipped, the other two succeed
+
+    with connect(db_path) as conn:
+        embedded_ids = {
+            row["id"]
+            for row in conn.execute(
+                "SELECT id FROM articles WHERE embedding_vec IS NOT NULL"
+            ).fetchall()
+        }
+    assert embedded_ids == {ids[0], ids[2]}
+
+
+# ── /api/ask surfaces a clean error on persistent embedding failure ────────
+
+
+def test_ask_endpoint_returns_503_when_embedding_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(_query: str, **_: Any) -> dict[str, Any]:
+        message = "embedding provider rate-limited after 4 attempts: rate limited"
+        raise EmbeddingUnavailableError(message)
+
+    monkeypatch.setattr("news_dashboard.embeddings.ask", _boom)
+
+    http = TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 1,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    try:
+        response = http.post("/api/ask", json={"query": "what happened today?"})
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 503
+    body = response.json()
+    assert "temporarily unavailable" in body["detail"]
+    assert "rate limited" not in body["detail"]


### PR DESCRIPTION
## Summary

Fixes #1011 — `/api/ask` (Ask AI) crashed with a raw 500 and leaked the OpenAI internal stack trace/message when the embedding provider rate-limited (429).

- `_embed()` now retries transient rate-limit (429) errors (`RateLimitError` / `APIStatusError` with status 429) with exponential backoff (up to `EMBED_MAX_ATTEMPTS = 4` attempts), and raises a new `EmbeddingUnavailableError` only once the retry budget is exhausted. Non-retryable errors (e.g. bad credentials) still propagate unchanged.
- `embed_all_eligible()` now isolates per-article failures during the bulk backfill loop — it logs and skips an article whose embedding call fails, instead of aborting the whole backfill and propagating the exception to the caller. It still returns the count of articles actually embedded.
- `/api/ask` now catches `EmbeddingUnavailableError` specifically and returns a clean `503` (`"Ask AI is temporarily unavailable, try again shortly."`) instead of a raw `500` with the internal OpenAI exception message.
- The already-graceful lazy-embed paths (`ingest.py`, `main.py`'s `_embed_article_background`) are unaffected — they already swallow embedding failures.

## Test plan

- [x] New tests in `backend/tests/test_embeddings.py`:
  - `_embed()` retries a `RateLimitError` and eventually succeeds.
  - `_embed()` raises `EmbeddingUnavailableError` after exhausting the retry budget on persistent 429s.
  - `_embed()` does **not** retry non-rate-limit errors.
  - `embed_all_eligible()` skips a failing article and still returns/persists the successfully embedded ones.
  - `/api/ask` returns `503` with a clean, non-leaking error message when the query embedding stays unavailable.
- [x] `pytest backend/tests/test_embeddings.py backend/tests/test_ask_scope.py backend/tests/test_semantic_similarity.py backend/tests/test_embedding_dedup.py backend/tests/test_agent_actions.py -q` — 48 passed
- [x] `ruff check` / `ruff format --check` — passed
- [x] `mypy` — passed
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)