### PR TITLE
feat: add i18n infrastructure with 29 languages, RTL, and language selector

### DIFF
--- a/frontend/src/__tests__/i18n.test.tsx
+++ b/frontend/src/__tests__/i18n.test.tsx
@@ -2,15 +2,17 @@
 /**
  * Tests for i18n functionality.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import { AuthProvider } from '@/contexts/auth';
 import userEvent from '@testing-library/user-event';
 import i18n from '@/lib/i18n';
+import { initLanguageDirection } from '@/lib/languages';
 import { LoginPage } from '@/pages/LoginPage';
 import * as api from '@/api';
+import translationEs from '@/locales/es/translation.json';
 
 function renderWithI18n(ui: React.ReactNode) {
   return render(
@@ -61,5 +63,73 @@ describe('i18n integration', () => {
     // Wait for and check the error message
     const alertElement = await screen.findByRole('alert');
     expect(alertElement).toHaveTextContent('Invalid username or password.');
+  });
+});
+
+describe('language switching', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('re-renders translated text when the active language changes', async () => {
+    renderWithI18n(<LoginPage />);
+    expect(await screen.findByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+
+    await i18n.changeLanguage('es');
+
+    expect(await screen.findByRole('button', { name: 'Iniciar sesión' })).toBeInTheDocument();
+    expect(await screen.findByLabelText('Usuario')).toBeInTheDocument();
+  });
+
+  it('persists the selected language to localStorage', async () => {
+    await i18n.changeLanguage('fr');
+    expect(localStorage.getItem('i18nextLng')).toBe('fr');
+  });
+});
+
+describe('key resolution fallback', () => {
+  afterEach(async () => {
+    // Restore the real Spanish bundle trimmed by the test below.
+    i18n.removeResourceBundle('es', 'translation');
+    i18n.addResourceBundle('es', 'translation', translationEs);
+    await i18n.changeLanguage('en');
+  });
+
+  it('falls back to English when a key is missing from the active language', async () => {
+    await i18n.changeLanguage('es');
+    expect(i18n.t('auth.sign_in')).toBe('Iniciar sesión');
+
+    // Simulate a translation gap: remove a key that exists in English but not (yet) in Spanish.
+    i18n.removeResourceBundle('es', 'translation');
+    i18n.addResourceBundle('es', 'translation', { auth: { sign_in: 'Iniciar sesión' } });
+
+    expect(i18n.t('auth.sign_in')).toBe('Iniciar sesión');
+    // 'auth.username' is missing from the trimmed Spanish bundle, so it falls back to English.
+    expect(i18n.t('auth.username')).toBe('Username');
+  });
+});
+
+describe('RTL direction', () => {
+  beforeEach(() => {
+    // main.tsx wires this up once at startup; replicate that here since tests
+    // don't go through main.tsx.
+    initLanguageDirection(i18n);
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('applies dir="rtl" for right-to-left languages and dir="ltr" otherwise', async () => {
+    await i18n.changeLanguage('ar');
+    expect(document.documentElement.dir).toBe('rtl');
+    expect(document.documentElement.lang).toBe('ar');
+
+    await i18n.changeLanguage('en');
+    expect(document.documentElement.dir).toBe('ltr');
+    expect(document.documentElement.lang).toBe('en');
+
+    await i18n.changeLanguage('he');
+    expect(document.documentElement.dir).toBe('rtl');
   });
 });

--- a/frontend/src/__tests__/locales.test.ts
+++ b/frontend/src/__tests__/locales.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { supportedLanguages, isRtlLanguage } from '@/lib/languages';
+
+const translationModules = import.meta.glob('../locales/*/translation.json', { eager: true });
+
+function keySet(obj: Record<string, unknown>, prefix = ''): Set<string> {
+  const keys = new Set<string>();
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      for (const nested of keySet(v as Record<string, unknown>, path)) keys.add(nested);
+    } else {
+      keys.add(path);
+    }
+  }
+  return keys;
+}
+
+describe('locale files', () => {
+  it('ship a translation.json for every supported language', () => {
+    for (const lang of supportedLanguages) {
+      expect(translationModules[`../locales/${lang.code}/translation.json`]).toBeDefined();
+    }
+  });
+
+  it('keep the same set of keys across every language, matching English', () => {
+    const enModule = translationModules['../locales/en/translation.json'] as {
+      default: Record<string, unknown>;
+    };
+    const englishKeys = keySet(enModule.default);
+
+    for (const lang of supportedLanguages) {
+      const mod = translationModules[`../locales/${lang.code}/translation.json`] as {
+        default: Record<string, unknown>;
+      };
+      const keys = keySet(mod.default);
+      expect(new Set(keys)).toEqual(englishKeys);
+    }
+  });
+
+  it('flags only Arabic and Hebrew as right-to-left', () => {
+    const rtl = supportedLanguages.filter((l) => isRtlLanguage(l.code)).map((l) => l.code);
+    expect(rtl.sort()).toEqual(['ar', 'he']);
+  });
+});

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -8,6 +8,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@/lib/i18n';
 import { AppShell } from '../components/AppShell';
 import { CommandPalette } from '../components/CommandPalette';
 import { ShortcutOverlay } from '../components/ShortcutOverlay';

--- a/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
+++ b/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
@@ -55,6 +55,7 @@ vi.mock('recharts', () => {
   };
 });
 
