### PR TITLE
feat: support generic SMTP for OTP sign-in email (#1086)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,7 +95,20 @@ DIGEST_TO=
 DIGEST_USER_ID=
 # Base URL used to build links (e.g. mark-read/article links) in digest emails. Default http://localhost:8000.
 APP_BASE_URL=http://localhost:8000
-# Gmail SMTP credentials for one-time-password sign-in emails (email.py); separate from the digest SMTP pair above.
+# SMTP for one-time-password sign-in emails (email.py). Resolution order:
+#   1. OTP_SMTP_* below, if set.
+#   2. The digest SMTP_HOST/SMTP_USER/SMTP_PASS pair above, if OTP_SMTP_* is unset.
+#   3. SMTP_USERNAME/SMTP_PASSWORD (legacy Gmail-only alias), defaulting the host
+#      to smtp.gmail.com:587 for existing deployments.
+OTP_SMTP_HOST=
+OTP_SMTP_PORT=
+OTP_SMTP_USER=
+OTP_SMTP_PASS=
+# From address for OTP emails. Defaults to the resolved username.
+OTP_SMTP_FROM=
+# TLS mode: starttls (default unless port 465), ssl, or none.
+OTP_SMTP_TLS=
+# Legacy Gmail-only alias, kept for backward compatibility with existing deployments.
 SMTP_USERNAME=
 SMTP_PASSWORD=
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,7 +608,12 @@ jobs:
   # │                                                                      │
   # │  SMTP_USERNAME    Optional Gmail SMTP creds used to send OTP sign-in  │
   # │  SMTP_PASSWORD    emails (send_otp_email). SMTP_PASSWORD must be a    │
-  # │                   Gmail App Password, not the account password.      │
+  # │                   Gmail App Password, not the account password. This  │
+  # │                   is a Gmail-only compatibility alias; self-hosters   │
+  # │                   using a non-Gmail relay set OTP_SMTP_HOST/PORT/     │
+  # │                   USER/PASS/FROM/TLS via Helm's app.email.smtp*       │
+  # │                   values instead (see helm/news-dashboard/values.yaml│
+  # │                   and .env.example).                                 │
   # └──────────────────────────────────────────────────────────────────────┘
   deploy:
     name: Deploy to mini PC

--- a/backend/news_dashboard/email.py
+++ b/backend/news_dashboard/email.py
@@ -1,30 +1,79 @@
-"""SMTP email dispatch via Gmail SMTP (STARTTLS)."""
+"""SMTP email dispatch for one-time-password sign-in emails.
+
+Supports a generic SMTP relay (host/port/user/pass/TLS mode/from) via
+``OTP_SMTP_*`` variables, falling back to the digest email's generic
+``SMTP_HOST``/``SMTP_PORT``/``SMTP_USER``/``SMTP_PASS`` variables, and finally
+to the legacy Gmail-only ``SMTP_USERNAME``/``SMTP_PASSWORD`` alias for
+backward compatibility with existing deployments.
+"""
 
 from __future__ import annotations
 
 import logging
 import os
 import smtplib
+import ssl
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
-_SMTP_HOST = "smtp.gmail.com"
-_SMTP_PORT = 587
+_GMAIL_HOST = "smtp.gmail.com"
+_DEFAULT_PORT = 587
 
 
-def _smtp_credentials() -> tuple[str, str]:
-    username = os.getenv("SMTP_USERNAME", "").strip()
-    password = os.getenv("SMTP_PASSWORD", "").strip()
-    return username, password
+def _first_env(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+class _SmtpConfig(NamedTuple):
+    host: str
+    port: int
+    username: str
+    password: str
+    tls_mode: str
+    from_addr: str
+
+
+def _smtp_config() -> _SmtpConfig:
+    """Resolve OTP SMTP settings.
+
+    Precedence for host/user/pass: ``OTP_SMTP_*`` > the digest email's generic
+    ``SMTP_HOST``/``SMTP_USER``/``SMTP_PASS`` > the legacy Gmail-only
+    ``SMTP_USERNAME``/``SMTP_PASSWORD`` compatibility alias.
+    """
+    username = _first_env("OTP_SMTP_USER", "SMTP_USERNAME", "SMTP_USER")
+    password = _first_env("OTP_SMTP_PASS", "SMTP_PASSWORD", "SMTP_PASS")
+
+    host = _first_env("OTP_SMTP_HOST", "SMTP_HOST")
+    if not host and _first_env("SMTP_USERNAME"):
+        # Legacy deployments that only set SMTP_USERNAME/SMTP_PASSWORD assumed Gmail.
+        host = _GMAIL_HOST
+
+    port_raw = _first_env("OTP_SMTP_PORT", "SMTP_PORT")
+    port = int(port_raw) if port_raw else _DEFAULT_PORT
+
+    tls_mode = _first_env("OTP_SMTP_TLS").lower() or ("ssl" if port == 465 else "starttls")
+
+    from_addr = _first_env("OTP_SMTP_FROM") or username
+
+    return _SmtpConfig(host, port, username, password, tls_mode, from_addr)
 
 
 def send_otp_email(to_email: str, otp: str) -> None:
-    """Send a 6-digit OTP to *to_email* via Gmail SMTP STARTTLS."""
-    username, password = _smtp_credentials()
-    if not username or not password:
-        err = "SMTP_USERNAME and SMTP_PASSWORD must be set to send OTP emails"
+    """Send a 6-digit OTP to *to_email* via the configured SMTP relay."""
+    config = _smtp_config()
+    if not config.host or not config.username or not config.password:
+        err = (
+            "OTP SMTP is not configured. Set OTP_SMTP_HOST/OTP_SMTP_USER/OTP_SMTP_PASS "
+            "(or the digest email's SMTP_HOST/SMTP_USER/SMTP_PASS, or the legacy "
+            "Gmail-only SMTP_USERNAME/SMTP_PASSWORD alias) to send OTP emails"
+        )
         raise RuntimeError(err)
 
     html_body = f"""\
@@ -108,14 +157,25 @@ def send_otp_email(to_email: str, otp: str) -> None:
 
     msg = MIMEMultipart("alternative")
     msg["Subject"] = "Your News Dashboard sign-in code"
-    msg["From"] = username
+    msg["From"] = config.from_addr
     msg["To"] = to_email
     msg.attach(MIMEText(html_body, "html"))
 
-    with smtplib.SMTP(_SMTP_HOST, _SMTP_PORT, timeout=15) as server:
-        server.ehlo()
-        server.starttls()
-        server.login(username, password)
-        server.sendmail(username, to_email, msg.as_string())
+    if config.tls_mode == "ssl":
+        context = ssl.create_default_context()
+        with smtplib.SMTP_SSL(config.host, config.port, context=context, timeout=15) as server:
+            server.login(config.username, config.password)
+            server.sendmail(config.from_addr, to_email, msg.as_string())
+    elif config.tls_mode == "none":
+        with smtplib.SMTP(config.host, config.port, timeout=15) as server:
+            server.ehlo()
+            server.login(config.username, config.password)
+            server.sendmail(config.from_addr, to_email, msg.as_string())
+    else:
+        with smtplib.SMTP(config.host, config.port, timeout=15) as server:
+            server.ehlo()
+            server.starttls()
+            server.login(config.username, config.password)
+            server.sendmail(config.from_addr, to_email, msg.as_string())
 
     logger.info("OTP email sent to %s", to_email)

--- a/backend/news_dashboard/email.py
+++ b/backend/news_dashboard/email.py
@@ -23,14 +23,6 @@ _GMAIL_HOST = "smtp.gmail.com"
 _DEFAULT_PORT = 587
 
 
-def _first_env(*names: str) -> str:
-    for name in names:
-        value = os.getenv(name, "").strip()
-        if value:
-            return value
-    return ""
-
-
 class _SmtpConfig(NamedTuple):
     host: str
     port: int
@@ -47,20 +39,32 @@ def _smtp_config() -> _SmtpConfig:
     ``SMTP_HOST``/``SMTP_USER``/``SMTP_PASS`` > the legacy Gmail-only
     ``SMTP_USERNAME``/``SMTP_PASSWORD`` compatibility alias.
     """
-    username = _first_env("OTP_SMTP_USER", "SMTP_USERNAME", "SMTP_USER")
-    password = _first_env("OTP_SMTP_PASS", "SMTP_PASSWORD", "SMTP_PASS")
+    legacy_username = os.environ.get("SMTP_USERNAME", "").strip()
+    username = (
+        os.environ.get("OTP_SMTP_USER", "").strip()
+        or legacy_username
+        or os.environ.get("SMTP_USER", "").strip()
+    )
+    password = (
+        os.environ.get("OTP_SMTP_PASS", "").strip()
+        or os.environ.get("SMTP_PASSWORD", "").strip()
+        or os.environ.get("SMTP_PASS", "").strip()
+    )
 
-    host = _first_env("OTP_SMTP_HOST", "SMTP_HOST")
-    if not host and _first_env("SMTP_USERNAME"):
+    host = os.environ.get("OTP_SMTP_HOST", "").strip() or os.environ.get("SMTP_HOST", "").strip()
+    if not host and legacy_username:
         # Legacy deployments that only set SMTP_USERNAME/SMTP_PASSWORD assumed Gmail.
         host = _GMAIL_HOST
 
-    port_raw = _first_env("OTP_SMTP_PORT", "SMTP_PORT")
+    port_raw = (
+        os.environ.get("OTP_SMTP_PORT", "").strip() or os.environ.get("SMTP_PORT", "").strip()
+    )
     port = int(port_raw) if port_raw else _DEFAULT_PORT
 
-    tls_mode = _first_env("OTP_SMTP_TLS").lower() or ("ssl" if port == 465 else "starttls")
+    tls_raw = os.environ.get("OTP_SMTP_TLS", "").strip().lower()
+    tls_mode = tls_raw or ("ssl" if port == 465 else "starttls")
 
-    from_addr = _first_env("OTP_SMTP_FROM") or username
+    from_addr = os.environ.get("OTP_SMTP_FROM", "").strip() or username
 
     return _SmtpConfig(host, port, username, password, tls_mode, from_addr)
 

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -1,52 +1,79 @@
-"""Tests for the OTP email content and branding."""
+"""Tests for the OTP email content, branding, and SMTP configuration."""
 
 from __future__ import annotations
 
 import smtplib
 from email import message_from_string
 from email.message import Message
+from typing import ClassVar
 from unittest.mock import patch
 
+import pytest
 
-def _capture_sent_message(to_email: str, otp: str) -> Message:
+
+class _FakeSMTP:
+    """Records constructor args and calls; captures the sent envelope."""
+
+    captured: ClassVar[list[tuple[str, str, str]]] = []
+    init_args: ClassVar[list[tuple[object, ...]]] = []
+    init_kwargs: ClassVar[list[dict[str, object]]] = []
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        type(self).init_args.append(args)
+        type(self).init_kwargs.append(kwargs)
+
+    def __enter__(self) -> _FakeSMTP:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        pass
+
+    def ehlo(self) -> None:
+        pass
+
+    def starttls(self) -> None:
+        pass
+
+    def login(self, user: str, _pw: str) -> None:
+        pass
+
+    def sendmail(self, frm: str, to: str, raw: str) -> None:
+        type(self).captured.append((frm, to, raw))
+
+
+def _fresh_fake_smtp() -> type[_FakeSMTP]:
+    """Return a _FakeSMTP subclass with its own capture buffers."""
+
+    class _Fake(_FakeSMTP):
+        captured: ClassVar[list[tuple[str, str, str]]] = []
+        init_args: ClassVar[list[tuple[object, ...]]] = []
+        init_kwargs: ClassVar[list[dict[str, object]]] = []
+
+    return _Fake
+
+
+def _capture_sent_message(
+    to_email: str,
+    otp: str,
+    env: dict[str, str] | None = None,
+    fake_cls: type[_FakeSMTP] | None = None,
+    patch_target: str = "SMTP",
+) -> Message:
     """Call send_otp_email with fake SMTP and return the captured MIME message."""
     import news_dashboard.email as email_mod
 
-    captured: list[tuple[str, str, str]] = []
-
-    class _FakeSMTP:
-        def __init__(self, *_args: object, **_kwargs: object) -> None:
-            pass
-
-        def __enter__(self) -> _FakeSMTP:
-            return self
-
-        def __exit__(self, *_args: object) -> None:
-            pass
-
-        def ehlo(self) -> None:
-            pass
-
-        def starttls(self) -> None:
-            pass
-
-        def login(self, user: str, _pw: str) -> None:
-            pass
-
-        def sendmail(self, frm: str, to: str, raw: str) -> None:
-            captured.append((frm, to, raw))
+    fake_cls = fake_cls or _fresh_fake_smtp()
+    if env is None:
+        env = {"SMTP_USERNAME": "noreply@example.com", "SMTP_PASSWORD": "secret"}
 
     with (
-        patch.dict(
-            "os.environ",
-            {"SMTP_USERNAME": "noreply@example.com", "SMTP_PASSWORD": "secret"},
-        ),
-        patch.object(smtplib, "SMTP", _FakeSMTP),
+        patch.dict("os.environ", env, clear=True),
+        patch.object(smtplib, patch_target, fake_cls),
     ):
         email_mod.send_otp_email(to_email, otp)
 
-    assert len(captured) == 1, "Expected exactly one email to be sent"
-    return message_from_string(captured[0][2])
+    assert len(fake_cls.captured) == 1, "Expected exactly one email to be sent"
+    return message_from_string(fake_cls.captured[0][2])
 
 
 def _extract_html_body(msg: Message) -> str | None:
@@ -89,3 +116,69 @@ def test_otp_email_from_header_uses_smtp_username() -> None:
     """From header must equal the configured SMTP_USERNAME."""
     msg = _capture_sent_message("user@example.com", "111222")
     assert msg["From"] == "noreply@example.com"
+
+
+def test_otp_email_generic_host_and_port_used() -> None:
+    """OTP_SMTP_HOST/OTP_SMTP_PORT should be honored over the Gmail default."""
+    fake_cls = _fresh_fake_smtp()
+    env = {
+        "OTP_SMTP_HOST": "smtp.example.net",
+        "OTP_SMTP_PORT": "2525",
+        "OTP_SMTP_USER": "relay-user",
+        "OTP_SMTP_PASS": "relay-pass",
+    }
+    _capture_sent_message("user@example.com", "333444", env=env, fake_cls=fake_cls)
+    assert fake_cls.init_args[0][:2] == ("smtp.example.net", 2525)
+
+
+def test_otp_email_falls_back_to_digest_generic_smtp_vars() -> None:
+    """When OTP_SMTP_* is unset, the digest email's generic SMTP_HOST/USER/PASS apply."""
+    fake_cls = _fresh_fake_smtp()
+    env = {
+        "SMTP_HOST": "relay.internal",
+        "SMTP_PORT": "2526",
+        "SMTP_USER": "digest-user",
+        "SMTP_PASS": "digest-pass",
+    }
+    msg = _capture_sent_message("user@example.com", "555666", env=env, fake_cls=fake_cls)
+    assert fake_cls.init_args[0][:2] == ("relay.internal", 2526)
+    assert msg["From"] == "digest-user"
+
+
+def test_otp_email_gmail_alias_still_works() -> None:
+    """Legacy SMTP_USERNAME/SMTP_PASSWORD deployments keep defaulting to Gmail."""
+    fake_cls = _fresh_fake_smtp()
+    env = {"SMTP_USERNAME": "noreply@example.com", "SMTP_PASSWORD": "secret"}
+    _capture_sent_message("user@example.com", "777888", env=env, fake_cls=fake_cls)
+    assert fake_cls.init_args[0][:2] == ("smtp.gmail.com", 587)
+
+
+def test_otp_email_tls_mode_ssl_uses_smtp_ssl() -> None:
+    """OTP_SMTP_TLS=ssl should dispatch via smtplib.SMTP_SSL."""
+    fake_cls = _fresh_fake_smtp()
+    env = {
+        "OTP_SMTP_HOST": "smtp.example.net",
+        "OTP_SMTP_PORT": "465",
+        "OTP_SMTP_USER": "relay-user",
+        "OTP_SMTP_PASS": "relay-pass",
+        "OTP_SMTP_TLS": "ssl",
+    }
+    _capture_sent_message(
+        "user@example.com",
+        "999000",
+        env=env,
+        fake_cls=fake_cls,
+        patch_target="SMTP_SSL",
+    )
+    assert fake_cls.init_args[0][:2] == ("smtp.example.net", 465)
+
+
+def test_otp_email_missing_config_raises_clear_error() -> None:
+    """Missing SMTP configuration should raise a RuntimeError explaining how to fix it."""
+    import news_dashboard.email as email_mod
+
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        pytest.raises(RuntimeError, match="OTP SMTP is not configured"),
+    ):
+        email_mod.send_otp_email("user@example.com", "123123")

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -118,6 +118,22 @@ spec:
                   key: {{ .Values.app.email.smtpPasswordKey | default "SMTP_PASSWORD" | quote }}
                   optional: true
 {{- end }}
+{{- if .Values.app.email.smtpHost }}
+            - name: OTP_SMTP_HOST
+              value: {{ .Values.app.email.smtpHost | quote }}
+{{- end }}
+{{- if .Values.app.email.smtpPort }}
+            - name: OTP_SMTP_PORT
+              value: {{ .Values.app.email.smtpPort | quote }}
+{{- end }}
+{{- if .Values.app.email.smtpFrom }}
+            - name: OTP_SMTP_FROM
+              value: {{ .Values.app.email.smtpFrom | quote }}
+{{- end }}
+{{- if .Values.app.email.smtpTlsMode }}
+            - name: OTP_SMTP_TLS
+              value: {{ .Values.app.email.smtpTlsMode | quote }}
+{{- end }}
 {{- end }}
             - name: SESSION_SECRET
               valueFrom:

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -127,10 +127,19 @@ app:
     # VAPID claims email address. Omit or leave empty to default safely.
     email: ""
   email:
-    # Optional: pre-existing Secret with Gmail SMTP creds for OTP sign-in emails.
+    # Optional: pre-existing Secret with SMTP creds for OTP sign-in emails.
+    # Legacy key names default to Gmail; point smtpUsernameKey/smtpPasswordKey
+    # at differently-named keys to reuse the same Secret for a generic relay.
     existingSecret: ""
     smtpUsernameKey: SMTP_USERNAME
     smtpPasswordKey: SMTP_PASSWORD
+    # Optional generic SMTP host/port/from/TLS mode for OTP sign-in email.
+    # Leave all empty to keep the legacy Gmail default (smtp.gmail.com:587).
+    smtpHost: ""
+    smtpPort: ""
+    smtpFrom: ""
+    # starttls (default unless port 465), ssl, or none.
+    smtpTlsMode: ""
   sentry:
     # Optional: pre-existing Secret with SENTRY_DSN and/or SENTRY_DSN_FRONTEND.
     existingSecret: ""

--- a/scripts/test_helm_email_secret.py
+++ b/scripts/test_helm_email_secret.py
@@ -61,10 +61,10 @@ def test_otp_smtp_generic_env_wired_from_values() -> None:
         ]
     )
     assert "OTP_SMTP_HOST" in rendered
