### PR TITLE
Resolve #943: Add offline saved articles queue

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -42,6 +42,9 @@ const ReadingDnaPage = lazy(() =>
 const ReadingListPage = lazy(() =>
   import('./pages/ReadingListPage').then((m) => ({ default: m.ReadingListPage }))
 );
+const OfflineSavedPage = lazy(() =>
+  import('./pages/OfflineSavedPage').then((m) => ({ default: m.OfflineSavedPage }))
+);
 const WeeklyRecapPage = lazy(() =>
   import('./pages/WeeklyRecapPage').then((m) => ({ default: m.WeeklyRecapPage }))
 );
@@ -205,6 +208,7 @@ export const routes: RouteObject[] = [
       },
       { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
       { path: 'reading-list', element: withSuspense(ReadingListPage) },
+      { path: 'offline-saved', element: withSuspense(OfflineSavedPage) },
       { path: 'recap', element: withSuspense(WeeklyRecapPage) },
       { path: 'archive', element: <ArchivePage /> },
       { path: 'collections', element: <CollectionsPage /> },

--- a/frontend/src/__tests__/appRouter.test.tsx
+++ b/frontend/src/__tests__/appRouter.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../pages/FeedsLogsPage', () => ({ FeedsLogsPage: stub('logs-page') }));
 vi.mock('../pages/StatsPage', () => ({ StatsPage: stub('stats-page') }));
 vi.mock('../pages/ArchivePage', () => ({ ArchivePage: stub('archive-page') }));
 vi.mock('../pages/SettingsPage', () => ({ SettingsPage: stub('settings-page') }));
+vi.mock('../pages/OfflineSavedPage', () => ({ OfflineSavedPage: stub('offline-saved-page') }));
 vi.mock('../pages/ArticlePage', () => ({ ArticlePage: stub('article-page') }));
 vi.mock('../pages/BriefingsHistoryPage', () => ({ BriefingsHistoryPage: stub('briefs-page') }));
 vi.mock('../pages/BriefingDetailPage', () => ({ BriefingDetailPage: stub('brief-detail-page') }));
@@ -77,6 +78,11 @@ describe('AppRouter routes', () => {
   it('renders a nested feeds child route', async () => {
     renderAt('/feeds/runs');
     expect(await screen.findByText('runs-page')).toBeTruthy();
+  });
+
+  it('renders the offline saved route', async () => {
+    renderAt('/offline-saved');
+    expect(await screen.findByText('offline-saved-page')).toBeTruthy();
   });
 
   describe('admin-guarded feeds operational routes', () => {

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -9,6 +9,14 @@ import * as api from '../api';
 import * as workflowApi from '../api/workflowApi';
 import type { Article } from '../types';
 
+interface SavedOfflineArticle {
+  id: string;
+  title: string;
+  source: string;
+  url: string;
+  bodyCacheKey: string;
+}
+
 vi.mock('../api/workflowApi', async (importOriginal) => {
   const actual = await importOriginal<typeof workflowApi>();
   return {
@@ -22,6 +30,16 @@ vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  window.localStorage.clear();
+  Object.defineProperty(window, 'caches', {
+    configurable: true,
+    value: {
+      open: vi.fn().mockResolvedValue({
+        add: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(true),
+      }),
+    },
+  });
   vi.spyOn(api, 'fetchArticleHighlights').mockResolvedValue([]);
   vi.spyOn(api, 'fetchAiFeedback').mockResolvedValue({});
 });
@@ -298,6 +316,87 @@ describe('ArticlePage — Open original link', () => {
     const links = screen.getAllByText('Open original');
     const hrefs = links.map((el) => el.closest('a')?.href);
     expect(hrefs).toContain('https://example.com/article');
+  });
+});
+
+describe('ArticlePage — offline saves', () => {
+  it('records article metadata when saving for offline', async () => {
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full text.' })
+    );
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full text.' })
+    );
+
+    renderReader('42', makeArticle({ body_status: 'ok', body: 'Full text.' }));
+    await waitFor(() => screen.getByText('Test Article Title'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save for offline' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Remove offline save' })).toBeTruthy()
+    );
+    const saved = JSON.parse(
+      window.localStorage.getItem('offline-articles:index:v1') ?? '[]'
+    ) as SavedOfflineArticle[];
+    expect(saved[0]).toMatchObject({
+      id: '42',
+      title: 'Test Article Title',
+      source: 'Test Source',
+      url: 'https://example.com/article',
+      bodyCacheKey: '/api/articles/42/body',
+    });
+  });
+
+  it('shows saved state for an already saved article and removes it', async () => {
+    window.localStorage.setItem(
+      'offline-articles:index:v1',
+      JSON.stringify([
+        {
+          id: '42',
+          title: 'Test Article Title',
+          source: 'Test Source',
+          url: 'https://example.com/article',
+          savedAt: '2026-07-08T09:30:00.000Z',
+          bodyCacheKey: '/api/articles/42/body',
+        },
+      ])
+    );
+    vi.spyOn(api, 'fetchArticle').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full text.' })
+    );
+    vi.spyOn(api, 'fetchArticleBody').mockResolvedValue(
+      makeArticle({ body_status: 'ok', body: 'Full text.' })
+    );
+
+    renderReader('42', makeArticle({ body_status: 'ok', body: 'Full text.' }));
+    await waitFor(() => screen.getByRole('button', { name: 'Remove offline save' }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove offline save' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save for offline' })).toBeTruthy()
+    );
+    expect(window.localStorage.getItem('offline-articles:index:v1')).toBe('[]');
+  });
+
+  it('does not show offline save controls for shared article routes', async () => {
+    vi.spyOn(api, 'fetchSharedArticle').mockResolvedValue(
+      makeArticle({ id: 99, title: 'Shared private article' })
+    );
+    vi.spyOn(api, 'fetchSharedArticleBody').mockResolvedValue(
+      makeArticle({
+        id: 99,
+        title: 'Shared private article',
+        body_status: 'ok',
+        body: 'Shared body',
+      })
+    );
+
+    renderSharedReader('123');
+    await waitFor(() => screen.getByText('Shared private article'));
+
+    expect(screen.queryByRole('button', { name: 'Save for offline' })).toBeNull();
   });
 });
 

