### PR TITLE
refactor: extract system/health routes into feature-module package (#826)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -71,7 +71,7 @@ from news_dashboard.briefings import (
     list_briefings,
 )
 from news_dashboard.db import connect, describe_database, init_db, row_to_dict
-from news_dashboard.error_tracking import frontend_error_tracking_dsn, init_error_tracking
+from news_dashboard.error_tracking import init_error_tracking
 from news_dashboard.ingest import (
     FeedFetchError,
     clean_html,
@@ -497,7 +497,6 @@ class CreateSourceRequest(BaseModel):
 
     def validated_slug(self, name: str) -> str:
         """Return a non-empty slug, normalised from name if not provided."""
-        import re
 
         raw = self.slug or re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")
         slug = re.sub(r"-{2,}", "-", raw).strip("-")[:80]
@@ -596,46 +595,6 @@ def _generate_opml(sources: list[dict[str, Any]]) -> str:
 public_router = APIRouter()
 
 
-@public_router.get("/api/health")
-def health() -> dict[str, Any]:
-    init_db()
-    return {"status": "ok"}
-
-
-@public_router.get("/api/live")
-def liveness() -> dict[str, Any]:
-    return {"status": "ok"}
-
-
-@public_router.get("/api/ready")
-def readiness() -> dict[str, Any]:
-    try:
-        with connect() as conn:
-            conn.execute("SELECT 1")
-    except Exception as exc:
-        raise HTTPException(status_code=503, detail="database unavailable") from exc
-    return {"status": "ok"}
-
-
-@public_router.get("/metrics")
-def prometheus_metrics() -> Response:
-    from news_dashboard.metrics import CONTENT_TYPE_LATEST, metrics_enabled, render_metrics
-
-    if not metrics_enabled():
-        raise HTTPException(status_code=404, detail="not found")
-    return Response(content=render_metrics(), media_type=CONTENT_TYPE_LATEST)
-
-
-@public_router.get("/api/config")
-def public_config() -> dict[str, Any]:
-    """Public, non-sensitive runtime config the SPA needs before login.
-
-    ``sentry_dsn`` is a Sentry/GlitchTip DSN, which is designed to be
-    exposed to clients — it only lets a client *send* events, not read data.
-    """
-    return {"sentry_dsn": frontend_error_tracking_dsn()}
-
-
 public_router.include_router(auth_public_router)
 
 
@@ -666,51 +625,6 @@ def _embed_article_background(article_id: int) -> None:
         ensure_article_embedded(article_id)
     except Exception:
         logger.debug("Background embedding skipped for article %d", article_id, exc_info=True)
-
-
-# ── Public version / changelog endpoints (no auth) ───────────────────────────
-
-_CHANGELOG_FILE = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
-
-# "## 1.2.3" or Keep a Changelog style "## [1.2.3] — 2026-07-03" (em dash or
-# hyphen). The version must come out bare: the frontend What's New popup
-# matches entry.version against the app version exactly.
-_CHANGELOG_HEADING = re.compile(r"^##\s+\[?(?P<version>[^\]\s]+)\]?(?:\s*[—-]\s*(?P<date>\S+))?")
-
-
-def _parse_changelog() -> list[dict[str, object]]:
-    try:
-        text = _CHANGELOG_FILE.read_text()
-    except OSError:
-        return []
-    entries: list[dict[str, object]] = []
-    current_items: list[str] = []
-    for line in text.splitlines():
-        if line.startswith("## "):
-            m = _CHANGELOG_HEADING.match(line)
-            current_items = []
-            entries.append(
-                {
-                    "version": m.group("version") if m else line[3:].strip(),
-                    "date": m.group("date") if m else None,
-                    "items": current_items,
-                }
-            )
-        elif line.startswith("- ") and entries:
-            current_items.append(line[2:].strip())
-    return entries
-
-
-@app.get("/api/version")
-def version_endpoint() -> dict[str, str]:
-    """Return the running app version, matching the OpenAPI ``info.version``."""
-    return {"version": app.version}
-
-
-@app.get("/api/changelog")
-def changelog_endpoint() -> dict[str, object]:
-    """Return changelog entries parsed from CHANGELOG.md."""
-    return {"version": app.version, "entries": _parse_changelog()}
 
 
 # ── Authenticated API router ─────────────────────────────────────────────────
@@ -3204,6 +3118,7 @@ from news_dashboard.reading_list.router import router as reading_list_router  # 
 from news_dashboard.reading_progress.router import router as reading_progress_router  # noqa: E402
 from news_dashboard.recaps.router import router as recaps_router  # noqa: E402
 from news_dashboard.saved_searches.router import router as saved_searches_router  # noqa: E402
+from news_dashboard.system.router import router as system_router  # noqa: E402
 
 api.include_router(ai_feedback_router)
 api.include_router(ai_stats_router)
@@ -3223,6 +3138,9 @@ app.include_router(admin)
 # `api` router.
 app.include_router(public_mcp_router)
 app.include_router(public_greader_router)
+# System/health endpoints are unauthenticated, so mount directly on the app
+# rather than the `api` router.
+app.include_router(system_router)
 
 
 # ── SPA static files ─────────────────────────────────────────────────────────

--- a/backend/news_dashboard/system/__init__.py
+++ b/backend/news_dashboard/system/__init__.py
@@ -1,0 +1,12 @@
+"""Public system/health endpoints: health, liveness, readiness, metrics, config, version, changelog.
+
+Feature-module package: HTTP routes live in :mod:`~news_dashboard.system.router`,
+business logic in :mod:`~news_dashboard.system.service`. See ``docs/adr`` for the
+layout rationale.
+
+The router is imported directly from the ``router`` submodule (``from
+news_dashboard.system.router import router``) rather than re-exported here, so
+the submodule name is never shadowed.
+"""
+
+from __future__ import annotations

--- a/backend/news_dashboard/system/router.py
+++ b/backend/news_dashboard/system/router.py
@@ -1,0 +1,61 @@
+"""HTTP routes for health, liveness, readiness, metrics, config, version, and changelog.
+
+The router carries no auth dependency; it is mounted directly on the app
+alongside ``main``'s ``public_router``, unauthenticated.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, Response
+
+from news_dashboard.system import service
+
+router = APIRouter()
+
+
+@router.get("/api/health")
+def health() -> dict[str, Any]:
+    service.check_health()
+    return {"status": "ok"}
+
+
+@router.get("/api/live")
+def liveness() -> dict[str, Any]:
+    return {"status": "ok"}
+
+
+@router.get("/api/ready")
+def readiness() -> dict[str, Any]:
+    try:
+        service.check_readiness()
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail="database unavailable") from exc
+    return {"status": "ok"}
+
+
+@router.get("/metrics")
+def prometheus_metrics() -> Response:
+    from news_dashboard.metrics import CONTENT_TYPE_LATEST, metrics_enabled, render_metrics
+
+    if not metrics_enabled():
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(content=render_metrics(), media_type=CONTENT_TYPE_LATEST)
+
+
+@router.get("/api/config")
+def public_config() -> dict[str, Any]:
+    return service.public_config()
+
+
+@router.get("/api/version")
+def version_endpoint(request: Request) -> dict[str, str]:
+    """Return the running app version, matching the OpenAPI ``info.version``."""
+    return {"version": request.app.version}
+
+
+@router.get("/api/changelog")
+def changelog_endpoint(request: Request) -> dict[str, object]:
+    """Return changelog entries parsed from CHANGELOG.md."""
+    return {"version": request.app.version, "entries": service.parse_changelog()}

--- a/backend/news_dashboard/system/service.py
+++ b/backend/news_dashboard/system/service.py
@@ -1,0 +1,58 @@
+"""Business logic for health/readiness checks, metrics, and changelog parsing."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.error_tracking import frontend_error_tracking_dsn
+
+_CHANGELOG_FILE = Path(__file__).resolve().parents[3] / "CHANGELOG.md"
+
+# "## 1.2.3" or Keep a Changelog style "## [1.2.3] — 2026-07-03" (em dash or
+# hyphen). The version must come out bare: the frontend What's New popup
+# matches entry.version against the app version exactly.
+_CHANGELOG_HEADING = re.compile(r"^##\s+\[?(?P<version>[^\]\s]+)\]?(?:\s*[—-]\s*(?P<date>\S+))?")
+
+
+def check_health() -> None:
+    init_db()
+
+
+def check_readiness() -> None:
+    with connect() as conn:
+        conn.execute("SELECT 1")
+
+
+def public_config() -> dict[str, Any]:
+    """Public, non-sensitive runtime config the SPA needs before login.
+
+    ``sentry_dsn`` is a Sentry/GlitchTip DSN, which is designed to be
+    exposed to clients — it only lets a client *send* events, not read data.
+    """
+    return {"sentry_dsn": frontend_error_tracking_dsn()}
+
+
+def parse_changelog() -> list[dict[str, object]]:
+    try:
+        text = _CHANGELOG_FILE.read_text()
+    except OSError:
+        return []
+    entries: list[dict[str, object]] = []
+    current_items: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## "):
+            m = _CHANGELOG_HEADING.match(line)
+            current_items = []
+            entries.append(
+                {
+                    "version": m.group("version") if m else line[3:].strip(),
+                    "date": m.group("date") if m else None,
+                    "items": current_items,
+                }
+            )
+        elif line.startswith("- ") and entries:
+            current_items.append(line[2:].strip())
+    return entries

--- a/backend/tests/test_changelog_endpoint.py
+++ b/backend/tests/test_changelog_endpoint.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from news_dashboard.main import _parse_changelog, app
+from news_dashboard.main import app
+from news_dashboard.system.service import parse_changelog
 
 
 def _client() -> TestClient:
@@ -15,7 +16,7 @@ def _client() -> TestClient:
     return TestClient(app, follow_redirects=False)
 
 
-# ── _parse_changelog unit tests ───────────────────────────────────────────────
+# ── parse_changelog unit tests ────────────────────────────────────────────────
 
 
 def test_parse_changelog_returns_entries() -> None:
@@ -29,9 +30,9 @@ def test_parse_changelog_returns_entries() -> None:
         ## 1.1.0
         - Bug fix C
     """)
-    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.return_value = md
-        entries = _parse_changelog()
+        entries = parse_changelog()
     assert len(entries) == 2
     assert entries[0] == {"version": "1.2.0", "date": None, "items": ["Feature A", "Feature B"]}
     assert entries[1] == {"version": "1.1.0", "date": None, "items": ["Bug fix C"]}
@@ -49,9 +50,9 @@ def test_parse_changelog_normalizes_keep_a_changelog_headings() -> None:
         ### Added
         - Share articles
     """)
