### PR TITLE
feat: add Google Project Zero as a security research source (#767)

### DIFF
--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -285,6 +285,14 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
         priority=74,
         interest_tags=("security", "infra", "product-news"),
     ),
+    SourceDefinition(
+        "google-project-zero",
+        "Google Project Zero",
+        "https://googleprojectzero.blogspot.com/feeds/posts/default",
+        "security",
+        priority=82,
+        interest_tags=("security", "research"),
+    ),
     # ── Cloud / infra ────────────────────────────────────────────────────────
     SourceDefinition(
         "kubernetes-blog",

--- a/backend/tests/test_google_project_zero_source.py
+++ b/backend/tests/test_google_project_zero_source.py
@@ -1,0 +1,89 @@
+"""Tests for Google Project Zero default source (issue #767)."""
+
+from __future__ import annotations
+
+import pytest
+
+from news_dashboard.ingest import sync_sources
+from news_dashboard.sources import DEFAULT_SOURCES
+
+# Unit tests (no DB)
+
+
+def test_google_project_zero_in_default_sources() -> None:
+    """google-project-zero SourceDefinition exists in DEFAULT_SOURCES."""
+    by_slug = {s.slug: s for s in DEFAULT_SOURCES}
+    assert "google-project-zero" in by_slug, (
+        f"google-project-zero not found; slugs: {sorted(by_slug)[:10]}..."
+    )
+
+
+def test_google_project_zero_metadata() -> None:
+    """google-project-zero has the expected metadata fields."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "google-project-zero")
+    assert src.name == "Google Project Zero"
+    assert src.url == "https://googleprojectzero.blogspot.com/feeds/posts/default"
+    assert src.category == "security"
+    assert src.kind == "rss_feed"
+    assert src.priority == 82
+    assert src.enabled is True
+    assert src.lang == "en"
+
+
+def test_google_project_zero_interest_tags() -> None:
+    """google-project-zero carries tags that match onboarding interests."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "google-project-zero")
+    assert "security" in src.interest_tags
+    assert "research" in src.interest_tags
+
+
+def test_google_project_zero_routes_to_rss_feed() -> None:
+    """google-project-zero kind is rss_feed, which ingest routes correctly."""
+    src = next(s for s in DEFAULT_SOURCES if s.slug == "google-project-zero")
+    assert src.kind == "rss_feed"
+
+
+# Integration tests (PostgreSQL)
+
+
+def test_google_project_zero_sync_persists_row(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """sync_sources() creates a sources row for google-project-zero."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        row = conn.execute(
+            "SELECT slug, name, url, category, kind, priority, enabled "
+            "FROM sources WHERE slug = 'google-project-zero'"
+        ).fetchone()
+
+    assert row is not None, "google-project-zero row missing from sources table"
+    assert row["slug"] == "google-project-zero"
+    assert row["name"] == "Google Project Zero"
+    assert row["url"] == "https://googleprojectzero.blogspot.com/feeds/posts/default"
+    assert row["category"] == "security"
+    assert row["kind"] == "rss_feed"
+    assert row["priority"] == 82
+    assert row["enabled"] is True
+
+
+def test_google_project_zero_sync_idempotent(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running sync_sources twice does not duplicate google-project-zero."""
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    sync_sources(pg_clean)
+
+    from news_dashboard.db import connect
+
+    with connect(pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS c FROM sources WHERE slug = 'google-project-zero'"
+        ).fetchone()["c"]
+
+    assert count == 1


### PR DESCRIPTION
## Summary
- Adds `google-project-zero` to `DEFAULT_SOURCES` in `backend/news_dashboard/sources.py`, in the Security section, with `category=security`, `kind=rss_feed`, `priority=82`, `interest_tags=(security, research)`.
- Uses the existing `rss_feed` ingest path (`_fetch_feed_entries` / `_fetch_entries_by_kind`) and `sync_sources()` psycopg persistence — no new code paths, database sniffing, or SQLite fallbacks introduced.

Closes #767.

## Test plan
- [x] Added `backend/tests/test_google_project_zero_source.py` (modeled on the existing `test_github_security_lab_source.py` pattern) covering: presence in `DEFAULT_SOURCES`, metadata fields, interest tags, `rss_feed` routing, `sync_sources()` PostgreSQL persistence, and sync idempotency.
- [x] `pytest backend/tests/test_google_project_zero_source.py` — 6 passed
- [x] `pytest backend/tests/test_new_feeds.py backend/tests/test_onboarding_interests.py` — 15 passed (no regressions)
- [x] `ruff check` — passed
- [x] pre-commit (ruff, mypy, ty, pyrefly, vulture) — all passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)