### PR TITLE
fix: guard direct Feeds operational routes for non-admin users (#776)

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -84,7 +84,7 @@ function withSuspense(Component: React.ComponentType) {
   );
 }
 
-function AdminOnlyGuard({ children }: { children: React.ReactNode }) {
+export function AdminOnlyGuard({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
   if (!user?.is_admin) {
     return (
@@ -157,9 +157,36 @@ export const routes: RouteObject[] = [
         element: <FeedsPage />,
         children: [
           { index: true, element: <SourcesPage /> },
-          { path: 'schedule', element: withSuspense(SchedulerPage) },
-          { path: 'runs', element: withSuspense(FeedsRunsPage) },
-          { path: 'logs', element: withSuspense(FeedsLogsPage) },
+          {
+            path: 'schedule',
+            element: (
+              <AdminOnlyGuard>
+                <Suspense fallback={<PageLoader />}>
+                  <SchedulerPage />
+                </Suspense>
+              </AdminOnlyGuard>
+            ),
+          },
+          {
+            path: 'runs',
+            element: (
+              <AdminOnlyGuard>
+                <Suspense fallback={<PageLoader />}>
+                  <FeedsRunsPage />
+                </Suspense>
+              </AdminOnlyGuard>
+            ),
+          },
+          {
+            path: 'logs',
+            element: (
+              <AdminOnlyGuard>
+                <Suspense fallback={<PageLoader />}>
+                  <FeedsLogsPage />
+                </Suspense>
+              </AdminOnlyGuard>
+            ),
+          },
         ],
       },
       { path: 'briefs', element: withSuspense(BriefingsHistoryPage) },

--- a/frontend/src/__tests__/appRouter.test.tsx
+++ b/frontend/src/__tests__/appRouter.test.tsx
@@ -1,12 +1,15 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 
 // Stub every page/shell so the route table can be exercised cheaply without
 // pulling in real data fetching. Each stub renders an identifiable marker.
-const { stub } = vi.hoisted(() => ({
+const { stub, authState } = vi.hoisted(() => ({
   stub: (label: string) => () => <div>{label}</div>,
+  authState: {
+    user: { id: 1, username: 'admin', is_admin: true },
+  },
 }));
 
 vi.mock('../components/RequireAuth', () => ({
@@ -18,6 +21,7 @@ vi.mock('../components/AppShell', async () => {
 });
 vi.mock('../contexts/auth', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => ({ user: authState.user, setUser: vi.fn() }),
 }));
 vi.mock('../contexts/focusedArticle', () => ({
   FocusedArticleProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -73,6 +77,33 @@ describe('AppRouter routes', () => {
   it('renders a nested feeds child route', async () => {
     renderAt('/feeds/runs');
     expect(await screen.findByText('runs-page')).toBeTruthy();
+  });
+
+  describe('admin-guarded feeds operational routes', () => {
+    afterEach(() => {
+      authState.user = { id: 1, username: 'admin', is_admin: true };
+    });
+
+    it.each([
+      ['/feeds/schedule', 'scheduler-page'],
+      ['/feeds/runs', 'runs-page'],
+      ['/feeds/logs', 'logs-page'],
+    ])('mounts %s for admin users', async (path, label) => {
+      authState.user = { id: 1, username: 'admin', is_admin: true };
+      renderAt(path);
+      expect(await screen.findByText(label)).toBeTruthy();
+    });
+
+    it.each([
+      ['/feeds/schedule', 'scheduler-page'],
+      ['/feeds/runs', 'runs-page'],
+      ['/feeds/logs', 'logs-page'],
+    ])('does not mount %s for non-admin users', async (path, label) => {
+      authState.user = { id: 2, username: 'user', is_admin: false };
+      renderAt(path);
+      expect(await screen.findByText('Admins only')).toBeTruthy();
+      expect(screen.queryByText(label)).toBeNull();
+    });
   });
 
   it('redirects legacy /inbox to /today', async () => {

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -34,6 +34,8 @@ const apiMock = vi.hoisted(() => {
     pauseScheduler: vi.fn(),
     resumeScheduler: vi.fn(),
     ingestNow: vi.fn(),
+    fetchIngestRuns: vi.fn(),
+    fetchIngestRunSources: vi.fn(),
     fetchOnboardingInterests: vi.fn().mockResolvedValue([]),
     fetchOnboardingSourceRecommendations: vi.fn().mockResolvedValue([]),
     fetchOnboardingStatus: vi.fn().mockResolvedValue({ completed: true }),
@@ -59,8 +61,10 @@ vi.mock('sonner', () => ({
 
 import { FeedsPage } from '../pages/FeedsPage';
 import { FeedsLogsPage } from '../pages/FeedsLogsPage';
+import { FeedsRunsPage } from '../pages/FeedsRunsPage';
 import { SourcesPage } from '../pages/SourcesPage';
 import { SchedulerPage } from '../pages/SchedulerPage';
+import { AdminOnlyGuard } from '../AppRouter';
 
 function SetUser({ user, children }: { user: User | null; children: ReactNode }) {
   const { setUser } = useAuth();
@@ -715,6 +719,92 @@ describe('SchedulerPage', () => {
     fireEvent.change(input, { target: { value: '45' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(apiMock.setSchedulerInterval).toHaveBeenCalledWith(45));
+  });
+});
+
+// ── Admin-only route guarding for Feeds operational pages ──────────────────
+
+describe('AdminOnlyGuard on Feeds operational routes', () => {
+  let eventSourceCreations = 0;
+
+  class FakeEventSource {
+    close = vi.fn();
+    addEventListener = vi.fn();
+    onopen: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    constructor() {
+      eventSourceCreations += 1;
+    }
+  }
+
+  beforeEach(() => {
+    eventSourceCreations = 0;
+    vi.stubGlobal('EventSource', FakeEventSource);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('blocks non-admin users from Scheduler and never calls fetchSchedulerStatus', () => {
+    withProviders(
+      <AdminOnlyGuard>
+        <SchedulerPage />
+      </AdminOnlyGuard>,
+      '/',
+      regularUser
+    );
+    expect(screen.getByText('Admins only')).toBeTruthy();
+    expect(apiMock.fetchSchedulerStatus).not.toHaveBeenCalled();
+  });
+
+  it('blocks non-admin users from Runs and never calls fetchIngestRuns or fetchIngestRunSources', () => {
+    withProviders(
+      <AdminOnlyGuard>
+        <FeedsRunsPage />
+      </AdminOnlyGuard>,
+      '/',
+      regularUser
+    );
+    expect(screen.getByText('Admins only')).toBeTruthy();
+    expect(apiMock.fetchIngestRuns).not.toHaveBeenCalled();
+    expect(apiMock.fetchIngestRunSources).not.toHaveBeenCalled();
+  });
+
+  it('blocks non-admin users from Logs and never opens the ingest EventSource', () => {
+    withProviders(
+      <AdminOnlyGuard>
+        <FeedsLogsPage />
+      </AdminOnlyGuard>,
+      '/',
+      regularUser
+    );
+    expect(screen.getByText('Admins only')).toBeTruthy();
+    expect(eventSourceCreations).toBe(0);
+  });
+
+  it('lets admin users through to the real Scheduler, Runs, and Logs pages', async () => {
+    apiMock.fetchSchedulerStatus.mockResolvedValue({
+      interval_minutes: 30,
+      paused: false,
+      next_run_at: null,
+    });
+    withProviders(
+      <AdminOnlyGuard>
+        <SchedulerPage />
+      </AdminOnlyGuard>,
+      '/',
+      adminUser
+    );
+    expect(await screen.findByText('▶ Running')).toBeTruthy();
+
+    apiMock.fetchIngestRuns.mockResolvedValue({ items: [], total: 0, page: 1, has_more: false });
+    withProviders(
+      <AdminOnlyGuard>
+        <FeedsRunsPage />
+      </AdminOnlyGuard>,
+      '/',
+      adminUser
+    );
+    await waitFor(() => expect(apiMock.fetchIngestRuns).toHaveBeenCalled());
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #776.

Non-admin users who navigated directly to `/feeds/schedule`, `/feeds/runs`, or `/feeds/logs` still mounted `SchedulerPage`, `FeedsRunsPage`, or `FeedsLogsPage`, which then called admin-only APIs (`fetchSchedulerStatus`, `fetchIngestRuns`, `fetchIngestRunSources`, `ingestNow`) and opened the admin-only `/api/ingest/stream` SSE connection — even though the Feeds tab navigation already hides those tabs for non-admins.

- Wrapped the three Feeds operational child routes in `frontend/src/AppRouter.tsx` with the existing `AdminOnlyGuard` component (the same guard already used for `/stats` and `/analytics`), so non-admins see the "Admins only" state and the page components never mount.
- Exported `AdminOnlyGuard` from `AppRouter.tsx` so it can be exercised directly in tests.
- `/feeds` Sources and backend admin authorization are unchanged.

## Test plan
- [x] `npm run test:frontend -- --run frontend/src/__tests__/feedsPages.test.tsx frontend/src/__tests__/appRouter.test.tsx` — added cases: admin/non-admin route mounting for `/feeds/schedule`, `/feeds/runs`, `/feeds/logs`; asserts non-admins never call `fetchSchedulerStatus`, `fetchIngestRuns`, `fetchIngestRunSources`, or open an `EventSource`.
- [x] `npm run test:frontend -- --run` — full suite, 837 passed.
- [x] `npm run typecheck` and `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)