+import '@/lib/i18n';
 import { StatsPage } from '../pages/StatsPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { FeedsRunsPage } from '../pages/FeedsRunsPage';

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate, Outlet, Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { LogOut, MoreHorizontal, Search, WifiOff } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
@@ -20,7 +21,7 @@ import { fetchSummary, fetchSharesUnreadCount, fetchAnalyticsSettings } from '@/
 import { startAnalytics, stopAnalytics, trackRoute, setAnalyticsAllowed } from '@/lib/analytics';
 import { useAuth } from '@/contexts/auth';
 import {
-  getPageTitle,
+  getPageTitleKey,
   getShortcutTarget,
   isNavigationItemActive,
   mobilePrimaryOverflowItems,
@@ -66,6 +67,7 @@ function useOnlineStatus() {
 }
 
 function DesktopRail({ pathname }: { pathname: string }) {
+  const { t } = useTranslation();
   const counts = useNavCounts();
   const { user } = useAuth();
   const handleLogout = useLogout();
@@ -85,7 +87,7 @@ function DesktopRail({ pathname }: { pathname: string }) {
           <NavLink
             key={n.to}
             to={n.to}
-            label={n.label}
+            label={t(n.labelKey)}
             icon={n.icon}
             isActive={isNavigationItemActive(n.to, pathname)}
             count={countFor(n)}
@@ -99,7 +101,7 @@ function DesktopRail({ pathname }: { pathname: string }) {
           <NavLink
             key={m.to}
             to={m.to}
-            label={m.label}
+            label={t(m.labelKey)}
             icon={m.icon}
             isActive={isNavigationItemActive(m.to, pathname)}
             variant="rail"
@@ -115,7 +117,7 @@ function DesktopRail({ pathname }: { pathname: string }) {
           className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-surface hover:text-foreground"
         >
           <LogOut className="size-4" />
-          Log out
+          {t('shell.log_out')}
         </button>
       </div>
     </aside>
@@ -123,6 +125,7 @@ function DesktopRail({ pathname }: { pathname: string }) {
 }
 
 export function AppShell() {
+  const { t } = useTranslation();
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -207,7 +210,7 @@ export function AppShell() {
     );
   }
 
-  const title = getPageTitle(pathname);
+  const title = t(getPageTitleKey(pathname));
 
   return (
     <div className="app-shell min-h-screen flex flex-col bg-background text-foreground">
@@ -222,7 +225,7 @@ export function AppShell() {
             {!online && (
               <div className="inline-flex items-center gap-1 rounded-md border border-border bg-surface px-2 py-1 text-xs font-medium text-muted-foreground">
                 <WifiOff className="size-3.5" />
-                Offline
+                {t('shell.offline')}
               </div>
             )}
             <button
@@ -230,21 +233,21 @@ export function AppShell() {
               className="hidden md:inline-flex items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:border-border-strong transition-colors"
             >
               <Search className="size-3.5" />
-              <span>Command</span>
+              <span>{t('shell.command')}</span>
               <kbd className="font-mono text-[10px] text-subtle">⌘K</kbd>
             </button>
             <Sheet open={moreOpen} onOpenChange={setMoreOpen}>
               <SheetTrigger asChild>
                 <button
                   className="inline-flex size-9 items-center justify-center rounded-md hover:bg-surface-2 text-muted-foreground hover:text-foreground transition-colors"
-                  aria-label="More"
+                  aria-label={t('shell.more')}
                 >
                   <MoreHorizontal className="size-5" />
                 </button>
               </SheetTrigger>
               <SheetContent side="right" className="w-[280px] p-0">
                 <SheetHeader className="px-5 pt-5 pb-3">
-                  <SheetTitle className="text-sm">Menu</SheetTitle>
+                  <SheetTitle className="text-sm">{t('shell.menu')}</SheetTitle>
                   {user && (
                     <p className="text-xs text-muted-foreground truncate">{user.username}</p>
                   )}
@@ -254,7 +257,7 @@ export function AppShell() {
                     <NavLink
                       key={m.to}
                       to={m.to}
-                      label={m.label}
+                      label={t(m.labelKey)}
                       icon={m.icon}
                       isActive={isNavigationItemActive(m.to, pathname)}
                       variant="sheet"
@@ -268,7 +271,7 @@ export function AppShell() {
                     <NavLink
                       key={m.to}
                       to={m.to}
-                      label={m.label}
+                      label={t(m.labelKey)}
                       icon={m.icon}
                       isActive={isNavigationItemActive(m.to, pathname)}
                       variant="sheet"
@@ -280,7 +283,7 @@ export function AppShell() {
                     className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-sm text-muted-foreground hover:bg-surface hover:text-foreground"
                   >
                     <LogOut className="size-4" />
-                    Log out
+                    {t('shell.log_out')}
                   </button>
                 </nav>
               </SheetContent>
@@ -317,7 +320,7 @@ export function AppShell() {
                 )}
               >
                 <Icon className={cn('size-5', active && 'stroke-[2.25]')} />
-                {n.label}
+                {t(n.labelKey)}
               </Link>
             );
           })}

--- a/frontend/src/components/settings/LanguageSection.tsx
+++ b/frontend/src/components/settings/LanguageSection.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+import { supportedLanguages } from '@/lib/languages';
+
+export function LanguageSection() {
+  const { t, i18n } = useTranslation();
+
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-wider text-subtle font-medium mb-2">
+        {t('settings.language.heading')}
+      </div>
+      <p className="text-xs text-muted-foreground mb-2">{t('settings.language.description')}</p>
+      <select
+        value={i18n.resolvedLanguage ?? i18n.language}
+        onChange={(e) => void i18n.changeLanguage(e.target.value)}
+        aria-label={t('settings.language.heading')}
+        className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm"
+      >
+        {supportedLanguages.map((lang) => (
+          <option key={lang.code} value={lang.code}>
+            {lang.nativeName}
+          </option>
+        ))}
+      </select>
+    </section>
+  );
+}

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -3,15 +3,71 @@ import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
 import translationEn from '@/locales/en/translation.json';
+import translationEs from '@/locales/es/translation.json';
+import translationFr from '@/locales/fr/translation.json';
+import translationDe from '@/locales/de/translation.json';
+import translationPt from '@/locales/pt/translation.json';
+import translationIt from '@/locales/it/translation.json';
+import translationNl from '@/locales/nl/translation.json';
+import translationPl from '@/locales/pl/translation.json';
+import translationRu from '@/locales/ru/translation.json';
+import translationZhCN from '@/locales/zh-CN/translation.json';
+import translationZhTW from '@/locales/zh-TW/translation.json';
+import translationJa from '@/locales/ja/translation.json';
+import translationKo from '@/locales/ko/translation.json';
+import translationAr from '@/locales/ar/translation.json';
+import translationHi from '@/locales/hi/translation.json';
+import translationTr from '@/locales/tr/translation.json';
+import translationVi from '@/locales/vi/translation.json';
+import translationTh from '@/locales/th/translation.json';
+import translationId from '@/locales/id/translation.json';
+import translationSv from '@/locales/sv/translation.json';
+import translationNo from '@/locales/no/translation.json';
+import translationDa from '@/locales/da/translation.json';
+import translationFi from '@/locales/fi/translation.json';
+import translationRo from '@/locales/ro/translation.json';
+import translationUk from '@/locales/uk/translation.json';
+import translationCs from '@/locales/cs/translation.json';
+import translationHu from '@/locales/hu/translation.json';
+import translationEl from '@/locales/el/translation.json';
+import translationHe from '@/locales/he/translation.json';
+
+import { supportedLanguages } from '@/lib/languages';
 
 // Default namespace
 const DEFAULT_NS = 'translation';
 
 // Language resources
 const resources = {
-  en: {
-    translation: translationEn,
-  },
+  en: { translation: translationEn },
+  es: { translation: translationEs },
+  fr: { translation: translationFr },
+  de: { translation: translationDe },
+  pt: { translation: translationPt },
+  it: { translation: translationIt },
+  nl: { translation: translationNl },
+  pl: { translation: translationPl },
+  ru: { translation: translationRu },
+  'zh-CN': { translation: translationZhCN },
+  'zh-TW': { translation: translationZhTW },
+  ja: { translation: translationJa },
+  ko: { translation: translationKo },
+  ar: { translation: translationAr },
+  hi: { translation: translationHi },
+  tr: { translation: translationTr },
+  vi: { translation: translationVi },
+  th: { translation: translationTh },
+  id: { translation: translationId },
+  sv: { translation: translationSv },
+  no: { translation: translationNo },
+  da: { translation: translationDa },
+  fi: { translation: translationFi },
+  ro: { translation: translationRo },
+  uk: { translation: translationUk },
+  cs: { translation: translationCs },
+  hu: { translation: translationHu },
+  el: { translation: translationEl },
+  he: { translation: translationHe },
 };
 
 void i18n
@@ -23,6 +79,7 @@ void i18n
   .init({
     resources,
     fallbackLng: 'en',
+    supportedLngs: supportedLanguages.map((l) => l.code),
     defaultNS: DEFAULT_NS,
     ns: [DEFAULT_NS],
     interpolation: {

--- a/frontend/src/lib/languages.ts
+++ b/frontend/src/lib/languages.ts
@@ -1,0 +1,62 @@
+import type { i18n as I18nInstance } from 'i18next';
+
+export interface SupportedLanguage {
+  code: string;
+  /** The language's own name for itself, as shown in the language picker. */
+  nativeName: string;
+  rtl?: boolean;
+}
+
+export const supportedLanguages: SupportedLanguage[] = [
+  { code: 'en', nativeName: 'English' },
+  { code: 'es', nativeName: 'Español' },
+  { code: 'fr', nativeName: 'Français' },
+  { code: 'de', nativeName: 'Deutsch' },
+  { code: 'pt', nativeName: 'Português' },
+  { code: 'it', nativeName: 'Italiano' },
+  { code: 'nl', nativeName: 'Nederlands' },
+  { code: 'pl', nativeName: 'Polski' },
+  { code: 'ru', nativeName: 'Русский' },
+  { code: 'zh-CN', nativeName: '简体中文' },
+  { code: 'zh-TW', nativeName: '繁體中文' },
+  { code: 'ja', nativeName: '日本語' },
+  { code: 'ko', nativeName: '한국어' },
+  { code: 'ar', nativeName: 'العربية', rtl: true },
+  { code: 'hi', nativeName: 'हिन्दी' },
+  { code: 'tr', nativeName: 'Türkçe' },
+  { code: 'vi', nativeName: 'Tiếng Việt' },
+  { code: 'th', nativeName: 'ไทย' },
+  { code: 'id', nativeName: 'Bahasa Indonesia' },
+  { code: 'sv', nativeName: 'Svenska' },
+  { code: 'no', nativeName: 'Norsk' },
+  { code: 'da', nativeName: 'Dansk' },
+  { code: 'fi', nativeName: 'Suomi' },
+  { code: 'ro', nativeName: 'Română' },
+  { code: 'uk', nativeName: 'Українська' },
+  { code: 'cs', nativeName: 'Čeština' },
+  { code: 'hu', nativeName: 'Magyar' },
+  { code: 'el', nativeName: 'Ελληνικά' },
+  { code: 'he', nativeName: 'עברית', rtl: true },
+];
+
+const rtlLanguageCodes = new Set(supportedLanguages.filter((l) => l.rtl).map((l) => l.code));
+
+export function isRtlLanguage(code: string): boolean {
+  return rtlLanguageCodes.has(code);
+}
+
+/** Sets `dir`/`lang` on the document root to match the active language. */
+export function applyDocumentDirection(code: string): void {
+  document.documentElement.dir = isRtlLanguage(code) ? 'rtl' : 'ltr';
+  document.documentElement.lang = code;
+}
+
+/**
+ * Run once before React renders (mirrors `initTheme`): applies the resolved
+ * language's direction immediately, then keeps it in sync as the user switches
+ * languages.
+ */
+export function initLanguageDirection(i18n: I18nInstance): void {
+  applyDocumentDirection(i18n.resolvedLanguage ?? i18n.language);
+  i18n.on('languageChanged', (lng) => applyDocumentDirection(lng));
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -25,6 +25,8 @@ import {
 export interface NavigationItem {
   to: string;
   label: string;
+  /** i18next key for the translated label, used by shell surfaces (rail, mobile nav, sheet menu). */
+  labelKey: string;
   icon: LucideIcon;
   commandLabel?: string;
   shortcut?: string;
@@ -32,33 +34,57 @@ export interface NavigationItem {
 }
 
 export const primaryNavigationItems: NavigationItem[] = [
-  { to: '/', label: 'Brief', icon: Newspaper, shortcut: 'b' },
-  { to: '/today', label: 'Today', icon: Inbox, shortcut: 't' },
-  { to: '/later', label: 'Later', icon: Clock, shortcut: 'l' },
-  { to: '/starred', label: 'Starred', icon: Star, shortcut: 's' },
-  { to: '/shared', label: 'Shared', icon: Send },
-  { to: '/search', label: 'Search', icon: Search },
-  { to: '/ask', label: 'Ask', commandLabel: 'Ask AI', icon: Sparkles, shortcut: 'a' },
+  { to: '/', label: 'Brief', labelKey: 'nav.brief', icon: Newspaper, shortcut: 'b' },
+  { to: '/today', label: 'Today', labelKey: 'nav.today', icon: Inbox, shortcut: 't' },
+  { to: '/later', label: 'Later', labelKey: 'nav.later', icon: Clock, shortcut: 'l' },
+  { to: '/starred', label: 'Starred', labelKey: 'nav.starred', icon: Star, shortcut: 's' },
+  { to: '/shared', label: 'Shared', labelKey: 'nav.shared', icon: Send },
+  { to: '/search', label: 'Search', labelKey: 'nav.search', icon: Search },
+  {
+    to: '/ask',
+    label: 'Ask',
+    labelKey: 'nav.ask',
+    commandLabel: 'Ask AI',
+    icon: Sparkles,
+    shortcut: 'a',
+  },
 ];
 
 export const secondaryNavigationItems: NavigationItem[] = [
-  { to: '/reading-list', label: 'Reading List', icon: Bookmark, shortcut: 'r' },
-  { to: '/briefs', label: 'Briefing History', icon: History, shortcut: 'h' },
-  { to: '/topic-map', label: 'Topic Map', icon: Network },
-  { to: '/ai-stats', label: 'AI Stats', icon: BrainCircuit },
-  { to: '/feeds', label: 'Feeds', icon: Radio, shortcut: 'f' },
-  { to: '/reading-dna', label: 'Reading DNA', icon: SlidersHorizontal },
-  { to: '/recap', label: 'Weekly Recap', icon: Flame },
-  { to: '/archive', label: 'Archive', icon: Archive },
-  { to: '/collections', label: 'Collections', icon: Tag },
-  { to: '/settings', label: 'Settings', icon: Settings },
+  {
+    to: '/reading-list',
+    label: 'Reading List',
+    labelKey: 'nav.reading_list',
+    icon: Bookmark,
+    shortcut: 'r',
+  },
+  {
+    to: '/briefs',
+    label: 'Briefing History',
+    labelKey: 'nav.briefing_history',
+    icon: History,
+    shortcut: 'h',
+  },
+  { to: '/topic-map', label: 'Topic Map', labelKey: 'nav.topic_map', icon: Network },
+  { to: '/ai-stats', label: 'AI Stats', labelKey: 'nav.ai_stats', icon: BrainCircuit },
+  { to: '/feeds', label: 'Feeds', labelKey: 'nav.feeds', icon: Radio, shortcut: 'f' },
+  {
+    to: '/reading-dna',
+    label: 'Reading DNA',
+    labelKey: 'nav.reading_dna',
+    icon: SlidersHorizontal,
+  },
+  { to: '/recap', label: 'Weekly Recap', labelKey: 'nav.weekly_recap', icon: Flame },
+  { to: '/archive', label: 'Archive', labelKey: 'nav.archive', icon: Archive },
+  { to: '/collections', label: 'Collections', labelKey: 'nav.collections', icon: Tag },
+  { to: '/settings', label: 'Settings', labelKey: 'nav.settings', icon: Settings },
 ];
 
 // Shown in the secondary nav only for admin users.
 export const adminNavigationItems: NavigationItem[] = [
-  { to: '/stats', label: 'Stats', icon: BarChart3 },
-  { to: '/analytics', label: 'Analytics', icon: Activity },
-  { to: '/admin', label: 'Users', icon: Users },
+  { to: '/stats', label: 'Stats', labelKey: 'nav.stats', icon: BarChart3 },
+  { to: '/analytics', label: 'Analytics', labelKey: 'nav.analytics', icon: Activity },
+  { to: '/admin', label: 'Users', labelKey: 'nav.users', icon: Users },
 ];
 
 export function secondaryNavigationItemsFor(isAdmin: boolean): NavigationItem[] {
@@ -130,26 +156,45 @@ export function isNavigationItemActive(to: string, pathname: string): boolean {
   return pathname.startsWith(to);
 }
 
+// Single source of truth for page titles: each rule pairs a route match with
+// its English label and i18next key, so the two can never drift out of sync.
+const pageTitleRules: { test: (pathname: string) => boolean; en: string; key: string }[] = [
+  { test: (p) => p === '/', en: 'Brief', key: 'page_title.brief' },
+  { test: (p) => p === '/today', en: 'Today', key: 'page_title.today' },
+  { test: (p) => p.startsWith('/later'), en: 'Later', key: 'page_title.later' },
+  { test: (p) => p.startsWith('/starred'), en: 'Starred', key: 'page_title.starred' },
+  { test: (p) => p.startsWith('/shared'), en: 'Shared', key: 'page_title.shared' },
+  { test: (p) => p.startsWith('/search'), en: 'Search', key: 'page_title.search' },
+  { test: (p) => p.startsWith('/ask'), en: 'Ask AI', key: 'page_title.ask' },
+  { test: (p) => p.startsWith('/topic-map'), en: 'Topic Map', key: 'page_title.topic_map' },
+  { test: (p) => p.startsWith('/ai-stats'), en: 'AI Stats', key: 'page_title.ai_stats' },
+  { test: (p) => p.startsWith('/briefs'), en: 'Briefs', key: 'page_title.briefs' },
+  { test: (p) => p.startsWith('/feeds'), en: 'Feeds', key: 'page_title.feeds' },
+  { test: (p) => p.startsWith('/stats'), en: 'Stats', key: 'page_title.stats' },
+  { test: (p) => p.startsWith('/reading-dna'), en: 'Reading DNA', key: 'page_title.reading_dna' },
+  {
+    test: (p) => p.startsWith('/reading-list'),
+    en: 'Reading List',
+    key: 'page_title.reading_list',
+  },
+  { test: (p) => p.startsWith('/recap'), en: 'Weekly Recap', key: 'page_title.weekly_recap' },
+  { test: (p) => p.startsWith('/archive'), en: 'Archive', key: 'page_title.archive' },
+  { test: (p) => p.startsWith('/collections'), en: 'Collections', key: 'page_title.collections' },
+  { test: (p) => p.startsWith('/settings'), en: 'Settings', key: 'page_title.settings' },
+  { test: (p) => p.startsWith('/analytics'), en: 'Analytics', key: 'page_title.analytics' },
+  { test: (p) => p.startsWith('/admin'), en: 'Users', key: 'page_title.users' },
+];
+const defaultPageTitle = { en: 'Radar', key: 'page_title.default' };
+
+function resolvePageTitle(pathname: string): { en: string; key: string } {
+  return pageTitleRules.find((rule) => rule.test(pathname)) ?? defaultPageTitle;
+}
+
 export function getPageTitle(pathname: string): string {
-  if (pathname === '/') return 'Brief';
-  if (pathname === '/today') return 'Today';
-  if (pathname.startsWith('/later')) return 'Later';
-  if (pathname.startsWith('/starred')) return 'Starred';
-  if (pathname.startsWith('/shared')) return 'Shared';
-  if (pathname.startsWith('/search')) return 'Search';
-  if (pathname.startsWith('/ask')) return 'Ask AI';
-  if (pathname.startsWith('/topic-map')) return 'Topic Map';
-  if (pathname.startsWith('/ai-stats')) return 'AI Stats';
-  if (pathname.startsWith('/briefs')) return 'Briefs';
-  if (pathname.startsWith('/feeds')) return 'Feeds';
-  if (pathname.startsWith('/stats')) return 'Stats';
-  if (pathname.startsWith('/reading-dna')) return 'Reading DNA';
-  if (pathname.startsWith('/reading-list')) return 'Reading List';
-  if (pathname.startsWith('/recap')) return 'Weekly Recap';
-  if (pathname.startsWith('/archive')) return 'Archive';
-  if (pathname.startsWith('/collections')) return 'Collections';
-  if (pathname.startsWith('/settings')) return 'Settings';
-  if (pathname.startsWith('/analytics')) return 'Analytics';
-  if (pathname.startsWith('/admin')) return 'Users';
-  return 'Radar';
+  return resolvePageTitle(pathname).en;
+}
+
+/** i18next key for the page title, for shell surfaces that render translated text. */
+export function getPageTitleKey(pathname: string): string {
+  return resolvePageTitle(pathname).key;
 }

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "لوحة الأخبار",
+    "tagline": "منصتك الإخبارية الخاصة"
+  },
+  "auth": {
+    "sign_in": "تسجيل الدخول",
+    "username": "اسم المستخدم",
+    "password": "كلمة المرور",
+    "email_address": "البريد الإلكتروني",
+    "use_email_code": "استخدام رمز عبر البريد الإلكتروني بدلاً من ذلك",
+    "back_to_password": "العودة إلى كلمة المرور",
+    "6_digit_code": "رمز مكوّن من 6 أرقام",
+    "resend_code": "إعادة إرسال الرمز",
+    "a_6_digit_code_was_sent_to": "تم إرسال رمز مكوّن من 6 أرقام إلى",
+    "invalid_username_or_password": "اسم المستخدم أو كلمة المرور غير صحيحة.",
+    "failed_to_send_code": "فشل إرسال الرمز. حاول مرة أخرى.",
+    "invalid_or_expired_code": "الرمز غير صالح أو منتهي الصلاحية. حاول مرة أخرى.",
+    "sending": "جارٍ الإرسال…",
+    "send_code": "إرسال الرمز",
+    "verifying": "جارٍ التحقق…",
+    "verify_code": "التحقق من الرمز",
+    "signing_in": "جارٍ تسجيل الدخول…",
+    "sign_in_with_keycloak": "تسجيل الدخول عبر Keycloak",
+    "create_account": "إنشاء حساب"
+  },
+  "nav": {
+    "brief": "الموجز",
+    "today": "اليوم",
+    "later": "لاحقًا",
+    "starred": "المميزة بنجمة",
+    "shared": "المشاركة",
+    "search": "بحث",
+    "ask": "اسأل",
+    "reading_list": "قائمة القراءة",
+    "briefing_history": "سجل الموجزات",
+    "topic_map": "خريطة الموضوعات",
+    "ai_stats": "إحصاءات الذكاء الاصطناعي",
+    "feeds": "المصادر",
+    "reading_dna": "حمض القراءة النووي",
+    "weekly_recap": "ملخص الأسبوع",
+    "archive": "الأرشيف",
+    "collections": "المجموعات",
+    "settings": "الإعدادات",
+    "stats": "الإحصاءات",
+    "analytics": "التحليلات",
+    "users": "المستخدمون"
+  },
+  "page_title": {
+    "brief": "الموجز",
+    "today": "اليوم",
+    "later": "لاحقًا",
+    "starred": "المميزة بنجمة",
+    "shared": "المشاركة",
+    "search": "بحث",
+    "ask": "اسأل الذكاء الاصطناعي",
+    "topic_map": "خريطة الموضوعات",
+    "ai_stats": "إحصاءات الذكاء الاصطناعي",
+    "briefs": "الموجزات",
+    "feeds": "المصادر",
+    "stats": "الإحصاءات",
+    "reading_dna": "حمض القراءة النووي",
+    "reading_list": "قائمة القراءة",
+    "weekly_recap": "ملخص الأسبوع",
+    "archive": "الأرشيف",
+    "collections": "المجموعات",
+    "settings": "الإعدادات",
+    "analytics": "التحليلات",
+    "users": "المستخدمون",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "غير متصل",
+    "command": "أمر",
+    "menu": "القائمة",
+    "more": "المزيد",
+    "log_out": "تسجيل الخروج"
+  },
+  "settings": {
+    "title": "الإعدادات",
+    "about_heading": "حول",
+    "about_body": "Radar أداة خاصة لفرز الأخبار التقنية. تُخزَّن الحالة على الخادم.",
+    "shortcuts_hint_prefix": "اضغط",
+    "shortcuts_hint_suffix": "في أي مكان لعرض اختصارات لوحة المفاتيح.",
+    "language": {
+      "heading": "اللغة",
+      "description": "اختر لغة واجهة التطبيق."
+    }
+  }
+}

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Přehled zpráv",
+    "tagline": "Vaše soukromá zpravodajská platforma"
+  },
+  "auth": {
+    "sign_in": "Přihlásit se",
+    "username": "Uživatelské jméno",
+    "password": "Heslo",
+    "email_address": "E-mailová adresa",
+    "use_email_code": "Použít místo toho kód e-mailem",
+    "back_to_password": "Zpět na přihlášení heslem",
+    "6_digit_code": "6místný kód",
+    "resend_code": "Odeslat kód znovu",
+    "a_6_digit_code_was_sent_to": "6místný kód byl odeslán na",
+    "invalid_username_or_password": "Neplatné uživatelské jméno nebo heslo.",
+    "failed_to_send_code": "Odeslání kódu se nezdařilo. Zkuste to znovu.",
+    "invalid_or_expired_code": "Neplatný nebo vypršelý kód. Zkuste to znovu.",
+    "sending": "Odesílání…",
+    "send_code": "Odeslat kód",
+    "verifying": "Ověřování…",
+    "verify_code": "Ověřit kód",
+    "signing_in": "Přihlašování…",
+    "sign_in_with_keycloak": "Přihlásit se přes Keycloak",
+    "create_account": "Vytvořit účet"
+  },
+  "nav": {
+    "brief": "Přehled",
+    "today": "Dnes",
+    "later": "Později",
+    "starred": "Oblíbené",
+    "shared": "Sdílené",
+    "search": "Hledat",
+    "ask": "Zeptat se",
+    "reading_list": "Seznam ke čtení",
+    "briefing_history": "Historie přehledů",
+    "topic_map": "Mapa témat",
+    "ai_stats": "Statistiky AI",
+    "feeds": "Zdroje",
+    "reading_dna": "Čtenářské DNA",
+    "weekly_recap": "Týdenní shrnutí",
+    "archive": "Archiv",
+    "collections": "Kolekce",
+    "settings": "Nastavení",
+    "stats": "Statistiky",
+    "analytics": "Analýza",
+    "users": "Uživatelé"
+  },
+  "page_title": {
+    "brief": "Přehled",
+    "today": "Dnes",
+    "later": "Později",
+    "starred": "Oblíbené",
+    "shared": "Sdílené",
+    "search": "Hledat",
+    "ask": "Zeptat se AI",
+    "topic_map": "Mapa témat",
+    "ai_stats": "Statistiky AI",
+    "briefs": "Přehledy",
+    "feeds": "Zdroje",
+    "stats": "Statistiky",
+    "reading_dna": "Čtenářské DNA",
+    "reading_list": "Seznam ke čtení",
+    "weekly_recap": "Týdenní shrnutí",
+    "archive": "Archiv",
+    "collections": "Kolekce",
+    "settings": "Nastavení",
+    "analytics": "Analýza",
+    "users": "Uživatelé",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Příkaz",
+    "menu": "Nabídka",
+    "more": "Více",
+    "log_out": "Odhlásit se"
+  },
+  "settings": {
+    "title": "Nastavení",
+    "about_heading": "O aplikaci",
+    "about_body": "Radar je soukromý nástroj pro třídění technických zpráv. Stav se ukládá na serveru.",
+    "shortcuts_hint_prefix": "Stiskněte",
+    "shortcuts_hint_suffix": "kdekoli pro zobrazení klávesových zkratek.",
+    "language": {
+      "heading": "Jazyk",
+      "description": "Vyberte jazyk rozhraní aplikace."
+    }
+  }
+}

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Nyhedspanel",
+    "tagline": "Din private nyhedsplatform"
+  },
+  "auth": {
+    "sign_in": "Log ind",
+    "username": "Brugernavn",
+    "password": "Adgangskode",
+    "email_address": "E-mailadresse",
+    "use_email_code": "Brug e-mailkode i stedet",
+    "back_to_password": "Tilbage til adgangskode",
+    "6_digit_code": "6-cifret kode",
+    "resend_code": "Send koden igen",
+    "a_6_digit_code_was_sent_to": "En 6-cifret kode er sendt til",
+    "invalid_username_or_password": "Ugyldigt brugernavn eller adgangskode.",
+    "failed_to_send_code": "Kunne ikke sende koden. Prøv igen.",
+    "invalid_or_expired_code": "Ugyldig eller udløbet kode. Prøv igen.",
+    "sending": "Sender…",
+    "send_code": "Send kode",
+    "verifying": "Bekræfter…",
+    "verify_code": "Bekræft kode",
+    "signing_in": "Logger ind…",
+    "sign_in_with_keycloak": "Log ind med Keycloak",
+    "create_account": "Opret konto"
+  },
+  "nav": {
+    "brief": "Overblik",
+    "today": "I dag",
+    "later": "Senere",
+    "starred": "Stjernemarkeret",
+    "shared": "Delt",
+    "search": "Søg",
+    "ask": "Spørg",
+    "reading_list": "Læseliste",
+    "briefing_history": "Overblikshistorik",
+    "topic_map": "Emnekort",
+    "ai_stats": "AI-statistik",
+    "feeds": "Feeds",
+    "reading_dna": "Læse-DNA",
+    "weekly_recap": "Ugentligt resumé",
+    "archive": "Arkiv",
+    "collections": "Samlinger",
+    "settings": "Indstillinger",
+    "stats": "Statistik",
+    "analytics": "Analyse",
+    "users": "Brugere"
+  },
+  "page_title": {
+    "brief": "Overblik",
+    "today": "I dag",
+    "later": "Senere",
+    "starred": "Stjernemarkeret",
+    "shared": "Delt",
+    "search": "Søg",
+    "ask": "Spørg AI",
+    "topic_map": "Emnekort",
+    "ai_stats": "AI-statistik",
+    "briefs": "Overblik",
+    "feeds": "Feeds",
+    "stats": "Statistik",
+    "reading_dna": "Læse-DNA",
+    "reading_list": "Læseliste",
+    "weekly_recap": "Ugentligt resumé",
+    "archive": "Arkiv",
+    "collections": "Samlinger",
+    "settings": "Indstillinger",
+    "analytics": "Analyse",
+    "users": "Brugere",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Kommando",
+    "menu": "Menu",
+    "more": "Mere",
+    "log_out": "Log ud"
+  },
+  "settings": {
+    "title": "Indstillinger",
+    "about_heading": "Om",
+    "about_body": "Radar er et privat værktøj til at sortere teknisk nyhedsstof. Status gemmes på serveren.",
+    "shortcuts_hint_prefix": "Tryk på",
+    "shortcuts_hint_suffix": "hvor som helst for tastaturgenveje.",
+    "language": {
+      "heading": "Sprog",
+      "description": "Vælg sproget for appens grænseflade."
+    }
+  }
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Nachrichten-Dashboard",
+    "tagline": "Ihre private Nachrichtenplattform"
+  },
+  "auth": {
+    "sign_in": "Anmelden",
+    "username": "Benutzername",
+    "password": "Passwort",
+    "email_address": "E-Mail-Adresse",
+    "use_email_code": "Stattdessen E-Mail-Code verwenden",
+    "back_to_password": "Zurück zum Passwort",
+    "6_digit_code": "6-stelliger Code",
+    "resend_code": "Code erneut senden",
+    "a_6_digit_code_was_sent_to": "Ein 6-stelliger Code wurde gesendet an",
+    "invalid_username_or_password": "Ungültiger Benutzername oder ungültiges Passwort.",
+    "failed_to_send_code": "Code konnte nicht gesendet werden. Bitte erneut versuchen.",
+    "invalid_or_expired_code": "Ungültiger oder abgelaufener Code. Bitte erneut versuchen.",
+    "sending": "Wird gesendet…",
+    "send_code": "Code senden",
+    "verifying": "Wird überprüft…",
+    "verify_code": "Code bestätigen",
+    "signing_in": "Anmeldung läuft…",
+    "sign_in_with_keycloak": "Mit Keycloak anmelden",
+    "create_account": "Konto erstellen"
+  },
+  "nav": {
+    "brief": "Übersicht",
+    "today": "Heute",
+    "later": "Später",
+    "starred": "Markiert",
+    "shared": "Geteilt",
+    "search": "Suche",
+    "ask": "Fragen",
+    "reading_list": "Leseliste",
+    "briefing_history": "Verlauf der Übersichten",
+    "topic_map": "Themenkarte",
+    "ai_stats": "KI-Statistiken",
+    "feeds": "Feeds",
+    "reading_dna": "Lese-DNA",
+    "weekly_recap": "Wochenrückblick",
+    "archive": "Archiv",
+    "collections": "Sammlungen",
+    "settings": "Einstellungen",
+    "stats": "Statistiken",
+    "analytics": "Analytik",
+    "users": "Benutzer"
+  },
+  "page_title": {
+    "brief": "Übersicht",
+    "today": "Heute",
+    "later": "Später",
+    "starred": "Markiert",
+    "shared": "Geteilt",
+    "search": "Suche",
+    "ask": "KI fragen",
+    "topic_map": "Themenkarte",
+    "ai_stats": "KI-Statistiken",
+    "briefs": "Übersichten",
+    "feeds": "Feeds",
+    "stats": "Statistiken",
+    "reading_dna": "Lese-DNA",
+    "reading_list": "Leseliste",
+    "weekly_recap": "Wochenrückblick",
+    "archive": "Archiv",
+    "collections": "Sammlungen",
+    "settings": "Einstellungen",
+    "analytics": "Analytik",
+    "users": "Benutzer",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Befehl",
+    "menu": "Menü",
+    "more": "Mehr",
+    "log_out": "Abmelden"
+  },
+  "settings": {
+    "title": "Einstellungen",
+    "about_heading": "Über",
+    "about_body": "Radar ist ein privates Werkzeug zur Sichtung technischer Nachrichten. Der Status wird auf dem Server gespeichert.",
+    "shortcuts_hint_prefix": "Drücke",
+    "shortcuts_hint_suffix": "überall für Tastenkürzel.",
+    "language": {
+      "heading": "Sprache",
+      "description": "Wähle die Sprache der App-Oberfläche."
+    }
+  }
+}

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Πίνακας Ειδήσεων",
+    "tagline": "Η προσωπική σας πλατφόρμα ειδήσεων"
+  },
+  "auth": {
+    "sign_in": "Σύνδεση",
+    "username": "Όνομα χρήστη",
+    "password": "Κωδικός πρόσβασης",
+    "email_address": "Διεύθυνση email",
+    "use_email_code": "Χρήση κωδικού μέσω email",
+    "back_to_password": "Επιστροφή στον κωδικό πρόσβασης",
+    "6_digit_code": "6ψήφιος κωδικός",
+    "resend_code": "Επαναποστολή κωδικού",
+    "a_6_digit_code_was_sent_to": "Ένας 6ψήφιος κωδικός στάλθηκε στο",
+    "invalid_username_or_password": "Μη έγκυρο όνομα χρήστη ή κωδικός πρόσβασης.",
+    "failed_to_send_code": "Αποτυχία αποστολής κωδικού. Δοκιμάστε ξανά.",
+    "invalid_or_expired_code": "Μη έγκυρος ή ληγμένος κωδικός. Δοκιμάστε ξανά.",
+    "sending": "Αποστολή…",
+    "send_code": "Αποστολή κωδικού",
+    "verifying": "Επαλήθευση…",
+    "verify_code": "Επαλήθευση κωδικού",
+    "signing_in": "Σύνδεση σε εξέλιξη…",
+    "sign_in_with_keycloak": "Σύνδεση με Keycloak",
+    "create_account": "Δημιουργία λογαριασμού"
+  },
+  "nav": {
+    "brief": "Σύνοψη",
+    "today": "Σήμερα",
+    "later": "Αργότερα",
+    "starred": "Με αστέρι",
+    "shared": "Κοινοποιημένα",
+    "search": "Αναζήτηση",
+    "ask": "Ρώτησε",
+    "reading_list": "Λίστα ανάγνωσης",
+    "briefing_history": "Ιστορικό συνόψεων",
+    "topic_map": "Χάρτης θεμάτων",
+    "ai_stats": "Στατιστικά AI",
+    "feeds": "Ροές",
+    "reading_dna": "DNA ανάγνωσης",
+    "weekly_recap": "Εβδομαδιαία ανασκόπηση",
+    "archive": "Αρχείο",
+    "collections": "Συλλογές",
+    "settings": "Ρυθμίσεις",
+    "stats": "Στατιστικά",
+    "analytics": "Αναλυτικά",
+    "users": "Χρήστες"
+  },
+  "page_title": {
+    "brief": "Σύνοψη",
+    "today": "Σήμερα",
+    "later": "Αργότερα",
+    "starred": "Με αστέρι",
+    "shared": "Κοινοποιημένα",
+    "search": "Αναζήτηση",
+    "ask": "Ρώτησε το AI",
+    "topic_map": "Χάρτης θεμάτων",
+    "ai_stats": "Στατιστικά AI",
+    "briefs": "Συνόψεις",
+    "feeds": "Ροές",
+    "stats": "Στατιστικά",
+    "reading_dna": "DNA ανάγνωσης",
+    "reading_list": "Λίστα ανάγνωσης",
+    "weekly_recap": "Εβδομαδιαία ανασκόπηση",
+    "archive": "Αρχείο",
+    "collections": "Συλλογές",
+    "settings": "Ρυθμίσεις",
+    "analytics": "Αναλυτικά",
+    "users": "Χρήστες",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Εκτός σύνδεσης",
+    "command": "Εντολή",
+    "menu": "Μενού",
+    "more": "Περισσότερα",
+    "log_out": "Αποσύνδεση"
+  },
+  "settings": {
+    "title": "Ρυθμίσεις",
+    "about_heading": "Σχετικά",
+    "about_body": "Το Radar είναι ένα προσωπικό εργαλείο ταξινόμησης τεχνικών ειδήσεων. Η κατάσταση αποθηκεύεται στον διακομιστή.",
+    "shortcuts_hint_prefix": "Πατήστε",
+    "shortcuts_hint_suffix": "οπουδήποτε για συντομεύσεις πληκτρολογίου.",
+    "language": {
+      "heading": "Γλώσσα",
+      "description": "Επιλέξτε τη γλώσσα διεπαφής της εφαρμογής."
+    }
+  }
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -23,5 +23,68 @@
     "signing_in": "Signing in…",
     "sign_in_with_keycloak": "Sign in with Keycloak",
     "create_account": "Create Account"
+  },
+  "nav": {
+    "brief": "Brief",
+    "today": "Today",
+    "later": "Later",
+    "starred": "Starred",
+    "shared": "Shared",
+    "search": "Search",
+    "ask": "Ask",
+    "reading_list": "Reading List",
+    "briefing_history": "Briefing History",
+    "topic_map": "Topic Map",
+    "ai_stats": "AI Stats",
+    "feeds": "Feeds",
+    "reading_dna": "Reading DNA",
+    "weekly_recap": "Weekly Recap",
+    "archive": "Archive",
+    "collections": "Collections",
+    "settings": "Settings",
+    "stats": "Stats",
+    "analytics": "Analytics",
+    "users": "Users"
+  },
+  "page_title": {
+    "brief": "Brief",
+    "today": "Today",
+    "later": "Later",
+    "starred": "Starred",
+    "shared": "Shared",
+    "search": "Search",
+    "ask": "Ask AI",
+    "topic_map": "Topic Map",
+    "ai_stats": "AI Stats",
+    "briefs": "Briefs",
+    "feeds": "Feeds",
+    "stats": "Stats",
+    "reading_dna": "Reading DNA",
+    "reading_list": "Reading List",
+    "weekly_recap": "Weekly Recap",
+    "archive": "Archive",
+    "collections": "Collections",
+    "settings": "Settings",
+    "analytics": "Analytics",
+    "users": "Users",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Command",
+    "menu": "Menu",
+    "more": "More",
+    "log_out": "Log out"
+  },
+  "settings": {
+    "title": "Settings",
+    "about_heading": "About",
+    "about_body": "Radar is a private technical news triage tool. State is stored on the server.",
+    "shortcuts_hint_prefix": "Press",
+    "shortcuts_hint_suffix": "anywhere for keyboard shortcuts.",
+    "language": {
+      "heading": "Language",
+      "description": "Choose the language for the app interface."
+    }
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Panel de Noticias",
+    "tagline": "Tu plataforma privada de noticias"
+  },
+  "auth": {
+    "sign_in": "Iniciar sesión",
+    "username": "Usuario",
+    "password": "Contraseña",
+    "email_address": "Correo electrónico",
+    "use_email_code": "Usar código por correo",
+    "back_to_password": "Volver a la contraseña",
+    "6_digit_code": "Código de 6 dígitos",
+    "resend_code": "Reenviar código",
+    "a_6_digit_code_was_sent_to": "Se envió un código de 6 dígitos a",
+    "invalid_username_or_password": "Usuario o contraseña incorrectos.",
+    "failed_to_send_code": "No se pudo enviar el código. Inténtalo de nuevo.",
+    "invalid_or_expired_code": "Código inválido o expirado. Inténtalo de nuevo.",
+    "sending": "Enviando…",
+    "send_code": "Enviar código",
+    "verifying": "Verificando…",
+    "verify_code": "Verificar código",
+    "signing_in": "Iniciando sesión…",
+    "sign_in_with_keycloak": "Iniciar sesión con Keycloak",
+    "create_account": "Crear cuenta"
+  },
+  "nav": {
+    "brief": "Resumen",
+    "today": "Hoy",
+    "later": "Más tarde",
+    "starred": "Destacados",
+    "shared": "Compartidos",
+    "search": "Buscar",
+    "ask": "Preguntar",
+    "reading_list": "Lista de lectura",
+    "briefing_history": "Historial de resúmenes",
+    "topic_map": "Mapa de temas",
+    "ai_stats": "Estadísticas de IA",
+    "feeds": "Fuentes",
+    "reading_dna": "ADN de lectura",
+    "weekly_recap": "Resumen semanal",
+    "archive": "Archivo",
+    "collections": "Colecciones",
+    "settings": "Configuración",
+    "stats": "Estadísticas",
+    "analytics": "Analítica",
+    "users": "Usuarios"
+  },
+  "page_title": {
+    "brief": "Resumen",
+    "today": "Hoy",
+    "later": "Más tarde",
+    "starred": "Destacados",
+    "shared": "Compartidos",
+    "search": "Buscar",
+    "ask": "Preguntar a la IA",
+    "topic_map": "Mapa de temas",
+    "ai_stats": "Estadísticas de IA",
+    "briefs": "Resúmenes",
+    "feeds": "Fuentes",
+    "stats": "Estadísticas",
+    "reading_dna": "ADN de lectura",
+    "reading_list": "Lista de lectura",
+    "weekly_recap": "Resumen semanal",
+    "archive": "Archivo",
+    "collections": "Colecciones",
+    "settings": "Configuración",
+    "analytics": "Analítica",
+    "users": "Usuarios",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Sin conexión",
+    "command": "Comando",
+    "menu": "Menú",
+    "more": "Más",
+    "log_out": "Cerrar sesión"
+  },
+  "settings": {
+    "title": "Configuración",
+    "about_heading": "Acerca de",
+    "about_body": "Radar es una herramienta privada de clasificación de noticias técnicas. El estado se guarda en el servidor.",
+    "shortcuts_hint_prefix": "Presiona",
+    "shortcuts_hint_suffix": "en cualquier lugar para ver los atajos de teclado.",
+    "language": {
+      "heading": "Idioma",
+      "description": "Elige el idioma de la interfaz de la aplicación."
+    }
+  }
+}

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Uutiskojelauta",
+    "tagline": "Yksityinen uutisalustasi"
+  },
+  "auth": {
+    "sign_in": "Kirjaudu sisään",
+    "username": "Käyttäjänimi",
+    "password": "Salasana",
+    "email_address": "Sähköpostiosoite",
+    "use_email_code": "Käytä sen sijaan sähköpostikoodia",
+    "back_to_password": "Takaisin salasanaan",
+    "6_digit_code": "6-numeroinen koodi",
+    "resend_code": "Lähetä koodi uudelleen",
+    "a_6_digit_code_was_sent_to": "6-numeroinen koodi on lähetetty osoitteeseen",
+    "invalid_username_or_password": "Virheellinen käyttäjänimi tai salasana.",
+    "failed_to_send_code": "Koodin lähetys epäonnistui. Yritä uudelleen.",
+    "invalid_or_expired_code": "Virheellinen tai vanhentunut koodi. Yritä uudelleen.",
+    "sending": "Lähetetään…",
+    "send_code": "Lähetä koodi",
+    "verifying": "Vahvistetaan…",
+    "verify_code": "Vahvista koodi",
+    "signing_in": "Kirjaudutaan sisään…",
+    "sign_in_with_keycloak": "Kirjaudu Keycloakilla",
+    "create_account": "Luo tili"
+  },
+  "nav": {
+    "brief": "Yhteenveto",
+    "today": "Tänään",
+    "later": "Myöhemmin",
+    "starred": "Tähdellä merkityt",
+    "shared": "Jaetut",
+    "search": "Haku",
+    "ask": "Kysy",
+    "reading_list": "Lukulista",
+    "briefing_history": "Yhteenvetohistoria",
+    "topic_map": "Aihekartta",
+    "ai_stats": "Tekoälytilastot",
+    "feeds": "Syötteet",
+    "reading_dna": "Lukemis-DNA",
+    "weekly_recap": "Viikkokooste",
+    "archive": "Arkisto",
+    "collections": "Kokoelmat",
+    "settings": "Asetukset",
+    "stats": "Tilastot",
+    "analytics": "Analytiikka",
+    "users": "Käyttäjät"
+  },
+  "page_title": {
+    "brief": "Yhteenveto",
+    "today": "Tänään",
+    "later": "Myöhemmin",
+    "starred": "Tähdellä merkityt",
+    "shared": "Jaetut",
+    "search": "Haku",
+    "ask": "Kysy tekoälyltä",
+    "topic_map": "Aihekartta",
+    "ai_stats": "Tekoälytilastot",
+    "briefs": "Yhteenvedot",
+    "feeds": "Syötteet",
+    "stats": "Tilastot",
+    "reading_dna": "Lukemis-DNA",
+    "reading_list": "Lukulista",
+    "weekly_recap": "Viikkokooste",
+    "archive": "Arkisto",
+    "collections": "Kokoelmat",
+    "settings": "Asetukset",
+    "analytics": "Analytiikka",
+    "users": "Käyttäjät",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Komento",
+    "menu": "Valikko",
+    "more": "Lisää",
+    "log_out": "Kirjaudu ulos"
+  },
+  "settings": {
+    "title": "Asetukset",
+    "about_heading": "Tietoja",
+    "about_body": "Radar on yksityinen työkalu teknisten uutisten lajitteluun. Tila tallennetaan palvelimelle.",
+    "shortcuts_hint_prefix": "Paina",
+    "shortcuts_hint_suffix": "missä tahansa nähdäksesi pikanäppäimet.",
+    "language": {
+      "heading": "Kieli",
+      "description": "Valitse sovelluksen käyttöliittymän kieli."
+    }
+  }
+}

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Tableau de bord d'actualités",
+    "tagline": "Votre plateforme d'actualités privée"
+  },
+  "auth": {
+    "sign_in": "Se connecter",
+    "username": "Nom d'utilisateur",
+    "password": "Mot de passe",
+    "email_address": "Adresse e-mail",
+    "use_email_code": "Utiliser un code par e-mail",
+    "back_to_password": "Revenir au mot de passe",
+    "6_digit_code": "Code à 6 chiffres",
+    "resend_code": "Renvoyer le code",
+    "a_6_digit_code_was_sent_to": "Un code à 6 chiffres a été envoyé à",
+    "invalid_username_or_password": "Nom d'utilisateur ou mot de passe invalide.",
+    "failed_to_send_code": "Échec de l'envoi du code. Réessayez.",
+    "invalid_or_expired_code": "Code invalide ou expiré. Réessayez.",
+    "sending": "Envoi…",
+    "send_code": "Envoyer le code",
+    "verifying": "Vérification…",
+    "verify_code": "Vérifier le code",
+    "signing_in": "Connexion…",
+    "sign_in_with_keycloak": "Se connecter avec Keycloak",
+    "create_account": "Créer un compte"
+  },
+  "nav": {
+    "brief": "Résumé",
+    "today": "Aujourd'hui",
+    "later": "Plus tard",
+    "starred": "Favoris",
+    "shared": "Partagés",
+    "search": "Rechercher",
+    "ask": "Demander",
+    "reading_list": "Liste de lecture",
+    "briefing_history": "Historique des résumés",
+    "topic_map": "Carte des sujets",
+    "ai_stats": "Statistiques IA",
+    "feeds": "Flux",
+    "reading_dna": "ADN de lecture",
+    "weekly_recap": "Récap hebdomadaire",
+    "archive": "Archives",
+    "collections": "Collections",
+    "settings": "Paramètres",
+    "stats": "Statistiques",
+    "analytics": "Analytique",
+    "users": "Utilisateurs"
+  },
+  "page_title": {
+    "brief": "Résumé",
+    "today": "Aujourd'hui",
+    "later": "Plus tard",
+    "starred": "Favoris",
+    "shared": "Partagés",
+    "search": "Rechercher",
+    "ask": "Demander à l'IA",
+    "topic_map": "Carte des sujets",
+    "ai_stats": "Statistiques IA",
+    "briefs": "Résumés",
+    "feeds": "Flux",
+    "stats": "Statistiques",
+    "reading_dna": "ADN de lecture",
+    "reading_list": "Liste de lecture",
+    "weekly_recap": "Récap hebdomadaire",
+    "archive": "Archives",
+    "collections": "Collections",
+    "settings": "Paramètres",
+    "analytics": "Analytique",
+    "users": "Utilisateurs",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Hors ligne",
+    "command": "Commande",
+    "menu": "Menu",
+    "more": "Plus",
+    "log_out": "Se déconnecter"
+  },
+  "settings": {
+    "title": "Paramètres",
+    "about_heading": "À propos",
+    "about_body": "Radar est un outil privé de tri d'actualités techniques. L'état est stocké sur le serveur.",
+    "shortcuts_hint_prefix": "Appuyez sur",
+    "shortcuts_hint_suffix": "n'importe où pour les raccourcis clavier.",
+    "language": {
+      "heading": "Langue",
+      "description": "Choisissez la langue de l'interface de l'application."
+    }
+  }
+}

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "לוח בקרת חדשות",
+    "tagline": "פלטפורמת החדשות הפרטית שלך"
+  },
+  "auth": {
+    "sign_in": "התחברות",
+    "username": "שם משתמש",
+    "password": "סיסמה",
+    "email_address": "כתובת אימייל",
+    "use_email_code": "השתמש בקוד באימייל במקום",
+    "back_to_password": "חזרה להתחברות עם סיסמה",
+    "6_digit_code": "קוד בן 6 ספרות",
+    "resend_code": "שלח קוד מחדש",
+    "a_6_digit_code_was_sent_to": "קוד בן 6 ספרות נשלח אל",
+    "invalid_username_or_password": "שם משתמש או סיסמה שגויים.",
+    "failed_to_send_code": "שליחת הקוד נכשלה. נסה שוב.",
+    "invalid_or_expired_code": "קוד לא תקין או פג תוקף. נסה שוב.",
+    "sending": "שולח…",
+    "send_code": "שלח קוד",
+    "verifying": "מאמת…",
+    "verify_code": "אימות קוד",
+    "signing_in": "מתחבר…",
+    "sign_in_with_keycloak": "התחבר עם Keycloak",
+    "create_account": "יצירת חשבון"
+  },
+  "nav": {
+    "brief": "תקציר",
+    "today": "היום",
+    "later": "מאוחר יותר",
+    "starred": "מסומן בכוכב",
+    "shared": "משותף",
+    "search": "חיפוש",
+    "ask": "שאל",
+    "reading_list": "רשימת קריאה",
+    "briefing_history": "היסטוריית תקצירים",
+    "topic_map": "מפת נושאים",
+    "ai_stats": "נתוני בינה מלאכותית",
+    "feeds": "פידים",
+    "reading_dna": "DNA קריאה",
+    "weekly_recap": "סיכום שבועי",
+    "archive": "ארכיון",
+    "collections": "אוספים",
+    "settings": "הגדרות",
+    "stats": "נתונים",
+    "analytics": "אנליטיקס",
+    "users": "משתמשים"
+  },
+  "page_title": {
+    "brief": "תקציר",
+    "today": "היום",
+    "later": "מאוחר יותר",
+    "starred": "מסומן בכוכב",
+    "shared": "משותף",
+    "search": "חיפוש",
+    "ask": "שאל את הבינה המלאכותית",
+    "topic_map": "מפת נושאים",
+    "ai_stats": "נתוני בינה מלאכותית",
+    "briefs": "תקצירים",
+    "feeds": "פידים",
+    "stats": "נתונים",
+    "reading_dna": "DNA קריאה",
+    "reading_list": "רשימת קריאה",
+    "weekly_recap": "סיכום שבועי",
+    "archive": "ארכיון",
+    "collections": "אוספים",
+    "settings": "הגדרות",
+    "analytics": "אנליטיקס",
+    "users": "משתמשים",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "לא מקוון",
+    "command": "פקודה",
+    "menu": "תפריט",
+    "more": "עוד",
+    "log_out": "התנתקות"
+  },
+  "settings": {
+    "title": "הגדרות",
+    "about_heading": "אודות",
+    "about_body": "Radar הוא כלי פרטי למיון חדשות טכנולוגיות. המצב נשמר בשרת.",
+    "shortcuts_hint_prefix": "לחץ",
+    "shortcuts_hint_suffix": "בכל מקום כדי להציג את קיצורי המקלדת.",
+    "language": {
+      "heading": "שפה",
+      "description": "בחר את שפת ממשק האפליקציה."
+    }
+  }
+}

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "न्यूज़ डैशबोर्ड",
+    "tagline": "आपका निजी समाचार प्लेटफ़ॉर्म"
+  },
+  "auth": {
+    "sign_in": "साइन इन करें",
+    "username": "उपयोगकर्ता नाम",
+    "password": "पासवर्ड",
+    "email_address": "ईमेल पता",
+    "use_email_code": "इसके बजाय ईमेल कोड का उपयोग करें",
+    "back_to_password": "पासवर्ड साइन-इन पर वापस जाएं",
+    "6_digit_code": "6-अंकीय कोड",
+    "resend_code": "कोड फिर से भेजें",
+    "a_6_digit_code_was_sent_to": "6-अंकीय कोड इस पते पर भेजा गया:",
+    "invalid_username_or_password": "अमान्य उपयोगकर्ता नाम या पासवर्ड।",
+    "failed_to_send_code": "कोड भेजने में विफल। कृपया फिर से प्रयास करें।",
+    "invalid_or_expired_code": "अमान्य या समाप्त हो चुका कोड। कृपया फिर से प्रयास करें।",
+    "sending": "भेजा जा रहा है…",
+    "send_code": "कोड भेजें",
+    "verifying": "सत्यापित किया जा रहा है…",
+    "verify_code": "कोड सत्यापित करें",
+    "signing_in": "साइन इन हो रहा है…",
+    "sign_in_with_keycloak": "Keycloak से साइन इन करें",
+    "create_account": "खाता बनाएं"
+  },
+  "nav": {
+    "brief": "ब्रीफ़",
+    "today": "आज",
+    "later": "बाद में",
+    "starred": "स्टार किए गए",
+    "shared": "साझा किए गए",
+    "search": "खोजें",
+    "ask": "पूछें",
+    "reading_list": "पठन सूची",
+    "briefing_history": "ब्रीफ़ इतिहास",
+    "topic_map": "विषय मानचित्र",
+    "ai_stats": "AI आँकड़े",
+    "feeds": "फ़ीड",
+    "reading_dna": "रीडिंग DNA",
+    "weekly_recap": "साप्ताहिक सारांश",
+    "archive": "संग्रह",
+    "collections": "संग्रहण",
+    "settings": "सेटिंग्स",
+    "stats": "आँकड़े",
+    "analytics": "विश्लेषिकी",
+    "users": "उपयोगकर्ता"
+  },
+  "page_title": {
+    "brief": "ब्रीफ़",
+    "today": "आज",
+    "later": "बाद में",
+    "starred": "स्टार किए गए",
+    "shared": "साझा किए गए",
+    "search": "खोजें",
+    "ask": "AI से पूछें",
+    "topic_map": "विषय मानचित्र",
+    "ai_stats": "AI आँकड़े",
+    "briefs": "ब्रीफ़",
+    "feeds": "फ़ीड",
+    "stats": "आँकड़े",
+    "reading_dna": "रीडिंग DNA",
+    "reading_list": "पठन सूची",
+    "weekly_recap": "साप्ताहिक सारांश",
+    "archive": "संग्रह",
+    "collections": "संग्रहण",
+    "settings": "सेटिंग्स",
+    "analytics": "विश्लेषिकी",
+    "users": "उपयोगकर्ता",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "ऑफ़लाइन",
+    "command": "कमांड",
+    "menu": "मेनू",
+    "more": "अधिक",
+    "log_out": "लॉग आउट करें"
+  },
+  "settings": {
+    "title": "सेटिंग्स",
+    "about_heading": "परिचय",
+    "about_body": "Radar तकनीकी समाचारों को छाँटने का एक निजी उपकरण है। स्थिति सर्वर पर संग्रहीत होती है।",
+    "shortcuts_hint_prefix": "कीबोर्ड शॉर्टकट देखने के लिए कहीं भी",
+    "shortcuts_hint_suffix": "दबाएँ।",
+    "language": {
+      "heading": "भाषा",
+      "description": "ऐप इंटरफ़ेस की भाषा चुनें।"
+    }
+  }
+}

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Hírműszerfal",
+    "tagline": "Az Ön saját hírplatformja"
+  },
+  "auth": {
+    "sign_in": "Bejelentkezés",
+    "username": "Felhasználónév",
+    "password": "Jelszó",
+    "email_address": "E-mail cím",
+    "use_email_code": "Inkább e-mailes kód használata",
+    "back_to_password": "Vissza a jelszavas bejelentkezéshez",
+    "6_digit_code": "6 jegyű kód",
+    "resend_code": "Kód újraküldése",
+    "a_6_digit_code_was_sent_to": "6 jegyű kódot küldtünk erre a címre:",
+    "invalid_username_or_password": "Érvénytelen felhasználónév vagy jelszó.",
+    "failed_to_send_code": "A kód küldése sikertelen. Próbálja újra.",
+    "invalid_or_expired_code": "Érvénytelen vagy lejárt kód. Próbálja újra.",
+    "sending": "Küldés…",
+    "send_code": "Kód küldése",
+    "verifying": "Ellenőrzés…",
+    "verify_code": "Kód ellenőrzése",
+    "signing_in": "Bejelentkezés…",
+    "sign_in_with_keycloak": "Bejelentkezés Keycloakkal",
+    "create_account": "Fiók létrehozása"
+  },
+  "nav": {
+    "brief": "Összefoglaló",
+    "today": "Ma",
+    "later": "Később",
+    "starred": "Csillagozott",
+    "shared": "Megosztott",
+    "search": "Keresés",
+    "ask": "Kérdezés",
+    "reading_list": "Olvasási lista",
+    "briefing_history": "Összefoglaló előzmények",
+    "topic_map": "Témakör-térkép",
+    "ai_stats": "AI statisztika",
+    "feeds": "Hírforrások",
+    "reading_dna": "Olvasási DNS",
+    "weekly_recap": "Heti összegzés",
+    "archive": "Archívum",
+    "collections": "Gyűjtemények",
+    "settings": "Beállítások",
+    "stats": "Statisztikák",
+    "analytics": "Analitika",
+    "users": "Felhasználók"
+  },
+  "page_title": {
+    "brief": "Összefoglaló",
+    "today": "Ma",
+    "later": "Később",
+    "starred": "Csillagozott",
+    "shared": "Megosztott",
+    "search": "Keresés",
+    "ask": "Kérdezd az AI-t",
+    "topic_map": "Témakör-térkép",
+    "ai_stats": "AI statisztika",
+    "briefs": "Összefoglalók",
+    "feeds": "Hírforrások",
+    "stats": "Statisztikák",
+    "reading_dna": "Olvasási DNS",
+    "reading_list": "Olvasási lista",
+    "weekly_recap": "Heti összegzés",
+    "archive": "Archívum",
+    "collections": "Gyűjtemények",
+    "settings": "Beállítások",
+    "analytics": "Analitika",
+    "users": "Felhasználók",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Parancs",
+    "menu": "Menü",
+    "more": "Több",
+    "log_out": "Kijelentkezés"
+  },
+  "settings": {
+    "title": "Beállítások",
+    "about_heading": "Névjegy",
+    "about_body": "A Radar egy privát eszköz a technikai hírek rendszerezésére. Az állapot a szerveren tárolódik.",
+    "shortcuts_hint_prefix": "Nyomd meg bárhol a",
+    "shortcuts_hint_suffix": "billentyűt a billentyűparancsok megjelenítéséhez.",
+    "language": {
+      "heading": "Nyelv",
+      "description": "Válaszd ki az alkalmazás felületének nyelvét."
+    }
+  }
+}

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Dasbor Berita",
+    "tagline": "Platform berita pribadi Anda"
+  },
+  "auth": {
+    "sign_in": "Masuk",
+    "username": "Nama pengguna",
+    "password": "Kata sandi",
+    "email_address": "Alamat email",
+    "use_email_code": "Gunakan kode email sebagai gantinya",
+    "back_to_password": "Kembali ke masuk dengan kata sandi",
+    "6_digit_code": "Kode 6 digit",
+    "resend_code": "Kirim ulang kode",
+    "a_6_digit_code_was_sent_to": "Kode 6 digit telah dikirim ke",
+    "invalid_username_or_password": "Nama pengguna atau kata sandi tidak valid.",
+    "failed_to_send_code": "Gagal mengirim kode. Silakan coba lagi.",
+    "invalid_or_expired_code": "Kode tidak valid atau kedaluwarsa. Silakan coba lagi.",
+    "sending": "Mengirim…",
+    "send_code": "Kirim kode",
+    "verifying": "Memverifikasi…",
+    "verify_code": "Verifikasi kode",
+    "signing_in": "Sedang masuk…",
+    "sign_in_with_keycloak": "Masuk dengan Keycloak",
+    "create_account": "Buat akun"
+  },
+  "nav": {
+    "brief": "Ringkasan",
+    "today": "Hari ini",
+    "later": "Nanti",
+    "starred": "Berbintang",
+    "shared": "Dibagikan",
+    "search": "Cari",
+    "ask": "Tanya",
+    "reading_list": "Daftar bacaan",
+    "briefing_history": "Riwayat ringkasan",
+    "topic_map": "Peta topik",
+    "ai_stats": "Statistik AI",
+    "feeds": "Umpan",
+    "reading_dna": "DNA bacaan",
+    "weekly_recap": "Rekap mingguan",
+    "archive": "Arsip",
+    "collections": "Koleksi",
+    "settings": "Pengaturan",
+    "stats": "Statistik",
+    "analytics": "Analitik",
+    "users": "Pengguna"
+  },
+  "page_title": {
+    "brief": "Ringkasan",
+    "today": "Hari ini",
+    "later": "Nanti",
+    "starred": "Berbintang",
+    "shared": "Dibagikan",
+    "search": "Cari",
+    "ask": "Tanya AI",
+    "topic_map": "Peta topik",
+    "ai_stats": "Statistik AI",
+    "briefs": "Ringkasan",
+    "feeds": "Umpan",
+    "stats": "Statistik",
+    "reading_dna": "DNA bacaan",
+    "reading_list": "Daftar bacaan",
+    "weekly_recap": "Rekap mingguan",
+    "archive": "Arsip",
+    "collections": "Koleksi",
+    "settings": "Pengaturan",
+    "analytics": "Analitik",
+    "users": "Pengguna",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Perintah",
+    "menu": "Menu",
+    "more": "Lainnya",
+    "log_out": "Keluar"
+  },
+  "settings": {
+    "title": "Pengaturan",
+    "about_heading": "Tentang",
+    "about_body": "Radar adalah alat pribadi untuk menyortir berita teknis. Status disimpan di server.",
+    "shortcuts_hint_prefix": "Tekan",
+    "shortcuts_hint_suffix": "di mana saja untuk pintasan keyboard.",
+    "language": {
+      "heading": "Bahasa",
+      "description": "Pilih bahasa antarmuka aplikasi."
+    }
+  }
+}

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Cruscotto Notizie",
+    "tagline": "La tua piattaforma di notizie privata"
+  },
+  "auth": {
+    "sign_in": "Accedi",
+    "username": "Nome utente",
+    "password": "Password",
+    "email_address": "Indirizzo e-mail",
+    "use_email_code": "Usa invece un codice via e-mail",
+    "back_to_password": "Torna alla password",
+    "6_digit_code": "Codice a 6 cifre",
+    "resend_code": "Invia di nuovo il codice",
+    "a_6_digit_code_was_sent_to": "Un codice a 6 cifre è stato inviato a",
+    "invalid_username_or_password": "Nome utente o password non validi.",
+    "failed_to_send_code": "Invio del codice non riuscito. Riprova.",
+    "invalid_or_expired_code": "Codice non valido o scaduto. Riprova.",
+    "sending": "Invio in corso…",
+    "send_code": "Invia codice",
+    "verifying": "Verifica in corso…",
+    "verify_code": "Verifica codice",
+    "signing_in": "Accesso in corso…",
+    "sign_in_with_keycloak": "Accedi con Keycloak",
+    "create_account": "Crea account"
+  },
+  "nav": {
+    "brief": "Riepilogo",
+    "today": "Oggi",
+    "later": "Più tardi",
+    "starred": "Preferiti",
+    "shared": "Condivisi",
+    "search": "Cerca",
+    "ask": "Chiedi",
+    "reading_list": "Lista di lettura",
+    "briefing_history": "Cronologia riepiloghi",
+    "topic_map": "Mappa argomenti",
+    "ai_stats": "Statistiche IA",
+    "feeds": "Feed",
+    "reading_dna": "DNA di lettura",
+    "weekly_recap": "Riepilogo settimanale",
+    "archive": "Archivio",
+    "collections": "Raccolte",
+    "settings": "Impostazioni",
+    "stats": "Statistiche",
+    "analytics": "Analisi",
+    "users": "Utenti"
+  },
+  "page_title": {
+    "brief": "Riepilogo",
+    "today": "Oggi",
+    "later": "Più tardi",
+    "starred": "Preferiti",
+    "shared": "Condivisi",
+    "search": "Cerca",
+    "ask": "Chiedi all'IA",
+    "topic_map": "Mappa argomenti",
+    "ai_stats": "Statistiche IA",
+    "briefs": "Riepiloghi",
+    "feeds": "Feed",
+    "stats": "Statistiche",
+    "reading_dna": "DNA di lettura",
+    "reading_list": "Lista di lettura",
+    "weekly_recap": "Riepilogo settimanale",
+    "archive": "Archivio",
+    "collections": "Raccolte",
+    "settings": "Impostazioni",
+    "analytics": "Analisi",
+    "users": "Utenti",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Comando",
+    "menu": "Menu",
+    "more": "Altro",
+    "log_out": "Esci"
+  },
+  "settings": {
+    "title": "Impostazioni",
+    "about_heading": "Informazioni",
+    "about_body": "Radar è uno strumento privato per la selezione di notizie tecniche. Lo stato è salvato sul server.",
+    "shortcuts_hint_prefix": "Premi",
+    "shortcuts_hint_suffix": "ovunque per le scorciatoie da tastiera.",
+    "language": {
+      "heading": "Lingua",
+      "description": "Scegli la lingua dell'interfaccia dell'app."
+    }
+  }
+}

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "ニュースダッシュボード",
+    "tagline": "あなた専用のニュースプラットフォーム"
+  },
+  "auth": {
+    "sign_in": "サインイン",
+    "username": "ユーザー名",
+    "password": "パスワード",
+    "email_address": "メールアドレス",
+    "use_email_code": "代わりにメールコードを使う",
+    "back_to_password": "パスワードでのサインインに戻る",
+    "6_digit_code": "6桁のコード",
+    "resend_code": "コードを再送信",
+    "a_6_digit_code_was_sent_to": "6桁のコードを次の宛先に送信しました：",
+    "invalid_username_or_password": "ユーザー名またはパスワードが正しくありません。",
+    "failed_to_send_code": "コードの送信に失敗しました。もう一度お試しください。",
+    "invalid_or_expired_code": "コードが無効か期限切れです。もう一度お試しください。",
+    "sending": "送信中…",
+    "send_code": "コードを送信",
+    "verifying": "確認中…",
+    "verify_code": "コードを確認",
+    "signing_in": "サインイン中…",
+    "sign_in_with_keycloak": "Keycloak でサインイン",
+    "create_account": "アカウントを作成"
+  },
+  "nav": {
+    "brief": "ブリーフ",
+    "today": "今日",
+    "later": "後で読む",
+    "starred": "スター付き",
+    "shared": "共有済み",
+    "search": "検索",
+    "ask": "質問",
+    "reading_list": "リーディングリスト",
+    "briefing_history": "ブリーフ履歴",
+    "topic_map": "トピックマップ",
+    "ai_stats": "AI統計",
+    "feeds": "フィード",
+    "reading_dna": "リーディングDNA",
+    "weekly_recap": "週間まとめ",
+    "archive": "アーカイブ",
+    "collections": "コレクション",
+    "settings": "設定",
+    "stats": "統計",
+    "analytics": "分析",
+    "users": "ユーザー"
+  },
+  "page_title": {
+    "brief": "ブリーフ",
+    "today": "今日",
+    "later": "後で読む",
+    "starred": "スター付き",
+    "shared": "共有済み",
+    "search": "検索",
+    "ask": "AIに質問",
+    "topic_map": "トピックマップ",
+    "ai_stats": "AI統計",
+    "briefs": "ブリーフ",
+    "feeds": "フィード",
+    "stats": "統計",
+    "reading_dna": "リーディングDNA",
+    "reading_list": "リーディングリスト",
+    "weekly_recap": "週間まとめ",
+    "archive": "アーカイブ",
+    "collections": "コレクション",
+    "settings": "設定",
+    "analytics": "分析",
+    "users": "ユーザー",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "オフライン",
+    "command": "コマンド",
+    "menu": "メニュー",
+    "more": "その他",
+    "log_out": "ログアウト"
+  },
+  "settings": {
+    "title": "設定",
+    "about_heading": "このアプリについて",
+    "about_body": "Radar は技術ニュースを整理するためのプライベートツールです。状態はサーバーに保存されます。",
+    "shortcuts_hint_prefix": "どこでも",
+    "shortcuts_hint_suffix": "を押すとキーボードショートカットが表示されます。",
+    "language": {
+      "heading": "言語",
+      "description": "アプリのインターフェース言語を選択してください。"
+    }
+  }
+}

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "뉴스 대시보드",
+    "tagline": "나만의 프라이빗 뉴스 플랫폼"
+  },
+  "auth": {
+    "sign_in": "로그인",
+    "username": "사용자 이름",
+    "password": "비밀번호",
+    "email_address": "이메일 주소",
+    "use_email_code": "대신 이메일 코드 사용",
+    "back_to_password": "비밀번호 로그인으로 돌아가기",
+    "6_digit_code": "6자리 코드",
+    "resend_code": "코드 재전송",
+    "a_6_digit_code_was_sent_to": "6자리 코드가 다음으로 전송되었습니다:",
+    "invalid_username_or_password": "사용자 이름 또는 비밀번호가 올바르지 않습니다.",
+    "failed_to_send_code": "코드 전송에 실패했습니다. 다시 시도해 주세요.",
+    "invalid_or_expired_code": "코드가 유효하지 않거나 만료되었습니다. 다시 시도해 주세요.",
+    "sending": "전송 중…",
+    "send_code": "코드 보내기",
+    "verifying": "확인 중…",
+    "verify_code": "코드 확인",
+    "signing_in": "로그인 중…",
+    "sign_in_with_keycloak": "Keycloak으로 로그인",
+    "create_account": "계정 만들기"
+  },
+  "nav": {
+    "brief": "브리핑",
+    "today": "오늘",
+    "later": "나중에",
+    "starred": "즐겨찾기",
+    "shared": "공유됨",
+    "search": "검색",
+    "ask": "질문하기",
+    "reading_list": "읽기 목록",
+    "briefing_history": "브리핑 기록",
+    "topic_map": "토픽 맵",
+    "ai_stats": "AI 통계",
+    "feeds": "피드",
+    "reading_dna": "독서 DNA",
+    "weekly_recap": "주간 요약",
+    "archive": "보관함",
+    "collections": "컬렉션",
+    "settings": "설정",
+    "stats": "통계",
+    "analytics": "분석",
+    "users": "사용자"
+  },
+  "page_title": {
+    "brief": "브리핑",
+    "today": "오늘",
+    "later": "나중에",
+    "starred": "즐겨찾기",
+    "shared": "공유됨",
+    "search": "검색",
+    "ask": "AI에게 질문",
+    "topic_map": "토픽 맵",
+    "ai_stats": "AI 통계",
+    "briefs": "브리핑",
+    "feeds": "피드",
+    "stats": "통계",
+    "reading_dna": "독서 DNA",
+    "reading_list": "읽기 목록",
+    "weekly_recap": "주간 요약",
+    "archive": "보관함",
+    "collections": "컬렉션",
+    "settings": "설정",
+    "analytics": "분석",
+    "users": "사용자",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "오프라인",
+    "command": "명령",
+    "menu": "메뉴",
+    "more": "더 보기",
+    "log_out": "로그아웃"
+  },
+  "settings": {
+    "title": "설정",
+    "about_heading": "정보",
+    "about_body": "Radar는 기술 뉴스를 분류하는 개인용 도구입니다. 상태는 서버에 저장됩니다.",
+    "shortcuts_hint_prefix": "어디서나",
+    "shortcuts_hint_suffix": "키를 누르면 키보드 단축키를 볼 수 있습니다.",
+    "language": {
+      "heading": "언어",
+      "description": "앱 인터페이스 언어를 선택하세요."
+    }
+  }
+}

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Nieuwsdashboard",
+    "tagline": "Jouw privé nieuwsplatform"
+  },
+  "auth": {
+    "sign_in": "Inloggen",
+    "username": "Gebruikersnaam",
+    "password": "Wachtwoord",
+    "email_address": "E-mailadres",
+    "use_email_code": "Gebruik in plaats daarvan een e-mailcode",
+    "back_to_password": "Terug naar wachtwoord",
+    "6_digit_code": "6-cijferige code",
+    "resend_code": "Code opnieuw versturen",
+    "a_6_digit_code_was_sent_to": "Een 6-cijferige code is verstuurd naar",
+    "invalid_username_or_password": "Ongeldige gebruikersnaam of wachtwoord.",
+    "failed_to_send_code": "Code verzenden mislukt. Probeer het opnieuw.",
+    "invalid_or_expired_code": "Ongeldige of verlopen code. Probeer het opnieuw.",
+    "sending": "Verzenden…",
+    "send_code": "Code versturen",
+    "verifying": "Verifiëren…",
+    "verify_code": "Code verifiëren",
+    "signing_in": "Inloggen…",
+    "sign_in_with_keycloak": "Inloggen met Keycloak",
+    "create_account": "Account aanmaken"
+  },
+  "nav": {
+    "brief": "Overzicht",
+    "today": "Vandaag",
+    "later": "Later",
+    "starred": "Favorieten",
+    "shared": "Gedeeld",
+    "search": "Zoeken",
+    "ask": "Vraag",
+    "reading_list": "Leeslijst",
+    "briefing_history": "Overzichtsgeschiedenis",
+    "topic_map": "Onderwerpenkaart",
+    "ai_stats": "AI-statistieken",
+    "feeds": "Feeds",
+    "reading_dna": "Lees-DNA",
+    "weekly_recap": "Wekelijkse samenvatting",
+    "archive": "Archief",
+    "collections": "Collecties",
+    "settings": "Instellingen",
+    "stats": "Statistieken",
+    "analytics": "Analyse",
+    "users": "Gebruikers"
+  },
+  "page_title": {
+    "brief": "Overzicht",
+    "today": "Vandaag",
+    "later": "Later",
+    "starred": "Favorieten",
+    "shared": "Gedeeld",
+    "search": "Zoeken",
+    "ask": "Vraag de AI",
+    "topic_map": "Onderwerpenkaart",
+    "ai_stats": "AI-statistieken",
+    "briefs": "Overzichten",
+    "feeds": "Feeds",
+    "stats": "Statistieken",
+    "reading_dna": "Lees-DNA",
+    "reading_list": "Leeslijst",
+    "weekly_recap": "Wekelijkse samenvatting",
+    "archive": "Archief",
+    "collections": "Collecties",
+    "settings": "Instellingen",
+    "analytics": "Analyse",
+    "users": "Gebruikers",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Commando",
+    "menu": "Menu",
+    "more": "Meer",
+    "log_out": "Uitloggen"
+  },
+  "settings": {
+    "title": "Instellingen",
+    "about_heading": "Over",
+    "about_body": "Radar is een privétool voor het sorteren van technisch nieuws. De status wordt op de server bewaard.",
+    "shortcuts_hint_prefix": "Druk op",
+    "shortcuts_hint_suffix": "overal voor sneltoetsen.",
+    "language": {
+      "heading": "Taal",
+      "description": "Kies de taal van de app-interface."
+    }
+  }
+}

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Nyhetspanel",
+    "tagline": "Din private nyhetsplattform"
+  },
+  "auth": {
+    "sign_in": "Logg inn",
+    "username": "Brukernavn",
+    "password": "Passord",
+    "email_address": "E-postadresse",
+    "use_email_code": "Bruk e-postkode i stedet",
+    "back_to_password": "Tilbake til passord",
+    "6_digit_code": "6-sifret kode",
+    "resend_code": "Send koden på nytt",
+    "a_6_digit_code_was_sent_to": "En 6-sifret kode er sendt til",
+    "invalid_username_or_password": "Ugyldig brukernavn eller passord.",
+    "failed_to_send_code": "Kunne ikke sende koden. Prøv igjen.",
+    "invalid_or_expired_code": "Ugyldig eller utløpt kode. Prøv igjen.",
+    "sending": "Sender…",
+    "send_code": "Send kode",
+    "verifying": "Verifiserer…",
+    "verify_code": "Bekreft kode",
+    "signing_in": "Logger inn…",
+    "sign_in_with_keycloak": "Logg inn med Keycloak",
+    "create_account": "Opprett konto"
+  },
+  "nav": {
+    "brief": "Oversikt",
+    "today": "I dag",
+    "later": "Senere",
+    "starred": "Stjernemerket",
+    "shared": "Delt",
+    "search": "Søk",
+    "ask": "Spør",
+    "reading_list": "Leseliste",
+    "briefing_history": "Oversikthistorikk",
+    "topic_map": "Emnekart",
+    "ai_stats": "AI-statistikk",
+    "feeds": "Kilder",
+    "reading_dna": "Lese-DNA",
+    "weekly_recap": "Ukesoppsummering",
+    "archive": "Arkiv",
+    "collections": "Samlinger",
+    "settings": "Innstillinger",
+    "stats": "Statistikk",
+    "analytics": "Analyse",
+    "users": "Brukere"
+  },
+  "page_title": {
+    "brief": "Oversikt",
+    "today": "I dag",
+    "later": "Senere",
+    "starred": "Stjernemerket",
+    "shared": "Delt",
+    "search": "Søk",
+    "ask": "Spør AI",
+    "topic_map": "Emnekart",
+    "ai_stats": "AI-statistikk",
+    "briefs": "Oversikter",
+    "feeds": "Kilder",
+    "stats": "Statistikk",
+    "reading_dna": "Lese-DNA",
+    "reading_list": "Leseliste",
+    "weekly_recap": "Ukesoppsummering",
+    "archive": "Arkiv",
+    "collections": "Samlinger",
+    "settings": "Innstillinger",
+    "analytics": "Analyse",
+    "users": "Brukere",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Frakoblet",
+    "command": "Kommando",
+    "menu": "Meny",
+    "more": "Mer",
+    "log_out": "Logg ut"
+  },
+  "settings": {
+    "title": "Innstillinger",
+    "about_heading": "Om",
+    "about_body": "Radar er et privat verktøy for å sortere tekniske nyheter. Status lagres på serveren.",
+    "shortcuts_hint_prefix": "Trykk",
+    "shortcuts_hint_suffix": "hvor som helst for tastatursnarveier.",
+    "language": {
+      "heading": "Språk",
+      "description": "Velg språk for appens grensesnitt."
+    }
+  }
+}

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Panel Wiadomości",
+    "tagline": "Twoja prywatna platforma informacyjna"
+  },
+  "auth": {
+    "sign_in": "Zaloguj się",
+    "username": "Nazwa użytkownika",
+    "password": "Hasło",
+    "email_address": "Adres e-mail",
+    "use_email_code": "Użyj kodu e-mail zamiast tego",
+    "back_to_password": "Wróć do hasła",
+    "6_digit_code": "6-cyfrowy kod",
+    "resend_code": "Wyślij kod ponownie",
+    "a_6_digit_code_was_sent_to": "6-cyfrowy kod został wysłany na",
+    "invalid_username_or_password": "Nieprawidłowa nazwa użytkownika lub hasło.",
+    "failed_to_send_code": "Nie udało się wysłać kodu. Spróbuj ponownie.",
+    "invalid_or_expired_code": "Nieprawidłowy lub wygasły kod. Spróbuj ponownie.",
+    "sending": "Wysyłanie…",
+    "send_code": "Wyślij kod",
+    "verifying": "Weryfikowanie…",
+    "verify_code": "Zweryfikuj kod",
+    "signing_in": "Logowanie…",
+    "sign_in_with_keycloak": "Zaloguj się przez Keycloak",
+    "create_account": "Utwórz konto"
+  },
+  "nav": {
+    "brief": "Podsumowanie",
+    "today": "Dziś",
+    "later": "Później",
+    "starred": "Oznaczone",
+    "shared": "Udostępnione",
+    "search": "Szukaj",
+    "ask": "Zapytaj",
+    "reading_list": "Lista do przeczytania",
+    "briefing_history": "Historia podsumowań",
+    "topic_map": "Mapa tematów",
+    "ai_stats": "Statystyki AI",
+    "feeds": "Kanały",
+    "reading_dna": "DNA czytania",
+    "weekly_recap": "Podsumowanie tygodnia",
+    "archive": "Archiwum",
+    "collections": "Kolekcje",
+    "settings": "Ustawienia",
+    "stats": "Statystyki",
+    "analytics": "Analityka",
+    "users": "Użytkownicy"
+  },
+  "page_title": {
+    "brief": "Podsumowanie",
+    "today": "Dziś",
+    "later": "Później",
+    "starred": "Oznaczone",
+    "shared": "Udostępnione",
+    "search": "Szukaj",
+    "ask": "Zapytaj AI",
+    "topic_map": "Mapa tematów",
+    "ai_stats": "Statystyki AI",
+    "briefs": "Podsumowania",
+    "feeds": "Kanały",
+    "stats": "Statystyki",
+    "reading_dna": "DNA czytania",
+    "reading_list": "Lista do przeczytania",
+    "weekly_recap": "Podsumowanie tygodnia",
+    "archive": "Archiwum",
+    "collections": "Kolekcje",
+    "settings": "Ustawienia",
+    "analytics": "Analityka",
+    "users": "Użytkownicy",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Polecenie",
+    "menu": "Menu",
+    "more": "Więcej",
+    "log_out": "Wyloguj się"
+  },
+  "settings": {
+    "title": "Ustawienia",
+    "about_heading": "O aplikacji",
+    "about_body": "Radar to prywatne narzędzie do segregowania wiadomości technicznych. Stan jest przechowywany na serwerze.",
+    "shortcuts_hint_prefix": "Naciśnij",
+    "shortcuts_hint_suffix": "w dowolnym miejscu, aby zobaczyć skróty klawiszowe.",
+    "language": {
+      "heading": "Język",
+      "description": "Wybierz język interfejsu aplikacji."
+    }
+  }
+}

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Painel de Notícias",
+    "tagline": "Sua plataforma privada de notícias"
+  },
+  "auth": {
+    "sign_in": "Entrar",
+    "username": "Usuário",
+    "password": "Senha",
+    "email_address": "Endereço de e-mail",
+    "use_email_code": "Usar código por e-mail",
+    "back_to_password": "Voltar para a senha",
+    "6_digit_code": "Código de 6 dígitos",
+    "resend_code": "Reenviar código",
+    "a_6_digit_code_was_sent_to": "Um código de 6 dígitos foi enviado para",
+    "invalid_username_or_password": "Usuário ou senha inválidos.",
+    "failed_to_send_code": "Falha ao enviar o código. Tente novamente.",
+    "invalid_or_expired_code": "Código inválido ou expirado. Tente novamente.",
+    "sending": "Enviando…",
+    "send_code": "Enviar código",
+    "verifying": "Verificando…",
+    "verify_code": "Verificar código",
+    "signing_in": "Entrando…",
+    "sign_in_with_keycloak": "Entrar com Keycloak",
+    "create_account": "Criar conta"
+  },
+  "nav": {
+    "brief": "Resumo",
+    "today": "Hoje",
+    "later": "Mais tarde",
+    "starred": "Favoritos",
+    "shared": "Compartilhados",
+    "search": "Buscar",
+    "ask": "Perguntar",
+    "reading_list": "Lista de leitura",
+    "briefing_history": "Histórico de resumos",
+    "topic_map": "Mapa de tópicos",
+    "ai_stats": "Estatísticas de IA",
+    "feeds": "Feeds",
+    "reading_dna": "DNA de leitura",
+    "weekly_recap": "Retrospectiva semanal",
+    "archive": "Arquivo",
+    "collections": "Coleções",
+    "settings": "Configurações",
+    "stats": "Estatísticas",
+    "analytics": "Análises",
+    "users": "Usuários"
+  },
+  "page_title": {
+    "brief": "Resumo",
+    "today": "Hoje",
+    "later": "Mais tarde",
+    "starred": "Favoritos",
+    "shared": "Compartilhados",
+    "search": "Buscar",
+    "ask": "Perguntar à IA",
+    "topic_map": "Mapa de tópicos",
+    "ai_stats": "Estatísticas de IA",
+    "briefs": "Resumos",
+    "feeds": "Feeds",
+    "stats": "Estatísticas",
+    "reading_dna": "DNA de leitura",
+    "reading_list": "Lista de leitura",
+    "weekly_recap": "Retrospectiva semanal",
+    "archive": "Arquivo",
+    "collections": "Coleções",
+    "settings": "Configurações",
+    "analytics": "Análises",
+    "users": "Usuários",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Comando",
+    "menu": "Menu",
+    "more": "Mais",
+    "log_out": "Sair"
+  },
+  "settings": {
+    "title": "Configurações",
+    "about_heading": "Sobre",
+    "about_body": "O Radar é uma ferramenta privada de triagem de notícias técnicas. O estado é armazenado no servidor.",
+    "shortcuts_hint_prefix": "Pressione",
+    "shortcuts_hint_suffix": "em qualquer lugar para ver os atalhos de teclado.",
+    "language": {
+      "heading": "Idioma",
+      "description": "Escolha o idioma da interface do aplicativo."
+    }
+  }
+}

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Panou de Știri",
+    "tagline": "Platforma ta privată de știri"
+  },
+  "auth": {
+    "sign_in": "Conectare",
+    "username": "Nume utilizator",
+    "password": "Parolă",
+    "email_address": "Adresă de e-mail",
+    "use_email_code": "Folosește în schimb un cod prin e-mail",
+    "back_to_password": "Înapoi la parolă",
+    "6_digit_code": "Cod din 6 cifre",
+    "resend_code": "Retrimite codul",
+    "a_6_digit_code_was_sent_to": "Un cod din 6 cifre a fost trimis la",
+    "invalid_username_or_password": "Nume de utilizator sau parolă incorecte.",
+    "failed_to_send_code": "Trimiterea codului a eșuat. Încearcă din nou.",
+    "invalid_or_expired_code": "Cod invalid sau expirat. Încearcă din nou.",
+    "sending": "Se trimite…",
+    "send_code": "Trimite codul",
+    "verifying": "Se verifică…",
+    "verify_code": "Verifică codul",
+    "signing_in": "Se conectează…",
+    "sign_in_with_keycloak": "Conectare cu Keycloak",
+    "create_account": "Creează cont"
+  },
+  "nav": {
+    "brief": "Rezumat",
+    "today": "Astăzi",
+    "later": "Mai târziu",
+    "starred": "Marcate",
+    "shared": "Partajate",
+    "search": "Căutare",
+    "ask": "Întreabă",
+    "reading_list": "Listă de lectură",
+    "briefing_history": "Istoric rezumate",
+    "topic_map": "Hartă de subiecte",
+    "ai_stats": "Statistici AI",
+    "feeds": "Fluxuri",
+    "reading_dna": "ADN de lectură",
+    "weekly_recap": "Recapitulare săptămânală",
+    "archive": "Arhivă",
+    "collections": "Colecții",
+    "settings": "Setări",
+    "stats": "Statistici",
+    "analytics": "Analitică",
+    "users": "Utilizatori"
+  },
+  "page_title": {
+    "brief": "Rezumat",
+    "today": "Astăzi",
+    "later": "Mai târziu",
+    "starred": "Marcate",
+    "shared": "Partajate",
+    "search": "Căutare",
+    "ask": "Întreabă AI",
+    "topic_map": "Hartă de subiecte",
+    "ai_stats": "Statistici AI",
+    "briefs": "Rezumate",
+    "feeds": "Fluxuri",
+    "stats": "Statistici",
+    "reading_dna": "ADN de lectură",
+    "reading_list": "Listă de lectură",
+    "weekly_recap": "Recapitulare săptămânală",
+    "archive": "Arhivă",
+    "collections": "Colecții",
+    "settings": "Setări",
+    "analytics": "Analitică",
+    "users": "Utilizatori",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Comandă",
+    "menu": "Meniu",
+    "more": "Mai multe",
+    "log_out": "Deconectare"
+  },
+  "settings": {
+    "title": "Setări",
+    "about_heading": "Despre",
+    "about_body": "Radar este un instrument privat pentru sortarea știrilor tehnice. Starea este stocată pe server.",
+    "shortcuts_hint_prefix": "Apasă",
+    "shortcuts_hint_suffix": "oriunde pentru comenzi rapide de la tastatură.",
+    "language": {
+      "heading": "Limbă",
+      "description": "Alege limba interfeței aplicației."
+    }
+  }
+}

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Панель новостей",
+    "tagline": "Ваша частная новостная платформа"
+  },
+  "auth": {
+    "sign_in": "Войти",
+    "username": "Имя пользователя",
+    "password": "Пароль",
+    "email_address": "Адрес электронной почты",
+    "use_email_code": "Использовать код по почте",
+    "back_to_password": "Вернуться к паролю",
+    "6_digit_code": "6-значный код",
+    "resend_code": "Отправить код повторно",
+    "a_6_digit_code_was_sent_to": "6-значный код был отправлен на",
+    "invalid_username_or_password": "Неверное имя пользователя или пароль.",
+    "failed_to_send_code": "Не удалось отправить код. Попробуйте снова.",
+    "invalid_or_expired_code": "Неверный или истёкший код. Попробуйте снова.",
+    "sending": "Отправка…",
+    "send_code": "Отправить код",
+    "verifying": "Проверка…",
+    "verify_code": "Проверить код",
+    "signing_in": "Вход…",
+    "sign_in_with_keycloak": "Войти через Keycloak",
+    "create_account": "Создать аккаунт"
+  },
+  "nav": {
+    "brief": "Сводка",
+    "today": "Сегодня",
+    "later": "Позже",
+    "starred": "Избранное",
+    "shared": "Общий доступ",
+    "search": "Поиск",
+    "ask": "Спросить",
+    "reading_list": "Список чтения",
+    "briefing_history": "История сводок",
+    "topic_map": "Карта тем",
+    "ai_stats": "Статистика ИИ",
+    "feeds": "Ленты",
+    "reading_dna": "ДНК чтения",
+    "weekly_recap": "Итоги недели",
+    "archive": "Архив",
+    "collections": "Коллекции",
+    "settings": "Настройки",
+    "stats": "Статистика",
+    "analytics": "Аналитика",
+    "users": "Пользователи"
+  },
+  "page_title": {
+    "brief": "Сводка",
+    "today": "Сегодня",
+    "later": "Позже",
+    "starred": "Избранное",
+    "shared": "Общий доступ",
+    "search": "Поиск",
+    "ask": "Спросить ИИ",
+    "topic_map": "Карта тем",
+    "ai_stats": "Статистика ИИ",
+    "briefs": "Сводки",
+    "feeds": "Ленты",
+    "stats": "Статистика",
+    "reading_dna": "ДНК чтения",
+    "reading_list": "Список чтения",
+    "weekly_recap": "Итоги недели",
+    "archive": "Архив",
+    "collections": "Коллекции",
+    "settings": "Настройки",
+    "analytics": "Аналитика",
+    "users": "Пользователи",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Нет сети",
+    "command": "Команда",
+    "menu": "Меню",
+    "more": "Ещё",
+    "log_out": "Выйти"
+  },
+  "settings": {
+    "title": "Настройки",
+    "about_heading": "О программе",
+    "about_body": "Radar — это частный инструмент для сортировки технических новостей. Состояние хранится на сервере.",
+    "shortcuts_hint_prefix": "Нажмите",
+    "shortcuts_hint_suffix": "в любом месте, чтобы увидеть горячие клавиши.",
+    "language": {
+      "heading": "Язык",
+      "description": "Выберите язык интерфейса приложения."
+    }
+  }
+}

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Nyhetspanel",
+    "tagline": "Din privata nyhetsplattform"
+  },
+  "auth": {
+    "sign_in": "Logga in",
+    "username": "Användarnamn",
+    "password": "Lösenord",
+    "email_address": "E-postadress",
+    "use_email_code": "Använd e-postkod istället",
+    "back_to_password": "Tillbaka till lösenord",
+    "6_digit_code": "6-siffrig kod",
+    "resend_code": "Skicka koden igen",
+    "a_6_digit_code_was_sent_to": "En 6-siffrig kod har skickats till",
+    "invalid_username_or_password": "Ogiltigt användarnamn eller lösenord.",
+    "failed_to_send_code": "Det gick inte att skicka koden. Försök igen.",
+    "invalid_or_expired_code": "Ogiltig eller utgången kod. Försök igen.",
+    "sending": "Skickar…",
+    "send_code": "Skicka kod",
+    "verifying": "Verifierar…",
+    "verify_code": "Verifiera kod",
+    "signing_in": "Loggar in…",
+    "sign_in_with_keycloak": "Logga in med Keycloak",
+    "create_account": "Skapa konto"
+  },
+  "nav": {
+    "brief": "Överblick",
+    "today": "Idag",
+    "later": "Senare",
+    "starred": "Stjärnmärkta",
+    "shared": "Delade",
+    "search": "Sök",
+    "ask": "Fråga",
+    "reading_list": "Läslista",
+    "briefing_history": "Överblickshistorik",
+    "topic_map": "Ämneskarta",
+    "ai_stats": "AI-statistik",
+    "feeds": "Flöden",
+    "reading_dna": "Läs-DNA",
+    "weekly_recap": "Veckosammanfattning",
+    "archive": "Arkiv",
+    "collections": "Samlingar",
+    "settings": "Inställningar",
+    "stats": "Statistik",
+    "analytics": "Analys",
+    "users": "Användare"
+  },
+  "page_title": {
+    "brief": "Överblick",
+    "today": "Idag",
+    "later": "Senare",
+    "starred": "Stjärnmärkta",
+    "shared": "Delade",
+    "search": "Sök",
+    "ask": "Fråga AI",
+    "topic_map": "Ämneskarta",
+    "ai_stats": "AI-statistik",
+    "briefs": "Överblickar",
+    "feeds": "Flöden",
+    "stats": "Statistik",
+    "reading_dna": "Läs-DNA",
+    "reading_list": "Läslista",
+    "weekly_recap": "Veckosammanfattning",
+    "archive": "Arkiv",
+    "collections": "Samlingar",
+    "settings": "Inställningar",
+    "analytics": "Analys",
+    "users": "Användare",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Offline",
+    "command": "Kommando",
+    "menu": "Meny",
+    "more": "Mer",
+    "log_out": "Logga ut"
+  },
+  "settings": {
+    "title": "Inställningar",
+    "about_heading": "Om",
+    "about_body": "Radar är ett privat verktyg för att sortera tekniska nyheter. Status lagras på servern.",
+    "shortcuts_hint_prefix": "Tryck på",
+    "shortcuts_hint_suffix": "var som helst för tangentbordsgenvägar.",
+    "language": {
+      "heading": "Språk",
+      "description": "Välj språk för appens gränssnitt."
+    }
+  }
+}

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "แดชบอร์ดข่าว",
+    "tagline": "แพลตฟอร์มข่าวส่วนตัวของคุณ"
+  },
+  "auth": {
+    "sign_in": "เข้าสู่ระบบ",
+    "username": "ชื่อผู้ใช้",
+    "password": "รหัสผ่าน",
+    "email_address": "ที่อยู่อีเมล",
+    "use_email_code": "ใช้รหัสทางอีเมลแทน",
+    "back_to_password": "กลับไปเข้าสู่ระบบด้วยรหัสผ่าน",
+    "6_digit_code": "รหัส 6 หลัก",
+    "resend_code": "ส่งรหัสอีกครั้ง",
+    "a_6_digit_code_was_sent_to": "ส่งรหัส 6 หลักไปที่",
+    "invalid_username_or_password": "ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง",
+    "failed_to_send_code": "ส่งรหัสไม่สำเร็จ กรุณาลองใหม่",
+    "invalid_or_expired_code": "รหัสไม่ถูกต้องหรือหมดอายุ กรุณาลองใหม่",
+    "sending": "กำลังส่ง…",
+    "send_code": "ส่งรหัส",
+    "verifying": "กำลังตรวจสอบ…",
+    "verify_code": "ยืนยันรหัส",
+    "signing_in": "กำลังเข้าสู่ระบบ…",
+    "sign_in_with_keycloak": "เข้าสู่ระบบด้วย Keycloak",
+    "create_account": "สร้างบัญชี"
+  },
+  "nav": {
+    "brief": "สรุปข่าว",
+    "today": "วันนี้",
+    "later": "ไว้ทีหลัง",
+    "starred": "ติดดาว",
+    "shared": "แชร์แล้ว",
+    "search": "ค้นหา",
+    "ask": "ถาม",
+    "reading_list": "รายการอ่าน",
+    "briefing_history": "ประวัติสรุปข่าว",
+    "topic_map": "แผนที่หัวข้อ",
+    "ai_stats": "สถิติ AI",
+    "feeds": "ฟีด",
+    "reading_dna": "ดีเอ็นเอการอ่าน",
+    "weekly_recap": "สรุปประจำสัปดาห์",
+    "archive": "เก็บถาวร",
+    "collections": "คอลเลกชัน",
+    "settings": "การตั้งค่า",
+    "stats": "สถิติ",
+    "analytics": "การวิเคราะห์",
+    "users": "ผู้ใช้"
+  },
+  "page_title": {
+    "brief": "สรุปข่าว",
+    "today": "วันนี้",
+    "later": "ไว้ทีหลัง",
+    "starred": "ติดดาว",
+    "shared": "แชร์แล้ว",
+    "search": "ค้นหา",
+    "ask": "ถาม AI",
+    "topic_map": "แผนที่หัวข้อ",
+    "ai_stats": "สถิติ AI",
+    "briefs": "สรุปข่าว",
+    "feeds": "ฟีด",
+    "stats": "สถิติ",
+    "reading_dna": "ดีเอ็นเอการอ่าน",
+    "reading_list": "รายการอ่าน",
+    "weekly_recap": "สรุปประจำสัปดาห์",
+    "archive": "เก็บถาวร",
+    "collections": "คอลเลกชัน",
+    "settings": "การตั้งค่า",
+    "analytics": "การวิเคราะห์",
+    "users": "ผู้ใช้",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "ออฟไลน์",
+    "command": "คำสั่ง",
+    "menu": "เมนู",
+    "more": "เพิ่มเติม",
+    "log_out": "ออกจากระบบ"
+  },
+  "settings": {
+    "title": "การตั้งค่า",
+    "about_heading": "เกี่ยวกับ",
+    "about_body": "Radar เป็นเครื่องมือส่วนตัวสำหรับจัดเรียงข่าวเทคโนโลยี สถานะจะถูกเก็บไว้บนเซิร์ฟเวอร์",
+    "shortcuts_hint_prefix": "กด",
+    "shortcuts_hint_suffix": "ที่ใดก็ได้เพื่อดูปุ่มลัดแป้นพิมพ์",
+    "language": {
+      "heading": "ภาษา",
+      "description": "เลือกภาษาของอินเทอร์เฟซแอป"
+    }
+  }
+}

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Haber Panosu",
+    "tagline": "Kendi özel haber platformunuz"
+  },
+  "auth": {
+    "sign_in": "Giriş yap",
+    "username": "Kullanıcı adı",
+    "password": "Şifre",
+    "email_address": "E-posta adresi",
+    "use_email_code": "Bunun yerine e-posta kodu kullan",
+    "back_to_password": "Şifreyle girişe dön",
+    "6_digit_code": "6 haneli kod",
+    "resend_code": "Kodu yeniden gönder",
+    "a_6_digit_code_was_sent_to": "6 haneli kod şu adrese gönderildi:",
+    "invalid_username_or_password": "Geçersiz kullanıcı adı veya şifre.",
+    "failed_to_send_code": "Kod gönderilemedi. Lütfen tekrar deneyin.",
+    "invalid_or_expired_code": "Geçersiz veya süresi dolmuş kod. Lütfen tekrar deneyin.",
+    "sending": "Gönderiliyor…",
+    "send_code": "Kodu gönder",
+    "verifying": "Doğrulanıyor…",
+    "verify_code": "Kodu doğrula",
+    "signing_in": "Giriş yapılıyor…",
+    "sign_in_with_keycloak": "Keycloak ile giriş yap",
+    "create_account": "Hesap oluştur"
+  },
+  "nav": {
+    "brief": "Özet",
+    "today": "Bugün",
+    "later": "Sonra",
+    "starred": "Yıldızlı",
+    "shared": "Paylaşılan",
+    "search": "Ara",
+    "ask": "Sor",
+    "reading_list": "Okuma listesi",
+    "briefing_history": "Özet geçmişi",
+    "topic_map": "Konu haritası",
+    "ai_stats": "Yapay zeka istatistikleri",
+    "feeds": "Kaynaklar",
+    "reading_dna": "Okuma DNA'sı",
+    "weekly_recap": "Haftalık özet",
+    "archive": "Arşiv",
+    "collections": "Koleksiyonlar",
+    "settings": "Ayarlar",
+    "stats": "İstatistikler",
+    "analytics": "Analitik",
+    "users": "Kullanıcılar"
+  },
+  "page_title": {
+    "brief": "Özet",
+    "today": "Bugün",
+    "later": "Sonra",
+    "starred": "Yıldızlı",
+    "shared": "Paylaşılan",
+    "search": "Ara",
+    "ask": "Yapay zekaya sor",
+    "topic_map": "Konu haritası",
+    "ai_stats": "Yapay zeka istatistikleri",
+    "briefs": "Özetler",
+    "feeds": "Kaynaklar",
+    "stats": "İstatistikler",
+    "reading_dna": "Okuma DNA'sı",
+    "reading_list": "Okuma listesi",
+    "weekly_recap": "Haftalık özet",
+    "archive": "Arşiv",
+    "collections": "Koleksiyonlar",
+    "settings": "Ayarlar",
+    "analytics": "Analitik",
+    "users": "Kullanıcılar",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Çevrimdışı",
+    "command": "Komut",
+    "menu": "Menü",
+    "more": "Daha fazla",
+    "log_out": "Çıkış yap"
+  },
+  "settings": {
+    "title": "Ayarlar",
+    "about_heading": "Hakkında",
+    "about_body": "Radar, teknik haberleri ayıklamak için özel bir araçtır. Durum sunucuda saklanır.",
+    "shortcuts_hint_prefix": "Klavye kısayolları için herhangi bir yerde",
+    "shortcuts_hint_suffix": "tuşuna basın.",
+    "language": {
+      "heading": "Dil",
+      "description": "Uygulama arayüz dilini seçin."
+    }
+  }
+}

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Панель новин",
+    "tagline": "Ваша приватна новинна платформа"
+  },
+  "auth": {
+    "sign_in": "Увійти",
+    "username": "Ім'я користувача",
+    "password": "Пароль",
+    "email_address": "Електронна адреса",
+    "use_email_code": "Використати код електронною поштою",
+    "back_to_password": "Повернутися до пароля",
+    "6_digit_code": "6-значний код",
+    "resend_code": "Надіслати код повторно",
+    "a_6_digit_code_was_sent_to": "6-значний код надіслано на",
+    "invalid_username_or_password": "Невірне ім'я користувача або пароль.",
+    "failed_to_send_code": "Не вдалося надіслати код. Спробуйте ще раз.",
+    "invalid_or_expired_code": "Недійсний або прострочений код. Спробуйте ще раз.",
+    "sending": "Надсилання…",
+    "send_code": "Надіслати код",
+    "verifying": "Перевірка…",
+    "verify_code": "Перевірити код",
+    "signing_in": "Вхід…",
+    "sign_in_with_keycloak": "Увійти через Keycloak",
+    "create_account": "Створити обліковий запис"
+  },
+  "nav": {
+    "brief": "Огляд",
+    "today": "Сьогодні",
+    "later": "Пізніше",
+    "starred": "Обрані",
+    "shared": "Спільні",
+    "search": "Пошук",
+    "ask": "Запитати",
+    "reading_list": "Список читання",
+    "briefing_history": "Історія оглядів",
+    "topic_map": "Карта тем",
+    "ai_stats": "Статистика ШІ",
+    "feeds": "Стрічки",
+    "reading_dna": "ДНК читання",
+    "weekly_recap": "Тижневий підсумок",
+    "archive": "Архів",
+    "collections": "Колекції",
+    "settings": "Налаштування",
+    "stats": "Статистика",
+    "analytics": "Аналітика",
+    "users": "Користувачі"
+  },
+  "page_title": {
+    "brief": "Огляд",
+    "today": "Сьогодні",
+    "later": "Пізніше",
+    "starred": "Обрані",
+    "shared": "Спільні",
+    "search": "Пошук",
+    "ask": "Запитати ШІ",
+    "topic_map": "Карта тем",
+    "ai_stats": "Статистика ШІ",
+    "briefs": "Огляди",
+    "feeds": "Стрічки",
+    "stats": "Статистика",
+    "reading_dna": "ДНК читання",
+    "reading_list": "Список читання",
+    "weekly_recap": "Тижневий підсумок",
+    "archive": "Архів",
+    "collections": "Колекції",
+    "settings": "Налаштування",
+    "analytics": "Аналітика",
+    "users": "Користувачі",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Офлайн",
+    "command": "Команда",
+    "menu": "Меню",
+    "more": "Більше",
+    "log_out": "Вийти"
+  },
+  "settings": {
+    "title": "Налаштування",
+    "about_heading": "Про застосунок",
+    "about_body": "Radar — це приватний інструмент для сортування технічних новин. Стан зберігається на сервері.",
+    "shortcuts_hint_prefix": "Натисніть",
+    "shortcuts_hint_suffix": "будь-де, щоб побачити комбінації клавіш.",
+    "language": {
+      "heading": "Мова",
+      "description": "Виберіть мову інтерфейсу застосунку."
+    }
+  }
+}

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "Bảng Tin Tức",
+    "tagline": "Nền tảng tin tức riêng của bạn"
+  },
+  "auth": {
+    "sign_in": "Đăng nhập",
+    "username": "Tên đăng nhập",
+    "password": "Mật khẩu",
+    "email_address": "Địa chỉ email",
+    "use_email_code": "Dùng mã qua email thay thế",
+    "back_to_password": "Quay lại đăng nhập bằng mật khẩu",
+    "6_digit_code": "Mã gồm 6 chữ số",
+    "resend_code": "Gửi lại mã",
+    "a_6_digit_code_was_sent_to": "Mã gồm 6 chữ số đã được gửi đến",
+    "invalid_username_or_password": "Tên đăng nhập hoặc mật khẩu không hợp lệ.",
+    "failed_to_send_code": "Gửi mã thất bại. Vui lòng thử lại.",
+    "invalid_or_expired_code": "Mã không hợp lệ hoặc đã hết hạn. Vui lòng thử lại.",
+    "sending": "Đang gửi…",
+    "send_code": "Gửi mã",
+    "verifying": "Đang xác minh…",
+    "verify_code": "Xác minh mã",
+    "signing_in": "Đang đăng nhập…",
+    "sign_in_with_keycloak": "Đăng nhập bằng Keycloak",
+    "create_account": "Tạo tài khoản"
+  },
+  "nav": {
+    "brief": "Tóm tắt",
+    "today": "Hôm nay",
+    "later": "Để sau",
+    "starred": "Đã gắn sao",
+    "shared": "Đã chia sẻ",
+    "search": "Tìm kiếm",
+    "ask": "Hỏi",
+    "reading_list": "Danh sách đọc",
+    "briefing_history": "Lịch sử tóm tắt",
+    "topic_map": "Bản đồ chủ đề",
+    "ai_stats": "Thống kê AI",
+    "feeds": "Nguồn tin",
+    "reading_dna": "DNA đọc",
+    "weekly_recap": "Tổng kết tuần",
+    "archive": "Lưu trữ",
+    "collections": "Bộ sưu tập",
+    "settings": "Cài đặt",
+    "stats": "Thống kê",
+    "analytics": "Phân tích",
+    "users": "Người dùng"
+  },
+  "page_title": {
+    "brief": "Tóm tắt",
+    "today": "Hôm nay",
+    "later": "Để sau",
+    "starred": "Đã gắn sao",
+    "shared": "Đã chia sẻ",
+    "search": "Tìm kiếm",
+    "ask": "Hỏi AI",
+    "topic_map": "Bản đồ chủ đề",
+    "ai_stats": "Thống kê AI",
+    "briefs": "Tóm tắt",
+    "feeds": "Nguồn tin",
+    "stats": "Thống kê",
+    "reading_dna": "DNA đọc",
+    "reading_list": "Danh sách đọc",
+    "weekly_recap": "Tổng kết tuần",
+    "archive": "Lưu trữ",
+    "collections": "Bộ sưu tập",
+    "settings": "Cài đặt",
+    "analytics": "Phân tích",
+    "users": "Người dùng",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "Ngoại tuyến",
+    "command": "Lệnh",
+    "menu": "Menu",
+    "more": "Thêm",
+    "log_out": "Đăng xuất"
+  },
+  "settings": {
+    "title": "Cài đặt",
+    "about_heading": "Giới thiệu",
+    "about_body": "Radar là công cụ riêng tư để phân loại tin tức công nghệ. Trạng thái được lưu trên máy chủ.",
+    "shortcuts_hint_prefix": "Nhấn",
+    "shortcuts_hint_suffix": "ở bất kỳ đâu để xem phím tắt.",
+    "language": {
+      "heading": "Ngôn ngữ",
+      "description": "Chọn ngôn ngữ cho giao diện ứng dụng."
+    }
+  }
+}

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "新闻仪表盘",
+    "tagline": "您的私人新闻平台"
+  },
+  "auth": {
+    "sign_in": "登录",
+    "username": "用户名",
+    "password": "密码",
+    "email_address": "电子邮件地址",
+    "use_email_code": "改用邮箱验证码",
+    "back_to_password": "返回密码登录",
+    "6_digit_code": "6 位验证码",
+    "resend_code": "重新发送验证码",
+    "a_6_digit_code_was_sent_to": "6 位验证码已发送至",
+    "invalid_username_or_password": "用户名或密码无效。",
+    "failed_to_send_code": "验证码发送失败，请重试。",
+    "invalid_or_expired_code": "验证码无效或已过期，请重试。",
+    "sending": "发送中…",
+    "send_code": "发送验证码",
+    "verifying": "验证中…",
+    "verify_code": "验证代码",
+    "signing_in": "登录中…",
+    "sign_in_with_keycloak": "使用 Keycloak 登录",
+    "create_account": "创建账户"
+  },
+  "nav": {
+    "brief": "简报",
+    "today": "今天",
+    "later": "稍后",
+    "starred": "已加星标",
+    "shared": "已分享",
+    "search": "搜索",
+    "ask": "提问",
+    "reading_list": "阅读清单",
+    "briefing_history": "简报历史",
+    "topic_map": "主题地图",
+    "ai_stats": "AI 统计",
+    "feeds": "信息源",
+    "reading_dna": "阅读画像",
+    "weekly_recap": "每周回顾",
+    "archive": "归档",
+    "collections": "收藏集",
+    "settings": "设置",
+    "stats": "统计",
+    "analytics": "分析",
+    "users": "用户"
+  },
+  "page_title": {
+    "brief": "简报",
+    "today": "今天",
+    "later": "稍后",
+    "starred": "已加星标",
+    "shared": "已分享",
+    "search": "搜索",
+    "ask": "向 AI 提问",
+    "topic_map": "主题地图",
+    "ai_stats": "AI 统计",
+    "briefs": "简报",
+    "feeds": "信息源",
+    "stats": "统计",
+    "reading_dna": "阅读画像",
+    "reading_list": "阅读清单",
+    "weekly_recap": "每周回顾",
+    "archive": "归档",
+    "collections": "收藏集",
+    "settings": "设置",
+    "analytics": "分析",
+    "users": "用户",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "离线",
+    "command": "命令",
+    "menu": "菜单",
+    "more": "更多",
+    "log_out": "退出登录"
+  },
+  "settings": {
+    "title": "设置",
+    "about_heading": "关于",
+    "about_body": "Radar 是一款私人技术新闻分拣工具，状态保存在服务器上。",
+    "shortcuts_hint_prefix": "按",
+    "shortcuts_hint_suffix": "可在任意位置查看键盘快捷键。",
+    "language": {
+      "heading": "语言",
+      "description": "选择应用界面的语言。"
+    }
+  }
+}

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "name": "新聞儀表板",
+    "tagline": "您的私人新聞平台"
+  },
+  "auth": {
+    "sign_in": "登入",
+    "username": "使用者名稱",
+    "password": "密碼",
+    "email_address": "電子郵件地址",
+    "use_email_code": "改用電子郵件驗證碼",
+    "back_to_password": "返回密碼登入",
+    "6_digit_code": "6 位數驗證碼",
+    "resend_code": "重新傳送驗證碼",
+    "a_6_digit_code_was_sent_to": "6 位數驗證碼已傳送至",
+    "invalid_username_or_password": "使用者名稱或密碼無效。",
+    "failed_to_send_code": "驗證碼傳送失敗，請再試一次。",
+    "invalid_or_expired_code": "驗證碼無效或已過期，請再試一次。",
+    "sending": "傳送中…",
+    "send_code": "傳送驗證碼",
+    "verifying": "驗證中…",
+    "verify_code": "驗證代碼",
+    "signing_in": "登入中…",
+    "sign_in_with_keycloak": "使用 Keycloak 登入",
+    "create_account": "建立帳戶"
+  },
+  "nav": {
+    "brief": "簡報",
+    "today": "今天",
+    "later": "稍後",
+    "starred": "已加星號",
+    "shared": "已分享",
+    "search": "搜尋",
+    "ask": "提問",
+    "reading_list": "閱讀清單",
+    "briefing_history": "簡報歷史",
+    "topic_map": "主題地圖",
+    "ai_stats": "AI 統計",
+    "feeds": "來源",
+    "reading_dna": "閱讀 DNA",
+    "weekly_recap": "每週回顧",
+    "archive": "封存",
+    "collections": "收藏集",
+    "settings": "設定",
+    "stats": "統計",
+    "analytics": "分析",
+    "users": "使用者"
+  },
+  "page_title": {
+    "brief": "簡報",
+    "today": "今天",
+    "later": "稍後",
+    "starred": "已加星號",
+    "shared": "已分享",
+    "search": "搜尋",
+    "ask": "詢問 AI",
+    "topic_map": "主題地圖",
+    "ai_stats": "AI 統計",
+    "briefs": "簡報",
+    "feeds": "來源",
+    "stats": "統計",
+    "reading_dna": "閱讀 DNA",
+    "reading_list": "閱讀清單",
+    "weekly_recap": "每週回顧",
+    "archive": "封存",
+    "collections": "收藏集",
+    "settings": "設定",
+    "analytics": "分析",
+    "users": "使用者",
+    "default": "Radar"
+  },
+  "shell": {
+    "offline": "離線",
+    "command": "指令",
+    "menu": "選單",
+    "more": "更多",
+    "log_out": "登出"
+  },
+  "settings": {
+    "title": "設定",
+    "about_heading": "關於",
+    "about_body": "Radar 是一款私人技術新聞分類工具，狀態儲存在伺服器上。",
+    "shortcuts_hint_prefix": "按下",
+    "shortcuts_hint_suffix": "可在任何地方查看鍵盤快速鍵。",
+    "language": {
+      "heading": "語言",
+      "description": "選擇應用程式介面的語言。"
+    }
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,9 +8,11 @@ import { initErrorTracking } from './lib/errorTracking';
 import { initTheme } from './lib/theme';
 import { queryClient } from './lib/queryClient';
 import { AppRouter } from './AppRouter';
-import '@/lib/i18n'; // Initialize i18n
+import i18n from '@/lib/i18n';
+import { initLanguageDirection } from '@/lib/languages';
 
 initTheme();
+initLanguageDirection(i18n);
 void initErrorTracking();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,6 @@
+import { useTranslation } from 'react-i18next';
 import { ThemeSection } from '@/components/settings/ThemeSection';
+import { LanguageSection } from '@/components/settings/LanguageSection';
 import { PersonalizationSection } from '@/components/settings/PersonalizationSection';
 import { WatchlistsSection } from '@/components/settings/WatchlistsSection';
 import { AiMemorySection } from '@/components/settings/AiMemorySection';
@@ -12,13 +14,16 @@ import { UpdatesSection } from '@/components/settings/UpdatesSection';
 import { DeleteAccountSection } from '@/components/settings/DeleteAccountSection';
 
 export function SettingsPage() {
+  const { t } = useTranslation();
+
   return (
     <div className="p-4 md:p-5 max-w-2xl space-y-6">
       <div>
-        <h2 className="text-[22px] font-semibold tracking-tight">Settings</h2>
+        <h2 className="text-[22px] font-semibold tracking-tight">{t('settings.title')}</h2>
       </div>
 
       <ThemeSection />
+      <LanguageSection />
       <PersonalizationSection />
       <WatchlistsSection />
       <AiMemorySection />
@@ -32,14 +37,16 @@ export function SettingsPage() {
       <DeleteAccountSection />
 
       <section className="text-xs text-muted-foreground space-y-2">
-        <div className="text-[10px] uppercase tracking-wider text-subtle font-medium">About</div>
-        <p>Radar is a private technical news triage tool. State is stored on the server.</p>
+        <div className="text-[10px] uppercase tracking-wider text-subtle font-medium">
+          {t('settings.about_heading')}
+        </div>
+        <p>{t('settings.about_body')}</p>
         <p>
-          Press{' '}
+          {t('settings.shortcuts_hint_prefix')}{' '}
           <kbd className="font-mono text-[10px] px-1 py-0.5 bg-surface-2 border border-border rounded">
             ?
           </kbd>{' '}
-          anywhere for keyboard shortcuts.
+          {t('settings.shortcuts_hint_suffix')}
         </p>
       </section>
     </div>


### PR DESCRIPTION
Closes #1050

## Summary
Adds i18n infrastructure to the frontend using the existing `i18next`/`react-i18next`/`i18next-browser-languagedetector` dependencies, covering 29 major world languages.

- `frontend/src/locales/<lang>/translation.json` for all 29 languages (en, es, fr, de, pt, it, nl, pl, ru, zh-CN, zh-TW, ja, ko, ar, hi, tr, vi, th, id, sv, no, da, fi, ro, uk, cs, hu, el, he), all key-parity checked against English
- Language selector dropdown in Settings (`LanguageSection`), showing each language's native name, persisted via `i18next-browser-languagedetector`'s localStorage cache (`i18nextLng`)
- RTL support: `initLanguageDirection` (mirrors the existing `initTheme` pattern) sets `dir`/`lang` on `<html>` for Arabic/Hebrew and keeps it in sync on language change
- Translated surfaces in this PR: login page (already wired), app shell (nav rail, mobile nav, sheet menu, header), and the Settings page
- `getPageTitle`/`getPageTitleKey` in `lib/navigation.ts` now derive from one shared rule table to avoid the English/i18n-key lists drifting apart

**Out of scope (tracked separately):** extracting/translating strings from the remaining ~55 page/component files (Inbox, Sources, Analytics, Admin, CommandPalette, etc.) — will follow in per-section PRs. Also opened #1052 to lazy-load language bundles instead of eagerly shipping all 29 in the initial JS bundle (currently ~124KB raw JSON total, flagged in review as a non-blocking efficiency concern).

## Test plan
- [x] `vitest run` — 824 tests passing, including new language-switching, English-fallback, and RTL-toggle tests
- [x] `tsc -b --noEmit` — clean
- [x] `eslint . --max-warnings 0` — clean
- [x] Manually verified in the running dev server: login page renders correctly in Arabic (RTL layout) and Japanese, language persists to localStorage, `dir`/`lang` update live on language change, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)