### PR TITLE
fix: make podcast token feed routes reachable without a session (#1088)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -615,7 +615,9 @@ def mark_read_via_token(article_id: int, token: Annotated[str, Query()]) -> dict
     return {"status": "marked_read", "article": article}
 
 
-app.include_router(public_router)
+# `public_router` is included further down (see `app.include_router(public_router)`
+# near the bottom of this module), after every route that mounts on it — including
+# the token-authenticated podcast routes defined later — has been registered.
 
 
 def _embed_article_background(article_id: int) -> None:
@@ -2204,7 +2206,7 @@ def regenerate_podcast_feed_token_endpoint(
     return {"token": token, "url": feed_url(token, _request_base_origin(request))}
 
 
-@api.get("/api/briefings/podcast.rss")
+@public_router.get("/api/briefings/podcast.rss")
 def podcast_rss_feed_endpoint(request: Request, token: Annotated[str, Query()]) -> Response:
     """Serve the authenticated user's podcast feed of previously-generated briefs.
 
@@ -2317,7 +2319,7 @@ def get_podcast_audio_endpoint(
     return FileResponse(audio_path, media_type="audio/mpeg", filename=f"podcast-{briefing_id}.mp3")
 
 
-@api.get("/api/briefings/{briefing_id}/podcast-audio")
+@public_router.get("/api/briefings/{briefing_id}/podcast-audio")
 def get_podcast_audio_by_token_endpoint(
     briefing_id: int,
     token: Annotated[str, Query()],
@@ -3145,6 +3147,7 @@ api.include_router(reading_progress_router)
 api.include_router(recaps_router)
 api.include_router(saved_searches_router)
 
+app.include_router(public_router)
 app.include_router(api)
 app.include_router(admin)
 # MCP tool-calling and GReader-sync endpoints authenticate via bearer token,

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -538,6 +538,81 @@ def test_get_podcast_audio_by_token_endpoint_invalid_token_returns_403(
     assert resp.status_code == 403
 
 
+# ── Anonymous access to podcast token routes ──────────────────────────────────
+#
+# Podcast clients cannot perform an interactive login, so these routes must be
+# reachable without a session cookie and authenticate purely via the revocable
+# feed token. Clearing `app.dependency_overrides` here removes the autouse fake
+# session from `override_auth`, so these requests exercise the real
+# `require_auth` boundary (or lack of one) rather than the test-only bypass.
+
+
+def test_podcast_rss_feed_anonymous_valid_token_returns_episode(
+    client: TestClient, monkeypatch: Any, tmp_path: Path
+) -> None:
+    from news_dashboard.podcast_feed import make_feed_token
+
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = make_feed_token(1, 1)
+
+    briefing = {
+        "id": 7,
+        "created_at": "2026-06-13T12:00:00+00:00",
+        "title": "AI Frameworks",
+        "summary": "New agent frameworks.",
+        "script": [{"speaker": "Alex", "voice": "onyx", "text": "hi"}],
+    }
+    monkeypatch.setattr(
+        "news_dashboard.briefings.list_briefings_with_script", lambda **_: [briefing]
+    )
+
+    audio_file = tmp_path / "podcast-7.mp3"
+    audio_file.write_bytes(b"audio-bytes")
+    monkeypatch.setattr("news_dashboard.tts._podcast_audio_path", lambda *_a, **_k: audio_file)
+
+    app.dependency_overrides.clear()
+    resp = client.get(f"/api/briefings/podcast.rss?token={token}")
+    assert resp.status_code == 200
+    assert "<title>AI Frameworks</title>" in resp.text
+
+
+def test_podcast_rss_feed_anonymous_invalid_token_returns_403_not_401(
+    client: TestClient,
+) -> None:
+    app.dependency_overrides.clear()
+    resp = client.get("/api/briefings/podcast.rss?token=bogus")
+    assert resp.status_code == 403
+
+
+def test_get_podcast_audio_by_token_endpoint_anonymous_success(
+    client: TestClient, monkeypatch: Any, tmp_path: Path
+) -> None:
+    from news_dashboard.podcast_feed import make_feed_token
+
+    monkeypatch.setattr("news_dashboard.auth.get_podcast_feed_token_version", lambda _uid: 1)
+    token = make_feed_token(1, 1)
+
+    briefing = dict(_SAMPLE_BRIEFING)
+    monkeypatch.setattr(main_mod, "get_briefing", lambda _, **__: briefing)
+
+    audio_file = tmp_path / "podcast-1.mp3"
+    audio_file.write_bytes(b"podcast-data")
+    monkeypatch.setattr("news_dashboard.tts._podcast_audio_path", lambda *_a, **_k: audio_file)
+
+    app.dependency_overrides.clear()
+    resp = client.get(f"/api/briefings/1/podcast-audio?token={token}")
+    assert resp.status_code == 200
+    assert resp.read() == b"podcast-data"
+
+
+def test_get_podcast_audio_by_token_endpoint_anonymous_invalid_token_returns_403_not_401(
+    client: TestClient,
+) -> None:
+    app.dependency_overrides.clear()
+    resp = client.get("/api/briefings/1/podcast-audio?token=bogus")
+    assert resp.status_code == 403
+
+
 # ── POST /api/briefings/{id}/chat ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #1088.

`GET /api/briefings/podcast.rss` and `GET /api/briefings/{briefing_id}/podcast-audio` are documented and implemented as token-authenticated endpoints (podcast clients can't perform an interactive login), but they were registered on `api = APIRouter(dependencies=[Depends(require_auth)])`. That meant an anonymous request was rejected with `401 Not authenticated` by the session dependency before the handler's own token verification ever ran, instead of returning the handler's `403` for an invalid/revoked token.

- Moved both routes from `@api.get(...)` to `@public_router.get(...)`.
- Deferred `app.include_router(public_router)` from its original location (right after the first two `public_router` routes) to just before `app.include_router(api)` near the bottom of `main.py`, so it picks up every route registered onto `public_router` throughout the module, including the podcast routes defined much later in the file.
- `/api/briefings/podcast-feed-token`, `/api/briefings/podcast-feed-token/regenerate`, `/api/briefings/{briefing_id}/podcast` (generation + session playback) are untouched and still require `require_auth`.
- Token verification behavior (403 for invalid/revoked tokens, per-user briefing ownership check) is unchanged.

## Test plan

- [x] Added regression tests in `backend/tests/test_briefings_api.py` that call `app.dependency_overrides.clear()` before hitting the podcast routes, so they exercise the real (non-test-bypassed) auth boundary as a true anonymous client:
  - `test_podcast_rss_feed_anonymous_valid_token_returns_episode`
  - `test_podcast_rss_feed_anonymous_invalid_token_returns_403_not_401`
  - `test_get_podcast_audio_by_token_endpoint_anonymous_success`
  - `test_get_podcast_audio_by_token_endpoint_anonymous_invalid_token_returns_403_not_401`
- [x] `pytest backend/tests/test_briefings_api.py -q` → 52 passed
- [x] `pytest backend/tests -k "briefings or main or auth" -q` → 302 passed
- [x] `mypy backend/news_dashboard/main.py` → no issues
- [x] `ruff check` → all checks passed
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) → all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)