-    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.return_value = md
-        entries = _parse_changelog()
+        entries = parse_changelog()
     assert entries == [
         {"version": "1.22.0", "date": "2026-07-03", "items": ["New feature"]},
         {"version": "1.21.0", "date": "2026-06-26", "items": ["Share articles"]},
@@ -59,9 +60,9 @@ def test_parse_changelog_normalizes_keep_a_changelog_headings() -> None:
 
 
 def test_parse_changelog_returns_empty_on_oserror() -> None:
-    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.side_effect = OSError("missing")
-        entries = _parse_changelog()
+        entries = parse_changelog()
     assert entries == []
 
 
@@ -71,9 +72,9 @@ def test_parse_changelog_ignores_non_bullet_lines() -> None:
         Some intro text.
         - Real item
     """)
-    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.return_value = md
-        entries = _parse_changelog()
+        entries = parse_changelog()
     assert entries == [{"version": "2.0.0", "date": None, "items": ["Real item"]}]
 
 
@@ -85,7 +86,7 @@ def test_changelog_endpoint_returns_version_and_entries() -> None:
         ## 9.9.9
         - New thing
     """)
-    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.return_value = md
         resp = _client().get("/api/changelog")
     assert resp.status_code == 200
@@ -95,7 +96,7 @@ def test_changelog_endpoint_returns_version_and_entries() -> None:
 
 
 def test_changelog_endpoint_version_matches_app_version() -> None:
