### PR TITLE
Add personal archive import and restore (#999)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,6 +178,9 @@ SENTRY_DSN_DESKTOP=
 MAX_OPML_IMPORT_BYTES=
 # Max number of <outline> elements accepted in an OPML import. Default 1000.
 MAX_OPML_IMPORT_OUTLINES=
+# Max accepted size in bytes for a personal archive JSON file uploaded to
+# POST /api/users/me/import. Default 20 MiB (20971520).
+MAX_ARCHIVE_IMPORT_BYTES=
 
 # --- One-off migration CLI (optional) -------------------------------------------
 # Used only by `news-dashboard-migrate sqlite-to-postgres`; prompts interactively if unset.

--- a/backend/news_dashboard/import_export.py
+++ b/backend/news_dashboard/import_export.py
@@ -1,0 +1,418 @@
+"""Restore a personal archive JSON export back into the authenticated user's data.
+
+Counterpart to `news_dashboard.export.assemble_user_export`. Only the archive
+schema produced by that module is accepted, and only for the authenticated
+user: this is a personal restore, not a cross-instance sync tool.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from news_dashboard.db import connect
+from news_dashboard.export import SCHEMA_VERSION
+
+logger = logging.getLogger(__name__)
+
+# Generous ceilings on object counts so a hostile or corrupted archive can't
+# make a restore run for an unbounded amount of time or memory.
+MAX_IMPORT_ARTICLES = 20_000
+MAX_IMPORT_BRIEFINGS = 5_000
+MAX_IMPORT_AI_MEMORIES = 5_000
+MAX_IMPORT_AI_MEMORY_EVENTS = 20_000
+
+_VALID_ARTICLE_STATES = frozenset({"today", "done", "skipped", "archived", "later"})
+
+
+class ArchiveImportError(ValueError):
+    """Raised when an uploaded archive fails validation before any write happens."""
+
+
+def validate_archive(payload: Any) -> None:
+    """Raise ArchiveImportError if the payload isn't a restorable archive."""
+    if not isinstance(payload, dict):
+        msg = "archive must be a JSON object"
+        raise ArchiveImportError(msg)
+
+    schema_version = payload.get("schema_version")
+    if schema_version != SCHEMA_VERSION:
+        msg = f"unsupported schema_version {schema_version!r} (expected {SCHEMA_VERSION})"
+        raise ArchiveImportError(msg)
+
+    for key, limit in (
+        ("articles", MAX_IMPORT_ARTICLES),
+        ("briefings", MAX_IMPORT_BRIEFINGS),
+        ("ai_memories", MAX_IMPORT_AI_MEMORIES),
+        ("ai_memory_events", MAX_IMPORT_AI_MEMORY_EVENTS),
+    ):
+        value = payload.get(key, [])
+        if value is None:
+            continue
+        if not isinstance(value, list):
+            msg = f"{key!r} must be a list"
+            raise ArchiveImportError(msg)
+        if len(value) > limit:
+            msg = f"archive has too many {key} entries (max {limit})"
+            raise ArchiveImportError(msg)
+
+
+def _upsert_article_state(  # noqa: PLR0913
+    conn: Any,
+    user_id: int,
+    article_id: int,
+    *,
+    state: str,
+    starred: bool,
+    done_at: str | None,
+    starred_at: str | None,
+    skipped_at: str | None,
+    archived_at: str | None,
+    later_until: str | None,
+    restored_at: str | None,
+    updated_at: str | None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO user_article_state(
+          user_id, article_id, state, starred,
+          done_at, starred_at, skipped_at, archived_at, later_until, restored_at, updated_at
+        ) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, COALESCE(%s, NOW()))
+        ON CONFLICT(user_id, article_id) DO UPDATE SET
+          state = excluded.state,
+          starred = excluded.starred,
+          done_at = COALESCE(excluded.done_at, user_article_state.done_at),
+          starred_at = COALESCE(excluded.starred_at, user_article_state.starred_at),
+          skipped_at = COALESCE(excluded.skipped_at, user_article_state.skipped_at),
+          archived_at = COALESCE(excluded.archived_at, user_article_state.archived_at),
+          later_until = COALESCE(excluded.later_until, user_article_state.later_until),
+          restored_at = COALESCE(excluded.restored_at, user_article_state.restored_at),
+          updated_at = excluded.updated_at
+        """,
+        (
+            user_id,
+            article_id,
+            state,
+            starred,
+            done_at,
+            starred_at,
+            skipped_at,
+            archived_at,
+            later_until,
+            restored_at,
+            updated_at,
+        ),
+    )
+
+
+def _resolve_article_id(conn: Any, item: dict[str, Any]) -> int | None:
+    canonical_url = item.get("canonical_url")
+    if not canonical_url or not isinstance(canonical_url, str):
+        return None
+
+    row = conn.execute(
+        "SELECT id FROM articles WHERE canonical_url = %s ORDER BY id ASC LIMIT 1",
+        (canonical_url,),
+    ).fetchone()
+    if row is not None:
+        return int(row["id"])
+
+    title = item.get("title")
+    source_slug = item.get("source_slug")
+    source_name = item.get("source_name")
+    category = item.get("category")
+    kind = item.get("kind")
+    required = (title, source_slug, source_name, category, kind)
+    if not all(isinstance(v, str) and v.strip() for v in required):
+        return None
+
+    source_exists = conn.execute("SELECT 1 FROM sources WHERE slug = %s", (source_slug,)).fetchone()
+    if source_exists is None:
+        return None
+
+    row = conn.execute(
+        """
+        INSERT INTO articles(url, canonical_url, title, source_slug, source_name, category, kind)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (url) DO UPDATE SET url = articles.url
+        RETURNING id
+        """,
+        (canonical_url, canonical_url, title, source_slug, source_name, category, kind),
+    ).fetchone()
+    return int(row["id"]) if row is not None else None
+
+
+def _restore_articles(conn: Any, user_id: int, articles: list[Any]) -> dict[str, int]:
+    counts = {"added": 0, "updated": 0, "skipped": 0}
+    for item in articles:
+        if not isinstance(item, dict):
+            counts["skipped"] += 1
+            continue
+        try:
+            with conn.transaction():
+                article_id = _resolve_article_id(conn, item)
+                if article_id is None:
+                    counts["skipped"] += 1
+                    continue
+
+                raw_state = item.get("state")
+                state: str = raw_state if isinstance(raw_state, str) else "today"
+                if state not in _VALID_ARTICLE_STATES:
+                    state = "today"
+
+                existing = conn.execute(
+                    "SELECT 1 FROM user_article_state WHERE user_id = %s AND article_id = %s",
+                    (user_id, article_id),
+                ).fetchone()
+
+                _upsert_article_state(
+                    conn,
+                    user_id,
+                    article_id,
+                    state=state,
+                    starred=bool(item.get("starred", False)),
+                    done_at=item.get("done_at"),
+                    starred_at=item.get("starred_at"),
+                    skipped_at=item.get("skipped_at"),
+                    archived_at=item.get("archived_at"),
+                    later_until=item.get("later_until"),
+                    restored_at=item.get("restored_at"),
+                    updated_at=item.get("updated_at"),
+                )
+                counts["updated" if existing is not None else "added"] += 1
+        except Exception:
+            logger.exception("Failed to restore archived article state")
+            counts["skipped"] += 1
+    return counts
+
+
+def _restore_cited_articles(conn: Any, briefing_id: int, cited_articles: Any) -> None:
+    if not isinstance(cited_articles, list):
+        return
+    for cited in cited_articles:
+        if not isinstance(cited, dict):
+            continue
+        canonical_url = cited.get("canonical_url")
+        if not canonical_url or not isinstance(canonical_url, str):
+            continue
+        row = conn.execute(
+            "SELECT id FROM articles WHERE canonical_url = %s", (canonical_url,)
+        ).fetchone()
+        if row is None:
+            continue
+        conn.execute(
+            """
+            INSERT INTO briefing_articles(briefing_id, article_id)
+            VALUES (%s, %s) ON CONFLICT DO NOTHING
+            """,
+            (briefing_id, int(row["id"])),
+        )
+
+
+def _restore_briefings(conn: Any, user_id: int, briefings: list[Any]) -> dict[str, int]:
+    counts = {"added": 0, "updated": 0, "skipped": 0}
+    for item in briefings:
+        if not isinstance(item, dict):
+            counts["skipped"] += 1
+            continue
+        created_at = item.get("created_at")
+        if not created_at or not isinstance(created_at, str):
+            counts["skipped"] += 1
+            continue
+        title = item.get("title")
+
+        try:
+            with conn.transaction():
+                existing = conn.execute(
+                    """
+                    SELECT id FROM briefings
+                    WHERE user_id = %s AND created_at = %s
+                      AND COALESCE(title, '') = COALESCE(%s, '')
+                    """,
+                    (user_id, created_at, title),
+                ).fetchone()
+
+                if existing is not None:
+                    briefing_id = int(existing["id"])
+                    conn.execute(
+                        """
+                        UPDATE briefings SET
+                          scope = %s, since_at = %s, until_at = %s, status = %s,
+                          summary = %s, focus_prompt = %s, model = %s
+                        WHERE id = %s
+                        """,
+                        (
+                            item.get("scope") or "since_last_briefing",
+                            item.get("since_at"),
+                            item.get("until_at"),
+                            item.get("status") or "complete",
+                            item.get("summary"),
+                            item.get("focus_prompt"),
+                            item.get("model"),
+                            briefing_id,
+                        ),
+                    )
+                    counts["updated"] += 1
+                else:
+                    row = conn.execute(
+                        """
+                        INSERT INTO briefings(
+                          user_id, created_at, scope, since_at, until_at, status,
+                          title, summary, focus_prompt, model
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        RETURNING id
+                        """,
+                        (
+                            user_id,
+                            created_at,
+                            item.get("scope") or "since_last_briefing",
+                            item.get("since_at"),
+                            item.get("until_at"),
+                            item.get("status") or "complete",
+                            title,
+                            item.get("summary"),
+                            item.get("focus_prompt"),
+                            item.get("model"),
+                        ),
+                    ).fetchone()
+                    if row is None:
+                        counts["skipped"] += 1
+                        continue
+                    briefing_id = int(row["id"])
+                    counts["added"] += 1
+
+                _restore_cited_articles(conn, briefing_id, item.get("cited_articles"))
+        except Exception:
+            logger.exception("Failed to restore archived briefing")
+            counts["skipped"] += 1
+    return counts
+
+
+def _restore_ai_memories(conn: Any, user_id: int, memories: list[Any]) -> dict[str, int]:
+    counts = {"added": 0, "updated": 0, "skipped": 0}
+    for item in memories:
+        if not isinstance(item, dict):
+            counts["skipped"] += 1
+            continue
+        content = item.get("content")
+        source = item.get("source")
+        if not isinstance(content, str) or not content.strip():
+            counts["skipped"] += 1
+            continue
+        if not isinstance(source, str) or not source.strip():
+            counts["skipped"] += 1
+            continue
+
+        memory_type = item.get("memory_type") or "preference"
+        confidence = item.get("confidence")
+        confidence = float(confidence) if isinstance(confidence, (int, float)) else 1.0
+        confidence = min(1.0, max(0.0, confidence))
+        active = bool(item.get("active", True))
+
+        try:
+            with conn.transaction():
+                existing = conn.execute(
+                    """
+                    SELECT id FROM user_ai_memories
+                    WHERE user_id = %s AND content = %s AND source = %s
+                    """,
+                    (user_id, content, source),
+                ).fetchone()
+                if existing is not None:
+                    conn.execute(
+                        """
+                        UPDATE user_ai_memories
+                        SET memory_type = %s, confidence = %s, active = %s, updated_at = NOW()
+                        WHERE id = %s
+                        """,
+                        (memory_type, confidence, active, existing["id"]),
+                    )
+                    counts["updated"] += 1
+                else:
+                    conn.execute(
+                        """
+                        INSERT INTO user_ai_memories(
+                          user_id, memory_type, content, source, confidence, active
+                        ) VALUES (%s, %s, %s, %s, %s, %s)
+                        """,
+                        (user_id, memory_type, content, source, confidence, active),
+                    )
+                    counts["added"] += 1
+        except Exception:
+            logger.exception("Failed to restore archived AI memory")
+            counts["skipped"] += 1
+    return counts
+
+
+def _restore_ai_memory_events(conn: Any, user_id: int, events: list[Any]) -> dict[str, int]:
+    counts = {"added": 0, "skipped": 0}
+    for item in events:
+        if not isinstance(item, dict):
+            counts["skipped"] += 1
+            continue
+        event_type = item.get("event_type")
+        source = item.get("source")
+        content = item.get("content")
+        created_at = item.get("created_at")
+        required = (event_type, source, content, created_at)
+        if not all(isinstance(v, str) and v.strip() for v in required):
+            counts["skipped"] += 1
+            continue
+
+        try:
+            with conn.transaction():
+                existing = conn.execute(
+                    """
+                    SELECT 1 FROM user_ai_memory_events
+                    WHERE user_id = %s AND event_type = %s AND source = %s
+                      AND content = %s AND created_at = %s
+                    """,
+                    (user_id, event_type, source, content, created_at),
+                ).fetchone()
+                if existing is not None:
+                    counts["skipped"] += 1
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO user_ai_memory_events(
+                      user_id, event_type, source, content, created_at
+                    )
+                    VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (user_id, event_type, source, content, created_at),
+                )
+                counts["added"] += 1
+        except Exception:
+            logger.exception("Failed to restore archived AI memory event")
+            counts["skipped"] += 1
+    return counts
+
+
+def restore_user_archive(
+    user_id: int,
+    payload: dict[str, Any],
+    database_url: str | None = None,
+) -> dict[str, dict[str, int]]:
+    """Restore a personal archive for `user_id`, returning per-section counts.
+
+    Idempotent: re-importing the same archive updates/keeps existing restored
+    state rather than duplicating rows, for object types with a stable
+    identity (article canonical_url, briefing created_at+title, AI memory
+    content+source). Only ever writes data scoped to `user_id`.
+    """
+    validate_archive(payload)
+
+    with connect(database_url=database_url) as conn:
+        articles = _restore_articles(conn, user_id, payload.get("articles") or [])
+        briefings = _restore_briefings(conn, user_id, payload.get("briefings") or [])
+        ai_memories = _restore_ai_memories(conn, user_id, payload.get("ai_memories") or [])
+        ai_memory_events = _restore_ai_memory_events(
+            conn, user_id, payload.get("ai_memory_events") or []
+        )
+
+    return {
+        "articles": articles,
+        "briefings": briefings,
+        "ai_memories": ai_memories,
+        "ai_memory_events": ai_memory_events,
+    }

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -2465,6 +2466,39 @@ def export_user_data(
     from news_dashboard.export import assemble_user_export
 
     return assemble_user_export(current_user["id"])
+
+
+# Archives are JSON text; 20 MiB covers even large multi-year histories while
+# bounding memory use and per-request import time for oversized uploads.
+MAX_ARCHIVE_IMPORT_BYTES = int(os.getenv("MAX_ARCHIVE_IMPORT_BYTES", str(20 * 1024 * 1024)))
+
+
+@api.post("/api/users/me/import")
+def import_user_archive(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    file: Annotated[UploadFile, File()],
+) -> dict[str, Any]:
+    """Restore a personal archive previously downloaded from /api/users/me/export."""
+    from news_dashboard.import_export import ArchiveImportError, restore_user_archive
+
+    contents = file.file.read(MAX_ARCHIVE_IMPORT_BYTES + 1)
+    if len(contents) > MAX_ARCHIVE_IMPORT_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Archive file too large (max {MAX_ARCHIVE_IMPORT_BYTES} bytes)",
+        )
+
+    try:
+        payload = json.loads(contents)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid archive JSON: {exc}") from exc
+
+    try:
+        result = restore_user_archive(current_user["id"], payload)
+    except ArchiveImportError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return result
 
 
 class DeleteAccountRequest(BaseModel):

--- a/backend/tests/test_import_export.py
+++ b/backend/tests/test_import_export.py
@@ -1,0 +1,489 @@
+"""Tests for #999 personal archive import and restore."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from news_dashboard.auth import create_user
+from news_dashboard.db import connect
+from news_dashboard.export import SCHEMA_VERSION, assemble_user_export
+from news_dashboard.import_export import ArchiveImportError, restore_user_archive
+from news_dashboard.ingest import set_article_starred, sync_sources, transition_article_state
+
+
+def _make_user(db_url: str, username: str) -> int:
+    return int(create_user(username, "password123", db_path=db_url)["id"])
+
+
+def _insert_article(db_url: str, *, url_suffix: str) -> int:
+    with connect(database_url=db_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name, category, kind
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                f"https://example.com/art{url_suffix}",
+                f"https://example.com/art{url_suffix}",
+                f"Article {url_suffix}",
+                "python-insider",
+                "Python Insider",
+                "python",
+                "rss_feed",
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _base_archive(**overrides: object) -> dict[str, Any]:
+    archive: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "includes_article_bodies": False,
+        "articles": [],
+        "briefings": [],
+        "ai_memories": [],
+        "ai_memory_events": [],
+        "source_subscriptions": [],
+        "preferences": {},
+    }
+    archive.update(overrides)
+    return archive
+
+
+# ── validation ─────────────────────────────────────────────────────────────
+
+
+def test_rejects_wrong_schema_version(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_bad_schema")
+
+    with pytest.raises(ArchiveImportError, match="schema_version"):
+        restore_user_archive(uid, _base_archive(schema_version=1), database_url=pg_clean)
+
+
+def test_rejects_non_object_payload(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_bad_payload")
+
+    not_an_object: Any = []
+    with pytest.raises(ArchiveImportError, match="JSON object"):
+        restore_user_archive(uid, not_an_object, database_url=pg_clean)
+
+
+def test_rejects_too_many_articles(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_too_many")
+
+    archive = _base_archive(articles=[{"canonical_url": f"https://x/{i}"} for i in range(20_001)])
+
+    with pytest.raises(ArchiveImportError, match="too many"):
+        restore_user_archive(uid, archive, database_url=pg_clean)
+
+
+# ── article state restore ───────────────────────────────────────────────────
+
+
+def test_restores_article_state_by_matching_existing_article(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_match_alice")
+    aid = _insert_article(pg_clean, url_suffix="match1")
+
+    archive = _base_archive(
+        articles=[
+            {
+                "id": 999999,
+                "canonical_url": "https://example.com/artmatch1",
+                "title": "Article match1",
+                "state": "done",
+                "starred": True,
+                "done_at": "2026-01-01T00:00:00+00:00",
+                "starred_at": "2026-01-01T00:00:00+00:00",
+            }
+        ]
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+
+    assert result["articles"] == {"added": 1, "updated": 0, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT state, starred FROM user_article_state WHERE user_id = %s AND article_id = %s",
+            (uid, aid),
+        ).fetchone()
+    assert row is not None
+    assert row["state"] == "done"
+    assert row["starred"] is True
+
+
+def test_restores_minimal_article_when_source_exists(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_minimal")
+
+    archive = _base_archive(
+        articles=[
+            {
+                "canonical_url": "https://example.com/brand-new-article",
+                "title": "Brand New Article",
+                "source_slug": "python-insider",
+                "source_name": "Python Insider",
+                "category": "python",
+                "kind": "rss_feed",
+                "state": "later",
+            }
+        ]
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+
+    assert result["articles"] == {"added": 1, "updated": 0, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT id FROM articles WHERE canonical_url = %s",
+            ("https://example.com/brand-new-article",),
+        ).fetchone()
+        assert row is not None
+        state_row = conn.execute(
+            "SELECT state FROM user_article_state WHERE user_id = %s AND article_id = %s",
+            (uid, row["id"]),
+        ).fetchone()
+    assert state_row is not None
+    assert state_row["state"] == "later"
+
+
+def test_skips_article_with_unknown_source_and_no_existing_match(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_unknown_source")
+
+    archive = _base_archive(
+        articles=[
+            {
+                "canonical_url": "https://example.com/orphan",
+                "title": "Orphan Article",
+                "source_slug": "does-not-exist",
+                "source_name": "Nowhere",
+                "category": "python",
+                "kind": "rss_feed",
+            }
+        ]
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+
+    assert result["articles"] == {"added": 0, "updated": 0, "skipped": 1}
+
+
+def test_reimporting_same_article_is_idempotent(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_idempotent")
+    _insert_article(pg_clean, url_suffix="idem1")
+
+    archive = _base_archive(
+        articles=[
+            {
+                "canonical_url": "https://example.com/artidem1",
+                "title": "Article idem1",
+                "state": "done",
+                "starred": False,
+            }
+        ]
+    )
+
+    first = restore_user_archive(uid, archive, database_url=pg_clean)
+    second = restore_user_archive(uid, archive, database_url=pg_clean)
+
+    assert first["articles"] == {"added": 1, "updated": 0, "skipped": 0}
+    assert second["articles"] == {"added": 0, "updated": 1, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS n FROM user_article_state WHERE user_id = %s", (uid,)
+        ).fetchone()
+    assert count is not None
+    assert count["n"] == 1
+
+
+def test_import_never_restores_data_for_another_user(pg_clean: str) -> None:
+    """An archive can only ever write rows for the importing user_id."""
+    sync_sources(pg_clean)
+    uid_alice = _make_user(pg_clean, "import_scope_alice")
+    uid_bob = _make_user(pg_clean, "import_scope_bob")
+    aid = _insert_article(pg_clean, url_suffix="scope1")
+
+    archive = _base_archive(
+        articles=[
+            {
+                "canonical_url": "https://example.com/artscope1",
+                "title": "Article scope1",
+                "state": "done",
+            }
+        ]
+    )
+
+    restore_user_archive(uid_alice, archive, database_url=pg_clean)
+
+    with connect(database_url=pg_clean) as conn:
+        bob_row = conn.execute(
+            "SELECT 1 FROM user_article_state WHERE user_id = %s AND article_id = %s",
+            (uid_bob, aid),
+        ).fetchone()
+    assert bob_row is None
+
+
+# ── briefings restore ────────────────────────────────────────────────────────
+
+
+def test_restores_briefing_and_cited_articles(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_brief")
+    aid = _insert_article(pg_clean, url_suffix="brief1")
+
+    archive = _base_archive(
+        briefings=[
+            {
+                "id": 12345,
+                "created_at": "2026-02-01T09:00:00+00:00",
+                "scope": "since_last_briefing",
+                "status": "complete",
+                "title": "Morning Brief",
+                "summary": "Summary text",
+                "cited_articles": [
+                    {"article_id": 12345, "canonical_url": "https://example.com/artbrief1"}
+                ],
+            }
+        ]
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+    assert result["briefings"] == {"added": 1, "updated": 0, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        brow = conn.execute("SELECT id, title FROM briefings WHERE user_id = %s", (uid,)).fetchone()
+        assert brow is not None
+        cited = conn.execute(
+            "SELECT article_id FROM briefing_articles WHERE briefing_id = %s", (brow["id"],)
+        ).fetchall()
+    assert brow["title"] == "Morning Brief"
+    assert [c["article_id"] for c in cited] == [aid]
+
+
+def test_reimporting_same_briefing_is_idempotent(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_brief_idem")
+
+    archive = _base_archive(
+        briefings=[
+            {
+                "created_at": "2026-02-02T09:00:00+00:00",
+                "title": "Morning Brief",
+                "summary": "v1",
+            }
+        ]
+    )
+    restore_user_archive(uid, archive, database_url=pg_clean)
+
+    archive["briefings"][0]["summary"] = "v2"
+    restore_user_archive(uid, archive, database_url=pg_clean)
+
+    with connect(database_url=pg_clean) as conn:
+        rows = conn.execute("SELECT summary FROM briefings WHERE user_id = %s", (uid,)).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["summary"] == "v2"
+
+
+# ── AI memory restore ────────────────────────────────────────────────────────
+
+
+def test_restores_ai_memory_by_content_and_source(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_memory")
+
+    archive = _base_archive(
+        ai_memories=[
+            {
+                "id": 555,
+                "memory_type": "preference",
+                "content": "Prefers concise summaries",
+                "source": "explicit",
+                "confidence": 0.9,
+                "active": True,
+            }
+        ],
+        ai_memory_events=[
+            {
+                "event_type": "created",
+                "source": "explicit",
+                "content": "Prefers concise summaries",
+                "created_at": "2026-01-05T00:00:00+00:00",
+            }
+        ],
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+    assert result["ai_memories"] == {"added": 1, "updated": 0, "skipped": 0}
+    assert result["ai_memory_events"] == {"added": 1, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        mem_row = conn.execute(
+            "SELECT content, confidence FROM user_ai_memories WHERE user_id = %s", (uid,)
+        ).fetchone()
+    assert mem_row is not None
+    assert mem_row["content"] == "Prefers concise summaries"
+
+
+def test_reimporting_same_ai_memory_updates_not_duplicates(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_memory_idem")
+
+    archive = _base_archive(
+        ai_memories=[
+            {"content": "Likes long-form articles", "source": "explicit", "confidence": 0.5}
+        ]
+    )
+    restore_user_archive(uid, archive, database_url=pg_clean)
+
+    archive["ai_memories"][0]["confidence"] = 1.0
+    second = restore_user_archive(uid, archive, database_url=pg_clean)
+
+    assert second["ai_memories"] == {"added": 0, "updated": 1, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        rows = conn.execute(
+            "SELECT confidence FROM user_ai_memories WHERE user_id = %s", (uid,)
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["confidence"] == 1.0
+
+
+def test_reimporting_same_memory_event_is_not_duplicated(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_memory_event_idem")
+
+    archive = _base_archive(
+        ai_memory_events=[
+            {
+                "event_type": "created",
+                "source": "explicit",
+                "content": "Some note",
+                "created_at": "2026-01-06T00:00:00+00:00",
+            }
+        ]
+    )
+    restore_user_archive(uid, archive, database_url=pg_clean)
+    second = restore_user_archive(uid, archive, database_url=pg_clean)
+
+    assert second["ai_memory_events"] == {"added": 0, "skipped": 1}
+
+    with connect(database_url=pg_clean) as conn:
+        rows = conn.execute(
+            "SELECT 1 FROM user_ai_memory_events WHERE user_id = %s", (uid,)
+        ).fetchall()
+    assert len(rows) == 1
+
+
+# ── round trip ───────────────────────────────────────────────────────────────
+
+
+def test_export_then_import_round_trip_into_fresh_user(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid_source = _make_user(pg_clean, "roundtrip_source")
+    aid = _insert_article(pg_clean, url_suffix="rt1")
+    transition_article_state(aid, "done", db_path=pg_clean, user_id=uid_source)
+    set_article_starred(aid, True, db_path=pg_clean, user_id=uid_source)
+
+    archive = assemble_user_export(uid_source, database_url=pg_clean)
+
+    uid_dest = _make_user(pg_clean, "roundtrip_dest")
+    result = restore_user_archive(uid_dest, archive, database_url=pg_clean)
+
+    assert result["articles"]["added"] == 1
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT state, starred FROM user_article_state WHERE user_id = %s AND article_id = %s",
+            (uid_dest, aid),
+        ).fetchone()
+    assert row is not None
+    assert row["state"] == "done"
+    assert row["starred"] is True
+
+
+# ── API endpoint ──────────────────────────────────────────────────────────────
+
+
+def test_import_endpoint_restores_archive(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+
+    import io
+
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    uid = _make_user(pg_clean, "endpoint_import_user")
+    _insert_article(pg_clean, url_suffix="ep_import1")
+
+    archive = _base_archive(
+        articles=[
+            {
+                "canonical_url": "https://example.com/artep_import1",
+                "title": "Article ep_import1",
+                "state": "done",
+            }
+        ]
+    )
+
+    fake_user = {"id": uid, "username": "endpoint_import_user", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            body = json.dumps(archive).encode("utf-8")
+            resp = client.post(
+                "/api/users/me/import",
+                files={"file": ("archive.json", io.BytesIO(body), "application/json")},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["articles"] == {"added": 1, "updated": 0, "skipped": 0}
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def test_import_endpoint_rejects_invalid_json(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+
+    import io
+
+    from fastapi.testclient import TestClient
+
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    uid = _make_user(pg_clean, "endpoint_import_bad")
+    fake_user = {"id": uid, "username": "endpoint_import_bad", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            resp = client.post(
+                "/api/users/me/import",
+                files={"file": ("archive.json", io.BytesIO(b"not json"), "application/json")},
+            )
+            assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.pop(require_auth, None)

--- a/docs/user-guide/saved-history.md
+++ b/docs/user-guide/saved-history.md
@@ -79,7 +79,7 @@ categories and sources.
 Want to back up or migrate your history? Use the built-in export:
 
 1. Go to Settings → Advanced
-2. Click "Download my data"
+2. Click "Download archive"
 3. Receive a JSON file containing:
    - Export metadata (`schema_version`, `generated_at`, and
      `includes_article_bodies`, which is currently `false`)
@@ -95,9 +95,15 @@ Want to back up or migrate your history? Use the built-in export:
      time/timezone, push-enabled, recap, analytics opt-in)
 
 The export does not include cached article body text. Secrets (password hash,
-session tokens, push subscription keys, API tokens) are never included. There
-is currently no import tool — this export is for backup and personal
-portability only.
+session tokens, push subscription keys, API tokens) are never included.
+
+To restore an archive, click "Restore archive" next to the download button
+and pick a previously downloaded JSON file. Re-importing the same file is
+safe: existing articles, briefings, and AI memories are matched and updated
+in place rather than duplicated. Only the same major archive schema version
+produced by this instance can be restored (an older or newer
+`schema_version` is rejected), and restoring only ever writes data for your
+own account.
 
 ## Auto-cleanup
 

--- a/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
+++ b/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
@@ -22,6 +22,7 @@ const apiMock = vi.hoisted(() => ({
   deactivateAiMemory: vi.fn(),
   learnAiMemoriesFromReading: vi.fn(),
   downloadUserExport: vi.fn(),
+  importUserArchive: vi.fn(),
   deleteOwnAccount: vi.fn(),
 }));
 vi.mock('../api', () => apiMock);
@@ -328,6 +329,39 @@ describe('SettingsPage', () => {
     renderPage(<SettingsPage />);
     fireEvent.click(screen.getByText('Download archive'));
     await waitFor(() => expect(screen.getByText('network error')).toBeTruthy());
+  });
+
+  it('shows the restore archive button', () => {
+    renderPage(<SettingsPage />);
+    expect(screen.getByText('Restore archive')).toBeTruthy();
+  });
+
+  it('restores an archive and shows the per-section counts', async () => {
+    apiMock.importUserArchive.mockResolvedValue({
+      articles: { added: 2, updated: 1, skipped: 0 },
+      briefings: { added: 1, updated: 0, skipped: 0 },
+      ai_memories: { added: 0, updated: 1, skipped: 0 },
+      ai_memory_events: { added: 3, skipped: 0 },
+    });
+    renderPage(<SettingsPage />);
+
+    const file = new File(['{"schema_version":2}'], 'archive.json', {
+      type: 'application/json',
+    });
+    fireEvent.change(screen.getByLabelText('Restore archive'), { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText(/Articles: 2 added/)).toBeTruthy());
+    expect(apiMock.importUserArchive).toHaveBeenCalledWith(file);
+  });
+
+  it('shows an error message when archive import fails', async () => {
+    apiMock.importUserArchive.mockRejectedValue(new Error('unsupported schema_version'));
+    renderPage(<SettingsPage />);
+
+    const file = new File(['not json'], 'archive.json', { type: 'application/json' });
+    fireEvent.change(screen.getByLabelText('Restore archive'), { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText('unsupported schema_version')).toBeTruthy());
   });
 
   it('requires typing the exact username before deletion is enabled', () => {

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,6 +1,7 @@
 import type {
   Achievement,
   AiMemory,
+  ArchiveImportResult,
   GreaderToken,
   McpToken,
   ReadingDna,
@@ -10,7 +11,7 @@ import type {
   Summary,
   WeeklyRecap,
 } from '../types';
-import { requestJson } from './core';
+import { HttpError, readErrorMessage, requestJson } from './core';
 
 export async function fetchSummary(): Promise<Summary> {
   return requestJson<Summary>('/api/summary');
@@ -132,6 +133,18 @@ export async function downloadUserExport(): Promise<void> {
   a.download = `reading-archive-${new Date().toISOString().slice(0, 10)}.json`;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+export async function importUserArchive(file: File): Promise<ArchiveImportResult> {
+  const form = new FormData();
+  form.append('file', file);
+  const response = await fetch('/api/users/me/import', {
+    method: 'POST',
+    credentials: 'same-origin',
+    body: form,
+  });
+  if (!response.ok) throw new HttpError(response.status, await readErrorMessage(response));
+  return response.json() as Promise<ArchiveImportResult>;
 }
 
 export async function deleteOwnAccount(confirmation: string): Promise<void> {

--- a/frontend/src/components/settings/DataExportSection.tsx
+++ b/frontend/src/components/settings/DataExportSection.tsx
@@ -1,12 +1,24 @@
 import { useState } from 'react';
-import { RefreshCw, Download } from 'lucide-react';
-import { downloadUserExport } from '@/api';
+import { RefreshCw, Download, Upload } from 'lucide-react';
+import { downloadUserExport, importUserArchive } from '@/api';
+import type { ArchiveImportResult } from '@/types';
 
 type ExportState = 'idle' | 'running' | 'done' | 'error';
+type ImportState = 'idle' | 'running' | 'done' | 'error';
+
+function formatCounts(counts: { added: number; updated?: number; skipped: number }): string {
+  const parts = [`${counts.added} added`];
+  if (counts.updated !== undefined) parts.push(`${counts.updated} updated`);
+  parts.push(`${counts.skipped} skipped`);
+  return parts.join(', ');
+}
 
 export function DataExportSection() {
   const [state, setState] = useState<ExportState>('idle');
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [importState, setImportState] = useState<ImportState>('idle');
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importResult, setImportResult] = useState<ArchiveImportResult | null>(null);
 
   const handleExport = async () => {
     setState('running');
@@ -53,6 +65,65 @@ export function DataExportSection() {
             {errorMsg ?? 'Export failed. Please try again.'}
           </p>
         )}
+
+        <div className="border-t border-border pt-3">
+          <p className="text-xs text-muted-foreground mb-2">
+            Restore a previously downloaded archive into this account. Existing articles, briefings,
+            and AI memories are matched and updated rather than duplicated.
+          </p>
+          <button
+            onClick={() => document.getElementById('archive-import-input')?.click()}
+            disabled={importState === 'running'}
+            className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors disabled:opacity-60"
+          >
+            {importState === 'running' ? (
+              <RefreshCw className="size-3 animate-spin" />
+            ) : (
+              <Upload className="size-3" />
+            )}
+            {importState === 'running' ? 'Restoring…' : 'Restore archive'}
+          </button>
+          <input
+            id="archive-import-input"
+            aria-label="Restore archive"
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const input = e.target;
+              setImportState('running');
+              setImportError(null);
+              setImportResult(null);
+              void (async () => {
+                try {
+                  const result = await importUserArchive(file);
+                  setImportResult(result);
+                  setImportState('done');
+                } catch (err) {
+                  setImportError(err instanceof Error ? err.message : 'Import failed.');
+                  setImportState('error');
+                } finally {
+                  input.value = '';
+                }
+              })();
+            }}
+          />
+
+          {importState === 'done' && importResult && (
+            <ul className="mt-2 text-xs text-green-600 dark:text-green-400 space-y-0.5">
+              <li>Articles: {formatCounts(importResult.articles)}</li>
+              <li>Briefings: {formatCounts(importResult.briefings)}</li>
+              <li>AI memories: {formatCounts(importResult.ai_memories)}</li>
+            </ul>
+          )}
+          {importState === 'error' && (
+            <p className="mt-2 text-xs text-destructive">
+              {importError ?? 'Import failed. Please try again.'}
+            </p>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -788,3 +788,16 @@ export interface OpmlImportResult {
   skipped: { url: string; reason: string }[];
   failed: { url: string; error: string }[];
 }
+
+export interface ArchiveImportCounts {
+  added: number;
+  updated: number;
+  skipped: number;
+}
+
+export interface ArchiveImportResult {
+  articles: ArchiveImportCounts;
+  briefings: ArchiveImportCounts;
+  ai_memories: ArchiveImportCounts;
+  ai_memory_events: { added: number; skipped: number };
+}


### PR DESCRIPTION
## Summary

Closes #999.

- Adds `POST /api/users/me/import`, the restore counterpart to the existing `GET /api/users/me/export`. Accepts the same JSON archive schema, validates `schema_version`, payload size (20 MiB cap), and per-section object counts before writing anything.
- Articles are matched to existing rows by `canonical_url`; a minimal article record is created only when the archive supplies enough metadata (title, source_slug/name, category, kind) *and* the referenced source already exists on this instance. Otherwise the article is skipped.
- Briefings are matched by `(user_id, created_at, title)`, AI memories by `(user_id, content, source)`, and AI memory events are deduplicated on their full identity tuple — so re-importing the same archive updates/keeps state instead of duplicating rows.
- Restores are always scoped to the authenticated user; the endpoint can never write rows for another `user_id`.
- No secrets, session data, OTPs, push subscriptions, or MCP tokens are ever accepted by the importer (the schema doesn't carry them in the first place).
- Adds a "Restore archive" control next to "Download archive" in Settings → Data Export, showing added/updated/skipped counts per section.
- Corrects `docs/user-guide/saved-history.md`, which previously stated "there is currently no import tool."

## Implementation notes

- New module `backend/news_dashboard/import_export.py` (mirrors `export.py`) rather than growing `main.py` further.
- Reuses the same per-item savepoint pattern as the existing OPML importer so one malformed row doesn't abort the whole restore.

## Test plan

- [x] `pytest backend/tests/test_import_export.py backend/tests/test_export.py` — 31 passed, including an export→import round-trip test and API endpoint tests.
- [x] `mypy`, `ty`, `pyrefly`, `ruff check`, `ruff format --check`, `vulture` all clean on changed backend files.
- [x] Frontend: `vitest run frontend/src/__tests__/statsSettingsRunsPages.test.tsx` — 23 passed, including new restore-archive success/error tests.
- [x] `npm run typecheck`, `eslint`, `prettier --check` clean on changed frontend files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)