-    assert "smtp.example.net" in rendered
+    assert 'value: "smtp.example.net"' in rendered
     assert "OTP_SMTP_PORT" in rendered
-    assert '"2525"' in rendered
+    assert 'value: "2525"' in rendered
     assert "OTP_SMTP_FROM" in rendered
-    assert "noreply@example.net" in rendered
+    assert 'value: "noreply@example.net"' in rendered
     assert "OTP_SMTP_TLS" in rendered
-    assert "starttls" in rendered
+    assert 'value: "starttls"' in rendered

--- a/scripts/test_helm_email_secret.py
+++ b/scripts/test_helm_email_secret.py
@@ -37,3 +37,34 @@ def test_email_env_wired_from_existing_secret() -> None:
     assert "SMTP_USERNAME" in rendered
     assert "SMTP_PASSWORD" in rendered
     assert "news-dashboard-email" in rendered
+
+
+def test_otp_smtp_generic_env_absent_by_default() -> None:
+    rendered = _helm_template([])
+    assert "OTP_SMTP_HOST" not in rendered
+    assert "OTP_SMTP_PORT" not in rendered
+    assert "OTP_SMTP_FROM" not in rendered
+    assert "OTP_SMTP_TLS" not in rendered
+
+
+def test_otp_smtp_generic_env_wired_from_values() -> None:
+    rendered = _helm_template(
+        [
+            "--set",
+            "app.email.smtpHost=smtp.example.net",
+            "--set-string",
+            "app.email.smtpPort=2525",
+            "--set",
+            "app.email.smtpFrom=noreply@example.net",
+            "--set",
+            "app.email.smtpTlsMode=starttls",
+        ]
+    )
+    assert "OTP_SMTP_HOST" in rendered
+    assert "smtp.example.net" in rendered
+    assert "OTP_SMTP_PORT" in rendered
+    assert '"2525"' in rendered
+    assert "OTP_SMTP_FROM" in rendered
+    assert "noreply@example.net" in rendered
+    assert "OTP_SMTP_TLS" in rendered
+    assert "starttls" in rendered


