### PR TITLE
fix: send briefing chat recovery to a real latest-briefing route (#1089)

### DIFF
--- a/frontend/src/__tests__/BriefingChat.test.tsx
+++ b/frontend/src/__tests__/BriefingChat.test.tsx
@@ -50,8 +50,12 @@ describe('BriefingChat', () => {
 
     await waitFor(() => expect(screen.getByTestId('briefing-unavailable')).toBeTruthy());
     expect(screen.getByText('This briefing is no longer available.')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Latest briefing' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Briefing history' })).toBeTruthy();
+
+    const latestBriefingLink = screen.getByRole('link', { name: 'Latest briefing' });
+    expect(latestBriefingLink.getAttribute('href')).toBe('/');
+
+    const briefingHistoryLink = screen.getByRole('link', { name: 'Briefing history' });
+    expect(briefingHistoryLink.getAttribute('href')).toBe('/briefs');
   });
 
   it('shows generic fallback for non-404 errors', async () => {

--- a/frontend/src/components/BriefingChat.tsx
+++ b/frontend/src/components/BriefingChat.tsx
@@ -122,7 +122,7 @@ export function BriefingChat({ briefingId }: { briefingId: number }) {
                 Refresh the briefing or open it from history.
               </p>
               <div className="flex gap-2 mt-3 flex-wrap">
-                <Link to="/brief">
+                <Link to="/">
                   <Button size="sm" variant="outline" onClick={() => setOpen(false)}>
                     Latest briefing
                   </Button>


### PR DESCRIPTION
## Summary
- Closes #1089
- The "Latest briefing" recovery button in `BriefingChat` linked to `/brief`, a route that doesn't exist, sending users to a 404 instead of the latest briefing.
- Point the link at `/`, which is the actual latest-briefing index route (see `frontend/src/AppRouter.tsx`), and leave the "Briefing history" link at `/briefs`.
- Strengthened the regression test in `frontend/src/__tests__/BriefingChat.test.tsx` to assert the `href` of each recovery link instead of only checking that the buttons render.

## Test plan
- [x] `npm run test:frontend -- frontend/src/__tests__/BriefingChat.test.tsx` — 3 passed
- [x] `npx eslint frontend/src/components/BriefingChat.tsx frontend/src/__tests__/BriefingChat.test.tsx` — clean
- [x] pre-commit hooks (eslint, prettier, knip, tsc) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)