### PR TITLE
fix: archive duplicate-url articles instead of crash-looping schema init

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -187,6 +187,68 @@ POSTGRES_SCHEMA = [
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS starred_at TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS later_until TEXT",
     "ALTER TABLE articles ADD COLUMN IF NOT EXISTS restored_at TEXT",
+    # Some rows in production already carry a duplicate `url` (see #1064),
+    # predating this constraint being consistently enforced on every insert
+    # path. `url` itself is never touched by the bulk UPDATEs below, but any
+    # non-HOT update rewriting those rows re-inserts their index entries and
+    # trips the articles_url_key UNIQUE constraint on the pre-existing
+    # duplicate. Merge duplicates (keeping the lowest id) before those
+    # UPDATEs run, repointing every FK column that references articles(id)
+    # (discovered dynamically, not hardcoded) so per-user state and other
+    # child data survive the merge instead of being cascade-deleted.
+    """
+    DO $$
+    DECLARE
+      dup RECORD;
+      fk RECORD;
+      child RECORD;
+    BEGIN
+      FOR dup IN
+        SELECT id AS loser_id, keep_id
+        FROM (
+          SELECT id, MIN(id) OVER (PARTITION BY url) AS keep_id
+          FROM articles
+        ) ranked
+        WHERE id <> keep_id
+      LOOP
+        FOR fk IN
+          SELECT tc.table_name, kcu.column_name
+          FROM information_schema.table_constraints tc
+          JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+           AND tc.table_schema = kcu.table_schema
+          JOIN information_schema.constraint_column_usage ccu
+            ON tc.constraint_name = ccu.constraint_name
+           AND tc.table_schema = ccu.table_schema
+          WHERE tc.constraint_type = 'FOREIGN KEY'
+            AND tc.table_schema = current_schema()
+            AND ccu.table_name = 'articles'
+            AND ccu.column_name = 'id'
+        LOOP
+          -- Repoint one child row at a time (by ctid) rather than a single
+          -- blanket UPDATE: if any row referencing the loser collides with
+          -- an existing keeper row, a whole-table UPDATE would fail and a
+          -- whole-table fallback DELETE would wipe out unrelated, non-
+          -- conflicting rows that also referenced the loser.
+          FOR child IN
+            EXECUTE format('SELECT ctid FROM %I WHERE %I = $1', fk.table_name, fk.column_name)
+            USING dup.loser_id
+          LOOP
+            BEGIN
+              EXECUTE format(
+                'UPDATE %I SET %I = $1 WHERE ctid = $2',
+                fk.table_name, fk.column_name
+              ) USING dup.keep_id, child.ctid;
+            EXCEPTION WHEN unique_violation THEN
+              EXECUTE format('DELETE FROM %I WHERE ctid = $1', fk.table_name)
+              USING child.ctid;
+            END;
+          END LOOP;
+        END LOOP;
+        DELETE FROM articles WHERE id = dup.loser_id;
+      END LOOP;
+    END $$;
+    """,
     """
     UPDATE articles SET state = CASE status
       WHEN 'new'      THEN 'today'

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -192,63 +192,22 @@ POSTGRES_SCHEMA = [
     # path. `url` itself is never touched by the bulk UPDATEs below, but any
     # non-HOT update rewriting those rows re-inserts their index entries and
     # trips the articles_url_key UNIQUE constraint on the pre-existing
-    # duplicate. Merge duplicates (keeping the lowest id) before those
-    # UPDATEs run, repointing every FK column that references articles(id)
-    # (discovered dynamically, not hardcoded) so per-user state and other
-    # child data survive the merge instead of being cascade-deleted.
-    """
-    DO $$
-    DECLARE
-      dup RECORD;
-      fk RECORD;
-      child RECORD;
-    BEGIN
-      FOR dup IN
-        SELECT id AS loser_id, keep_id
-        FROM (
-          SELECT id, MIN(id) OVER (PARTITION BY url) AS keep_id
-          FROM articles
-        ) ranked
-        WHERE id <> keep_id
-      LOOP
-        FOR fk IN
-          SELECT tc.table_name, kcu.column_name
-          FROM information_schema.table_constraints tc
-          JOIN information_schema.key_column_usage kcu
-            ON tc.constraint_name = kcu.constraint_name
-           AND tc.table_schema = kcu.table_schema
-          JOIN information_schema.constraint_column_usage ccu
-            ON tc.constraint_name = ccu.constraint_name
-           AND tc.table_schema = ccu.table_schema
-          WHERE tc.constraint_type = 'FOREIGN KEY'
-            AND tc.table_schema = current_schema()
-            AND ccu.table_name = 'articles'
-            AND ccu.column_name = 'id'
-        LOOP
-          -- Repoint one child row at a time (by ctid) rather than a single
-          -- blanket UPDATE: if any row referencing the loser collides with
-          -- an existing keeper row, a whole-table UPDATE would fail and a
-          -- whole-table fallback DELETE would wipe out unrelated, non-
-          -- conflicting rows that also referenced the loser.
-          FOR child IN
-            EXECUTE format('SELECT ctid FROM %I WHERE %I = $1', fk.table_name, fk.column_name)
-            USING dup.loser_id
-          LOOP
-            BEGIN
-              EXECUTE format(
-                'UPDATE %I SET %I = $1 WHERE ctid = $2',
-                fk.table_name, fk.column_name
-              ) USING dup.keep_id, child.ctid;
-            EXCEPTION WHEN unique_violation THEN
-              EXECUTE format('DELETE FROM %I WHERE ctid = $1', fk.table_name)
-              USING child.ctid;
-            END;
-          END LOOP;
-        END LOOP;
-        DELETE FROM articles WHERE id = dup.loser_id;
-      END LOOP;
-    END $$;
-    """,
+    # duplicate. Fold each duplicate into the lowest-id row using the same
+    # canonical/duplicate shape as embedding_dedup._merge_duplicate (older
+    # row stays canonical; the rest become archived with canonical_id set)
+    # instead of deleting them: deleting would cascade away other users'
+    # per-article state (user_article_state, ai_feedback, ...) on the
+    # duplicate row, and this repo's one other duplicate-merge path never
+    # does that. The url is suffixed to stay unique since, unlike that
+    # embedding-similarity path, these rows share one literal url and can't
+    # both keep it.
+    (
+        "UPDATE articles AS dup SET"
+        " url = dup.url || '#dup-' || dup.id::text,"
+        " state = 'archived', status = 'archived', canonical_id = ranked.keep_id"
+        " FROM (SELECT id, MIN(id) OVER (PARTITION BY url) AS keep_id FROM articles) AS ranked"
+        " WHERE dup.id = ranked.id AND dup.id != ranked.keep_id"
+    ),
     """
     UPDATE articles SET state = CASE status
       WHEN 'new'      THEN 'today'

--- a/backend/tests/test_db_dedupe_article_urls.py
+++ b/backend/tests/test_db_dedupe_article_urls.py
@@ -5,8 +5,8 @@ Production already contains `articles` rows that share the same `url`
 every insert path). Because `url` is UNIQUE, a bulk UPDATE that rewrites those
 rows (like the state backfill in POSTGRES_SCHEMA) surfaces the latent
 duplicate as a UniqueViolation and crash-loops init_db(). These tests confirm
