### PR TITLE
fix: add a safe Helm local-auth mode (#843)

### DIFF
--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -87,6 +87,86 @@ def test_helm_template_default() -> None:
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_keycloak_auth_mode_injects_session_secret_and_keycloak_env() -> None:
+    output = _render_chart()
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    session_secret = _env_entry(deployment_env, "SESSION_SECRET")
+    assert "name: news-dashboard-news-dashboard-auth" in session_secret
+    assert "key: SESSION_SECRET" in session_secret
+
+    assert _env_entry(deployment_env, "KEYCLOAK_AUTH_ENABLED") == (
+        '- name: KEYCLOAK_AUTH_ENABLED\n  value: "1"'
+    )
+    assert "KEYCLOAK_CLIENT_ID" in deployment_env
+    assert "BOOTSTRAP_ADMIN_USERNAME" not in deployment_env
+    assert "BOOTSTRAP_ADMIN_PASSWORD" not in deployment_env
+
+    secret_manifest = _manifest_for_kind(output, "Secret")
+    assert "KEYCLOAK_CLIENT_SECRET" in secret_manifest
+    assert "KEYCLOAK_ADMIN_CLIENT_SECRET" in secret_manifest
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_local_password_auth_mode_omits_keycloak_env() -> None:
+    output = _render_chart(
+        "app.auth.keycloak.enabled=false",
+        "app.auth.bootstrapAdmin.existingSecret=news-dashboard-bootstrap-admin",
+    )
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    session_secret = _env_entry(deployment_env, "SESSION_SECRET")
+    assert "key: SESSION_SECRET" in session_secret
+
+    assert "KEYCLOAK_AUTH_ENABLED" not in deployment_env
+    assert "KEYCLOAK_CLIENT_ID" not in deployment_env
+    assert "KEYCLOAK_SERVER_URL" not in deployment_env
+
+    bootstrap_username = _env_entry(deployment_env, "BOOTSTRAP_ADMIN_USERNAME")
+    assert 'name: "news-dashboard-bootstrap-admin"' in bootstrap_username
+    assert 'key: "BOOTSTRAP_ADMIN_USERNAME"' in bootstrap_username
+    bootstrap_password = _env_entry(deployment_env, "BOOTSTRAP_ADMIN_PASSWORD")
+    assert 'name: "news-dashboard-bootstrap-admin"' in bootstrap_password
+    assert 'key: "BOOTSTRAP_ADMIN_PASSWORD"' in bootstrap_password
+
+    secret_manifest = _manifest_for_kind(output, "Secret")
+    assert "KEYCLOAK_CLIENT_SECRET" not in secret_manifest
+    assert "KEYCLOAK_ADMIN_CLIENT_SECRET" not in secret_manifest
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_local_password_auth_mode_without_bootstrap_secret_omits_env() -> None:
+    output = _render_chart("app.auth.keycloak.enabled=false")
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert "KEYCLOAK_AUTH_ENABLED" not in deployment_env
+    assert "BOOTSTRAP_ADMIN_USERNAME" not in deployment_env
+    assert "BOOTSTRAP_ADMIN_PASSWORD" not in deployment_env
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_fails_without_session_secret_in_local_password_mode() -> None:
+    assert HELM_BIN is not None
+    res = subprocess.run(  # noqa: S603
+        [
+            HELM_BIN,
+            "template",
+            "news-dashboard",
+            str(CHART_DIR),
+            "--set-string",
+            "postgresql.password=dummy-postgres-password-for-render-only",
+            "--set",
+            "app.auth.keycloak.enabled=false",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode != 0
+    assert "app.auth.sessionSecret is required" in res.stderr
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
 def test_helm_template_app_mounts_writable_data_dir() -> None:
     output = _render_chart()
     deployment = _manifest_for_kind(output, "Deployment")

--- a/helm/news-dashboard/templates/auth-secret.yaml
+++ b/helm/news-dashboard/templates/auth-secret.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.app.auth.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 stringData:
-  SESSION_SECRET: {{ required "app.auth.sessionSecret is required when app.auth.enabled=true" .Values.app.auth.sessionSecret | quote }}
+  SESSION_SECRET: {{ required "app.auth.sessionSecret is required" .Values.app.auth.sessionSecret | quote }}
   TOKEN_SECRET: {{ .Values.app.auth.tokenSecret | quote }}
-  KEYCLOAK_CLIENT_SECRET: {{ .Values.app.auth.clientSecret | quote }}
-  KEYCLOAK_ADMIN_CLIENT_SECRET: {{ .Values.app.auth.adminClientSecret | quote }}
+{{- if .Values.app.auth.keycloak.enabled }}
+  KEYCLOAK_CLIENT_SECRET: {{ .Values.app.auth.keycloak.clientSecret | quote }}
+  KEYCLOAK_ADMIN_CLIENT_SECRET: {{ .Values.app.auth.keycloak.adminClientSecret | quote }}
 {{- end }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -119,33 +119,6 @@ spec:
                   optional: true
 {{- end }}
 {{- end }}
-{{- if .Values.app.auth.enabled }}
-            - name: KEYCLOAK_AUTH_ENABLED
-              value: "1"
-            - name: NEWS_DASHBOARD_BASE_URL
-              value: {{ .Values.app.auth.publicBaseUrl | quote }}
-            - name: KEYCLOAK_SERVER_URL
-              value: {{ .Values.app.auth.keycloakServerUrl | quote }}
-            - name: KEYCLOAK_INTERNAL_SERVER_URL
-              value: {{ .Values.app.auth.keycloakInternalServerUrl | quote }}
-            - name: KEYCLOAK_REALM
-              value: {{ .Values.app.auth.realm | quote }}
-            - name: KEYCLOAK_CLIENT_ID
-              value: {{ .Values.app.auth.clientId | quote }}
-            - name: KEYCLOAK_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "news-dashboard.fullname" . }}-auth
-                  key: KEYCLOAK_CLIENT_SECRET
-            - name: KEYCLOAK_ADMIN_USERNAMES
-              value: {{ .Values.app.auth.adminUsernames | quote }}
-            - name: KEYCLOAK_ADMIN_CLIENT_ID
-              value: {{ .Values.app.auth.adminClientId | quote }}
-            - name: KEYCLOAK_ADMIN_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "news-dashboard.fullname" . }}-auth
-                  key: KEYCLOAK_ADMIN_CLIENT_SECRET
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:
@@ -156,6 +129,46 @@ spec:
                 secretKeyRef:
                   name: {{ include "news-dashboard.fullname" . }}-auth
                   key: TOKEN_SECRET
