### PR TITLE
fix: sanitize generated release notes before publishing (#987)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,9 +511,12 @@ jobs:
           COMMITS: ${{ steps.log.outputs.commits }}
         run: |
           echo "$V" > VERSION
-          # If inference returned nothing, fall back to a user-facing summary of
-          # the commits — never the raw "chore:/ci:" subjects a customer can't read.
-          BODY="$NOTES"
+          # Strip any leaked model reasoning (<think> blocks, prompt
+          # narration, code fences) before it can reach CHANGELOG.md.
+          BODY=$(printf '%s\n' "$NOTES" | python3 scripts/humanize_commits.py --sanitize)
+          # If inference returned nothing usable, fall back to a user-facing
+          # summary of the commits — never raw "chore:/ci:" subjects or model
+          # reasoning a customer can't read.
           if [ -z "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
             BODY=$(printf '%s\n' "$COMMITS" | python3 scripts/humanize_commits.py)
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,8 +123,13 @@ jobs:
           changelog=$(pi -e "$PI_EXTENSION" -p "$SYSTEM_PROMPT
 
           $PROMPT" || true)
-          # If inference returned nothing, fall back to a user-facing summary of
-          # the commits — never the raw "chore:/ci:" subjects a customer can't read.
+          # Strip any leaked model reasoning (<think> blocks, prompt
+          # narration, code fences) before it can reach a GitHub Release or
+          # CHANGELOG.md.
+          changelog=$(printf '%s\n' "$changelog" | python3 scripts/humanize_commits.py --sanitize)
+          # If inference returned nothing usable, fall back to a user-facing
+          # summary of the commits — never raw "chore:/ci:" subjects or model
+          # reasoning a customer can't read.
           if [ -z "$(printf '%s' "$changelog" | tr -d '[:space:]')" ]; then
             changelog=$(printf '%s\n' "$COMMITS" | python3 scripts/humanize_commits.py)
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Stability and performance improvements.
 
 ## [1.118.2] — 2026-07-05
-- Fixed an issue where AI-powered features could temporarily stop working under heavy load.  
+- Fixed an issue where AI-powered features could temporarily stop working under heavy load.
 - Stability and performance improvements.
 
 ## [1.118.0] — 2026-07-05
@@ -21,10 +21,6 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [1.108.2] — 2026-07-04
 - Stability and performance improvements.
-
----
-
-*If this release had additional commits, I would process them here. The two provided commits are internal-only (chore + refactor) with no user-facing changes, so they collapse into the standard single bullet.*
 
 ## [1.108.1] — 2026-07-04
 - Fixed an issue where your default news source settings could be saved twice, so your preferences now apply correctly the first time.
@@ -42,17 +38,7 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Your dashboard now remembers your preferences and habits over time, so it gets better at suggesting what matters to you.
 
 ## [1.90.1] — 2026-07-03
-The user wants me to write "What's new" release notes for end users based on a single git commit. Let me analyze the commit:
-
-- `fix: keep committed VERSION and CHANGELOG.md in sync with release tags (#967)`
-
-This is clearly internal/devops work - it's about keeping VERSION and CHANGELOG.md files in sync with release tags. There's zero user-facing benefit. According to the rules, I should omit anything with no visible effect for users.
-
-Since a release is entirely internal work, I should summarize it as a single bullet: "Stability and performance improvements." or similar.
-
-Actually, let me re-read. The commit is about keeping version/changelog in sync with tags - this is about the release process itself, not the app. No user-facing effect at all.
-
-I'll output a single bullet summarizing internal work. </think> - Stability and performance improvements.
+- Stability and performance improvements.
 
 ## [1.89.0] — 2026-07-03
 - Log in more easily with a verification code sent to your email

--- a/backend/news_dashboard/system/service.py
+++ b/backend/news_dashboard/system/service.py
@@ -16,6 +16,14 @@ _CHANGELOG_FILE = Path(__file__).resolve().parents[3] / "CHANGELOG.md"
 # matches entry.version against the app version exactly.
 _CHANGELOG_HEADING = re.compile(r"^##\s+\[?(?P<version>[^\]\s]+)\]?(?:\s*[—-]\s*(?P<date>\S+))?")
 
+# Defense in depth: the release pipeline sanitizes generated notes before they
+# reach CHANGELOG.md, but reject any bullet that still looks like leaked model
+# reasoning rather than a genuine release note.
+_LEAKED_REASONING_RE = re.compile(
+    r"</?think>|^(the user wants|i'll |i should|i need to|let me |as an ai)",
+    re.IGNORECASE,
+)
+
 
 def check_health() -> None:
     init_db()
@@ -54,5 +62,7 @@ def parse_changelog() -> list[dict[str, object]]:
                 }
             )
         elif line.startswith("- ") and entries:
-            current_items.append(line[2:].strip())
+            item = line[2:].strip()
+            if not _LEAKED_REASONING_RE.search(item):
+                current_items.append(item)
     return entries

--- a/backend/tests/test_changelog_endpoint.py
+++ b/backend/tests/test_changelog_endpoint.py
@@ -59,6 +59,19 @@ def test_parse_changelog_normalizes_keep_a_changelog_headings() -> None:
     ]
 
 
