### PR TITLE
Allow least-privilege MCP token scopes (#988)

### DIFF
--- a/backend/news_dashboard/mcp/models.py
+++ b/backend/news_dashboard/mcp/models.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from news_dashboard.mcp.service import KNOWN_SCOPES
 
 MAX_QUERY_LENGTH = 2_000
 MAX_RESULT_LIMIT = 25
@@ -10,6 +12,21 @@ MAX_RESULT_LIMIT = 25
 
 class TokenCreateRequest(BaseModel):
     name: str = Field(min_length=1, max_length=120)
+    scopes: list[str] | None = None
+
+    @field_validator("scopes")
+    @classmethod
+    def _validate_scopes(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        if not value:
+            message = "scopes must not be empty"
+            raise ValueError(message)
+        unknown = sorted(set(value) - KNOWN_SCOPES)
+        if unknown:
+            message = f"unknown scopes: {', '.join(unknown)}"
+            raise ValueError(message)
+        return value
 
 
 class McpRpcRequest(BaseModel):

--- a/backend/news_dashboard/mcp/router.py
+++ b/backend/news_dashboard/mcp/router.py
@@ -27,8 +27,9 @@ def create_mcp_token(
 ) -> dict[str, Any]:
     if not service.mcp_enabled():
         raise HTTPException(status_code=403, detail="MCP server is not enabled on this instance")
+    scopes = service.DEFAULT_SCOPES if payload.scopes is None else tuple(payload.scopes)
     try:
-        return service.create_token(int(current_user["id"]), payload.name)
+        return service.create_token(int(current_user["id"]), payload.name, scopes=scopes)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/backend/news_dashboard/mcp/service.py
+++ b/backend/news_dashboard/mcp/service.py
@@ -10,6 +10,7 @@ from news_dashboard.db import connect, init_db, row_to_dict
 
 TOKEN_PREFIX = "ndmcp_"  # noqa: S105 -- token prefix, not a credential
 DEFAULT_SCOPES = ("search", "read", "ask", "briefings")
+KNOWN_SCOPES = frozenset(DEFAULT_SCOPES)
 MAX_TOKENS_PER_USER = 10
 MAX_TOKEN_NAME_LENGTH = 120
 

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -380,6 +380,7 @@ def test_token_management_endpoints_when_enabled(
         assert created.status_code == 200
         body = created.json()
         assert body["token"].startswith("ndmcp_")
+        assert sorted(body["scopes"]) == sorted(["search", "read", "ask", "briefings"])
         token_id = body["id"]
 
         listed = client.get("/api/users/me/mcp-tokens")
@@ -391,6 +392,47 @@ def test_token_management_endpoints_when_enabled(
         revoked = client.delete(f"/api/users/me/mcp-tokens/{token_id}")
         assert revoked.status_code == 200
         assert revoked.json()["revoked_at"] is not None
+
+
+def test_create_token_with_explicit_scope_subset(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    alice = _make_user(pg_clean, "alice-scopes")
+
+    with _client_for(alice) as client:
+        created = client.post(
+            "/api/users/me/mcp-tokens",
+            json={"name": "search-only", "scopes": ["search"]},
+        )
+        assert created.status_code == 200
+        assert created.json()["scopes"] == ["search"]
+
+
+def test_create_token_rejects_unknown_scope(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    alice = _make_user(pg_clean, "alice-badscope")
+
+    with _client_for(alice) as client:
+        resp = client.post(
+            "/api/users/me/mcp-tokens",
+            json={"name": "client", "scopes": ["search", "delete_everything"]},
+        )
+        assert resp.status_code == 422
+
+
+def test_create_token_rejects_empty_scope_list(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    alice = _make_user(pg_clean, "alice-emptyscope")
+
+    with _client_for(alice) as client:
+        resp = client.post(
+            "/api/users/me/mcp-tokens",
+            json={"name": "client", "scopes": []},
+        )
+        assert resp.status_code == 422
 
 
 def test_rpc_endpoint_rejects_missing_or_invalid_bearer(
@@ -441,6 +483,30 @@ def test_rpc_endpoint_calls_tool_with_valid_token(
     body = resp.json()
     assert body["tool"] == "search_articles"
     assert any(a["id"] == 7 for a in body["result"]["articles"])
+
+
+def test_rpc_endpoint_denies_tool_outside_token_scopes(
+    client: TestClient, pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    alice = _make_user(pg_clean, "alice-scoped-rpc")
+    created = service.create_token(alice, "search-only", scopes=("search",), database_url=pg_clean)
+
+    ok = client.post(
+        "/api/mcp/rpc",
+        json={"tool": "search_articles", "arguments": {}},
+        headers={"Authorization": f"Bearer {created['token']}"},
+    )
+    assert ok.status_code == 200
+
+    denied = client.post(
+        "/api/mcp/rpc",
+        json={"tool": "list_briefings", "arguments": {}},
+        headers={"Authorization": f"Bearer {created['token']}"},
+    )
+    assert denied.status_code == 403
 
 
 def test_rpc_endpoint_lists_tools(

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -87,10 +87,10 @@ export async function fetchMcpTokens(): Promise<{ items: McpToken[]; enabled: bo
   return requestJson('/api/users/me/mcp-tokens');
 }
 
-export async function createMcpToken(name: string): Promise<McpToken> {
+export async function createMcpToken(name: string, scopes?: string[]): Promise<McpToken> {
   return requestJson<McpToken>('/api/users/me/mcp-tokens', {
     method: 'POST',
-    body: JSON.stringify({ name }),
+    body: JSON.stringify(scopes ? { name, scopes } : { name }),
   });
 }
 

--- a/frontend/src/components/settings/McpTokensSection.tsx
+++ b/frontend/src/components/settings/McpTokensSection.tsx
@@ -5,10 +5,18 @@ import type { McpToken } from '@/types';
 
 type McpTokenState = 'idle' | 'loading' | 'creating' | 'error';
 
+const ALL_SCOPES: { value: string; label: string; description: string }[] = [
+  { value: 'search', label: 'Search', description: 'Search articles visible to you.' },
+  { value: 'read', label: 'Read', description: 'Fetch a single article by id.' },
+  { value: 'ask', label: 'Ask', description: 'Ask questions answered over your corpus.' },
+  { value: 'briefings', label: 'Briefings', description: 'List your recent briefing metadata.' },
+];
+
 export function McpTokensSection() {
   const [tokens, setTokens] = useState<McpToken[]>([]);
   const [enabled, setEnabled] = useState(false);
   const [newName, setNewName] = useState('');
+  const [newScopes, setNewScopes] = useState<string[]>(ALL_SCOPES.map((s) => s.value));
   const [mintedToken, setMintedToken] = useState<string | null>(null);
   const [state, setState] = useState<McpTokenState>('loading');
 
@@ -32,15 +40,22 @@ export function McpTokensSection() {
     };
   }, []);
 
+  const toggleScope = (scope: string) => {
+    setNewScopes((current) =>
+      current.includes(scope) ? current.filter((s) => s !== scope) : [...current, scope]
+    );
+  };
+
   const create = async () => {
     const name = newName.trim();
-    if (!name) return;
+    if (!name || newScopes.length === 0) return;
     setState('creating');
     try {
-      const token = await createMcpToken(name);
+      const token = await createMcpToken(name, newScopes);
       setTokens((current) => [token, ...current]);
       setMintedToken(token.token ?? null);
       setNewName('');
+      setNewScopes(ALL_SCOPES.map((s) => s.value));
       setState('idle');
     } catch {
       setState('error');
@@ -91,22 +106,52 @@ export function McpTokensSection() {
           </div>
         )}
 
-        <div className="flex gap-2">
-          <input
-            value={newName}
-            onChange={(event) => setNewName(event.target.value)}
-            placeholder="Token name (e.g. Claude Desktop)"
-            aria-label="New MCP token name"
-            className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-          <button
-            onClick={() => void create()}
-            disabled={state === 'creating' || !newName.trim() || !enabled}
-            className="flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-60"
-          >
-            {state === 'creating' ? <RefreshCw className="size-3 animate-spin" /> : null}
-            Create token
-          </button>
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <input
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+              placeholder="Token name (e.g. Claude Desktop)"
+              aria-label="New MCP token name"
+              className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+            <button
+              onClick={() => void create()}
+              disabled={
+                state === 'creating' || !newName.trim() || newScopes.length === 0 || !enabled
+              }
+              className="flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-60"
+            >
+              {state === 'creating' ? <RefreshCw className="size-3 animate-spin" /> : null}
+              Create token
+            </button>
+          </div>
+
+          <fieldset className="space-y-1.5">
+            <legend className="text-[11px] text-muted-foreground mb-1">
+              Scopes — the token can only use the tool groups selected here.
+            </legend>
+            <div className="flex flex-wrap gap-3">
+              {ALL_SCOPES.map((scope) => (
+                <label
+                  key={scope.value}
+                  title={scope.description}
+                  className="flex items-center gap-1.5 text-xs text-foreground"
+                >
+                  <input
+                    type="checkbox"
+                    checked={newScopes.includes(scope.value)}
+                    onChange={() => toggleScope(scope.value)}
+                    aria-label={`${scope.label} scope`}
+                  />
+                  {scope.label}
+                </label>
+              ))}
+            </div>
+            {newScopes.length === 0 && (
+              <p className="text-[11px] text-destructive">Select at least one scope.</p>
+            )}
+          </fieldset>
         </div>
 
         {state === 'error' && (

--- a/website/docs/configuration/mcp-server.md
+++ b/website/docs/configuration/mcp-server.md
@@ -19,14 +19,16 @@ When unset (or falsy), all `/api/mcp/*` endpoints and the token-management endpo
 
 ## Creating a token
 
-Once enabled, a signed-in user can create a token from **Settings → MCP Client Access**, or via:
+Once enabled, a signed-in user can create a token from **Settings → MCP Client Access**, choosing which scopes to grant, or via:
 
 ```bash
 curl -X POST https://your-instance/api/users/me/mcp-tokens \
   -H 'Content-Type: application/json' \
   --cookie "nd_session=$SESSION_COOKIE" \
-  -d '{"name": "Claude Desktop"}'
+  -d '{"name": "Claude Desktop", "scopes": ["search", "read"]}'
 ```
+
+`scopes` is optional and must be a non-empty subset of `search`, `read`, `ask`, and `briefings`; unknown scopes or an empty list are rejected with a validation error. Omitting `scopes` entirely grants all four, preserving the previous default behavior.
 
 The response includes the plaintext token (prefixed `ndmcp_`) exactly once — only its hash is stored (SHA-256) alongside a short prefix, creation time, and last-used time. Losing the token means creating a new one; tokens can be revoked at any time from the same Settings section, which sets `revoked_at` and immediately invalidates it. Each user may hold up to 10 active tokens.
 
@@ -53,7 +55,7 @@ Available tools, all read-only and scoped to the token owner's visible articles:
 | `list_briefings` | `briefings` | List the token owner's recent briefing metadata (no article bodies). |
 | `ask` | `ask` | Ask a question answered via retrieval over the token owner's corpus. |
 
-Every new token is issued all four scopes by default. Requests are bounded: queries are capped at 2,000 characters and result lists at 25 items, matching the limits used by the browser-facing `/api/ask` and search endpoints.
+A token can only call tools whose scope it holds; calling a tool outside its granted scopes returns `403 Forbidden`. New tokens are issued all four scopes unless the creation request narrows them, so a search-only dashboard integration or a briefings-only automation can be scoped to just what it needs. Requests are bounded: queries are capped at 2,000 characters and result lists at 25 items, matching the limits used by the browser-facing `/api/ask` and search endpoints.
 
 ## Security boundaries
 


### PR DESCRIPTION
## Summary

Closes #988.

MCP tokens were always minted with all four scopes (`search`, `read`, `ask`, `briefings`), which prevented least-privilege setups (e.g. a search-only dashboard integration).

- `TokenCreateRequest` (`backend/news_dashboard/mcp/models.py`) gains an optional `scopes` field, validated as a non-empty subset of the known scope set (`KNOWN_SCOPES` in `backend/news_dashboard/mcp/service.py`); unknown or empty scope lists are rejected with a `422`.
- `backend/news_dashboard/mcp/router.py` passes the explicit scopes into `McpTokenService.create_token`, defaulting to all four scopes when omitted (preserves existing behavior for callers that don't specify scopes).
- The Settings UI (`frontend/src/components/settings/McpTokensSection.tsx`) now presents a scope checkbox group when creating a token, defaulting to all scopes selected, with per-scope descriptions and a guard against submitting zero scopes. Existing tokens continue to display their stored scopes (unchanged).
- `frontend/src/api/users.ts` `createMcpToken` accepts an optional `scopes` array.
- `website/docs/configuration/mcp-server.md` documents scope selection, validation rules, and the default-all-scopes behavior when `scopes` is omitted.
- Tool execution was already scope-gated (`backend/news_dashboard/mcp/tools.py`); added tests proving a token cannot call a tool outside its selected scopes.

## Test plan

- [x] `backend/tests/test_mcp.py` — 27 tests pass, including new coverage: explicit scope subset creation, unknown-scope rejection, empty-scope-list rejection, and RPC-level scope denial (search-only token can call `search_articles` but gets `403` on `list_briefings`).
- [x] Full backend suite: `1846 passed`.
- [x] `mypy`, `ruff`, `tsc --noEmit`, `eslint` all clean on changed files.
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly, vulture, eslint, prettier, knip, tsc) all passed on commit.