+{{- if .Values.app.auth.keycloak.enabled }}
+            - name: KEYCLOAK_AUTH_ENABLED
+              value: "1"
+            - name: NEWS_DASHBOARD_BASE_URL
+              value: {{ .Values.app.auth.keycloak.publicBaseUrl | quote }}
+            - name: KEYCLOAK_SERVER_URL
+              value: {{ .Values.app.auth.keycloak.keycloakServerUrl | quote }}
+            - name: KEYCLOAK_INTERNAL_SERVER_URL
+              value: {{ .Values.app.auth.keycloak.keycloakInternalServerUrl | quote }}
+            - name: KEYCLOAK_REALM
+              value: {{ .Values.app.auth.keycloak.realm | quote }}
+            - name: KEYCLOAK_CLIENT_ID
+              value: {{ .Values.app.auth.keycloak.clientId | quote }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "news-dashboard.fullname" . }}-auth
+                  key: KEYCLOAK_CLIENT_SECRET
+            - name: KEYCLOAK_ADMIN_USERNAMES
+              value: {{ .Values.app.auth.keycloak.adminUsernames | quote }}
+            - name: KEYCLOAK_ADMIN_CLIENT_ID
+              value: {{ .Values.app.auth.keycloak.adminClientId | quote }}
+            - name: KEYCLOAK_ADMIN_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "news-dashboard.fullname" . }}-auth
+                  key: KEYCLOAK_ADMIN_CLIENT_SECRET
+{{- else if .Values.app.auth.bootstrapAdmin.existingSecret }}
+            - name: BOOTSTRAP_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.auth.bootstrapAdmin.existingSecret | quote }}
+                  key: {{ .Values.app.auth.bootstrapAdmin.usernameKey | default "BOOTSTRAP_ADMIN_USERNAME" | quote }}
+                  optional: true
+            - name: BOOTSTRAP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.auth.bootstrapAdmin.existingSecret | quote }}
+                  key: {{ .Values.app.auth.bootstrapAdmin.passwordKey | default "BOOTSTRAP_ADMIN_PASSWORD" | quote }}
+                  optional: true
 {{- end }}
 {{- include "news-dashboard.configEnv" . | indent 12 }}
           ports:

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -62,27 +62,43 @@ app:
       size: 1Gi
       storageClassName: ""
   auth:
-    enabled: true
-    publicBaseUrl: https://news.lihor.ro
-    keycloakServerUrl: https://news.lihor.ro/keycloak
-    keycloakInternalServerUrl: https://news.lihor.ro/keycloak
-    realm: news-dashboard
-    clientId: news-dashboard
-    # Optional. Set this when the Keycloak client uses "confidential" access type.
-    clientSecret: ""
-    # Comma-separated usernames that become app admins when first seen from Keycloak.
-    adminUsernames: ioachim
-    # Optional. Confidential client (service account) used by the in-app admin
-    # page to create users via the Keycloak Admin REST API. The client needs the
-    # realm-management "manage-users" role. Defaults to clientId when unset.
-    adminClientId: ""
-    # Service-account secret for adminClientId. Leave empty to disable in-app
-    # user creation (the admin page then reports it is not configured).
-    adminClientSecret: ""
-    # Override in CI/local deploy with a long random string.
+    # SESSION_SECRET is always required and always injected, regardless of
+    # auth mode: it signs the local session cookie for both Keycloak logins
+    # and local-password logins. Override in CI/local deploy with a long
+    # random string.
     sessionSecret: ""
     # Optional. Overrides digest mark-read token signing separately from sessionSecret.
     tokenSecret: ""
+    keycloak:
+      # Set to false for a self-hosted install that only wants local
+      # username/password auth (no SSO). When false, KEYCLOAK_AUTH_ENABLED
+      # and the KEYCLOAK_* env vars below are not rendered, and the app uses
+      # bootstrapAdmin below to provision the first local admin account.
+      enabled: true
+      publicBaseUrl: https://news.lihor.ro
+      keycloakServerUrl: https://news.lihor.ro/keycloak
+      keycloakInternalServerUrl: https://news.lihor.ro/keycloak
+      realm: news-dashboard
+      clientId: news-dashboard
+      # Optional. Set this when the Keycloak client uses "confidential" access type.
+      clientSecret: ""
+      # Comma-separated usernames that become app admins when first seen from Keycloak.
+      adminUsernames: ioachim
+      # Optional. Confidential client (service account) used by the in-app admin
+      # page to create users via the Keycloak Admin REST API. The client needs the
+      # realm-management "manage-users" role. Defaults to clientId when unset.
+      adminClientId: ""
+      # Service-account secret for adminClientId. Leave empty to disable in-app
+      # user creation (the admin page then reports it is not configured).
+      adminClientSecret: ""
+    # Local-password bootstrap admin, used only when keycloak.enabled=false.
+    # Ignored when a user already exists. Prefer an existing Secret over
+    # plain values so credentials never land in rendered manifests.
+    bootstrapAdmin:
+      # Name of a pre-existing Secret with the two keys below.
+      existingSecret: ""
+      usernameKey: BOOTSTRAP_ADMIN_USERNAME
+      passwordKey: BOOTSTRAP_ADMIN_PASSWORD
   ai:
     # Optional: pre-existing Secret with OPENAI_API_KEY and FREE_LLM_API_KEY.
     existingSecret: ""

--- a/website/docs/configuration/authentication.md
+++ b/website/docs/configuration/authentication.md
@@ -70,7 +70,9 @@ https://news.lihor.ro/keycloak
 
 ## Helm
 
-The chart exposes the Keycloak settings under `app.auth` in `helm/news-dashboard/values.yaml`. When `app.auth.enabled=true`, Helm renders an auth Secret containing `SESSION_SECRET` and injects the Keycloak env vars into the app deployment.
+The chart always renders an auth Secret containing `SESSION_SECRET` — it is required in every install, Keycloak or not, because it signs the local session cookie either way.
+
+Keycloak SSO is controlled separately by `app.auth.keycloak.enabled` in `helm/news-dashboard/values.yaml` (default `true`, matching this deployment). When `true`, Helm also injects `KEYCLOAK_AUTH_ENABLED=1` and the `KEYCLOAK_*` env vars from `app.auth.keycloak.*`.
 
 For local deployment, override `app.auth.sessionSecret` with a generated value:
 
