### PR TITLE
fix: enforce Reading List import upload size limit (#920)

### DIFF
--- a/backend/news_dashboard/reading_list/importers.py
+++ b/backend/news_dashboard/reading_list/importers.py
@@ -163,3 +163,8 @@ PARSERS = {
 }
 
 MAX_IMPORT_ITEMS = 5000
+
+# Upload memory/parse protection, independent of MAX_IMPORT_ITEMS (which caps
+# the database write size). 10 MiB comfortably covers 5,000 URL rows with
+# titles and tags in any of the supported formats.
+MAX_IMPORT_BYTES = 10 * 1024 * 1024

--- a/backend/news_dashboard/reading_list/router.py
+++ b/backend/news_dashboard/reading_list/router.py
@@ -17,13 +17,19 @@ from fastapi import (
     Form,
     HTTPException,
     Query,
+    Request,
     Response,
     UploadFile,
 )
 
 from news_dashboard.auth import require_auth
 from news_dashboard.reading_list import service
-from news_dashboard.reading_list.importers import MAX_IMPORT_ITEMS, PARSERS, ImportParseError
+from news_dashboard.reading_list.importers import (
+    MAX_IMPORT_BYTES,
+    MAX_IMPORT_ITEMS,
+    PARSERS,
+    ImportParseError,
+)
 from news_dashboard.reading_list.models import (
     ReadingListAddRequest,
     ReadingListReorderRequest,
@@ -53,6 +59,7 @@ def add_reading_list_item_endpoint(
 
 @router.post("/api/reading-list/import")
 async def import_reading_list_endpoint(
+    request: Request,
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
     file: Annotated[UploadFile, File()],
     source: Annotated[str, Form()],
@@ -64,7 +71,25 @@ async def import_reading_list_endpoint(
             status_code=400,
             detail=f"Unsupported import source {source!r}; expected one of {sorted(PARSERS)}",
         )
-    contents = await file.read()
+
+    declared_length = request.headers.get("content-length")
+    if (
+        declared_length is not None
+        and declared_length.isdigit()
+        and int(declared_length) > MAX_IMPORT_BYTES
+    ):
+        raise HTTPException(
+            status_code=413,
+            detail=f"Import file exceeds the {MAX_IMPORT_BYTES}-byte limit",
+        )
+
+    contents = await file.read(MAX_IMPORT_BYTES + 1)
+    if len(contents) > MAX_IMPORT_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Import file exceeds the {MAX_IMPORT_BYTES}-byte limit",
+        )
+
     try:
         items = parser(contents)
     except ImportParseError as exc:

--- a/backend/tests/test_reading_list_import.py
+++ b/backend/tests/test_reading_list_import.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 from news_dashboard.auth import require_auth
 from news_dashboard.db import connect, init_db
 from news_dashboard.main import app
-from news_dashboard.reading_list import importers, service
+from news_dashboard.reading_list import importers, router, service
 
 POCKET_CSV = (
     "title,url,time_added,tags,status\n"
@@ -249,3 +249,79 @@ def test_import_enforces_batch_cap(monkeypatch: pytest.MonkeyPatch, pg_clean: st
 
     with pytest.raises(service.ImportTooLargeError):
         service.import_items(user_id, items, max_items=2, database_url=database_url)
+
+
+def test_import_rejects_oversized_upload(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    monkeypatch.setattr(router, "MAX_IMPORT_BYTES", 100)
+    oversized_csv = "url\n" + "\n".join(f"https://example.com/{i}" for i in range(50))
+    assert len(oversized_csv) > 100
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("pocket.csv", oversized_csv, "text/csv")},
+                data={"source": "pocket"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 413
+
+    with connect(database_url=database_url) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM reading_list_items WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()["count"]
+    assert count == 0
+
+
+def test_import_rejects_oversized_content_length_before_parsing(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    monkeypatch.setattr(router, "MAX_IMPORT_BYTES", 100)
+    calls: list[bytes] = []
+
+    def _tracking_parser(contents: bytes) -> list[importers.ImportedItem]:
+        calls.append(contents)
+        return []
+
+    monkeypatch.setattr(router, "PARSERS", {"pocket": _tracking_parser})
+    oversized_csv = "url\n" + "\n".join(f"https://example.com/{i}" for i in range(50))
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("pocket.csv", oversized_csv, "text/csv")},
+                data={"source": "pocket"},
+                headers={"content-length": str(len(oversized_csv) * 10)},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 413
+    assert calls == []
+
+
+def test_import_under_limit_still_succeeds(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+    monkeypatch.setattr(router, "MAX_IMPORT_BYTES", 10_000)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/reading-list/import",
+                files={"file": ("pocket.csv", POCKET_CSV, "text/csv")},
+                data={"source": "pocket"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json() == {"added": 2, "skipped": 0, "failed": 0}


### PR DESCRIPTION
## Summary

Closes #920

`import_reading_list_endpoint()` previously called `await file.read()` with no byte limit, so an oversized or malformed upload was fully buffered in memory and parsed by `csv.DictReader`/`json.loads()` before the existing `MAX_IMPORT_ITEMS` item-count cap could reject it.

- Added `MAX_IMPORT_BYTES` (10 MiB) in `backend/news_dashboard/reading_list/importers.py` as a named upload-size cap, separate from `MAX_IMPORT_ITEMS` (which remains the database batch cap).
- `import_reading_list_endpoint()` in `backend/news_dashboard/reading_list/router.py` now:
  - rejects the request with `413` immediately if a `Content-Length` header declares a size over the cap, before touching the file
  - reads at most `MAX_IMPORT_BYTES + 1` bytes and rejects with `413` if the actual body exceeds the cap, before any parser (`parse_pocket_csv`/`parse_instapaper_csv`/`parse_omnivore_json`) runs
- No frontend changes needed: `readErrorMessage()` in `frontend/src/api/core.ts` already surfaces the `detail` field from any non-2xx JSON response, so the 413's message reaches `ReadingListPage.tsx`'s existing error UI unchanged.

## Test plan
- [x] `pytest backend/tests/test_reading_list_import.py -q` — 16 passed (includes new tests for under-limit success, oversized-body rejection, oversized-`Content-Length` rejection before parsing, and the existing item-count-cap test)
- [x] `ruff check backend/news_dashboard/reading_list backend/tests/test_reading_list_import.py`
- [x] `mypy backend/news_dashboard`
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)