### PR TITLE
fix: persist generated audio in production Docker quickstarts (#921)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,12 @@ docker run -d \
   -e SESSION_SECRET="$(python -c 'import secrets; print(secrets.token_hex(32))')" \
   -e BOOTSTRAP_ADMIN_USERNAME=admin \
   -e BOOTSTRAP_ADMIN_PASSWORD=change-me \
+  -e DATA_DIR=/data \
+  -v news-dashboard-data:/data \
   --restart unless-stopped \
   ghcr.io/lihor-hub/news-dashboard:latest
 ```
-**Note**: Replace `latest` with a specific version tag (e.g., `v1.21.0`) or commit SHA for pinned deployments. See [Configuration](#configuration) for all required environment variables.
+**Note**: Replace `latest` with a specific version tag (e.g., `v1.21.0`) or commit SHA for pinned deployments. The `news-dashboard-data:/data` volume keeps generated audio and other app data across container recreates; without it, optional TTS and podcast MP3 caches are lost during upgrades. See [Configuration](#configuration) for all required environment variables.
 
 Open [http://localhost:8080](http://localhost:8080).
 

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -72,6 +72,26 @@ def test_compose_prod_file_exists() -> None:
     assert COMPOSE_PROD_FILE.exists(), f"docker-compose.prod.yml not found at {COMPOSE_PROD_FILE}"
 
 
+def test_compose_prod_persists_app_data_dir() -> None:
+    """Production compose must persist generated audio and other app data."""
+    compose = yaml.safe_load(COMPOSE_PROD_FILE.read_text())
+    services = compose.get("services", {})
+    assert "news-dashboard" in services, "news-dashboard service missing from prod compose"
+
+    app_service = services["news-dashboard"]
+    env = app_service.get("environment", {})
+    if isinstance(env, list):
+        env = dict(item.split("=", 1) if "=" in item else (item, "") for item in env)
+
+    assert env.get("DATA_DIR") == "/data", "prod compose must set DATA_DIR=/data"
+    assert "news-dashboard-data" in compose.get("volumes", {}), (
+        "prod compose must declare news-dashboard-data volume"
+    )
+    assert "news-dashboard-data:/data" in app_service.get("volumes", []), (
+        "prod compose must mount news-dashboard-data at /data"
+    )
+
+
 def test_compose_demo_file_exists() -> None:
     assert COMPOSE_DEMO_FILE.exists(), f"docker-compose.demo.yml not found at {COMPOSE_DEMO_FILE}"
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,10 +27,13 @@ services:
       SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required}
       BOOTSTRAP_ADMIN_USERNAME: ${BOOTSTRAP_ADMIN_USERNAME:?BOOTSTRAP_ADMIN_USERNAME is required}
       BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD:?BOOTSTRAP_ADMIN_PASSWORD is required}
+      DATA_DIR: /data
       # Optional AI features (uncomment as needed)
       # OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       # FREE_LLM_API_KEY: ${FREE_LLM_API_KEY:-}
       # FREE_LLM_BASE_URL: ${FREE_LLM_BASE_URL:-}
+    volumes:
+      - news-dashboard-data:/data
     depends_on:
       postgres:
         condition: service_healthy
@@ -50,3 +53,4 @@ services:
 
 volumes:
   news-dashboard-postgres:
+  news-dashboard-data:

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -60,6 +60,13 @@ docker compose -f docker-compose.prod.yml up -d
 
 The compose file will fail fast if required secrets (`SESSION_SECRET`, `BOOTSTRAP_ADMIN_USERNAME`, `BOOTSTRAP_ADMIN_PASSWORD`, `POSTGRES_PASSWORD`) are not set.
 
+`docker-compose.prod.yml` also mounts the named `news-dashboard-data` volume at
+`/data` and sets `DATA_DIR=/data`. Generated article audio and briefing podcast
+MP3 caches live under `/data/audio`, so keep that volume backed by persistent
+storage in production. If you run the container manually with `docker run`, pass
+both `-e DATA_DIR=/data` and `-v news-dashboard-data:/data`; otherwise audio
+files are lost when the app container is recreated.
+
 ### Verifying the Deployment
 
 ```bash
@@ -364,7 +371,8 @@ Upgrade safely by following these steps in order.
 
 1. **Read the release notes** — check the [CHANGELOG](../CHANGELOG.md) for any breaking changes, config deprecations, or manual steps.
 2. **Back up your database** — a backup is your safety net for rollback. See [PostgreSQL Backup and Restore](https://docs.lihor.ro/docs/configuration/postgres-backup) for backup strategies.
-3. **Check the new image tag** — browse available tags on [GHCR](https://ghcr.io/lihor-hub/news-dashboard) or the [releases page](https://github.com/lihor-hub/news-dashboard/releases).
+3. **Back up app data** — if audio features are enabled, keep the `/data` volume (`news-dashboard-data` in Docker Compose) with your normal backup set so generated MP3 caches survive container replacement.
+4. **Check the new image tag** — browse available tags on [GHCR](https://ghcr.io/lihor-hub/news-dashboard) or the [releases page](https://github.com/lihor-hub/news-dashboard/releases).
 
 ### Docker Compose (Production)
 


### PR DESCRIPTION
Closes #921

## Summary
- mount a named `news-dashboard-data` volume at `/data` in `docker-compose.prod.yml`
- set `DATA_DIR=/data` explicitly for the production Compose app service
- document `/data` persistence for Docker Compose and `docker run` self-hosting paths
- add a compose regression test that keeps the production `/data` mount in place

## Tests
- `pytest backend/tests/test_compose_auth_env.py::test_compose_prod_persists_app_data_dir -q`
- `pytest backend/tests/test_compose_auth_env.py -q`
- `POSTGRES_PASSWORD=dummy SESSION_SECRET=dummy BOOTSTRAP_ADMIN_USERNAME=admin BOOTSTRAP_ADMIN_PASSWORD=dummy docker compose -f docker-compose.prod.yml config`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make typecheck`
- `set -a; . ./.env; set +a; PATH="$PWD/.venv/bin:$PATH" make test` (passed; shell printed a `.env` sourcing warning before tests started)