### PR TITLE
fix: cap scraped-page HTML response size (#919)

### DIFF
--- a/backend/news_dashboard/scraper.py
+++ b/backend/news_dashboard/scraper.py
@@ -6,6 +6,7 @@ Scrapers must be polite: single request, reasonable timeout, proper user-agent.
 
 from __future__ import annotations
 
+import contextlib
 import re
 import urllib.request
 from html.parser import HTMLParser
@@ -15,6 +16,13 @@ from news_dashboard.url_safety import open_server_fetch_url, validate_server_fet
 
 USER_AGENT = "news-dashboard/0.1 (personal RSS reader; contact@lihor.ro)"
 TIMEOUT_SECS = 15
+# Scraped news-listing pages are rarely more than a few hundred KB; 2 MiB leaves
+# headroom for verbose pages while bounding memory use and parse time for bad actors.
+SCRAPE_FETCH_MAX_BYTES = 2 * 1024 * 1024
+
+
+class ScrapeFetchError(RuntimeError):
+    """Raised when a scraped-page fetch fails or exceeds the size cap."""
 
 
 def _fetch_html(url: str, *, use_selenium: bool = False) -> str:
@@ -25,7 +33,21 @@ def _fetch_html(url: str, *, use_selenium: bool = False) -> str:
         return fetch_spa_html(url)
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})  # noqa: S310 - scheme validated above
     with open_server_fetch_url(req, timeout=TIMEOUT_SECS) as resp:
-        raw: bytes = resp.read()
+        content_length = resp.headers.get("Content-Length")
+        if content_length is not None:
+            # Content-Length is attacker-controlled and may be non-numeric;
+            # ignore malformed values rather than failing the fetch on them.
+            with contextlib.suppress(ValueError):
+                if int(content_length) > SCRAPE_FETCH_MAX_BYTES:
+                    msg = (
+                        f"Scraped-page response too large ({content_length} bytes, "
+                        f"max {SCRAPE_FETCH_MAX_BYTES}): {url}"
+                    )
+                    raise ScrapeFetchError(msg)
+        raw: bytes = resp.read(SCRAPE_FETCH_MAX_BYTES + 1)
+        if len(raw) > SCRAPE_FETCH_MAX_BYTES:
+            msg = f"Scraped-page response exceeded {SCRAPE_FETCH_MAX_BYTES} byte limit: {url}"
+            raise ScrapeFetchError(msg)
         charset = resp.headers.get_content_charset("utf-8") or "utf-8"
         return raw.decode(str(charset), errors="replace")
 

--- a/backend/tests/test_scraper.py
+++ b/backend/tests/test_scraper.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
-from news_dashboard.scraper import _AnthropicParser, scrape_source
+from news_dashboard.scraper import (
+    SCRAPE_FETCH_MAX_BYTES,
+    ScrapeFetchError,
+    _AnthropicParser,
+    _fetch_html,
+    scrape_source,
+)
 from news_dashboard.sources import SourceDefinition
 
 # Minimal static HTML that mimics the Anthropic news page structure
@@ -74,7 +82,6 @@ def test_scrape_source_uses_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_fetch_html_rejects_private_network_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    from news_dashboard.scraper import _fetch_html
 
     called = False
 
@@ -96,3 +103,73 @@ def test_scrape_source_unknown_slug_raises() -> None:
     )
     with pytest.raises(NotImplementedError, match="no-scraper"):
         scrape_source(source)
+
+
+class _FakeHeaders:
+    def __init__(self, content_length: str | None) -> None:
+        self._content_length = content_length
+
+    def get(self, name: str, default: Any = None) -> Any:
+        if name == "Content-Length":
+            return self._content_length
+        return default
+
+    def get_content_charset(self, default: str = "utf-8") -> str:
+        return default
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, content_length: str | None) -> None:
+        self._body = body
+        self.headers = _FakeHeaders(content_length)
+
+    def read(self, amt: int | None = None) -> bytes:
+        if amt is None:
+            return self._body
+        return self._body[:amt]
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+def test_fetch_html_under_limit_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = b"<html>hello</html>"
+    monkeypatch.setattr(
+        "news_dashboard.scraper.open_server_fetch_url",
+        lambda _req, **_kwargs: _FakeResponse(body, str(len(body))),
+    )
+    html = _fetch_html("https://example.com/news")
+    assert html == "<html>hello</html>"
+
+
+def test_fetch_html_rejects_oversized_content_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    read_called = False
+
+    class _NoReadResponse(_FakeResponse):
+        def read(self, amt: int | None = None) -> bytes:
+            nonlocal read_called
+            read_called = True
+            return super().read(amt)
+
+    monkeypatch.setattr(
+        "news_dashboard.scraper.open_server_fetch_url",
+        lambda _req, **_kwargs: _NoReadResponse(b"x", str(SCRAPE_FETCH_MAX_BYTES + 1)),
+    )
+    with pytest.raises(ScrapeFetchError, match="too large"):
+        _fetch_html("https://example.com/news")
+    assert read_called is False
+
+
+def test_fetch_html_rejects_body_over_limit_without_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oversized_body = b"x" * (SCRAPE_FETCH_MAX_BYTES + 100)
+    monkeypatch.setattr(
+        "news_dashboard.scraper.open_server_fetch_url",
+        lambda _req, **_kwargs: _FakeResponse(oversized_body, None),
+    )
+    with pytest.raises(ScrapeFetchError, match="exceeded"):
+        _fetch_html("https://example.com/news")


### PR DESCRIPTION
Fixes #919

## Summary
- `_fetch_html()` in `backend/news_dashboard/scraper.py` previously called `resp.read()` with no size limit, so a broken or hostile `scraped_page` source could force an ingest run to buffer and parse an unbounded HTML response.
- Added a named `SCRAPE_FETCH_MAX_BYTES` cap (2 MiB, matching the existing `FEED_FETCH_MAX_BYTES` style in `ingest.py`).
- Oversized `Content-Length` is rejected before reading the body.
- Responses without (or with an unusable) `Content-Length` are read up to `max + 1` bytes and rejected if they exceed the cap.
- New `ScrapeFetchError` is raised on either rejection; it propagates through the existing generic `except Exception` handling in the ingest run loop, so source-health/error reporting is unaffected.
- SSRF validation, the no-redirect opener, timeout, user-agent, and the Selenium branch are all unchanged — this only touches the stdlib fetch path.

## Test plan
- [x] `pytest backend/tests/test_scraper.py -q` — 9 passed (added tests for under-limit success, oversized `Content-Length` rejection without reading the body, and body-over-limit rejection without `Content-Length`)
- [x] `ruff check backend/news_dashboard/scraper.py backend/tests/test_scraper.py` — clean
- [x] `mypy backend/news_dashboard/scraper.py` — clean
- [x] `pytest backend/tests/test_source_subscriptions.py backend/tests/test_cohere_blog_source.py backend/tests/test_mistral_ai_news_source.py backend/tests/test_deepmind_blog_source.py backend/tests/test_source_preview.py backend/tests/test_meta_ai_blog_source.py -q` — 56 passed (existing scraped-page source consumers unaffected)
- [x] pre-commit hooks (ruff, ruff format, mypy, ty, pyrefly, vulture) all passed on commit