### PR TITLE
Fix #952: Exclude article bodies from personal export

### DIFF
--- a/backend/news_dashboard/export.py
+++ b/backend/news_dashboard/export.py
@@ -40,7 +40,6 @@ def _export_articles(conn: Any, user_id: int) -> list[dict[str, Any]]:
             a.summary,
             a.reason,
             a.tags,
-            a.body,
             uas.state,
             uas.starred,
             uas.done_at,
@@ -240,7 +239,7 @@ def assemble_user_export(
 
     Includes:
     - articles the user has explicitly interacted with (user_article_state rows),
-      joined with article metadata (title, URL, category, summary, tags, body).
+      joined with article metadata (title, URL, category, summary, tags).
     - user-owned briefings with their cited article IDs.
     - source_subscriptions: the user's enabled/disabled state for global sources,
       plus any private sources the user owns. Other users' private sources are
@@ -270,7 +269,7 @@ def assemble_user_export(
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": datetime.now(UTC).isoformat(),
-        "includes_article_bodies": True,
+        "includes_article_bodies": False,
         "articles": articles,
         "briefings": briefings,
         "ai_memories": memories,

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from psycopg.types.json import Jsonb
 
@@ -11,14 +13,14 @@ from news_dashboard.export import assemble_user_export
 from news_dashboard.ingest import set_article_starred, sync_sources, transition_article_state
 
 
-def _insert_article(db_url: str, *, url_suffix: str = "1") -> int:
+def _insert_article(db_url: str, *, url_suffix: str = "1", body: str | None = None) -> int:
     with connect(database_url=db_url) as conn:
         row = conn.execute(
             """
             INSERT INTO articles(
               url, canonical_url, title, source_slug, source_name,
-              category, kind, state
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+              category, kind, state, body
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -30,6 +32,7 @@ def _insert_article(db_url: str, *, url_suffix: str = "1") -> int:
                 "python",
                 "rss_feed",
                 "today",
+                body,
             ),
         ).fetchone()
     assert row is not None
@@ -81,6 +84,24 @@ def test_export_includes_user_article_state(pg_clean: str) -> None:
     assert a["done_at"] is not None
     assert a["canonical_url"] == "https://example.com/artexp1"
     assert a["title"] == "Article exp1"
+
+
+def test_export_excludes_cached_article_body_text(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "exporter_no_body")
+    cached_body = "Full cached article body that should not leave the database."
+    aid = _insert_article(pg_clean, url_suffix="no_body", body=cached_body)
+
+    transition_article_state(aid, "done", db_path=pg_clean, user_id=uid)
+
+    result = assemble_user_export(uid, database_url=pg_clean)
+
+    assert result["includes_article_bodies"] is False
+    article = result["articles"][0]
+    assert article["id"] == aid
+    assert article["state"] == "done"
+    assert "body" not in article
+    assert cached_body not in json.dumps(result)
 
 
 def test_export_includes_starred_articles(pg_clean: str) -> None:
@@ -268,7 +289,7 @@ def test_export_metadata_and_body_flag(pg_clean: str) -> None:
 
     assert result["schema_version"] == 2
     assert result["generated_at"]
-    assert result["includes_article_bodies"] is True
+    assert result["includes_article_bodies"] is False
 
 
 def test_export_source_subscriptions_reflect_disabled_global_source(pg_clean: str) -> None:

--- a/docs/user-guide/saved-history.md
+++ b/docs/user-guide/saved-history.md
@@ -81,10 +81,10 @@ Want to back up or migrate your history? Use the built-in export:
 1. Go to Settings → Advanced
 2. Click "Download my data"
 3. Receive a JSON file containing:
-   - Export metadata (`schema_version`, `generated_at`, and whether cached
-     article bodies are included)
+   - Export metadata (`schema_version`, `generated_at`, and
+     `includes_article_bodies`, which is currently `false`)
    - Your article interactions (read/saved/starred/etc. timestamps),
-     including cached article body text where available
+     article metadata, summaries, source information, and workflow state
    - Applied tags
    - Briefings history, with cited article IDs
    - `source_subscriptions` — your enabled/disabled state for global sources,
@@ -94,10 +94,10 @@ Want to back up or migrate your history? Use the built-in export:
      interests/completion state, and notification settings (briefing
      time/timezone, push-enabled, recap, analytics opt-in)
 
-The export includes cached article body text when present, so the file can be
-large. Secrets (password hash, session tokens, push subscription keys, API
-tokens) are never included. There is currently no import tool — this export
-is for backup and personal portability only.
+The export does not include cached article body text. Secrets (password hash,
+session tokens, push subscription keys, API tokens) are never included. There
+is currently no import tool — this export is for backup and personal
+portability only.
 
 ## Auto-cleanup
 

--- a/frontend/src/components/settings/DataExportSection.tsx
+++ b/frontend/src/components/settings/DataExportSection.tsx
@@ -29,8 +29,8 @@ export function DataExportSection() {
         <p className="text-xs text-muted-foreground">
           Download a personal archive of your reading history, starred articles, workflow state,
           daily briefings, source subscriptions, and preferences (recommendation weights, onboarding
-          interests, notification settings) as a JSON file. Cached article body text is included
-          when available; secrets are never included.
+          interests, notification settings) as a JSON file. Cached article body text and secrets are
+          not included.
         </p>
         <button
           onClick={() => void handleExport()}

--- a/website/docs/user-guide/saved-history.md
+++ b/website/docs/user-guide/saved-history.md
@@ -28,5 +28,9 @@ enabled.
 ## Export and cleanup
 
 The app can export your personal state as JSON for backup or migration. The
-`user_events` table is pruned according to `ANALYTICS_RETENTION_DAYS`, which
+export includes reading workflow state, article metadata, briefings, source
+subscriptions, preferences, and other personal settings, but excludes cached
+article body text and secrets.
+
+The `user_events` table is pruned according to `ANALYTICS_RETENTION_DAYS`, which
 defaults to 180 days.


### PR DESCRIPTION
Closes #952

## Summary
- remove cached `articles.body` from personal export article entries
- mark `includes_article_bodies` as `false`
- add a regression test proving cached body text is absent from exported JSON
- update Settings and mirrored saved-history docs to describe the body-free export

## Tests
- `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_export.py` (15 passed, 2 warnings)
- `PATH="$PWD/.venv/bin:$PATH" make lint` (passed)
- `PATH="$PWD/.venv/bin:$PATH" make typecheck` (passed)
- `PATH="$PWD/.venv/bin:$PATH" pytest -n0 backend/tests/test_pgvector_migration.py::test_sql_topk_orders_candidates_by_cosine_distance backend/tests/test_workflow_state.py::test_today_to_done backend/tests/test_stats.py::test_ingested_vs_handled_counts_user_article_state_done` (3 passed)
- `npm run test:frontend --silent` (857 passed; noisy localhost ECONNREFUSED logs from tests)
- `npm run build --silent` (passed; existing chunk-size warning)

## Local full-suite note
- `PATH="$PWD/.venv/bin:$PATH" make test` failed in existing parallel tmp-path database tests with PostgreSQL deadlocks / duplicate keys unrelated to export behavior; representative failing tests pass serially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)