### PR TITLE
Add reading list filters (#942)

### DIFF
--- a/backend/news_dashboard/reading_list/router.py
+++ b/backend/news_dashboard/reading_list/router.py
@@ -106,8 +106,10 @@ async def import_reading_list_endpoint(
 def list_reading_list_endpoint(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
     status: Annotated[str | None, Query(pattern="^(unread|done|archived)$")] = None,
+    q: Annotated[str | None, Query(max_length=300)] = None,
+    kind: Annotated[str | None, Query(pattern="^(article|video|channel|link)$")] = None,
 ) -> dict[str, Any]:
-    return {"items": service.list_items(current_user["id"], status)}
+    return {"items": service.list_items(current_user["id"], status, q=q, kind=kind)}
 
 
 @router.post("/api/reading-list/reorder")

--- a/backend/news_dashboard/reading_list/service.py
+++ b/backend/news_dashboard/reading_list/service.py
@@ -111,6 +111,8 @@ def add_item(
 def list_items(
     user_id: int,
     status: str | None = None,
+    q: str | None = None,
+    kind: str | None = None,
     *,
     database_url: str | None = None,
 ) -> list[dict[str, Any]]:
@@ -120,6 +122,21 @@ def list_items(
     if status is not None:
         query += " AND status = %s"
         params.append(status)
+    if kind is not None:
+        query += " AND kind = %s"
+        params.append(kind)
+    if q is not None and q.strip():
+        query += """
+            AND (
+                title ILIKE %s
+                OR url ILIKE %s
+                OR description ILIKE %s
+                OR site_name ILIKE %s
+                OR note ILIKE %s
+            )
+        """
+        term = f"%{q.strip()}%"
+        params.extend([term, term, term, term, term])
     query += " ORDER BY priority ASC, created_at ASC, id ASC"
     with connect(database_url=database_url) as conn:
         rows = conn.execute(query, params).fetchall()

--- a/backend/tests/test_reading_list.py
+++ b/backend/tests/test_reading_list.py
@@ -264,6 +264,67 @@ def test_mark_done_sets_done_at_and_status_filter(
         app.dependency_overrides.pop(require_auth, None)
 
 
+def test_list_items_filters_by_text_kind_status_and_user(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    alice = _make_user(database_url, "alice")
+    bob = _make_user(database_url, "bob")
+
+    article = service.add_item(
+        alice, "https://example.com/briefing", note="weekly market notes", database_url=database_url
+    )
+    video = service.add_item(
+        alice, "https://www.youtube.com/watch?v=abc", database_url=database_url
+    )
+    bob_item = service.add_item(bob, "https://example.com/private", database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            UPDATE reading_list_items
+            SET title = %s, description = %s, site_name = %s
+            WHERE id = %s
+            """,
+            ("Market briefing", "Energy equities recap", "Desk", article["id"]),
+        )
+        conn.execute(
+            """
+            UPDATE reading_list_items
+            SET title = %s, description = %s, site_name = %s, status = 'done'
+            WHERE id = %s
+            """,
+            ("Launch video", "Product walkthrough", "YouTube", video["id"]),
+        )
+        conn.execute(
+            "UPDATE reading_list_items SET title = %s WHERE id = %s",
+            ("Market private", bob_item["id"]),
+        )
+
+    text_matches = service.list_items(alice, q="market", database_url=database_url)
+    assert [item["id"] for item in text_matches] == [article["id"]]
+
+    video_matches = service.list_items(alice, kind="video", database_url=database_url)
+    assert [item["id"] for item in video_matches] == [video["id"]]
+
+    combined = service.list_items(
+        alice, status="done", q="walkthrough", kind="video", database_url=database_url
+    )
+    assert [item["id"] for item in combined] == [video["id"]]
+
+
+def test_list_endpoint_validates_kind(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    database_url = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(database_url)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.get("/api/reading-list?kind=podcast")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 422
+
+
 def test_delete_item_enforces_ownership(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
     database_url = _setup_db(monkeypatch, pg_clean)
     alice = _make_user(database_url, "alice")

--- a/frontend/src/__tests__/readingList.test.tsx
+++ b/frontend/src/__tests__/readingList.test.tsx
@@ -86,6 +86,54 @@ describe('ReadingListPage', () => {
     expect(screen.getByText('A very insightful post.')).toBeTruthy();
   });
 
+  it('sends search and type filters to the reading list API', async () => {
+    const fetchSpy = vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([makeItem()]);
+
+    renderPage();
+    await screen.findByText('Great post');
+
+    await userEvent.type(screen.getByPlaceholderText(/search saved links/i), 'video');
+    await userEvent.selectOptions(screen.getByLabelText(/filter by type/i), 'video');
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenLastCalledWith({
+        status: 'unread',
+        q: 'video',
+        kind: 'video',
+      });
+    });
+  });
+
+  it('clears search and type filters without a page reload', async () => {
+    const fetchSpy = vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([makeItem()]);
+
+    renderPage();
+    await screen.findByText('Great post');
+
+    await userEvent.type(screen.getByPlaceholderText(/search saved links/i), 'briefing');
+    await userEvent.selectOptions(screen.getByLabelText(/filter by type/i), 'article');
+    await userEvent.click(screen.getByRole('button', { name: /clear filters/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenLastCalledWith({
+        status: 'unread',
+        q: '',
+        kind: undefined,
+      });
+    });
+  });
+
+  it('shows a no-matches empty state for active filters', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([]);
+
+    renderPage();
+    await screen.findByText('Your reading list is empty');
+    await userEvent.type(screen.getByPlaceholderText(/search saved links/i), 'missing');
+
+    expect(await screen.findByText('No matching saved links')).toBeTruthy();
+    expect(screen.getByText(/clear search or type filters/i)).toBeTruthy();
+  });
+
   it('reveals the AI summary when the toggle is clicked', async () => {
     vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([
       makeItem({ summary: 'A concise take on the post.', summary_status: 'ok' }),

--- a/frontend/src/api/readingListApi.ts
+++ b/frontend/src/api/readingListApi.ts
@@ -33,8 +33,20 @@ interface ReadingListResponse {
   items: ReadingListItem[];
 }
 
-export async function fetchReadingList(status?: ReadingListStatus): Promise<ReadingListItem[]> {
-  const suffix = status ? `?status=${status}` : '';
+export interface ReadingListFilters {
+  status?: ReadingListStatus;
+  q?: string;
+  kind?: ReadingListKind;
+}
+
+export async function fetchReadingList(
+  filters: ReadingListFilters = {}
+): Promise<ReadingListItem[]> {
+  const params = new URLSearchParams();
+  if (filters.status) params.set('status', filters.status);
+  if (filters.q?.trim()) params.set('q', filters.q.trim());
+  if (filters.kind) params.set('kind', filters.kind);
+  const suffix = params.toString() ? `?${params.toString()}` : '';
   const data = await requestJson<ReadingListResponse>(`/api/reading-list${suffix}`);
   return data.items;
 }

--- a/frontend/src/pages/ReadingListPage.tsx
+++ b/frontend/src/pages/ReadingListPage.tsx
@@ -9,6 +9,8 @@ import {
   Loader2,
   MonitorPlay,
   Newspaper,
+  Search,
+  X,
   RotateCcw,
   Sparkles,
   Trash2,
@@ -53,6 +55,14 @@ const IMPORT_SOURCES: { value: ReadingListImportSource; label: string }[] = [
   { value: 'pocket', label: 'Pocket (CSV)' },
   { value: 'instapaper', label: 'Instapaper (CSV)' },
   { value: 'omnivore', label: 'Omnivore (JSON)' },
+];
+
+const KIND_FILTERS: { value: ReadingListKind | 'all'; label: string }[] = [
+  { value: 'all', label: 'All types' },
+  { value: 'article', label: 'Articles' },
+  { value: 'video', label: 'Videos' },
+  { value: 'channel', label: 'Channels' },
+  { value: 'link', label: 'Links' },
 ];
 
 const KIND_META: Record<ReadingListKind, { label: string; Icon: typeof Newspaper }> = {
@@ -218,6 +228,8 @@ export function ReadingListPage() {
   const queryClient = useQueryClient();
   const [newUrl, setNewUrl] = useState('');
   const [filter, setFilter] = useState<ReadingListStatus>('unread');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [kindFilter, setKindFilter] = useState<ReadingListKind | 'all'>('all');
   const [importSource, setImportSource] = useState<ReadingListImportSource>('pocket');
   const [importResult, setImportResult] = useState<ReadingListImportResult | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
@@ -227,13 +239,19 @@ export function ReadingListPage() {
   );
 
   const { data: items = [], isLoading } = useQuery({
-    queryKey: ['reading-list', filter],
-    queryFn: () => fetchReadingList(filter),
+    queryKey: ['reading-list', filter, searchQuery.trim(), kindFilter],
+    queryFn: () =>
+      fetchReadingList({
+        status: filter,
+        q: searchQuery,
+        kind: kindFilter === 'all' ? undefined : kindFilter,
+      }),
     refetchInterval: (query) =>
       query.state.data?.some((item) => item.fetch_status === 'pending') ? 2000 : false,
   });
 
   const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['reading-list'] });
+  const filtersActive = Boolean(searchQuery.trim()) || kindFilter !== 'all';
 
   const addMutation = useMutation({
     mutationFn: (url: string) => addReadingListItem(url),
@@ -410,14 +428,68 @@ export function ReadingListPage() {
         ))}
       </div>
 
+      <div className="px-4 md:px-5 pb-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="relative w-full max-w-xl">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search saved links"
+            className="h-9 w-full rounded-md border border-border bg-surface pl-9 pr-9 text-sm outline-none focus:border-border-strong"
+          />
+          {searchQuery ? (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => setSearchQuery('')}
+              className="absolute right-2 top-1/2 rounded-sm p-1 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="size-4" strokeWidth={1.75} />
+            </button>
+          ) : null}
+        </div>
+        <select
+          aria-label="Filter by type"
+          value={kindFilter}
+          onChange={(e) => setKindFilter(e.target.value as ReadingListKind | 'all')}
+          className="h-9 rounded-md border border-border bg-surface px-2 text-sm outline-none focus:border-border-strong"
+        >
+          {KIND_FILTERS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {filtersActive ? (
+          <button
+            type="button"
+            onClick={() => {
+              setSearchQuery('');
+              setKindFilter('all');
+            }}
+            className="h-9 rounded-md px-2 text-sm text-muted-foreground hover:text-foreground"
+          >
+            Clear filters
+          </button>
+        ) : null}
+      </div>
+
       {isLoading ? null : items.length === 0 ? (
         <EmptyState
           icon={BookmarkPlus}
-          title={filter === 'done' ? 'Nothing finished yet' : 'Your reading list is empty'}
+          title={
+            filtersActive
+              ? 'No matching saved links'
+              : filter === 'done'
+                ? 'Nothing finished yet'
+                : 'Your reading list is empty'
+          }
           subtitle={
-            filter === 'done'
-              ? 'Items you mark as done will show up here.'
-              : 'Paste a link above to save it for later.'
+            filtersActive
+              ? 'Clear search or type filters to show the full list.'
+              : filter === 'done'
+                ? 'Items you mark as done will show up here.'
+                : 'Paste a link above to save it for later.'
           }
         />
       ) : (


### PR DESCRIPTION
Closes #942

## Summary
- Add optional `q` and `kind` filters to `GET /api/reading-list` while preserving user scoping and list ordering.
- Wire Reading List API calls to send status, search, and type filters.
- Add search/type controls, clear-filter behavior, and a no-matches empty state to the Reading List page.

## Tests
- `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_reading_list.py`
- `npm run test:frontend -- frontend/src/__tests__/readingList.test.tsx`
- `PATH="$PWD/.venv/bin:$PATH" ruff check backend/news_dashboard/reading_list/service.py backend/news_dashboard/reading_list/router.py backend/tests/test_reading_list.py`
- `npm run lint -- --max-warnings 0`
- `npm run typecheck`
- `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)