### PR TITLE
fix: use a Prometheus histogram for HTTP request duration (#951)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -218,7 +218,7 @@ async def record_request_metrics(request: Request, call_next: Any) -> Any:
     path = route.path if route is not None else request.url.path
     labels = {"method": request.method, "path": path}
     http_requests_total.labels(status=str(response.status_code), **labels).inc()
-    http_request_duration_seconds.labels(**labels).inc(duration)
+    http_request_duration_seconds.labels(**labels).observe(duration)
     return response
 
 

--- a/backend/news_dashboard/metrics.py
+++ b/backend/news_dashboard/metrics.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 
 import os
 
-from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, generate_latest
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Histogram,
+    generate_latest,
+)
 
 registry = CollectorRegistry()
 
@@ -21,9 +27,9 @@ http_requests_total = Counter(
     registry=registry,
 )
 
-http_request_duration_seconds = Counter(
-    "news_dashboard_http_request_duration_seconds_sum",
-    "Cumulative HTTP request duration in seconds.",
+http_request_duration_seconds = Histogram(
+    "news_dashboard_http_request_duration_seconds",
+    "HTTP request duration in seconds.",
     ["method", "path"],
     registry=registry,
 )

--- a/backend/tests/test_metrics_endpoint.py
+++ b/backend/tests/test_metrics_endpoint.py
@@ -48,3 +48,18 @@ def test_metrics_disabled_flag_values(monkeypatch: pytest.MonkeyPatch, flag_valu
     monkeypatch.setenv("METRICS_ENABLED", flag_value)
     resp = _client().get("/metrics")
     assert resp.status_code == 404
+
+
+@pytest.mark.smoke
+def test_request_duration_is_exposed_as_histogram(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("METRICS_ENABLED", "true")
+    client = _client()
+
+    # The request-duration middleware records each request's own latency
+    # after the response is built, so it shows up starting on the next scrape.
+    client.get("/metrics")
+    body = client.get("/metrics").text
+
+    assert "news_dashboard_http_request_duration_seconds_bucket" in body
+    assert "news_dashboard_http_request_duration_seconds_sum" in body
+    assert "news_dashboard_http_request_duration_seconds_count" in body

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -327,7 +327,8 @@ it from inside your cluster/VPC).
 
 Metrics exposed:
 
-- `news_dashboard_http_requests_total{method,path,status}` / `news_dashboard_http_request_duration_seconds_sum{method,path}` — request counts and cumulative latency, labeled by route template (e.g. `/api/articles/{article_id}`), never the raw URL.
+- `news_dashboard_http_requests_total{method,path,status}` — request counts, labeled by route template (e.g. `/api/articles/{article_id}`), never the raw URL.
+- `news_dashboard_http_request_duration_seconds{method,path}` — HTTP request latency histogram (exposed as `_bucket`, `_sum`, and `_count` series), labeled by route template, never the raw URL.
 - `news_dashboard_ingest_runs_total{status}` — ingest run outcomes (`success`/`failure`).
 - `news_dashboard_ingest_articles_new_total` — new articles discovered across all ingest runs.
 - `news_dashboard_source_health_checks_total{status}` — per-source fetch outcomes (`ok`/`error`) during ingest. No source identity is included in labels, since private-feed names/slugs are user-defined.


### PR DESCRIPTION
## Summary
- Fixes #951
- Replaces the `news_dashboard_http_request_duration_seconds_sum` Counter with a proper Prometheus `Histogram` named `news_dashboard_http_request_duration_seconds`, exposed with the usual `_bucket`, `_sum`, and `_count` series.
- `record_request_metrics` middleware in `backend/news_dashboard/main.py` now calls `.observe(duration)` instead of incrementing a counter by the duration value.
- Labels remain low-cardinality: HTTP method + route template path only (unchanged). `news_dashboard_http_requests_total` request-count Counter is untouched.
- Updated `docs/SELF_HOSTING.md` to describe the corrected metric name/shape.
- Added a test asserting the histogram's `_bucket`/`_sum`/`_count` series are exposed.

## Test plan
- [x] `pytest backend/tests/test_metrics_endpoint.py` — 8 passed
- [x] `pytest backend/tests -m smoke` — 36 passed
- [x] `ruff check` on touched backend files — passed
- [x] `ty check` on touched backend files — passed
- [x] Manual check: hit `/metrics` twice with `METRICS_ENABLED=true` and confirmed `news_dashboard_http_request_duration_seconds_bucket/_sum/_count` appear in the exposition output
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)