+def test_parse_changelog_drops_leaked_model_reasoning() -> None:
+    md = dedent("""\
+        ## 3.0.0
+        - The user wants me to write release notes for this commit.
+        - I'll output a single bullet. </think>
+        - Real user-facing bullet
+    """)
+    with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
+        cf.read_text.return_value = md
+        entries = parse_changelog()
+    assert entries == [{"version": "3.0.0", "date": None, "items": ["Real user-facing bullet"]}]
+
+
 def test_parse_changelog_returns_empty_on_oserror() -> None:
     with patch("news_dashboard.system.service._CHANGELOG_FILE") as cf:
         cf.read_text.side_effect = OSError("missing")

--- a/scripts/humanize_commits.py
+++ b/scripts/humanize_commits.py
@@ -78,8 +78,75 @@ def humanize_commits(commits: str) -> str:
     return "\n".join(bullets)
 
 
+# ── Sanitizer for LLM-generated release notes ────────────────────────────────
+#
+# The release pipeline asks an LLM to write the changelog/GitHub-release
+# prose. Occasionally the model leaks its reasoning instead of (or alongside)
+# the requested bullets: <think> blocks, prompt narration ("The user wants
+# me to..."), or stray markdown code fences. That text must never reach
+# CHANGELOG.md or a published GitHub Release.
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.IGNORECASE | re.DOTALL)
+_THINK_TAG_RE = re.compile(r"</?think>", re.IGNORECASE)
+_FENCED_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_STRAY_FENCE_RE = re.compile(r"^```.*$", re.MULTILINE)
+
+# Prefixes (checked against the start of a bullet's body, lowercased) that
+# mark model reasoning/narration rather than a genuine release note.
+_NARRATION_PREFIXES = (
+    "the user wants",
+    "i'll ",
+    "i should",
+    "i need to",
+    "let me ",
+    "as an ai",
+    "according to the rules",
+    "according to the instructions",
+)
+
+
+def _is_narration(bullet_body: str) -> bool:
+    lowered = bullet_body.strip().lower()
+    return any(lowered.startswith(prefix) for prefix in _NARRATION_PREFIXES)
+
+
+def sanitize_release_notes(text: str) -> str | None:
+    """Return ``text`` reduced to safe user-facing bullet lines, or ``None``.
+
+    Only lines that look like a genuine "- " bullet and don't open with a
+    known reasoning marker survive. ``None`` means nothing usable remained —
+    the caller should fall back to a deterministic summary rather than
+    publish raw model output.
+    """
+    if not text:
+        return None
+
+    cleaned = _THINK_BLOCK_RE.sub("", text)
+    cleaned = _THINK_TAG_RE.sub("", cleaned)
+    cleaned = _FENCED_BLOCK_RE.sub("", cleaned)
+    cleaned = _STRAY_FENCE_RE.sub("", cleaned)
+
+    bullets = []
+    for line in cleaned.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        if _is_narration(stripped[2:]):
+            continue
+        bullets.append(stripped)
+
+    if not bullets:
+        return None
+    return "\n".join(bullets)
+
+
 def main() -> None:
     import sys
+
+    if "--sanitize" in sys.argv:
+        sanitized = sanitize_release_notes(sys.stdin.read())
+        print(sanitized if sanitized is not None else "")
+        return
 
     print(humanize_commits(sys.stdin.read()))
 