--- a/frontend/src/__tests__/offline.test.ts
+++ b/frontend/src/__tests__/offline.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getOfflineArticle,
+  isArticleSavedOffline,
+  listOfflineArticles,
+  removeOfflineArticle,
+  saveOfflineArticle,
+} from '../lib/offline';
+
+const addedUrls: string[] = [];
+const deletedUrls: string[] = [];
+
+beforeEach(() => {
+  window.localStorage.clear();
+  addedUrls.length = 0;
+  deletedUrls.length = 0;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-08T09:30:00Z'));
+  Object.defineProperty(window, 'caches', {
+    configurable: true,
+    value: {
+      open: vi.fn().mockResolvedValue({
+        add: vi.fn((url: string) => {
+          addedUrls.push(url);
+          return Promise.resolve();
+        }),
+        delete: vi.fn((url: string) => {
+          deletedUrls.push(url);
+          return Promise.resolve(true);
+        }),
+      }),
+    },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('offline article index', () => {
+  it('records metadata after caching an article body', async () => {
+    await saveOfflineArticle({
+      id: 42,
+      title: 'Offline title',
+      source: 'Example Feed',
+      url: 'https://example.com/article',
+    });
+
+    expect(addedUrls).toEqual(['/api/articles/42/body']);
+    expect(listOfflineArticles()).toEqual([
+      {
+        id: '42',
+        title: 'Offline title',
+        source: 'Example Feed',
+        url: 'https://example.com/article',
+        savedAt: '2026-07-08T09:30:00.000Z',
+        bodyCacheKey: '/api/articles/42/body',
+      },
+    ]);
+    expect(isArticleSavedOffline(42)).toBe(true);
+  });
+
+  it('does not duplicate existing saves', async () => {
+    await saveOfflineArticle({
+      id: 42,
+      title: 'Offline title',
+      source: 'Example Feed',
+      url: 'https://example.com/article',
+    });
+    await saveOfflineArticle({
+      id: 42,
+      title: 'Changed title',
+      source: 'Other Feed',
+      url: 'https://example.com/other',
+    });
+
+    expect(listOfflineArticles()).toHaveLength(1);
+    expect(getOfflineArticle(42)?.title).toBe('Offline title');
+  });
+
+  it('removes the local index entry and cached body', async () => {
+    await saveOfflineArticle({
+      id: 42,
+      title: 'Offline title',
+      source: 'Example Feed',
+      url: 'https://example.com/article',
+    });
+
+    await removeOfflineArticle(42);
+
+    expect(listOfflineArticles()).toEqual([]);
+    expect(deletedUrls).toEqual(['/api/articles/42/body']);
+  });
+});

--- a/frontend/src/__tests__/offlineSavedPage.test.tsx
+++ b/frontend/src/__tests__/offlineSavedPage.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { OfflineSavedPage } from '../pages/OfflineSavedPage';
+import { saveOfflineArticle } from '../lib/offline';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  Object.defineProperty(window, 'caches', {
+    configurable: true,
+    value: {
+      open: vi.fn().mockResolvedValue({
+        add: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(true),
+      }),
+    },
+  });
+});
+
+describe('OfflineSavedPage', () => {
+  it('shows saved offline articles with article links', async () => {
+    await saveOfflineArticle({
+      id: 42,
+      title: 'Cached article',
+      source: 'Example Feed',
+      url: 'https://example.com/cached',
+    });
+
+    render(
+      <MemoryRouter>
+        <OfflineSavedPage />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: 'Cached article' });
+    expect(link.getAttribute('href')).toBe('/a/42');
+    expect(screen.getByText('Example Feed')).toBeTruthy();
+  });
+
+  it('removes saved articles from the list', async () => {
+    await saveOfflineArticle({
+      id: 42,
+      title: 'Cached article',
+      source: 'Example Feed',
+      url: 'https://example.com/cached',
+    });
+
+    render(
+      <MemoryRouter>
+        <OfflineSavedPage />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Cached article' }));
+
+    await waitFor(() => expect(screen.queryByText('Cached article')).toBeNull());
+    expect(screen.getByText('No offline articles')).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -250,6 +250,26 @@ describe('#118 — Briefing History in secondary nav', () => {
   });
 });
 
+describe('#943 — Offline Saved navigation', () => {
+  it('shows Offline Saved in shell navigation', async () => {
+    renderShell('/');
+    await waitFor(() => {
+      const links = screen.getAllByRole('link', { name: /offline saved/i });
+      expect(links.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('Offline Saved link points to /offline-saved', async () => {
+    renderShell('/');
+    await waitFor(() => {
+      const link = screen
+        .getAllByRole('link', { name: /offline saved/i })
+        .find((l) => l.getAttribute('href') === '/offline-saved');
+      expect(link).toBeTruthy();
+    });
+  });
+});
+
 describe('#118 — Briefing History in command palette', () => {
   it('shows Briefing History as a nav item', () => {
     renderPalette();

--- a/frontend/src/components/article/ArticleReaderHeader.tsx
+++ b/frontend/src/components/article/ArticleReaderHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, ExternalLink, Download } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ExternalLink, Download, Trash2 } from 'lucide-react';
 import { isOfflineCacheSupported } from '@/lib/offline';
 
 export function ArticleReaderHeader({
@@ -9,7 +9,9 @@ export function ArticleReaderHeader({
   nextId,
   articleUrl,
   isShared,
+  isSavedOffline,
   onSaveOffline,
+  onRemoveOffline,
 }: {
   goBack: () => void;
   goPrev: () => void;
@@ -18,7 +20,9 @@ export function ArticleReaderHeader({
   nextId: string | null;
   articleUrl: string;
   isShared: boolean;
+  isSavedOffline: boolean;
   onSaveOffline: () => void;
+  onRemoveOffline: () => void;
 }) {
   return (
     <header className="sticky top-0 z-20 border-b border-border bg-background/90 backdrop-blur">
@@ -57,11 +61,11 @@ export function ArticleReaderHeader({
           </a>
           {isOfflineCacheSupported() && !isShared && (
             <button
-              onClick={onSaveOffline}
+              onClick={isSavedOffline ? onRemoveOffline : onSaveOffline}
               className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-surface"
-              aria-label="Save for offline"
+              aria-label={isSavedOffline ? 'Remove offline save' : 'Save for offline'}
             >
-              <Download className="size-4" />
+              {isSavedOffline ? <Trash2 className="size-4" /> : <Download className="size-4" />}
             </button>
           )}
         </div>

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -3,6 +3,7 @@ import {
   Archive,
   BarChart3,
   Bookmark,
+  Download,
   BrainCircuit,
   Clock,
   Flame,
@@ -57,6 +58,13 @@ export const secondaryNavigationItems: NavigationItem[] = [
     labelKey: 'nav.reading_list',
     icon: Bookmark,
     shortcut: 'r',
+  },
+  {
+    to: '/offline-saved',
+    label: 'Offline Saved',
+    labelKey: 'nav.offline_saved',
+    icon: Download,
+    shortcut: 'o',
   },
   {
     to: '/briefs',
@@ -176,6 +184,11 @@ const pageTitleRules: { test: (pathname: string) => boolean; en: string; key: st
     test: (p) => p.startsWith('/reading-list'),
     en: 'Reading List',
     key: 'page_title.reading_list',
+  },
+  {
+    test: (p) => p.startsWith('/offline-saved'),
+    en: 'Offline Saved',
+    key: 'page_title.offline_saved',
   },
   { test: (p) => p.startsWith('/recap'), en: 'Weekly Recap', key: 'page_title.weekly_recap' },
   { test: (p) => p.startsWith('/archive'), en: 'Archive', key: 'page_title.archive' },

--- a/frontend/src/lib/offline.ts
+++ b/frontend/src/lib/offline.ts
@@ -1,13 +1,65 @@
 const OFFLINE_ARTICLE_CACHE = 'offline-articles-v1';
+const OFFLINE_ARTICLE_INDEX_KEY = 'offline-articles:index:v1';
+
+export interface OfflineArticle {
+  id: string;
+  title: string;
+  source: string;
+  url: string;
+  savedAt: string;
+  bodyCacheKey: string;
+}
+
+export interface OfflineArticleInput {
+  id: string | number;
+  title: string;
+  source: string;
+  url: string;
+}
 
 export function isOfflineCacheSupported(): boolean {
   return typeof window !== 'undefined' && 'caches' in window;
 }
 
+function articleBodyCacheKey(articleId: string | number): string {
+  return `/api/articles/${articleId}/body`;
+}
+
+function readOfflineArticleIndex(): OfflineArticle[] {
+  if (typeof window === 'undefined') return [];
+  const raw = window.localStorage.getItem(OFFLINE_ARTICLE_INDEX_KEY);
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isOfflineArticle);
+  } catch {
+    return [];
+  }
+}
+
+function writeOfflineArticleIndex(articles: OfflineArticle[]): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(OFFLINE_ARTICLE_INDEX_KEY, JSON.stringify(articles));
+}
+
+function isOfflineArticle(value: unknown): value is OfflineArticle {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<Record<keyof OfflineArticle, unknown>>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.title === 'string' &&
+    typeof candidate.source === 'string' &&
+    typeof candidate.url === 'string' &&
+    typeof candidate.savedAt === 'string' &&
+    typeof candidate.bodyCacheKey === 'string'
+  );
+}
+
 export async function cacheArticleBody(articleId: string | number): Promise<void> {
   if (!isOfflineCacheSupported()) return;
   const cache = await caches.open(OFFLINE_ARTICLE_CACHE);
-  await cache.add(`/api/articles/${articleId}/body`);
+  await cache.add(articleBodyCacheKey(articleId));
 }
 
 export async function cacheArticleBodies(articleIds: (string | number)[]): Promise<number> {
@@ -16,11 +68,54 @@ export async function cacheArticleBodies(articleIds: (string | number)[]): Promi
   let cached = 0;
   for (const articleId of articleIds) {
     try {
-      await cache.add(`/api/articles/${articleId}/body`);
+      await cache.add(articleBodyCacheKey(articleId));
       cached += 1;
     } catch {
       // Keep caching the rest of the queue when one article body is unavailable.
     }
   }
   return cached;
+}
+
+export function listOfflineArticles(): OfflineArticle[] {
+  return readOfflineArticleIndex().sort((a, b) => b.savedAt.localeCompare(a.savedAt));
+}
+
+export function getOfflineArticle(articleId: string | number): OfflineArticle | null {
+  const id = String(articleId);
+  return readOfflineArticleIndex().find((article) => article.id === id) ?? null;
+}
+
+export function isArticleSavedOffline(articleId: string | number): boolean {
+  return getOfflineArticle(articleId) !== null;
+}
+
+export async function saveOfflineArticle(input: OfflineArticleInput): Promise<OfflineArticle> {
+  await cacheArticleBody(input.id);
+  const id = String(input.id);
+  const existing = getOfflineArticle(id);
+  if (existing) return existing;
+  const saved: OfflineArticle = {
+    id,
+    title: input.title,
+    source: input.source,
+    url: input.url,
+    savedAt: new Date().toISOString(),
+    bodyCacheKey: articleBodyCacheKey(input.id),
+  };
+  writeOfflineArticleIndex([
+    saved,
+    ...readOfflineArticleIndex().filter((article) => article.id !== id),
+  ]);
+  return saved;
+}
+
+export async function removeOfflineArticle(articleId: string | number): Promise<void> {
+  const id = String(articleId);
+  const existing = getOfflineArticle(id);
+  if (isOfflineCacheSupported()) {
+    const cache = await caches.open(OFFLINE_ARTICLE_CACHE);
+    await cache.delete(existing?.bodyCacheKey ?? articleBodyCacheKey(id));
+  }
+  writeOfflineArticleIndex(readOfflineArticleIndex().filter((article) => article.id !== id));
 }

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -44,7 +44,8 @@
     "settings": "الإعدادات",
     "stats": "الإحصاءات",
     "analytics": "التحليلات",
-    "users": "المستخدمون"
+    "users": "المستخدمون",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "الموجز",
@@ -67,7 +68,8 @@
     "settings": "الإعدادات",
     "analytics": "التحليلات",
     "users": "المستخدمون",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "غير متصل",

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -44,7 +44,8 @@
     "settings": "Nastavení",
     "stats": "Statistiky",
     "analytics": "Analýza",
-    "users": "Uživatelé"
+    "users": "Uživatelé",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Přehled",
@@ -67,7 +68,8 @@
     "settings": "Nastavení",
     "analytics": "Analýza",
     "users": "Uživatelé",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -44,7 +44,8 @@
     "settings": "Indstillinger",
     "stats": "Statistik",
     "analytics": "Analyse",
-    "users": "Brugere"
+    "users": "Brugere",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Overblik",
@@ -67,7 +68,8 @@
     "settings": "Indstillinger",
     "analytics": "Analyse",
     "users": "Brugere",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -44,7 +44,8 @@
     "settings": "Einstellungen",
     "stats": "Statistiken",
     "analytics": "Analytik",
-    "users": "Benutzer"
+    "users": "Benutzer",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Übersicht",
@@ -67,7 +68,8 @@
     "settings": "Einstellungen",
     "analytics": "Analytik",
     "users": "Benutzer",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -44,7 +44,8 @@
     "settings": "Ρυθμίσεις",
     "stats": "Στατιστικά",
     "analytics": "Αναλυτικά",
-    "users": "Χρήστες"
+    "users": "Χρήστες",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Σύνοψη",
@@ -67,7 +68,8 @@
     "settings": "Ρυθμίσεις",
     "analytics": "Αναλυτικά",
     "users": "Χρήστες",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Εκτός σύνδεσης",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -44,7 +44,8 @@
     "settings": "Settings",
     "stats": "Stats",
     "analytics": "Analytics",
-    "users": "Users"
+    "users": "Users",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Brief",
@@ -67,7 +68,8 @@
     "settings": "Settings",
     "analytics": "Analytics",
     "users": "Users",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -44,7 +44,8 @@
     "settings": "Configuración",
     "stats": "Estadísticas",
     "analytics": "Analítica",
-    "users": "Usuarios"
+    "users": "Usuarios",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Resumen",
@@ -67,7 +68,8 @@
     "settings": "Configuración",
     "analytics": "Analítica",
     "users": "Usuarios",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Sin conexión",

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -44,7 +44,8 @@
     "settings": "Asetukset",
     "stats": "Tilastot",
     "analytics": "Analytiikka",
-    "users": "Käyttäjät"
+    "users": "Käyttäjät",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Yhteenveto",
@@ -67,7 +68,8 @@
     "settings": "Asetukset",
     "analytics": "Analytiikka",
     "users": "Käyttäjät",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -44,7 +44,8 @@
     "settings": "Paramètres",
     "stats": "Statistiques",
     "analytics": "Analytique",
-    "users": "Utilisateurs"
+    "users": "Utilisateurs",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Résumé",
@@ -67,7 +68,8 @@
     "settings": "Paramètres",
     "analytics": "Analytique",
     "users": "Utilisateurs",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Hors ligne",

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -44,7 +44,8 @@
     "settings": "הגדרות",
     "stats": "נתונים",
     "analytics": "אנליטיקס",
-    "users": "משתמשים"
+    "users": "משתמשים",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "תקציר",
@@ -67,7 +68,8 @@
     "settings": "הגדרות",
     "analytics": "אנליטיקס",
     "users": "משתמשים",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "לא מקוון",

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -44,7 +44,8 @@
     "settings": "सेटिंग्स",
     "stats": "आँकड़े",
     "analytics": "विश्लेषिकी",
-    "users": "उपयोगकर्ता"
+    "users": "उपयोगकर्ता",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "ब्रीफ़",
@@ -67,7 +68,8 @@
     "settings": "सेटिंग्स",
     "analytics": "विश्लेषिकी",
     "users": "उपयोगकर्ता",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "ऑफ़लाइन",

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -44,7 +44,8 @@
     "settings": "Beállítások",
     "stats": "Statisztikák",
     "analytics": "Analitika",
-    "users": "Felhasználók"
+    "users": "Felhasználók",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Összefoglaló",
@@ -67,7 +68,8 @@
     "settings": "Beállítások",
     "analytics": "Analitika",
     "users": "Felhasználók",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -44,7 +44,8 @@
     "settings": "Pengaturan",
     "stats": "Statistik",
     "analytics": "Analitik",
-    "users": "Pengguna"
+    "users": "Pengguna",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Ringkasan",
@@ -67,7 +68,8 @@
     "settings": "Pengaturan",
     "analytics": "Analitik",
     "users": "Pengguna",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -44,7 +44,8 @@
     "settings": "Impostazioni",
     "stats": "Statistiche",
     "analytics": "Analisi",
-    "users": "Utenti"
+    "users": "Utenti",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Riepilogo",
@@ -67,7 +68,8 @@
     "settings": "Impostazioni",
     "analytics": "Analisi",
     "users": "Utenti",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -44,7 +44,8 @@
     "settings": "設定",
     "stats": "統計",
     "analytics": "分析",
-    "users": "ユーザー"
+    "users": "ユーザー",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "ブリーフ",
@@ -67,7 +68,8 @@
     "settings": "設定",
     "analytics": "分析",
     "users": "ユーザー",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "オフライン",

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -44,7 +44,8 @@
     "settings": "설정",
     "stats": "통계",
     "analytics": "분석",
-    "users": "사용자"
+    "users": "사용자",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "브리핑",
@@ -67,7 +68,8 @@
     "settings": "설정",
     "analytics": "분석",
     "users": "사용자",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "오프라인",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -44,7 +44,8 @@
     "settings": "Instellingen",
     "stats": "Statistieken",
     "analytics": "Analyse",
-    "users": "Gebruikers"
+    "users": "Gebruikers",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Overzicht",
@@ -67,7 +68,8 @@
     "settings": "Instellingen",
     "analytics": "Analyse",
     "users": "Gebruikers",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -44,7 +44,8 @@
     "settings": "Innstillinger",
     "stats": "Statistikk",
     "analytics": "Analyse",
-    "users": "Brukere"
+    "users": "Brukere",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Oversikt",
@@ -67,7 +68,8 @@
     "settings": "Innstillinger",
     "analytics": "Analyse",
     "users": "Brukere",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Frakoblet",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -44,7 +44,8 @@
     "settings": "Ustawienia",
     "stats": "Statystyki",
     "analytics": "Analityka",
-    "users": "Użytkownicy"
+    "users": "Użytkownicy",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Podsumowanie",
@@ -67,7 +68,8 @@
     "settings": "Ustawienia",
     "analytics": "Analityka",
     "users": "Użytkownicy",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -44,7 +44,8 @@
     "settings": "Configurações",
     "stats": "Estatísticas",
     "analytics": "Análises",
-    "users": "Usuários"
+    "users": "Usuários",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Resumo",
@@ -67,7 +68,8 @@
     "settings": "Configurações",
     "analytics": "Análises",
     "users": "Usuários",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -44,7 +44,8 @@
     "settings": "Setări",
     "stats": "Statistici",
     "analytics": "Analitică",
-    "users": "Utilizatori"
+    "users": "Utilizatori",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Rezumat",
@@ -67,7 +68,8 @@
     "settings": "Setări",
     "analytics": "Analitică",
     "users": "Utilizatori",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -44,7 +44,8 @@
     "settings": "Настройки",
     "stats": "Статистика",
     "analytics": "Аналитика",
-    "users": "Пользователи"
+    "users": "Пользователи",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Сводка",
@@ -67,7 +68,8 @@
     "settings": "Настройки",
     "analytics": "Аналитика",
     "users": "Пользователи",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Нет сети",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -44,7 +44,8 @@
     "settings": "Inställningar",
     "stats": "Statistik",
     "analytics": "Analys",
-    "users": "Användare"
+    "users": "Användare",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Överblick",
@@ -67,7 +68,8 @@
     "settings": "Inställningar",
     "analytics": "Analys",
     "users": "Användare",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -44,7 +44,8 @@
     "settings": "การตั้งค่า",
     "stats": "สถิติ",
     "analytics": "การวิเคราะห์",
-    "users": "ผู้ใช้"
+    "users": "ผู้ใช้",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "สรุปข่าว",
@@ -67,7 +68,8 @@
     "settings": "การตั้งค่า",
     "analytics": "การวิเคราะห์",
     "users": "ผู้ใช้",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "ออฟไลน์",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -44,7 +44,8 @@
     "settings": "Ayarlar",
     "stats": "İstatistikler",
     "analytics": "Analitik",
-    "users": "Kullanıcılar"
+    "users": "Kullanıcılar",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Özet",
@@ -67,7 +68,8 @@
     "settings": "Ayarlar",
     "analytics": "Analitik",
     "users": "Kullanıcılar",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Çevrimdışı",

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -44,7 +44,8 @@
     "settings": "Налаштування",
     "stats": "Статистика",
     "analytics": "Аналітика",
-    "users": "Користувачі"
+    "users": "Користувачі",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Огляд",
@@ -67,7 +68,8 @@
     "settings": "Налаштування",
     "analytics": "Аналітика",
     "users": "Користувачі",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Офлайн",

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -44,7 +44,8 @@
     "settings": "Cài đặt",
     "stats": "Thống kê",
     "analytics": "Phân tích",
-    "users": "Người dùng"
+    "users": "Người dùng",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "Tóm tắt",
@@ -67,7 +68,8 @@
     "settings": "Cài đặt",
     "analytics": "Phân tích",
     "users": "Người dùng",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "Ngoại tuyến",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -44,7 +44,8 @@
     "settings": "设置",
     "stats": "统计",
     "analytics": "分析",
-    "users": "用户"
+    "users": "用户",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "简报",
@@ -67,7 +68,8 @@
     "settings": "设置",
     "analytics": "分析",
     "users": "用户",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "离线",

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -44,7 +44,8 @@
     "settings": "設定",
     "stats": "統計",
     "analytics": "分析",
-    "users": "使用者"
+    "users": "使用者",
+    "offline_saved": "Offline Saved"
   },
   "page_title": {
     "brief": "簡報",
@@ -67,7 +68,8 @@
     "settings": "設定",
     "analytics": "分析",
     "users": "使用者",
-    "default": "Radar"
+    "default": "Radar",
+    "offline_saved": "Offline Saved"
   },
   "shell": {
     "offline": "離線",

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -7,7 +7,7 @@ import { fetchArticle, fetchArticleBody, fetchSharedArticle, fetchSharedArticleB
 import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflowApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { getReaderList } from '@/lib/readerList';
-import { cacheArticleBody } from '@/lib/offline';
+import { getOfflineArticle, removeOfflineArticle, saveOfflineArticle } from '@/lib/offline';
 import { trackArticleOpen, trackArticleClose } from '@/lib/analytics';
 import { useArticleAudio } from '@/hooks/useArticleAudio';
 import { useArticleKeyboardShortcuts } from '@/hooks/useArticleKeyboardShortcuts';
@@ -43,10 +43,16 @@ export function ArticlePage() {
 
   const article = useMemo(() => (rawArticle ? adaptArticle(rawArticle) : null), [rawArticle]);
   const [showOriginal, setShowOriginal] = useState(false);
+  const [offlineSavedArticleId, setOfflineSavedArticleId] = useState<string | null>(null);
 
   useEffect(() => {
     setShowOriginal(false);
-  }, [articleKey]);
+    if (!id || shareId) {
+      setOfflineSavedArticleId(null);
+      return;
+    }
+    setOfflineSavedArticleId(getOfflineArticle(id)?.id ?? null);
+  }, [articleKey, id, shareId]);
 
   // Trigger body fetch in parallel with metadata — fire at mount so we don't
   // wait for the GET /api/articles/:id round-trip before starting the slow scrape.
@@ -136,10 +142,27 @@ export function ArticlePage() {
   async function saveCurrentArticleOffline() {
     if (!article) return;
     try {
-      await cacheArticleBody(article.id);
+      const saved = await saveOfflineArticle({
+        id: article.id,
+        title: article.title,
+        source: article.sourceName,
+        url: article.url,
+      });
+      setOfflineSavedArticleId(saved.id);
       toast('Saved for offline');
     } catch {
       toast.error('Could not save offline');
+    }
+  }
+
+  async function removeCurrentArticleOffline() {
+    if (!article) return;
+    try {
+      await removeOfflineArticle(article.id);
+      setOfflineSavedArticleId(null);
+      toast('Removed offline save');
+    } catch {
+      toast.error('Could not remove offline save');
     }
   }
 
@@ -209,7 +232,9 @@ export function ArticlePage() {
           nextId={nextId}
           articleUrl={article.url}
           isShared={Boolean(shareId)}
+          isSavedOffline={offlineSavedArticleId === String(article.id)}
           onSaveOffline={() => void saveCurrentArticleOffline()}
+          onRemoveOffline={() => void removeCurrentArticleOffline()}
         />
 
         {/* Article content */}

--- a/frontend/src/pages/OfflineSavedPage.tsx
+++ b/frontend/src/pages/OfflineSavedPage.tsx
@@ -1,0 +1,81 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ExternalLink, Trash2, WifiOff } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { listOfflineArticles, removeOfflineArticle, type OfflineArticle } from '@/lib/offline';
+
+function formatSavedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Saved offline';
+  return `Saved ${date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
+}
+
+export function OfflineSavedPage() {
+  const [articles, setArticles] = useState<OfflineArticle[]>(() => listOfflineArticles());
+  const hasArticles = articles.length > 0;
+
+  const savedCount = useMemo(
+    () => `${articles.length} ${articles.length === 1 ? 'article' : 'articles'}`,
+    [articles.length]
+  );
+
+  async function removeArticle(articleId: string) {
+    await removeOfflineArticle(articleId);
+    setArticles(listOfflineArticles());
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6">
+      <div className="mb-5 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight text-foreground">Offline Saved</h2>
+          <p className="text-sm text-muted-foreground">{savedCount}</p>
+        </div>
+      </div>
+
+      {!hasArticles ? (
+        <div className="flex min-h-[240px] flex-col items-center justify-center rounded-lg border border-dashed border-border px-6 text-center">
+          <WifiOff className="mb-3 size-7 text-muted-foreground" />
+          <h3 className="text-sm font-medium text-foreground">No offline articles</h3>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+            Saved article bodies will appear here and remain available without a network.
+          </p>
+        </div>
+      ) : (
+        <div className="divide-y divide-border rounded-lg border border-border bg-surface">
+          {articles.map((article) => (
+            <article key={article.id} className="flex gap-3 p-4">
+              <div className="min-w-0 flex-1">
+                <Link
+                  to={`/a/${article.id}`}
+                  className="line-clamp-2 text-sm font-medium text-foreground hover:underline"
+                >
+                  {article.title}
+                </Link>
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                  <span>{article.source}</span>
+                  <span>{formatSavedAt(article.savedAt)}</span>
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <Button variant="ghost" size="icon" asChild aria-label="Open original">
+                  <a href={article.url} target="_blank" rel="noreferrer">
+                    <ExternalLink className="size-4" />
+                  </a>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Remove ${article.title}`}
+                  onClick={() => void removeArticle(article.id)}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #943

## Summary
- Add a browser-local offline article index alongside the existing offline body cache.
- Add an Offline Saved page reachable from app navigation for opening and removing saved articles.
- Update the article reader offline button to show saved state, remove saves, and keep shared routes uncached.

## Tests
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:frontend
- npm run build