-    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.return_value = "## 1.0.0\n- item\n"
         resp = _client().get("/api/changelog")
     assert resp.status_code == 200
@@ -103,7 +104,7 @@ def test_changelog_endpoint_version_matches_app_version() -> None:
 
 
 def test_changelog_endpoint_entries_empty_on_missing_file() -> None:
-    with patch("news_dashboard.main._CHANGELOG_FILE") as cf:
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.side_effect = OSError("missing")
         resp = _client().get("/api/changelog")
     assert resp.status_code == 200

--- a/backend/tests/test_health_endpoints.py
+++ b/backend/tests/test_health_endpoints.py
@@ -19,7 +19,7 @@ def _client() -> TestClient:
 
 @pytest.mark.smoke
 def test_live_returns_200_without_db() -> None:
-    with patch("news_dashboard.main.connect") as mock_connect:
+    with patch("news_dashboard.system.service.connect") as mock_connect:
         resp = _client().get("/api/live")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
@@ -36,7 +36,7 @@ def test_ready_returns_200_when_db_ok() -> None:
 
         yield _Conn()
 
-    with patch("news_dashboard.main.connect", fake_connect):
+    with patch("news_dashboard.system.service.connect", fake_connect):
         resp = _client().get("/api/ready")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
@@ -53,6 +53,6 @@ def test_ready_returns_503_when_db_unavailable() -> None:
 
         yield _BrokenConn()
 