-the dedupe migration step merges such rows instead of crashing, and repoints
-per-user state onto the surviving "keeper" article.
+the dedupe migration step archives the duplicate onto the surviving "keeper"
+article, in place, instead of crashing or deleting per-user state.
 """
 
 from __future__ import annotations
@@ -50,15 +50,25 @@ def test_init_db_merges_duplicate_url_articles(pg_clean: str) -> None:
     db = pg_clean
     sync_sources(db)
     _drop_url_unique_constraint(db)
+    # pg_clean's schema is reused by later tests in this worker; leaving the
+    # constraint dropped would break their ON CONFLICT (url) inserts.
+    try:
+        _run_merge_test(db)
+    finally:
+        with connect(db) as conn:
+            conn.execute("ALTER TABLE articles ADD CONSTRAINT articles_url_key UNIQUE (url)")
 
+
+def _run_merge_test(db: str) -> None:
     keeper_id = _insert_duplicate_article(db, title="First copy")
     loser_id = _insert_duplicate_article(db, title="Second copy")
     assert loser_id > keeper_id
 
     user = create_user("dupe-tester", "password123", db_path=db)
     with connect(db) as conn:
-        # A state row on the keeper for this user, so repointing the loser's
-        # row would collide with the (user_id, article_id) primary key.
+        # Each duplicate has its own per-user state, referencing its own
+        # article id. Nothing here is repointed, so no PK collision is
+        # possible even when the same user triaged both duplicates.
         conn.execute(
             "INSERT INTO user_article_state(user_id, article_id, state) VALUES (%s, %s, 'done')",
             (user["id"], keeper_id),
@@ -68,35 +78,38 @@ def test_init_db_merges_duplicate_url_articles(pg_clean: str) -> None:
             (user["id"], loser_id),
         )
 
-    other_user = create_user("dupe-tester-2", "password123", db_path=db)
-    with connect(db) as conn:
-        # Only the loser has state for this user, so it must be repointed
-        # onto the keeper rather than dropped.
-        conn.execute(
-            "INSERT INTO user_article_state(user_id, article_id, state) VALUES (%s, %s, 'later')",
-            (other_user["id"], loser_id),
-        )
-
     db_mod._INITIALIZED_DATABASES.clear()
     init_db(db)
 
     with connect(db) as conn:
-        articles = conn.execute(
-            "SELECT id FROM articles WHERE url = %s", (DUPLICATE_URL,)
-        ).fetchall()
-        assert len(articles) == 1
-        assert int(articles[0]["id"]) == keeper_id
+        keeper = conn.execute(
+            "SELECT url, state, status, canonical_id FROM articles WHERE id = %s",
+            (keeper_id,),
+        ).fetchone()
+        loser = conn.execute(
+            "SELECT url, state, status, canonical_id FROM articles WHERE id = %s",
+            (loser_id,),
+        ).fetchone()
 
         state_rows = {
-            row["user_id"]: (row["article_id"], row["state"])
+            row["article_id"]: row["state"]
             for row in conn.execute(
-                "SELECT user_id, article_id, state FROM user_article_state WHERE article_id = %s",
-                (keeper_id,),
+                "SELECT article_id, state FROM user_article_state WHERE user_id = %s",
+                (user["id"],),
             ).fetchall()
         }
 
-    # The keeper's own state for the first user survives; the loser's
-    # conflicting duplicate row for that user is dropped, not preferred.
-    assert state_rows[user["id"]] == (keeper_id, "done")
-    # The second user only had state on the loser, so it must be repointed.
-    assert state_rows[other_user["id"]] == (keeper_id, "later")
+    # The keeper keeps the real url and is never archived by the merge.
+    assert keeper["url"] == DUPLICATE_URL
+    assert keeper["canonical_id"] is None
+
+    # The loser is archived in place and points at the keeper, rather than
+    # being deleted — its url is freed up so it no longer collides.
+    assert loser["url"] != DUPLICATE_URL
+    assert loser["state"] == "archived"
+    assert loser["status"] == "archived"
+    assert int(loser["canonical_id"]) == keeper_id
+
+    # Both duplicates' own per-user state survive untouched, on their own ids.
+    assert state_rows[keeper_id] == "done"
+    assert state_rows[loser_id] == "today"

--- a/backend/tests/test_db_dedupe_article_urls.py
+++ b/backend/tests/test_db_dedupe_article_urls.py
@@ -1,0 +1,102 @@
+"""Tests for #1064 — merging duplicate-url articles during schema init.
+
+Production already contains `articles` rows that share the same `url`
+(pre-existing data corruption predating consistent `ON CONFLICT (url)` use on
+every insert path). Because `url` is UNIQUE, a bulk UPDATE that rewrites those
+rows (like the state backfill in POSTGRES_SCHEMA) surfaces the latent
+duplicate as a UniqueViolation and crash-loops init_db(). These tests confirm
+the dedupe migration step merges such rows instead of crashing, and repoints
+per-user state onto the surviving "keeper" article.
+"""
+
+from __future__ import annotations
+
+from news_dashboard import db as db_mod
+from news_dashboard.auth import create_user
+from news_dashboard.db import connect, init_db
+from news_dashboard.ingest import sync_sources
+
+DUPLICATE_URL = "https://example.com/duplicate-article"
+
+
+def _drop_url_unique_constraint(db_path: str) -> None:
+    """Simulate the pre-existing production corruption behind #1064.
+
+    `articles_url_key` has always been declared on the table, so a live app
+    can never insert a real duplicate; the constraint must be dropped to
+    reproduce rows that already violate it, matching what's actually in
+    production today.
+    """
+    with connect(db_path) as conn:
+        conn.execute("ALTER TABLE articles DROP CONSTRAINT articles_url_key")
+
+
+def _insert_duplicate_article(db_path: str, *, title: str) -> int:
+    """Insert an articles row directly, bypassing the app's ON CONFLICT guard."""
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(url, canonical_url, title, source_slug, source_name,
+              category, kind)
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed')
+            RETURNING id
+            """,
+            (DUPLICATE_URL, DUPLICATE_URL, title, "python-insider", "Python Insider"),
+        ).fetchone()
+    return int(row[0] if isinstance(row, tuple) else row["id"])
+
+
+def test_init_db_merges_duplicate_url_articles(pg_clean: str) -> None:
+    db = pg_clean
+    sync_sources(db)
+    _drop_url_unique_constraint(db)
+
+    keeper_id = _insert_duplicate_article(db, title="First copy")
+    loser_id = _insert_duplicate_article(db, title="Second copy")
+    assert loser_id > keeper_id
+
+    user = create_user("dupe-tester", "password123", db_path=db)
+    with connect(db) as conn:
+        # A state row on the keeper for this user, so repointing the loser's
+        # row would collide with the (user_id, article_id) primary key.
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state) VALUES (%s, %s, 'done')",
+            (user["id"], keeper_id),
+        )
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state) VALUES (%s, %s, 'today')",
+            (user["id"], loser_id),
+        )
+
+    other_user = create_user("dupe-tester-2", "password123", db_path=db)
+    with connect(db) as conn:
+        # Only the loser has state for this user, so it must be repointed
+        # onto the keeper rather than dropped.
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state) VALUES (%s, %s, 'later')",
+            (other_user["id"], loser_id),
+        )
+
+    db_mod._INITIALIZED_DATABASES.clear()
+    init_db(db)
+
+    with connect(db) as conn:
+        articles = conn.execute(
+            "SELECT id FROM articles WHERE url = %s", (DUPLICATE_URL,)
+        ).fetchall()
+        assert len(articles) == 1
+        assert int(articles[0]["id"]) == keeper_id
+
+        state_rows = {
+            row["user_id"]: (row["article_id"], row["state"])
+            for row in conn.execute(
+                "SELECT user_id, article_id, state FROM user_article_state WHERE article_id = %s",
+                (keeper_id,),
+            ).fetchall()
+        }
+
+    # The keeper's own state for the first user survives; the loser's
+    # conflicting duplicate row for that user is dropped, not preferred.
+    assert state_rows[user["id"]] == (keeper_id, "done")
+    # The second user only had state on the loser, so it must be repointed.
+    assert state_rows[other_user["id"]] == (keeper_id, "later")


### PR DESCRIPTION
Closes #1064

## Problem
Production pod crash-loops on startup:

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "articles_url_key"
DETAIL:  Key (url)=(https://www.infoq.com/news/2026/06/elastic-atlas-agent-memory/) already exists.
```

`init_db()` fails on the state-backfill `UPDATE articles SET state = CASE status ...` statement in `POSTGRES_SCHEMA`. That statement never touches `url`, but production already has two `articles` rows sharing the exact same `url` — real pre-existing data corruption predating consistent `ON CONFLICT (url)` use on every insert path. A bulk UPDATE that rewrites those rows' index entries surfaces the latent duplicate as a hard failure, blocking every future schema init.

## Fix
Add an idempotent migration statement to `POSTGRES_SCHEMA` (`backend/news_dashboard/db.py`), run immediately before the state backfill, that merges duplicate-url articles: for each duplicate group it keeps the lowest-id row and archives the rest in place — mirroring this repo's existing duplicate-merge convention (`embedding_dedup._merge_duplicate`): `state`/`status` set to `'archived'`, `canonical_id` pointing at the keeper, and the duplicate's `url` suffixed so it stops colliding. FK references (`user_article_state`, `ai_feedback`, etc.) are left untouched since the duplicate row stays alive — no cascade deletes, no per-user history lost.

An earlier version of this fix hard-deleted duplicates with dynamic FK-repointing; code review caught that it could silently drop unrelated rows on incidental unique-constraint collisions and diverged from the existing archive-in-place convention, so it was replaced with this simpler, safer approach.

## Test
`backend/tests/test_db_dedupe_article_urls.py` seeds two articles sharing a url (after dropping the constraint to simulate the corrupted state) with separate per-user state on each, runs `init_db()`, and asserts it doesn't raise, the keeper keeps the real url, the loser is archived with `canonical_id` set and a freed-up url, and both articles' per-user state rows survive untouched.

Full backend (1917 tests) and frontend (837 tests) suites pass; ruff/mypy/ty/pyrefly all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)