### PR TITLE
perf: lazy-load i18n translation bundles per language (#1052)

### DIFF
--- a/frontend/src/__tests__/i18n.test.tsx
+++ b/frontend/src/__tests__/i18n.test.tsx
@@ -109,6 +109,29 @@ describe('key resolution fallback', () => {
   });
 });
 
+describe('lazy language loading', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('loads a language bundle on demand and exposes it via getResourceBundle', async () => {
+    expect(i18n.getDataByLanguage('it')?.translation).toBeUndefined();
+
+    await i18n.changeLanguage('it');
+
+    expect(i18n.t('auth.sign_in')).toBe('Accedi');
+    expect(i18n.getDataByLanguage('it')?.translation).toBeDefined();
+  });
+
+  it('does not eagerly bundle every language module (code-split per language)', () => {
+    const localeModules = import.meta.glob('../locales/*/translation.json');
+    // Each entry is a lazy loader function, not the already-resolved module.
+    for (const loader of Object.values(localeModules)) {
+      expect(typeof loader).toBe('function');
+    }
+  });
+});
+
 describe('RTL direction', () => {
   beforeEach(() => {
     // main.tsx wires this up once at startup; replicate that here since tests

--- a/frontend/src/__tests__/i18n.test.tsx
+++ b/frontend/src/__tests__/i18n.test.tsx
@@ -130,6 +130,32 @@ describe('lazy language loading', () => {
       expect(typeof loader).toBe('function');
     }
   });
+
+  it('reports a missing-bundle error instead of throwing for an unknown language', async () => {
+    const services = i18n.services as unknown as {
+      backendConnector: {
+        backend: {
+          read: (
+            language: string,
+            namespace: string,
+            callback: (err: Error | null, data: unknown) => void
+          ) => void;
+        };
+      };
+    };
+
+    await new Promise<void>((resolve) => {
+      services.backendConnector.backend.read(
+        'xx-not-a-real-language',
+        'translation',
+        (err, data) => {
+          expect(err).toBeInstanceOf(Error);
+          expect(data).toBe(false);
+          resolve();
+        }
+      );
+    });
+  });
 });
 
 describe('RTL direction', () => {

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,83 +1,50 @@
 import i18n from 'i18next';
+import type { BackendModule } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-
-import translationEn from '@/locales/en/translation.json';
-import translationEs from '@/locales/es/translation.json';
-import translationFr from '@/locales/fr/translation.json';
-import translationDe from '@/locales/de/translation.json';
-import translationPt from '@/locales/pt/translation.json';
-import translationIt from '@/locales/it/translation.json';
-import translationNl from '@/locales/nl/translation.json';
-import translationPl from '@/locales/pl/translation.json';
-import translationRu from '@/locales/ru/translation.json';
-import translationZhCN from '@/locales/zh-CN/translation.json';
-import translationZhTW from '@/locales/zh-TW/translation.json';
-import translationJa from '@/locales/ja/translation.json';
-import translationKo from '@/locales/ko/translation.json';
-import translationAr from '@/locales/ar/translation.json';
-import translationHi from '@/locales/hi/translation.json';
-import translationTr from '@/locales/tr/translation.json';
-import translationVi from '@/locales/vi/translation.json';
-import translationTh from '@/locales/th/translation.json';
-import translationId from '@/locales/id/translation.json';
-import translationSv from '@/locales/sv/translation.json';
-import translationNo from '@/locales/no/translation.json';
-import translationDa from '@/locales/da/translation.json';
-import translationFi from '@/locales/fi/translation.json';
-import translationRo from '@/locales/ro/translation.json';
-import translationUk from '@/locales/uk/translation.json';
-import translationCs from '@/locales/cs/translation.json';
-import translationHu from '@/locales/hu/translation.json';
-import translationEl from '@/locales/el/translation.json';
-import translationHe from '@/locales/he/translation.json';
 
 import { supportedLanguages } from '@/lib/languages';
 
 // Default namespace
 const DEFAULT_NS = 'translation';
 
-// Language resources
-const resources = {
-  en: { translation: translationEn },
-  es: { translation: translationEs },
-  fr: { translation: translationFr },
-  de: { translation: translationDe },
-  pt: { translation: translationPt },
-  it: { translation: translationIt },
-  nl: { translation: translationNl },
-  pl: { translation: translationPl },
-  ru: { translation: translationRu },
-  'zh-CN': { translation: translationZhCN },
-  'zh-TW': { translation: translationZhTW },
-  ja: { translation: translationJa },
-  ko: { translation: translationKo },
-  ar: { translation: translationAr },
-  hi: { translation: translationHi },
-  tr: { translation: translationTr },
-  vi: { translation: translationVi },
-  th: { translation: translationTh },
-  id: { translation: translationId },
-  sv: { translation: translationSv },
-  no: { translation: translationNo },
-  da: { translation: translationDa },
-  fi: { translation: translationFi },
-  ro: { translation: translationRo },
-  uk: { translation: translationUk },
-  cs: { translation: translationCs },
-  hu: { translation: translationHu },
-  el: { translation: translationEl },
-  he: { translation: translationHe },
+// One dynamic-import loader per language, so Vite code-splits each
+// translation.json into its own chunk instead of bundling all 29 upfront.
+const localeLoaders = import.meta.glob<{ default: Record<string, unknown> }>(
+  '../locales/*/translation.json'
+);
+
+function findLoader(language: string) {
+  const suffix = `/locales/${language}/translation.json`;
+  const entry = Object.entries(localeLoaders).find(([path]) => path.endsWith(suffix));
+  return entry?.[1];
+}
+
+/** i18next backend that lazy-loads each language's bundle on first use. */
+const lazyBackend: BackendModule = {
+  type: 'backend',
+  init: () => undefined,
+  read: (language, _namespace, callback) => {
+    const loader = findLoader(language);
+    if (!loader) {
+      callback(new Error(`No translation bundle for language: ${language}`), false);
+      return;
+    }
+    loader()
+      .then((mod) => callback(null, mod.default))
+      .catch((err: Error) => callback(err, false));
+  },
 };
 
 void i18n
+  // Lazy-load translation bundles per language instead of bundling all of them.
+  .use(lazyBackend)
   // Detect user language
   .use(LanguageDetector)
   // Pass the i18n instance to react-i18next.
   .use(initReactI18next)
   // Initialize i18next
   .init({
-    resources,
     fallbackLng: 'en',
     supportedLngs: supportedLanguages.map((l) => l.code),
     defaultNS: DEFAULT_NS,


### PR DESCRIPTION
## Summary
- Fixes #1052
- `frontend/src/lib/i18n.ts` previously statically imported all 29 `translation.json` files and passed them all into `i18next.init({ resources })`, so every client downloaded every language's strings regardless of which one was active.
- Replaced the eager `resources` map with a custom i18next backend (`lazyBackend`) that dynamically imports only the requested language via `import.meta.glob('../locales/*/translation.json')`, so Vite code-splits each language's bundle into its own chunk (~2-4KB gzipped each vs. one ~124KB raw blob).
- Switching languages in Settings (`i18n.changeLanguage(...)`) now lazy-loads the newly selected language's chunk through the same backend — no static imports, no full page reload.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npx eslint frontend/src/lib/i18n.ts frontend/src/__tests__/i18n.test.tsx` passes
- [x] Full frontend suite: `npx vitest run` — 83 files / 826 tests passed
- [x] Added test coverage in `frontend/src/__tests__/i18n.test.tsx` asserting a language's bundle is not loaded until `changeLanguage` is called, and that the glob returns lazy loader functions (not eagerly resolved modules)
- [x] `npm run build` confirmed per-language `translation-*.js` chunks in `frontend/dist/assets/` instead of one bundled blob
- [x] Existing RTL, fallback, and persistence i18n tests still pass unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)