@@ -78,6 +80,23 @@ For local deployment, override `app.auth.sessionSecret` with a generated value:
 helm upgrade --install news-dashboard ./helm/news-dashboard \
   --set app.auth.sessionSecret="$(python -c 'import secrets; print(secrets.token_hex(32))')"
 ```
+
+### Local-password mode (no Keycloak)
+
+Set `app.auth.keycloak.enabled=false` to skip Keycloak entirely and use the app's built-in username/password auth. `SESSION_SECRET` is still required. Optionally point `app.auth.bootstrapAdmin.existingSecret` at a pre-existing Secret containing `BOOTSTRAP_ADMIN_USERNAME`/`BOOTSTRAP_ADMIN_PASSWORD` keys so the app can provision the first admin account on startup:
+
+```bash
+kubectl -n news-dashboard create secret generic news-dashboard-bootstrap-admin \
+  --from-literal=BOOTSTRAP_ADMIN_USERNAME=admin \
+  --from-literal=BOOTSTRAP_ADMIN_PASSWORD="$(python -c 'import secrets; print(secrets.token_urlsafe(24))')"
+
+helm upgrade --install news-dashboard ./helm/news-dashboard \
+  --set app.auth.keycloak.enabled=false \
+  --set app.auth.bootstrapAdmin.existingSecret=news-dashboard-bootstrap-admin \
+  --set app.auth.sessionSecret="$(python -c 'import secrets; print(secrets.token_hex(32))')"
+```
+
+If no bootstrap admin is supplied, the app starts but logs a warning and login is impossible until an admin is created another way.
 
 ## Keycloak realm/client
 


### PR DESCRIPTION
## Summary

Fixes #843. `app.auth.enabled=false` previously disabled the auth Secret entirely, which removed `SESSION_SECRET` and left the backend unable to sign/verify session cookies — a self-hoster running the chart without Keycloak had no safe local-password path.

- Split Keycloak-specific settings into `app.auth.keycloak.enabled` (default `true`, preserving the existing `news.lihor.ro` Keycloak deployment behavior unchanged).
- `SESSION_SECRET`/`TOKEN_SECRET` are now always required and injected, regardless of auth mode.
- Added `app.auth.bootstrapAdmin.existingSecret` so a local-password install can source `BOOTSTRAP_ADMIN_USERNAME`/`BOOTSTRAP_ADMIN_PASSWORD` from a pre-existing Kubernetes Secret instead of embedding credentials in values.
- `KEYCLOAK_AUTH_ENABLED` and the `KEYCLOAK_*` env vars now only render when `app.auth.keycloak.enabled=true`.
- Missing `app.auth.sessionSecret` now fails `helm template` with a clear error in both modes (previously only enforced when `app.auth.enabled=true`).
- Updated `website/docs/configuration/authentication.md` with a local-password mode walkthrough.

## Test plan

- [x] `pytest backend/tests/test_chart_render.py` — 18 passed, including 4 new tests covering both auth modes and the sessionSecret-required failure case.
- [x] `pytest backend/tests/test_compose_auth_env.py` — 8 passed (unaffected, sanity check).
- [x] Replicated all three `helm-validate` CI render commands (defaults, production-like overrides, external postgres) against the updated chart — all succeed.
- [x] Manually rendered `helm template` with `app.auth.keycloak.enabled=false` + `app.auth.bootstrapAdmin.existingSecret=...` and confirmed `SESSION_SECRET` is present, `KEYCLOAK_*` env vars are absent, and `BOOTSTRAP_ADMIN_USERNAME`/`PASSWORD` are sourced from the given secret.
- [x] Manually rendered default values and confirmed `SESSION_SECRET` + all `KEYCLOAK_*` env vars are still present (no behavior change for the existing Keycloak deployment).
- [x] `pre-commit run` (ruff, ruff format, mypy, ty, pyrefly, vulture) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)