--- a/scripts/test_humanize_commits.py
+++ b/scripts/test_humanize_commits.py
@@ -8,7 +8,7 @@ import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(__file__))
-from humanize_commits import humanize_commits
+from humanize_commits import humanize_commits, sanitize_release_notes
 
 _INTERNAL_ONLY = """- chore: make API docs exposure configurable (#646) (#817)
 - ci: generate SBOM and build provenance for releases (#814)
@@ -55,6 +55,34 @@ class TestHumanizeCommits(unittest.TestCase):
     def test_capitalizes_first_letter(self):
         out = humanize_commits("- feat: lowercase start stays readable")
         self.assertTrue(out.startswith("- Lowercase"))
+
+
+class TestSanitizeReleaseNotes(unittest.TestCase):
+    def test_clean_bullets_pass_through_unchanged(self):
+        notes = "- Add dark mode (#123)\n- [See the docs](https://example.com)"
+        self.assertEqual(sanitize_release_notes(notes), notes)
+
+    def test_strips_fenced_code_block(self):
+        notes = "```\n- Some code snippet\n```\n- Real bullet"
+        self.assertEqual(sanitize_release_notes(notes), "- Real bullet")
+
+    def test_strips_think_block_and_stray_tags(self):
+        notes = "<think>reasoning about the release</think>\n- Add feature\n</think>"
+        self.assertEqual(sanitize_release_notes(notes), "- Add feature")
+
+    def test_drops_prompt_narration_lines(self):
+        notes = (
+            "The user wants me to write release notes for this commit.\n"
+            "- Stability and performance improvements."
+        )
+        self.assertEqual(sanitize_release_notes(notes), "- Stability and performance improvements.")
+
+    def test_reasoning_only_input_returns_none(self):
+        notes = "The user wants me to summarize this release.\nI should keep it short."
+        self.assertIsNone(sanitize_release_notes(notes))
+
+    def test_empty_input_returns_none(self):
+        self.assertIsNone(sanitize_release_notes(""))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #987. The release pipeline (`.github/workflows/release.yml`, `.github/workflows/ci.yml`) asks an LLM to write "What's new" release notes, but published the response verbatim — no guard against leaked chain-of-thought, prompt narration, or markdown code fences reaching `CHANGELOG.md` or a GitHub Release. The committed `CHANGELOG.md` entry for `1.90.1` (and a stray block under `1.108.2`) contained exactly this kind of leaked reasoning.

- Adds `sanitize_release_notes()` to `scripts/humanize_commits.py`: strips `<think>...</think>` blocks, fenced code blocks, and lines that open with known reasoning/narration markers (`the user wants`, `i'll `, `i should`, `let me `, etc.), keeping only genuine `- ` bullet lines. Returns `None` if nothing usable survives.
- Wires the sanitizer into both `.github/workflows/release.yml` (GitHub Releases notes / rolling `CHANGELOG.md` sync) and `.github/workflows/ci.yml` (per-push `CHANGELOG.md` bake), applied to the raw model response *before* the existing "fall back to `humanize_commits.py`" empty check — so an unusable/leaked response now falls back to the same deterministic commit-summary path as an empty one.
- Cleans the already-leaked `1.90.1` and `1.108.2` entries in `CHANGELOG.md` to plain, user-facing bullets.
- Adds a lightweight defense-in-depth guard in `backend/news_dashboard/system/service.py`'s `parse_changelog()` so `/api/changelog` drops any bullet that still looks like leaked reasoning, even if a bad entry slipped past the pipeline sanitizer.
- New unit tests for the sanitizer (`scripts/test_humanize_commits.py`) and for the backend guard (`backend/tests/test_changelog_endpoint.py`).

## Test plan

- [x] `python3 -m unittest scripts.test_humanize_commits scripts.test_update_changelog` — 27 passed
- [x] `pytest backend/tests/test_changelog_endpoint.py` — 8 passed (includes new `test_parse_changelog_drops_leaked_model_reasoning`)
- [x] `ruff check` / `ty check` clean on all changed Python files
- [x] Workflow YAML parses (`yaml.safe_load` on both modified workflow files)
- [ ] Full backend suite (`pytest backend/tests/`) — running locally under heavy contention from concurrent worktrees; CI will be the authoritative full-suite gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)