### PR TITLE
fix: use pgvector in nightly backend tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_DB: news_dashboard
           POSTGRES_USER: news_dashboard

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -54,6 +54,8 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(db_mark, append=True)
 
 
+_TESTCONTAINERS_PG_IMAGE = "pgvector/pgvector:pg16"
+
 _SCHEMA_SWEEP_LOCK_KEY = 727271
 _WORKER_SCHEMA_RE = re.compile(r"^test_[A-Za-z0-9]+_(\d+)$")
 
@@ -177,7 +179,7 @@ def pg_url() -> Generator[str]:
             )
 
         try:
-            container = PostgresContainer("postgres:16")
+            container = PostgresContainer(_TESTCONTAINERS_PG_IMAGE)
             container.start()
         except Exception as exc:
             pytest.skip(f"PostgreSQL container could not start (Docker unavailable?): {exc}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -177,6 +177,7 @@ def pg_url() -> Generator[str]:
             pytest.skip(
                 "testcontainers package not installed (pip install testcontainers[postgres])"
             )
+            raise
 
         try:
             container = PostgresContainer(_TESTCONTAINERS_PG_IMAGE)


### PR DESCRIPTION
## Summary
- `.github/workflows/nightly.yml`'s `backend-full` service container now uses `pgvector/pgvector:pg16` instead of plain `postgres:16`, matching `ci.yml` and `pr-timing.yml`.
- `backend/tests/conftest.py`'s local `PostgresContainer` fallback (used when `TEST_DATABASE_URL` isn't set) now starts the same pgvector image, extracted into a `_TESTCONTAINERS_PG_IMAGE` constant for future bumps.

Fixes #1085. Plain `postgres:16` doesn't ship the `vector` extension, so the nightly job could fail in `init_db()`'s `CREATE EXTENSION IF NOT EXISTS vector` before any test assertions ran.

## Test plan
- [x] `pytest backend/tests/test_pgvector_migration.py backend/tests/test_database_config.py` — 20 passed
- [x] `pytest backend/tests -m db` (full db-marked suite against local pgvector Postgres) — 662 passed
- [x] `ruff check` and pre-commit hooks (mypy, ty, pyrefly, vulture) pass
- [x] Verified nightly.yml still parses as valid YAML after the edit