### PR TITLE
Fix #944: suggest cleanup for repeatedly failing sources

### DIFF
--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -7,6 +7,7 @@ from news_dashboard.db import connect, init_db, row_to_dict
 
 LOW_SIGNAL_MIN_ARTICLES = 50
 LOW_SIGNAL_SKIP_RATE = 0.9
+REPEATED_ERROR_STREAK_MIN = 3
 
 
 def _clean_error(value: Any) -> str | None:
@@ -213,13 +214,54 @@ def generate_subscription_cleanup_suggestions(
               LEFT JOIN user_article_state uas
                 ON uas.article_id = a.id AND uas.user_id = %s
               GROUP BY uvs.slug, uvs.name
+            ),
+            ordered_runs AS (
+              SELECT
+                uvs.slug,
+                irs.error_message,
+                ROW_NUMBER() OVER source_order AS row_number,
+                COUNT(*) FILTER (
+                  WHERE irs.error_message IS NULL OR irs.error_message = ''
+                ) OVER (
+                  PARTITION BY uvs.slug
+                  ORDER BY irs.run_id DESC, irs.id DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                ) AS successes_before
+              FROM user_visible_sources uvs
+              JOIN ingest_run_sources irs
+                ON lower(btrim(irs.source_name)) IN (
+                  lower(btrim(uvs.slug)),
+                  lower(btrim(uvs.name))
+                )
+              WINDOW source_order AS (
+                PARTITION BY uvs.slug ORDER BY irs.run_id DESC, irs.id DESC
+              )
+            ),
+            error_streaks AS (
+              SELECT
+                slug,
+                COUNT(*) FILTER (
+                  WHERE COALESCE(successes_before, 0) = 0
+                    AND error_message IS NOT NULL
+                    AND error_message <> ''
+                ) AS error_streak,
+                MAX(error_message) FILTER (WHERE row_number = 1) AS latest_error
+              FROM ordered_runs
+              GROUP BY slug
             )
-            SELECT *
+            SELECT
+              source_totals.*,
+              COALESCE(error_streaks.error_streak, 0) AS error_streak,
+              error_streaks.latest_error
             FROM source_totals
+            LEFT JOIN error_streaks ON error_streaks.slug = source_totals.slug
             WHERE lifetime_articles > 0
-            ORDER BY articles_last_30_days DESC, name ASC
+               OR COALESCE(error_streaks.error_streak, 0) >= %s
+            ORDER BY COALESCE(error_streaks.error_streak, 0) DESC,
+                     articles_last_30_days DESC,
+                     name ASC
             """,
-            (user_id, user_id, user_id),
+            (user_id, user_id, user_id, REPEATED_ERROR_STREAK_MIN),
         ).fetchall()
 
     suggestions: list[dict[str, Any]] = []
@@ -232,11 +274,19 @@ def generate_subscription_cleanup_suggestions(
         archived = _as_int(source.get("archived_count"))
         skip_rate = round(skipped / total, 2) if total else 0.0
         engagement_score = round((done + starred) / total, 2) if total else 0.0
+        error_streak = _as_int(source.get("error_streak"))
+        latest_error = _clean_error(source.get("latest_error"))
         source_name = str(source["name"])
 
         reason: str | None = None
         message: str | None = None
-        if total >= LOW_SIGNAL_MIN_ARTICLES and skip_rate > LOW_SIGNAL_SKIP_RATE:
+        if error_streak >= REPEATED_ERROR_STREAK_MIN:
+            reason = "repeated_errors"
+            message = f"Unsubscribe from '{source_name}' ({error_streak} consecutive failures"
+            if latest_error:
+                message += f": {latest_error}"
+            message += ")"
+        elif total >= LOW_SIGNAL_MIN_ARTICLES and skip_rate > LOW_SIGNAL_SKIP_RATE:
             reason = "low_signal"
             message = (
                 f"Unsubscribe from '{source_name}' ({skip_rate:.0%} skipped in the last 30 days)"
@@ -262,6 +312,8 @@ def generate_subscription_cleanup_suggestions(
                 "archived_count": archived,
                 "skip_rate": _as_float(skip_rate),
                 "engagement_score": _as_float(engagement_score),
+                "error_streak": error_streak,
+                "last_error": latest_error,
             }
         )
 

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -125,6 +125,28 @@ def _add_article(
     )
 
 
+def _add_ingest_result(
+    conn: Any,
+    *,
+    run_id: int,
+    source_name: str,
+    error_message: str | None,
+) -> None:
+    conn.execute(
+        "INSERT INTO ingest_runs(id, started_at) VALUES (%s, NOW() - (%s * INTERVAL '1 day'))",
+        (run_id, 10 - run_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO ingest_run_sources(
+          run_id, source_name, articles_found, articles_new, error_message
+        )
+        VALUES (%s, %s, %s, %s, %s)
+        """,
+        (run_id, source_name, 0 if error_message else 5, 0 if error_message else 2, error_message),
+    )
+
+
 def test_source_columns_present(tmp_path: Path) -> None:
     sync_sources(tmp_path / "health.db")
     with connect(tmp_path / "health.db") as conn:
@@ -356,6 +378,8 @@ def test_subscription_cleanup_suggests_high_skip_rate_source(
             "archived_count": 0,
             "skip_rate": 0.92,
             "engagement_score": 0.08,
+            "error_streak": 0,
+            "last_error": None,
         }
     ]
 
@@ -383,8 +407,103 @@ def test_subscription_cleanup_suggests_stale_source(pg_clean: str, monkeypatch: 
             "archived_count": 0,
             "skip_rate": 0.0,
             "engagement_score": 0.0,
+            "error_streak": 0,
+            "last_error": None,
         }
     ]
+
+
+def test_subscription_cleanup_suggests_repeated_error_source(
+    pg_clean: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "broken-feed", "Broken Feed")
+        for run_id, error in (
+            (1, None),
+            (2, "temporary outage"),
+            (3, "HTTP 500"),
+            (4, 'Traceback (most recent call last):\n  File "feed.py", line 1\nTimeoutError'),
+        ):
+            _add_ingest_result(
+                conn,
+                run_id=run_id,
+                source_name="Broken Feed",
+                error_message=error,
+            )
+
+    suggestions = generate_subscription_cleanup_suggestions(uid, database_url=pg_clean)
+
+    assert suggestions == [
+        {
+            "source_slug": "broken-feed",
+            "source_name": "Broken Feed",
+            "action": "unsubscribe",
+            "reason": "repeated_errors",
+            "message": "Unsubscribe from 'Broken Feed' (3 consecutive failures: TimeoutError)",
+            "articles_last_30_days": 0,
+            "skipped_count": 0,
+            "done_count": 0,
+            "starred_count": 0,
+            "archived_count": 0,
+            "skip_rate": 0.0,
+            "engagement_score": 0.0,
+            "error_streak": 3,
+            "last_error": "TimeoutError",
+        }
+    ]
+
+
+def test_subscription_cleanup_repeated_errors_ignore_one_off_and_reset_success(
+    pg_clean: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    uid = _make_user(pg_clean)
+    with connect(pg_clean) as conn:
+        _add_source(conn, "one-off-feed", "One Off Feed")
+        _add_source(conn, "recovered-feed", "Recovered Feed")
+        _add_ingest_result(conn, run_id=1, source_name="One Off Feed", error_message="timeout")
+        for run_id, error in ((2, "timeout"), (3, "HTTP 500"), (4, "bad xml"), (5, None)):
+            _add_ingest_result(
+                conn,
+                run_id=run_id,
+                source_name="Recovered Feed",
+                error_message=error,
+            )
+
+    suggestions = generate_subscription_cleanup_suggestions(uid, database_url=pg_clean)
+
+    assert suggestions == []
+
+
+def test_subscription_cleanup_repeated_errors_respect_source_visibility(
+    pg_clean: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    alice_id = _make_user(pg_clean, "alice")
+    bob_id = _make_user(pg_clean, "bob")
+    with connect(pg_clean) as conn:
+        _add_private_source(conn, "alice-broken", "Alice Broken Feed", alice_id)
+        _add_private_source(conn, "bob-broken", "Bob Broken Feed", bob_id)
+        for run_id in range(1, 4):
+            _add_ingest_result(
+                conn,
+                run_id=run_id,
+                source_name="Alice Broken Feed",
+                error_message="timeout",
+            )
+        for run_id in range(4, 7):
+            _add_ingest_result(
+                conn,
+                run_id=run_id,
+                source_name="Bob Broken Feed",
+                error_message="timeout",
+            )
+
+    suggestions = generate_subscription_cleanup_suggestions(alice_id, database_url=pg_clean)
+
+    assert [suggestion["source_slug"] for suggestion in suggestions] == ["alice-broken"]
 
 
 def test_subscription_cleanup_api_unsubscribes_requested_sources(

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -485,6 +485,36 @@ describe('SourcesPage', () => {
     expect(await screen.findAllByText('My Blog')).toHaveLength(2); // desktop + mobile
   });
 
+  it('renders repeated error cleanup suggestions and applies them', async () => {
+    const suggestion = {
+      source_slug: 'broken-feed',
+      source_name: 'Broken Feed',
+      action: 'unsubscribe' as const,
+      reason: 'repeated_errors' as const,
+      message: "Unsubscribe from 'Broken Feed' (3 consecutive failures: TimeoutError)",
+      articles_last_30_days: 0,
+      skip_rate: 0,
+      skipped_count: 0,
+      done_count: 0,
+      starred_count: 0,
+      archived_count: 0,
+      engagement_score: 0,
+      error_streak: 3,
+      last_error: 'TimeoutError',
+    };
+    apiMock.fetchSources.mockResolvedValue([source({ slug: 'broken-feed', name: 'Broken Feed' })]);
+    apiMock.fetchSourceCleanupSuggestions.mockResolvedValue([suggestion]);
+    apiMock.applySourceCleanup.mockResolvedValue({ updated: ['broken-feed'], skipped: [] });
+    withProviders(<SourcesPage />);
+
+    expect(await screen.findAllByText('Broken Feed')).toHaveLength(2);
+    expect(screen.getByText('3 consecutive failures · TimeoutError')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /apply cleanup/i }));
+
+    await waitFor(() => expect(apiMock.applySourceCleanup).toHaveBeenCalledWith(['broken-feed']));
+  });
+
   it('notifies and restores the source list when cleanup fails', async () => {
     const suggestion = {
       source_slug: 'acme',

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -90,6 +90,13 @@ const SOURCE_CLEANUP_KEY = 'source-cleanup-suggestions';
 
 function formatSuggestionMeta(suggestion: SourceCleanupSuggestion): string {
   if (suggestion.reason === 'stale') return 'No articles in 30 days';
+  if (suggestion.reason === 'repeated_errors') {
+    const failures = suggestion.error_streak ?? 0;
+    const label = failures === 1 ? 'failure' : 'failures';
+    return suggestion.last_error
+      ? `${failures} consecutive ${label} · ${suggestion.last_error}`
+      : `${failures} consecutive ${label}`;
+  }
   return `${Math.round(suggestion.skip_rate * 100)}% skipped · ${suggestion.articles_last_30_days} articles`;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -158,7 +158,7 @@ export interface SourceCleanupSuggestion {
   source_slug: string;
   source_name: string;
   action: 'unsubscribe';
-  reason: 'low_signal' | 'stale';
+  reason: 'low_signal' | 'stale' | 'repeated_errors';
   message: string;
   articles_last_30_days: number;
   skipped_count: number;
@@ -167,6 +167,8 @@ export interface SourceCleanupSuggestion {
   archived_count: number;
   skip_rate: number;
   engagement_score: number;
+  error_streak?: number;
+  last_error?: string | null;
 }
 
 export interface Summary {


### PR DESCRIPTION
Closes #944

## Summary
- adds `repeated_errors` cleanup suggestions for visible/subscribed sources with 3 consecutive ingest failures
- includes the error streak and sanitized latest error in the suggestion payload/message
- renders repeated-error metadata in the Subscription Optimizer and keeps the existing apply-cleanup flow

## Tests
- `dotenv run -- pytest backend/tests/test_source_health.py` (23 passed)
- `npm run test:frontend -- frontend/src/__tests__/feedsPages.test.tsx` (41 passed)
- `make lint` (passed)
- `make typecheck` (passed)
- `dotenv run -- make test` (backend 1933 passed; frontend 85 files / 852 tests passed; vitest emitted localhost:3000 ECONNREFUSED diagnostics but exited 0)
- `npm run build` (passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