-    with patch("news_dashboard.main.connect", broken_connect):
+    with patch("news_dashboard.system.service.connect", broken_connect):
         resp = _client().get("/api/ready")
     assert resp.status_code == 503


### PR DESCRIPTION
## Summary

Extracts the **system/public** domain listed in the [#826 tracking issue](https://github.com/lihor-hub/news-dashboard/issues/826) into its own feature-module package, following the layout established by #825 / [ADR-0003](docs/adr/0003-feature-module-packages.md):

- `/api/health`, `/api/live`, `/api/ready`, `/metrics`, `/api/config`, `/api/version`, `/api/changelog` move out of `main.py` into `backend/news_dashboard/system/router.py` + `service.py`.
- `main.py` now just imports `system_router` and mounts it via `app.include_router(system_router)`.
- No route paths, status codes, or response shapes change — this is a pure structural refactor.
- Rebased on top of the recently-merged `auth` domain extraction (#1056) which touched the same `public_router` section of `main.py`.

Two existing white-box tests referenced private helpers on `news_dashboard.main` directly and were updated to point at the new module:
- `backend/tests/test_changelog_endpoint.py` now imports `parse_changelog` from `news_dashboard.system.service` and patches `news_dashboard.system.service._CHANGELOG_FILE`.
- `backend/tests/test_health_endpoints.py` now patches `news_dashboard.system.service.connect` for the readiness-probe tests.

## Test plan
- [x] `ruff check backend/` — clean
- [x] `mypy backend/news_dashboard` — clean
- [x] Full backend suite: `pytest backend/tests` — 1820 passed, 1 pre-existing flaky failure (`test_embedding_dedup.py::test_no_op_without_embedding_credentials`, a transient Postgres connection timeout under parallel load) confirmed unrelated by re-running in isolation (passes).
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)