### PR TITLE
Fix watchlist push article routes (#997)

### DIFF
--- a/backend/news_dashboard/watchlist_agent.py
+++ b/backend/news_dashboard/watchlist_agent.py
@@ -417,7 +417,7 @@ def evaluate_watchlists(
                         user_id,
                         f"Watchlist: {wl['label']}",
                         str(match["article"].get("title") or ""),
-                        target_url=f"/article/{match['article']['id']}",
+                        target_url=f"/a/{match['article']['id']}",
                         database_url=dsn,
                     )
                 except Exception:

--- a/backend/tests/test_watchlist_agent.py
+++ b/backend/tests/test_watchlist_agent.py
@@ -236,14 +236,22 @@ def test_evaluate_watchlists_creates_nudge_and_dedupes(pg_clean: str) -> None:
     uid = _make_user(pg_clean)
     with connect(pg_clean) as conn:
         _add_source(conn, "global-feed", "Global Feed")
-        _add_article(conn, slug="global-feed", index=1, title="Quantum computing breakthrough")
+        article_id = _add_article(
+            conn, slug="global-feed", index=1, title="Quantum computing breakthrough"
+        )
     create_watchlist(uid, "Quantum", "quantum computing", database_url=pg_clean)
 
     with patch("news_dashboard.push.send_push_for_user") as mock_push:
         summary = evaluate_watchlists(use_ai=False, database_url=pg_clean)
     assert summary["watchlists_evaluated"] == 1
     assert summary["nudges_created"] == 1
-    mock_push.assert_called_once()
+    mock_push.assert_called_once_with(
+        uid,
+        "Watchlist: Quantum",
+        "Quantum computing breakthrough",
+        target_url=f"/a/{article_id}",
+        database_url=pg_clean,
+    )
 
     nudges = list_nudges(uid, database_url=pg_clean)
     assert len(nudges) == 1


### PR DESCRIPTION
Closes #997

## Summary
- Route watchlist article-match push notifications to the canonical `/a/{id}` article page.
- Strengthen the watchlist evaluation regression test to assert the exact push target URL.

## Tests
- `make lint`
- `make typecheck`
- `dotenv -f .env run -- pytest backend/tests/test_watchlist_agent.py -q`
- `dotenv -f .env run -- pytest backend/tests/test_push_notifications.py -q`