### PR TITLE
refactor: extract auth HTTP routes into auth_routes feature-module package (#826)

### DIFF
--- a/backend/news_dashboard/auth_routes/__init__.py
+++ b/backend/news_dashboard/auth_routes/__init__.py
@@ -1,0 +1,17 @@
+"""HTTP routes for login, registration, OTP, Keycloak SSO, and the current user.
+
+Feature-module package: HTTP routes live in
+:mod:`~news_dashboard.auth_routes.router`, request models in
+:mod:`~news_dashboard.auth_routes.models`. Business logic (session tokens,
+Keycloak exchange, user/OTP persistence) stays in the existing
+:mod:`~news_dashboard.auth` module, which is imported across ~60 files
+(``require_auth``, ``require_admin``, etc.); this package is a thin HTTP
+layer on top of it rather than a replacement. See ``docs/adr`` for the
+feature-module layout rationale.
+
+The routers are imported directly from the ``router`` submodule (``from
+news_dashboard.auth_routes.router import public_router, router``) rather than
+re-exported here, so the submodule name is never shadowed.
+"""
+
+from __future__ import annotations

--- a/backend/news_dashboard/auth_routes/models.py
+++ b/backend/news_dashboard/auth_routes/models.py
@@ -1,0 +1,19 @@
+"""Request models for the login/OTP HTTP layer."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class OTPRequestPayload(BaseModel):
+    email: str
+
+
+class OTPLoginPayload(BaseModel):
+    email: str
+    otp: str

--- a/backend/news_dashboard/auth_routes/router.py
+++ b/backend/news_dashboard/auth_routes/router.py
@@ -1,0 +1,203 @@
+"""HTTP routes for login, registration, OTP, Keycloak SSO, and the current user.
+
+``public_router`` carries no auth dependency and is mounted directly on the
+app (via ``main``'s ``public_router``), matching the pre-migration behavior.
+``router`` holds the one authenticated endpoint (``/api/auth/me``) and is
+mounted on ``main``'s authenticated ``api`` router, inheriting its
+``require_auth`` gate.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Annotated, Any
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
+from fastapi.responses import RedirectResponse
+
+from news_dashboard.auth import (
+    _session_days,
+    authenticate,
+    consume_otp,
+    create_otp_for_user,
+    create_session_token,
+    exchange_keycloak_code,
+    get_or_create_otp_user,
+    keycloak_auth_metadata,
+    keycloak_authorization_url,
+    keycloak_config,
+    keycloak_logout_url,
+    keycloak_registration_url,
+    require_auth,
+)
+from news_dashboard.auth_routes.models import LoginRequest, OTPLoginPayload, OTPRequestPayload
+from news_dashboard.login_throttle import clear_failures, is_throttled, record_failure
+
+SESSION_COOKIE = "nd_session"
+OAUTH_STATE_COOKIE = "nd_oauth_state"
+
+public_router = APIRouter()
+router = APIRouter()
+
+
+@public_router.get("/api/auth/config")
+def auth_config() -> dict[str, Any]:
+    return keycloak_auth_metadata()
+
+
+@public_router.get("/api/auth/metadata")
+def auth_metadata() -> dict[str, Any]:
+    return keycloak_auth_metadata()
+
+
+@public_router.get("/auth/login")
+def keycloak_login() -> RedirectResponse:
+    if not keycloak_config().enabled:
+        return RedirectResponse(url="/login")
+    state = secrets.token_urlsafe(32)
+    redirect = RedirectResponse(url=keycloak_authorization_url(state))
+    redirect.set_cookie(
+        key=OAUTH_STATE_COOKIE,
+        value=state,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=600,
+        path="/auth/callback",
+    )
+    return redirect
+
+
+@public_router.get("/auth/register")
+def keycloak_register() -> RedirectResponse:
+    if not keycloak_config().enabled:
+        return RedirectResponse(url="/login")
+    state = secrets.token_urlsafe(32)
+    redirect = RedirectResponse(url=keycloak_registration_url(state))
+    redirect.set_cookie(
+        key=OAUTH_STATE_COOKIE,
+        value=state,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=600,
+        path="/auth/callback",
+    )
+    return redirect
+
+
+@public_router.get("/auth/callback")
+async def keycloak_callback(request: Request) -> RedirectResponse:
+    expected_state = request.cookies.get(OAUTH_STATE_COOKIE)
+    state = request.query_params.get("state")
+    code = request.query_params.get("code")
+    if not expected_state or not state or not secrets.compare_digest(expected_state, state):
+        raise HTTPException(status_code=400, detail="Invalid Keycloak OAuth state")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing Keycloak OAuth code")
+
+    user = await exchange_keycloak_code(code)
+    token = create_session_token(user["id"], bool(user["is_admin"]))
+    redirect = RedirectResponse(url="/")
+    redirect.set_cookie(
+        key=SESSION_COOKIE,
+        value=token,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=_session_days() * 86400,
+        path="/",
+    )
+    redirect.delete_cookie(key=OAUTH_STATE_COOKIE, path="/auth/callback")
+    return redirect
+
+
+@public_router.get("/auth/logout")
+def keycloak_logout() -> RedirectResponse:
+    redirect = RedirectResponse(url=keycloak_logout_url())
+    redirect.delete_cookie(key=SESSION_COOKIE, path="/")
+    return redirect
+
+
+@public_router.post("/api/auth/login")
+def login(payload: LoginRequest, response: Response) -> dict[str, Any]:
+    if keycloak_config().enabled:
+        raise HTTPException(status_code=409, detail="Password login is disabled; use Keycloak")
+    if is_throttled(payload.username):
+        raise HTTPException(
+            status_code=429,
+            detail="Too many failed login attempts; try again later",
+        )
+    user = authenticate(payload.username, payload.password)
+    if not user:
+        record_failure(payload.username)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    clear_failures(payload.username)
+    token = create_session_token(user["id"], bool(user["is_admin"]))
+    response.set_cookie(
+        key=SESSION_COOKIE,
+        value=token,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=_session_days() * 86400,
+        path="/",
+    )
+    return {"id": user["id"], "username": user["username"], "is_admin": bool(user["is_admin"])}
+
+
+@public_router.get("/api/auth/logout")
+def logout(response: Response) -> dict[str, str]:
+    response.delete_cookie(key=SESSION_COOKIE, path="/")
+    return {"status": "logged_out"}
+
+
+@public_router.post("/api/auth/otp/request")
+def otp_request(payload: OTPRequestPayload, background_tasks: BackgroundTasks) -> dict[str, str]:
+    from news_dashboard.email import send_otp_email
+
+    request_key = f"otp-request:{payload.email.strip().lower()}"
+    if is_throttled(request_key):
+        raise HTTPException(status_code=429, detail="Too many code requests; try again later")
+    record_failure(request_key)
+
+    user = get_or_create_otp_user(payload.email)
+    if user:
+        otp = create_otp_for_user(int(user["id"]))
+        background_tasks.add_task(send_otp_email, payload.email, otp)
+    # Always return success to prevent user enumeration
+    return {"status": "sent"}
+
+
+@public_router.post("/api/auth/otp/login")
+def otp_login(payload: OTPLoginPayload, response: Response) -> dict[str, Any]:
+    login_key = f"otp-login:{payload.email.strip().lower()}"
+    if is_throttled(login_key):
+        raise HTTPException(status_code=429, detail="Too many code attempts; try again later")
+
+    user = consume_otp(payload.email, payload.otp)
+    if not user:
+        record_failure(login_key)
+        raise HTTPException(status_code=401, detail="Invalid or expired code")
+    clear_failures(login_key)
+    token = create_session_token(int(user["id"]), bool(user["is_admin"]))
+    response.set_cookie(
+        key=SESSION_COOKIE,
+        value=token,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=_session_days() * 86400,
+        path="/",
+    )
+    return {"id": user["id"], "username": user["username"], "is_admin": bool(user["is_admin"])}
+
+
+@router.get("/api/auth/me")
+def auth_me(current_user: Annotated[dict[str, Any], Depends(require_auth)]) -> dict[str, Any]:
+    return {
+        "id": current_user["id"],
+        "username": current_user["username"],
+        "email": current_user.get("email"),
+        "is_admin": bool(current_user["is_admin"]),
+    }

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -28,7 +28,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from psycopg.errors import UniqueViolation
 from psycopg.types.json import Jsonb
@@ -44,29 +44,21 @@ from news_dashboard.analytics import (
     record_events,
 )
 from news_dashboard.auth import (
-    _session_days,
-    authenticate,
-    consume_otp,
     count_admins,
-    create_otp_for_user,
-    create_session_token,
     create_user,
     delete_user,
-    exchange_keycloak_code,
-    get_or_create_otp_user,
     get_user_by_id,
     init_auth,
-    keycloak_auth_metadata,
-    keycloak_authorization_url,
     keycloak_config,
-    keycloak_logout_url,
-    keycloak_registration_url,
     list_users,
     require_admin,
     require_auth,
     update_password,
     verify_session_token,
 )
+from news_dashboard.auth_routes.router import SESSION_COOKIE as _SESSION_COOKIE
+from news_dashboard.auth_routes.router import public_router as auth_public_router
+from news_dashboard.auth_routes.router import router as auth_router
 from news_dashboard.body_fetch import fetch_and_cache_body, get_article, prefetch_article_bodies
 from news_dashboard.briefings import (
     BriefingAINotConfiguredError,
@@ -95,7 +87,6 @@ from news_dashboard.ingest import (
     transition_article_state,
 )
 from news_dashboard.ingest_events import stream_ingest_events
-from news_dashboard.login_throttle import clear_failures, is_throttled, record_failure
 from news_dashboard.run_history import get_ingest_run_sources, list_ingest_runs
 from news_dashboard.scheduler import (
     get_interval_minutes,
@@ -126,9 +117,6 @@ from news_dashboard.stats import (
 from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
 
 logger = logging.getLogger(__name__)
-
-_SESSION_COOKIE = "nd_session"
-_OAUTH_STATE_COOKIE = "nd_oauth_state"
 
 _VERSION_FILE = Path(__file__).resolve().parents[2] / "VERSION"
 
@@ -552,11 +540,6 @@ class IntervalUpdate(BaseModel):
     minutes: int
 
 
-class LoginRequest(BaseModel):
-    username: str
-    password: str
-
-
 class CreateUserRequest(BaseModel):
     username: str
     password: str
@@ -584,15 +567,6 @@ class AnalyticsEvent(BaseModel):
 
 class AnalyticsEventsRequest(BaseModel):
     events: list[AnalyticsEvent] = Field(max_length=MAX_EVENTS_PER_BATCH)
-
-
-class OTPRequestPayload(BaseModel):
-    email: str
-
-
-class OTPLoginPayload(BaseModel):
-    email: str
-    otp: str
 
 
 # ── OPML helpers ──────────────────────────────────────────────────────────────
@@ -662,157 +636,7 @@ def public_config() -> dict[str, Any]:
     return {"sentry_dsn": frontend_error_tracking_dsn()}
 
 
-@public_router.get("/api/auth/config")
-def auth_config() -> dict[str, Any]:
-    return keycloak_auth_metadata()
-
-
-@public_router.get("/api/auth/metadata")
-def auth_metadata() -> dict[str, Any]:
-    return keycloak_auth_metadata()
-
-
-@public_router.get("/auth/login")
-def keycloak_login() -> RedirectResponse:
-    if not keycloak_config().enabled:
-        return RedirectResponse(url="/login")
-    state = secrets.token_urlsafe(32)
-    redirect = RedirectResponse(url=keycloak_authorization_url(state))
-    redirect.set_cookie(
-        key=_OAUTH_STATE_COOKIE,
-        value=state,
-        httponly=True,
-        secure=True,
-        samesite="lax",
-        max_age=600,
-        path="/auth/callback",
-    )
-    return redirect
-
-
-@public_router.get("/auth/register")
-def keycloak_register() -> RedirectResponse:
-    if not keycloak_config().enabled:
-        return RedirectResponse(url="/login")
-    state = secrets.token_urlsafe(32)
-    redirect = RedirectResponse(url=keycloak_registration_url(state))
-    redirect.set_cookie(
-        key=_OAUTH_STATE_COOKIE,
-        value=state,
-        httponly=True,
-        secure=True,
-        samesite="lax",
-        max_age=600,
-        path="/auth/callback",
-    )
-    return redirect
-
-
-@public_router.get("/auth/callback")
-async def keycloak_callback(request: Request) -> RedirectResponse:
-    expected_state = request.cookies.get(_OAUTH_STATE_COOKIE)
-    state = request.query_params.get("state")
-    code = request.query_params.get("code")
-    if not expected_state or not state or not secrets.compare_digest(expected_state, state):
-        raise HTTPException(status_code=400, detail="Invalid Keycloak OAuth state")
-    if not code:
-        raise HTTPException(status_code=400, detail="Missing Keycloak OAuth code")
-
-    user = await exchange_keycloak_code(code)
-    token = create_session_token(user["id"], bool(user["is_admin"]))
-    redirect = RedirectResponse(url="/")
-    redirect.set_cookie(
-        key=_SESSION_COOKIE,
-        value=token,
-        httponly=True,
-        secure=True,
-        samesite="strict",
-        max_age=_session_days() * 86400,
-        path="/",
-    )
-    redirect.delete_cookie(key=_OAUTH_STATE_COOKIE, path="/auth/callback")
-    return redirect
-
-
-@public_router.get("/auth/logout")
-def keycloak_logout() -> RedirectResponse:
-    redirect = RedirectResponse(url=keycloak_logout_url())
-    redirect.delete_cookie(key=_SESSION_COOKIE, path="/")
-    return redirect
-
-
-@public_router.post("/api/auth/login")
-def login(payload: LoginRequest, response: Response) -> dict[str, Any]:
-    if keycloak_config().enabled:
-        raise HTTPException(status_code=409, detail="Password login is disabled; use Keycloak")
-    if is_throttled(payload.username):
-        raise HTTPException(
-            status_code=429,
-            detail="Too many failed login attempts; try again later",
-        )
-    user = authenticate(payload.username, payload.password)
-    if not user:
-        record_failure(payload.username)
-        raise HTTPException(status_code=401, detail="Invalid credentials")
-    clear_failures(payload.username)
-    token = create_session_token(user["id"], bool(user["is_admin"]))
-    response.set_cookie(
-        key=_SESSION_COOKIE,
-        value=token,
-        httponly=True,
-        secure=True,
-        samesite="strict",
-        max_age=_session_days() * 86400,
-        path="/",
-    )
-    return {"id": user["id"], "username": user["username"], "is_admin": bool(user["is_admin"])}
-
-
-@public_router.get("/api/auth/logout")
-def logout(response: Response) -> dict[str, str]:
-    response.delete_cookie(key=_SESSION_COOKIE, path="/")
-    return {"status": "logged_out"}
-
-
-@public_router.post("/api/auth/otp/request")
-def otp_request(payload: OTPRequestPayload, background_tasks: BackgroundTasks) -> dict[str, str]:
-    from news_dashboard.email import send_otp_email
-
-    request_key = f"otp-request:{payload.email.strip().lower()}"
-    if is_throttled(request_key):
-        raise HTTPException(status_code=429, detail="Too many code requests; try again later")
-    record_failure(request_key)
-
-    user = get_or_create_otp_user(payload.email)
-    if user:
-        otp = create_otp_for_user(int(user["id"]))
-        background_tasks.add_task(send_otp_email, payload.email, otp)
-    # Always return success to prevent user enumeration
-    return {"status": "sent"}
-
-
-@public_router.post("/api/auth/otp/login")
-def otp_login(payload: OTPLoginPayload, response: Response) -> dict[str, Any]:
-    login_key = f"otp-login:{payload.email.strip().lower()}"
-    if is_throttled(login_key):
-        raise HTTPException(status_code=429, detail="Too many code attempts; try again later")
-
-    user = consume_otp(payload.email, payload.otp)
-    if not user:
-        record_failure(login_key)
-        raise HTTPException(status_code=401, detail="Invalid or expired code")
-    clear_failures(login_key)
-    token = create_session_token(int(user["id"]), bool(user["is_admin"]))
-    response.set_cookie(
-        key=_SESSION_COOKIE,
-        value=token,
-        httponly=True,
-        secure=True,
-        samesite="strict",
-        max_age=_session_days() * 86400,
-        path="/",
-    )
-    return {"id": user["id"], "username": user["username"], "is_admin": bool(user["is_admin"])}
+public_router.include_router(auth_public_router)
 
 
 @public_router.get("/api/articles/{article_id}/read")
@@ -904,14 +728,7 @@ def ingest_events(
     return {"stored": stored}
 
 
-@api.get("/api/auth/me")
-def auth_me(current_user: Annotated[dict[str, Any], Depends(require_auth)]) -> dict[str, Any]:
-    return {
-        "id": current_user["id"],
-        "username": current_user["username"],
-        "email": current_user.get("email"),
-        "is_admin": bool(current_user["is_admin"]),
-    }
+api.include_router(auth_router)
 
 
 @api.post("/api/ingest", dependencies=[Depends(require_admin)])

--- a/backend/tests/test_auth_routes_package.py
+++ b/backend/tests/test_auth_routes_package.py
@@ -1,0 +1,52 @@
+"""Structural tests for the ``auth_routes`` feature-module package.
+
+These guard the router layout (see the feature-module ADR) and ensure the
+refactor stays behaviour-preserving: every ``/auth/*`` and ``/api/auth/*``
+route remains mounted on the app with its original path. Unlike other
+feature-module domains, business logic (session tokens, Keycloak exchange,
+OTP persistence) stays in the existing ``news_dashboard.auth`` module rather
+than moving into a ``service.py``, since that module is imported across the
+rest of the codebase.
+"""
+
+from __future__ import annotations
+
+from news_dashboard.main import app
+
+
+def test_auth_routes_package_modules_import() -> None:
+    """public_router/router are importable from the auth_routes package."""
+    from fastapi import APIRouter
+
+    from news_dashboard.auth_routes import models
+    from news_dashboard.auth_routes.router import public_router, router
+
+    assert isinstance(public_router, APIRouter)
+    assert isinstance(router, APIRouter)
+    assert hasattr(models, "LoginRequest")
+    assert hasattr(models, "OTPRequestPayload")
+    assert hasattr(models, "OTPLoginPayload")
+
+
+def test_auth_routes_stay_mounted() -> None:
+    """The refactor must not drop or rename any login/OTP/Keycloak/me route.
+
+    Routers are mounted lazily (as ``_IncludedRouter`` objects) rather than
+    flattened into ``app.routes``, so assert against the resolved OpenAPI paths.
+    """
+    paths = set(app.openapi()["paths"])
+    expected = {
+        "/api/auth/config",
+        "/api/auth/metadata",
+        "/auth/login",
+        "/auth/register",
+        "/auth/callback",
+        "/auth/logout",
+        "/api/auth/login",
+        "/api/auth/logout",
+        "/api/auth/otp/request",
+        "/api/auth/otp/login",
+        "/api/auth/me",
+    }
+    missing = expected - paths
+    assert not missing, f"missing routes after refactor: {sorted(missing)}"

--- a/backend/tests/test_main_oauth.py
+++ b/backend/tests/test_main_oauth.py
@@ -1,8 +1,10 @@
 """Tests for the public OAuth / Keycloak endpoints and the version endpoint.
 
-These routes live in main.py and were previously uncovered. Keycloak helpers
-are patched so no real identity provider is contacted; the TestClient is built
-without auth overrides because every route here is public.
+The OAuth/login/OTP routes live in the ``auth_routes`` feature-module package
+(mounted on ``main``'s ``public_router``); the version endpoints stay in
+main.py. Keycloak helpers are patched so no real identity provider is
+contacted; the TestClient is built without auth overrides because every route
+here is public.
 """
 
 from __future__ import annotations
@@ -26,7 +28,10 @@ def _client() -> TestClient:
 
 
 def test_keycloak_login_redirects_to_local_login_when_disabled() -> None:
-    with patch("news_dashboard.main.keycloak_config", return_value=SimpleNamespace(enabled=False)):
+    with patch(
+        "news_dashboard.auth_routes.router.keycloak_config",
+        return_value=SimpleNamespace(enabled=False),
+    ):
         resp = _client().get("/auth/login")
     assert resp.status_code == 307
     assert resp.headers["location"] == "/login"
@@ -34,9 +39,12 @@ def test_keycloak_login_redirects_to_local_login_when_disabled() -> None:
 
 def test_keycloak_login_redirects_to_provider_and_sets_state_cookie() -> None:
     with (
-        patch("news_dashboard.main.keycloak_config", return_value=SimpleNamespace(enabled=True)),
         patch(
-            "news_dashboard.main.keycloak_authorization_url",
+            "news_dashboard.auth_routes.router.keycloak_config",
+            return_value=SimpleNamespace(enabled=True),
+        ),
+        patch(
+            "news_dashboard.auth_routes.router.keycloak_authorization_url",
             return_value="https://idp.example/auth?state=x",
         ),
     ):
@@ -75,10 +83,10 @@ def test_keycloak_callback_success_sets_session_and_redirects() -> None:
     client.cookies.set("nd_oauth_state", "match")
     with (
         patch(
-            "news_dashboard.main.exchange_keycloak_code",
+            "news_dashboard.auth_routes.router.exchange_keycloak_code",
             new=AsyncMock(return_value={"id": 7, "is_admin": False}),
         ),
-        patch("news_dashboard.main.create_session_token", return_value="sess-token"),
+        patch("news_dashboard.auth_routes.router.create_session_token", return_value="sess-token"),
     ):
         resp = client.get("/auth/callback?state=match&code=good")
     assert resp.status_code == 307
@@ -91,7 +99,8 @@ def test_keycloak_callback_success_sets_session_and_redirects() -> None:
 
 def test_keycloak_logout_redirects_to_provider_logout() -> None:
     with patch(
-        "news_dashboard.main.keycloak_logout_url", return_value="https://idp.example/logout"
+        "news_dashboard.auth_routes.router.keycloak_logout_url",
+        return_value="https://idp.example/logout",
     ):
         resp = _client().get("/auth/logout")
     assert resp.status_code == 307
@@ -102,7 +111,10 @@ def test_keycloak_logout_redirects_to_provider_logout() -> None:
 
 
 def test_password_login_returns_409_when_keycloak_enabled() -> None:
-    with patch("news_dashboard.main.keycloak_config", return_value=SimpleNamespace(enabled=True)):
+    with patch(
+        "news_dashboard.auth_routes.router.keycloak_config",
+        return_value=SimpleNamespace(enabled=True),
+    ):
         resp = _client().post("/api/auth/login", json={"username": "u", "password": "p"})
     assert resp.status_code == 409
 
@@ -111,7 +123,10 @@ def test_password_login_returns_409_when_keycloak_enabled() -> None:
 
 
 def test_auth_config_returns_metadata() -> None:
-    with patch("news_dashboard.main.keycloak_auth_metadata", return_value={"provider": "password"}):
+    with patch(
+        "news_dashboard.auth_routes.router.keycloak_auth_metadata",
+        return_value={"provider": "password"},
+    ):
         resp = _client().get("/api/auth/config")
     assert resp.status_code == 200
     assert resp.json() == {"provider": "password"}


### PR DESCRIPTION
## Summary

Migrates the **auth** domain (`/auth/*`, `/api/auth/*`) from `main.py` into a per-domain feature-module package, following the `quizzes` reference implementation (#825) tracked in #826.

- `backend/news_dashboard/auth_routes/router.py` — `public_router` (Keycloak login/register/callback/logout, password login/logout, OTP request/login, config/metadata; mounted on `main`'s `public_router`, no auth) and `router` (`/api/auth/me`; mounted on `main`'s authenticated `api` router).
- `backend/news_dashboard/auth_routes/models.py` — `LoginRequest`, `OTPRequestPayload`, `OTPLoginPayload`.
- No route paths or auth semantics changed (behavior-preserving, per the tracking issue's rules).

**Scope note:** unlike `quizzes`, business logic stays in the existing `news_dashboard.auth` module rather than moving into a new `service.py`. That module is imported across ~60 files in the codebase (`require_auth`, `require_admin`, session/OTP/Keycloak helpers), so folding it into this package would be a much larger, riskier change than one domain's routes. `auth_routes/` is a thin HTTP layer on top of it — the same public/authenticated router split `greader.py` already uses.

## Test plan

- [x] `pytest tests/test_auth.py tests/test_auth_extra.py tests/test_main_oauth.py tests/test_auth_routes_package.py tests/test_quizzes_package.py` → 115 passed
- [x] Updated `test_main_oauth.py` patch targets (`news_dashboard.main.keycloak_*` → `news_dashboard.auth_routes.router.keycloak_*`) since those symbols moved
- [x] Added `test_auth_routes_package.py` (mirrors `test_quizzes_package.py`): package imports cleanly, every `/auth/*` and `/api/auth/*` route stays mounted
- [x] `ruff check .` → all checks passed
- [x] `mypy news_dashboard` → no issues in 94 source files
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) → all passed

Closes one item in the #826 tracking checklist (auth domain); tracking issue stays open until all remaining domains are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)