### PR TITLE
fix: limit OPML import size and outline count (#998)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,11 @@ SENTRY_DSN_FRONTEND=
 # stays disabled when unset. In production, store this as the
 # SENTRY_DSN_DESKTOP GitHub Actions secret.
 SENTRY_DSN_DESKTOP=
+# Max accepted size in bytes for an OPML file uploaded to POST /api/sources/import.
+# Default 5 MiB (5242880).
+MAX_OPML_IMPORT_BYTES=
+# Max number of <outline> elements accepted in an OPML import. Default 1000.
+MAX_OPML_IMPORT_OUTLINES=
 
 # --- One-off migration CLI (optional) -------------------------------------------
 # Used only by `news-dashboard-migrate sqlite-to-postgres`; prompts interactively if unset.

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1736,6 +1736,13 @@ def export_opml(
     )
 
 
+# OPML files are plain text and rarely exceed a few hundred KB even with
+# thousands of outlines; 5 MiB and 1000 outlines leave headroom while bounding
+# memory use and per-request import time for oversized or hostile uploads.
+MAX_OPML_IMPORT_BYTES = int(os.getenv("MAX_OPML_IMPORT_BYTES", str(5 * 1024 * 1024)))
+MAX_OPML_IMPORT_OUTLINES = int(os.getenv("MAX_OPML_IMPORT_OUTLINES", "1000"))
+
+
 @api.post("/api/sources/import")
 def import_opml(
     current_user: Annotated[dict[str, Any], Depends(require_auth)],
@@ -1744,13 +1751,29 @@ def import_opml(
     """Import RSS feed subscriptions from an OPML file."""
     init_db()
     uid = current_user["id"]
-    contents = file.file.read()
+    contents = file.file.read(MAX_OPML_IMPORT_BYTES + 1)
+    if len(contents) > MAX_OPML_IMPORT_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"OPML file too large (max {MAX_OPML_IMPORT_BYTES} bytes); "
+                "split it into smaller files and import them separately"
+            ),
+        )
     try:
         root = safe_fromstring(contents)
     except (ET.ParseError, DefusedXmlException) as exc:
         raise HTTPException(status_code=400, detail=f"Invalid OPML: {exc}") from exc
 
     outlines = root.findall(".//outline")
+    if len(outlines) > MAX_OPML_IMPORT_OUTLINES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"OPML file has too many outlines ({len(outlines)}, "
+                f"max {MAX_OPML_IMPORT_OUTLINES}); split it into smaller files"
+            ),
+        )
     added: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     failed: list[dict[str, Any]] = []

--- a/backend/tests/test_opml.py
+++ b/backend/tests/test_opml.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import pytest
 from fastapi.testclient import TestClient
 
+from news_dashboard import main
 from news_dashboard.db import connect, init_db
 from news_dashboard.main import _generate_opml, app
 
@@ -245,3 +246,54 @@ def test_export_import_roundtrip(client: TestClient, pg_clean: str) -> None:
     added_names = {s["name"] for s in data["added"]}
     assert "ArXiv AI" in added_names
     assert "Hacker News" in added_names
+
+
+def test_import_opml_rejects_oversized_file(
+    client: TestClient, pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    init_db(database_url=pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash, is_admin)"
+            " VALUES (1, 'reader', 'x', FALSE)"
+        )
+    monkeypatch.setattr(main, "MAX_OPML_IMPORT_BYTES", 100)
+    oversized = OPML_VALID + ("<!-- padding -->" * 20)
+    assert len(oversized.encode()) > 100
+    response = client.post(
+        "/api/sources/import",
+        files={"file": ("big.opml", BytesIO(oversized.encode()), "application/xml")},
+    )
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"]
+
+
+def test_import_opml_rejects_too_many_outlines(
+    client: TestClient, pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    init_db(database_url=pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash, is_admin)"
+            " VALUES (1, 'reader', 'x', FALSE)"
+        )
+    monkeypatch.setattr(main, "MAX_OPML_IMPORT_OUTLINES", 2)
+    outlines = "\n".join(
+        f'    <outline type="rss" text="Feed {i}" xmlUrl="https://feed{i}.example.com/rss" />'
+        for i in range(3)
+    )
+    opml_many = f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Many</title></head>
+  <body>
+{outlines}
+  </body>
+</opml>
+"""
+    response = client.post(
+        "/api/sources/import",
+        files={"file": ("many.opml", BytesIO(opml_many.encode()), "application/xml")},
+    )
+    assert response.status_code == 400
+    assert "too many outlines" in response.json()["detail"]


### PR DESCRIPTION
## Summary

Closes #998.

`POST /api/sources/import` read the entire uploaded OPML file into memory with no byte limit and parsed every `<outline>` element with no count limit, letting a very large or hostile OPML file consume excessive memory/CPU and hold open a long database transaction.

- Reads at most `MAX_OPML_IMPORT_BYTES + 1` bytes (default 5 MiB, env-overridable) and returns `413` with a clear message if the upload exceeds the limit, before parsing.
- Rejects OPML documents with more than `MAX_OPML_IMPORT_OUTLINES` outlines (default 1000, env-overridable) with a `400` and clear message, before any database writes.
- The existing frontend error path (`readErrorMessage` → `err.message` in `SourcesPage.tsx`) already surfaces FastAPI's `detail` field, so no frontend changes were needed to show these errors in the Settings import UI.

## Test plan

- [x] `pytest backend/tests/test_opml.py` — 12 passed, including two new tests: oversized file → 413, too many outlines → 400.
- [x] `ruff check` / `ty check` on changed files — clean.
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)