### PR DESCRIPTION
## Summary

Closes #1086.

OTP sign-in email (`send_otp_email` in `backend/news_dashboard/email.py`) previously hard-coded Gmail's `smtp.gmail.com:587` and only accepted `SMTP_USERNAME`/`SMTP_PASSWORD`. Self-hosters running a generic SMTP relay for the daily digest (`SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/`SMTP_PASS`) had no way to reuse it for OTP unless it was Gmail-compatible.

`send_otp_email` now resolves SMTP configuration with this precedence:

1. `OTP_SMTP_HOST` / `OTP_SMTP_PORT` / `OTP_SMTP_USER` / `OTP_SMTP_PASS` / `OTP_SMTP_FROM` / `OTP_SMTP_TLS` (new, OTP-specific)
2. The digest email's generic `SMTP_HOST` / `SMTP_USER` / `SMTP_PASS` (reused if OTP-specific vars are unset)
3. The legacy Gmail-only `SMTP_USERNAME` / `SMTP_PASSWORD` alias, which keeps defaulting the host to `smtp.gmail.com:587` for existing deployments

`OTP_SMTP_TLS` supports `starttls` (default unless port is 465), `ssl`, and `none`.

- Digest email (`digest.py`) is untouched — its config and behavior are unchanged.
- `.env.example`, Helm chart values (`app.email.smtp{Host,Port,From,TlsMode}`) and `deployment.yaml`, and the CI deploy-secret comment block now document the new contract.
- Existing Gmail App Password deployments using only `SMTP_USERNAME`/`SMTP_PASSWORD` continue to work unchanged.

## Test plan

- [x] `pytest backend/tests/test_email.py` — 9 passed, including new coverage for generic host/port, digest-generic fallback, Gmail alias, SSL/STARTTLS TLS modes, and the missing-config error message.
- [x] `pytest scripts/test_helm_email_secret.py` — 4 passed, including new coverage that `OTP_SMTP_*` env vars are absent by default and correctly rendered when `app.email.smtp*` values are set.
- [x] `ruff check` / `ruff format --check` / `mypy` on changed files — all pass.
- [x] Full pre-commit hook suite (ruff, mypy, ty, pyrefly, vulture) — all pass on commit.
- [x] `pytest backend/tests/test_auth.py` (OTP request flow, DB-backed) — not run locally; Docker/Postgres was unavailable in this environment. These tests mock `send_otp_email` directly and are unaffected by the internal SMTP resolution change, but CI should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)