### PR TITLE
Add optional Neo4j knowledge graph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,8 @@ NEWSLETTER_POLL_MINUTES=15
 INGEST_INTERVAL_MINUTES=30
 # Interval for the background entity-extraction job feeding the knowledge graph. Default 30.
 ENTITY_EXTRACTION_INTERVAL_MINUTES=30
+# Interval for typed relationship extraction into the optional Neo4j graph store. Default 60.
+ENTITY_RELATIONSHIP_EXTRACTION_INTERVAL_MINUTES=60
 # Interval for the reading-list metadata sweep retrying pending link previews. Default 5.
 READING_LIST_FETCH_INTERVAL_MINUTES=5
 # Interval for the proactive AI watchlist evaluator (watchlist_agent.py). Default 15.
@@ -147,6 +149,14 @@ ANALYTICS_RETENTION_DAYS=180
 # Instance-wide analytics kill switch: set to false to stop ingesting user_events for
 # every user regardless of their individual Settings preference. Default true.
 ANALYTICS_ENABLED=true
+
+# --- Optional Neo4j knowledge graph -------------------------------------------
+# PostgreSQL remains the application database. Set all three connection values
+# below only when you want the knowledge graph mirrored into Neo4j.
+NEO4J_URI=
+NEO4J_USER=
+NEO4J_PASSWORD=
+NEO4J_DATABASE=neo4j
 
 # --- Misc / app ----------------------------------------------------------------
 # Comma-separated browser dev origins allowed by CORS.

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,12 @@ test-full: test-nightly
 
 ## helm-validate: lint and render the Helm chart with default and production-like values
 helm-validate:
-	helm lint ./helm/news-dashboard
+	helm lint ./helm/news-dashboard \
+		--set-string "app.auth.sessionSecret=dummy-session-secret-for-render-only" \
+		--set-string "postgresql.password=dummy-postgres-password-for-render-only"
 	helm template news-dashboard ./helm/news-dashboard \
-		--set-string "app.auth.sessionSecret=dummy-session-secret-for-render-only"
+		--set-string "app.auth.sessionSecret=dummy-session-secret-for-render-only" \
+		--set-string "postgresql.password=dummy-postgres-password-for-render-only"
 	helm template news-dashboard ./helm/news-dashboard \
 		--set "image.tag=abc1234" \
 		--set "image.pullSecretName=ghcr-pull-secret" \
@@ -93,6 +96,7 @@ helm-validate:
 		--set-string "app.ai.briefingModel=gpt-4o" \
 		--set-string "app.ai.langfuse.host=http://langfuse.local" \
 		--set-string "app.push.email=test@example.com" \
+		--set-string "postgresql.password=dummy-postgres-password-for-render-only" \
 		--set "postgresql.persistence.hostPath=/home/ioachim-minipc/news-dashboard-postgres-data"
 	helm template news-dashboard ./helm/news-dashboard \
 		--set "postgresql.enabled=false" \

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,6 +10,10 @@ and how to run with no outbound calls at all.
 - Articles, feeds, sources, users, sessions, saved/read/starred/snoozed
   state, ingest run history, and search all live in your PostgreSQL
   database and are never sent anywhere.
+- Optional Neo4j graph data also stays on your instance. It mirrors article IDs,
+  titles, URLs, source slugs, discovery timestamps, entity nodes, mention
+  edges, and extracted relationship edges for graph exploration; PostgreSQL
+  remains the application database.
 - Local usage analytics (`user_events` — page views, article opens, reading
   duration) are recorded only in your database. See
   [Local analytics](#local-analytics-user_events) below.
@@ -18,7 +22,7 @@ and how to run with no outbound calls at all.
 
 | Feature | Triggering env var | What's sent | To whom |
 | --- | --- | --- | --- |
-| Embeddings, Ask AI, briefings, insights, chat completions | `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL`, or `OPENAI_API_KEY` / `OPENAI_BASE_URL` | Article titles/bodies and your prompts/questions, as needed for the feature | The configured LLM gateway (a self-hosted gateway if you point `FREE_LLM_*` at one, otherwise OpenAI) |
+| Embeddings, Ask AI, briefings, insights, chat completions | `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL`, or `OPENAI_API_KEY` / `OPENAI_BASE_URL` | Article titles/bodies, extracted entity relationship context, and your prompts/questions, as needed for the feature | The configured LLM gateway (a self-hosted gateway if you point `FREE_LLM_*` at one, otherwise OpenAI) |
 | Text-to-speech / audio generation | `OPENAI_API_KEY` (always OpenAI; not replaceable by `FREE_LLM_*`) | Text to be synthesized into audio | OpenAI |
 | AI-fallback body fetch (Crawl4AI / deterministic extraction fallback) | Feature-internal; used when normal ingestion fails to extract article body | The article URL being fetched | The configured LLM/body-fetch backend |
 | LLM call tracing | `LANGFUSE_HOST` (or `LANGFUSE_BASE_URL`), `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` | Full request/response payloads for every OpenAI-compatible call (embeddings, Ask AI, briefings, insights, TTS, body fetch), each tagged with a descriptive trace name | Your configured Langfuse instance (only when **both** keys are set; otherwise tracing is inactive and no data is sent) |

--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -55,6 +55,24 @@ def articles(status: str | None = None, limit: int = 20) -> None:
         )
 
 
+@app.command(name="graph-backfill")
+def graph_backfill(limit: int = 250, days: int = 30) -> None:
+    """Sync cached article entities from PostgreSQL into Neo4j."""
+    from news_dashboard.entities import sync_cached_entities_to_graph
+
+    synced = sync_cached_entities_to_graph(limit=limit, days=days)
+    typer.echo(f"graph entities synced: {synced}")
+
+
+@app.command(name="graph-relationship-backfill")
+def graph_relationship_backfill(limit: int = 50, days: int = 7) -> None:
+    """Extract and sync typed entity relationships into Neo4j."""
+    from news_dashboard.entities import extract_missing_entity_relationships
+
+    synced = extract_missing_entity_relationships(limit=limit, days=days)
+    typer.echo(f"graph relationships synced: {synced}")
+
+
 @app.command(name="rec-health")
 def rec_health() -> None:
     """Print a diagnostic snapshot of stale/missing recommendation scores."""

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -186,6 +186,66 @@ def _answer(
     return response.choices[0].message.content or ""
 
 
+def graph_context_for_articles(article_ids: list[int]) -> dict[str, Any] | None:
+    """Fetch optional Neo4j context for article IDs already authorized by Ask retrieval."""
+    from news_dashboard.graph_store import GraphUnavailableError, graph_store_from_env
+
+    try:
+        graph_store = graph_store_from_env()
+    except GraphUnavailableError:
+        logger.exception("Neo4j graph store is configured but unavailable")
+        return None
+    if graph_store is None:
+        return None
+    try:
+        return graph_store.ask_context(article_ids=article_ids)
+    except Exception:
+        logger.exception("Failed to load Ask AI graph context")
+        return None
+    finally:
+        close = getattr(graph_store, "close", None)
+        if callable(close):
+            close()
+
+
+def _format_graph_context(context: dict[str, Any] | None) -> str:
+    if not context:
+        return ""
+    entities = context.get("entities")
+    relationships = context.get("relationships")
+    if not isinstance(entities, list) or not isinstance(relationships, list):
+        return ""
+
+    entity_names = {
+        str(entity.get("id")): str(entity.get("name"))
+        for entity in entities
+        if isinstance(entity, dict) and entity.get("id") and entity.get("name")
+    }
+    lines: list[str] = []
+    for relationship in relationships[:8]:
+        if not isinstance(relationship, dict):
+            continue
+        source_id = str(relationship.get("source") or "")
+        target_id = str(relationship.get("target") or "")
+        if not source_id or not target_id:
+            continue
+        label = str(
+            relationship.get("label")
+            or str(relationship.get("relationship_type") or "").replace("_", " ")
+        ).strip()
+        article_ids = relationship.get("article_ids")
+        if not isinstance(article_ids, list):
+            article_ids = []
+        refs = ", ".join(str(int(article_id)) for article_id in article_ids if article_id)
+        source = str(relationship.get("source_name") or entity_names.get(source_id, source_id))
+        target = str(relationship.get("target_name") or entity_names.get(target_id, target_id))
+        suffix = f" (articles [{refs}])" if refs else ""
+        lines.append(f"- {source} {label} {target}{suffix}")
+    if not lines:
+        return ""
+    return "Knowledge graph:\n" + "\n".join(lines)
+
+
 # ── Cosine similarity ──────────────────────────────────────────────────────
 
 
@@ -415,6 +475,8 @@ def ask(
             f"[{i}] Title: {row['title']}\nURL: {row['url']}\nSummary: {row['summary']}"
         )
     context_text = "\n\n".join(context_blocks)
+    graph_context = graph_context_for_articles([int(row["id"]) for row in rows])
+    graph_context_text = _format_graph_context(graph_context)
 
     from news_dashboard.ai_client import get_prompt, observe
     from news_dashboard.ai_memory.service import format_memories_for_prompt
@@ -422,7 +484,8 @@ def ask(
     prompt = get_prompt("ask-system", fallback=ASK_SYSTEM_PROMPT)
     memory_text = format_memories_for_prompt(user_id)
     memory_block = f"{memory_text}\n\n" if memory_text else ""
-    user_prompt = f"{memory_block}Articles:\n\n{context_text}\n\nQuestion: {query}"
+    graph_block = f"\n\n{graph_context_text}" if graph_context_text else ""
+    user_prompt = f"{memory_block}Articles:\n\n{context_text}{graph_block}\n\nQuestion: {query}"
 
     # 6. Call OpenAI for the answer, grouping retrieval + generation under one
     #    Langfuse trace so its id can carry user feedback (see /api/feedback).
@@ -432,4 +495,11 @@ def ask(
 
     # 7. Return answer + source list (top-k order)
     sources = [{"id": row["id"], "title": row["title"], "url": row["url"]} for row in rows]
-    return {"answer": answer_text, "sources": sources, "trace_id": trace.trace_id}
+    result: dict[str, Any] = {
+        "answer": answer_text,
+        "sources": sources,
+        "trace_id": trace.trace_id,
+    }
+    if graph_context is not None:
+        result["graph_context"] = graph_context
+    return result

--- a/backend/news_dashboard/entities.py
+++ b/backend/news_dashboard/entities.py
@@ -16,14 +16,17 @@ import os
 from typing import Any
 
 from news_dashboard.db import connect, init_db
+from news_dashboard.graph_store import GraphUnavailableError, graph_store_from_env
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_ENTITIES_MODEL = "gpt-4o-mini"
 ENTITIES_CACHE_VERSION = 1
+RELATIONSHIPS_CACHE_VERSION = 1
 _ENTITY_TYPES = frozenset({"person", "org", "product", "place"})
 _MAX_TEXT_CHARS = 4_000
 _MAX_ENTITIES_PER_ARTICLE = 10
+_MAX_RELATIONSHIPS_PER_ARTICLE = 12
 _MAX_GRAPH_ARTICLES = 300
 _PROMPT = (
     "Extract the named entities from the news article below. "
@@ -33,6 +36,16 @@ _PROMPT = (
     "Use the most canonical short form of each name (e.g. 'OpenAI', not "
     "'OpenAI, Inc.'). Only include entities that are clearly mentioned in the "
     "article text; do not invent or infer entities from general knowledge."
+)
+_RELATIONSHIP_PROMPT = (
+    "Extract explicit relationships between the provided named entities from the news article. "
+    "Return ONLY a JSON array (no prose, no code fences) of at most "
+    f"{_MAX_RELATIONSHIPS_PER_ARTICLE} objects, each shaped "
+    '{"source_name": "...", "source_type": "person|org|product|place", '
+    '"target_name": "...", "target_type": "person|org|product|place", '
+    '"relationship_type": "short_snake_case", "label": "human readable", '
+    '"confidence": 0.0}. Only include relationships directly supported by the article text. '
+    "Do not infer relationships from general knowledge."
 )
 
 
@@ -93,6 +106,83 @@ def _parse_entities(response_text: str) -> list[dict[str, str]]:
     return entities
 
 
+def _json_text(response_text: str) -> str:
+    text = response_text.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        text = text.removeprefix("json").strip()
+    return text
+
+
+def _confidence(value: Any) -> float:
+    try:
+        confidence = float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, confidence))
+
+
+def _parse_relationships(
+    response_text: str,
+    entities: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Parse, validate, and dedupe model-extracted entity relationships."""
+    entity_lookup = {
+        (str(entity.get("name") or "").lower(), str(entity.get("type") or "").lower()): (
+            str(entity.get("name") or "").strip(),
+            str(entity.get("type") or "").strip().lower(),
+        )
+        for entity in entities
+        if str(entity.get("name") or "").strip()
+        and str(entity.get("type") or "").strip().lower() in _ENTITY_TYPES
+    }
+    try:
+        raw = json.loads(_json_text(response_text))
+    except ValueError:
+        return []
+    if not isinstance(raw, list):
+        return []
+
+    relationships: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        source_key = (
+            str(item.get("source_name") or "").strip().lower(),
+            str(item.get("source_type") or "").strip().lower(),
+        )
+        target_key = (
+            str(item.get("target_name") or "").strip().lower(),
+            str(item.get("target_type") or "").strip().lower(),
+        )
+        source = entity_lookup.get(source_key)
+        target = entity_lookup.get(target_key)
+        relationship_type = str(item.get("relationship_type") or "").strip().lower()
+        label = str(item.get("label") or relationship_type.replace("_", " ")).strip()
+        if source is None or target is None or not relationship_type:
+            continue
+        dedupe_key = (source[0].lower(), target[0].lower(), relationship_type)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        confidence = _confidence(item.get("confidence"))
+        relationships.append(
+            {
+                "source_name": source[0],
+                "source_type": source[1],
+                "target_name": target[0],
+                "target_type": target[1],
+                "relationship_type": relationship_type,
+                "label": label,
+                "confidence": confidence,
+            }
+        )
+        if len(relationships) >= _MAX_RELATIONSHIPS_PER_ARTICLE:
+            break
+    return relationships
+
+
 def extract_entities(article: dict[str, Any], user_id: int | None = None) -> list[dict[str, str]]:
     """Call the LLM and return the extracted entity list.
 
@@ -125,7 +215,44 @@ def extract_entities(article: dict[str, Any], user_id: int | None = None) -> lis
     return entities
 
 
-def _decode_cached(raw: str | None) -> list[dict[str, str]] | None:
+def extract_entity_relationships(
+    article: dict[str, Any],
+    entities: list[dict[str, str]],
+    user_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Call the LLM for explicit relationships between already-extracted entities."""
+    if len(entities) < 2:
+        return []
+    api_key, base_url, model = _entities_ai_config()
+    text = _build_text(article)
+    if not text.strip():
+        return []
+
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
+
+    client = get_chat_client(api_key=api_key, base_url=base_url)
+    prompt = get_prompt("entity-relationship-extraction", fallback=_RELATIONSHIP_PROMPT)
+    entity_text = json.dumps(entities)
+    result = chat_create(
+        client,
+        name="entity-relationship-extraction",
+        tags=["entities", "relationships"],
+        user_id=user_id,
+        prompt=prompt,
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": f"{prompt.text}\n\nEntities:\n{entity_text}\n\nArticle:\n{text}",
+            }
+        ],
+        max_tokens=768,
+    )
+    response_text = (result.choices[0].message.content or "").strip()
+    return _parse_relationships(response_text, entities)
+
+
+def _decode_cached_payload(raw: str | None) -> dict[str, Any] | None:
     if raw is None:
         return None
     try:
@@ -134,16 +261,80 @@ def _decode_cached(raw: str | None) -> list[dict[str, str]] | None:
         return None
     if not isinstance(payload, dict):
         return None
+    return payload
+
+
+def _decode_cached(raw: str | None) -> list[dict[str, str]] | None:
+    payload = _decode_cached_payload(raw)
+    if payload is None:
+        return None
     entities = payload.get("entities")
     if not isinstance(entities, list):
         return None
     return [e for e in entities if isinstance(e, dict)]
 
 
+def _decode_cached_relationships(raw: str | None) -> list[dict[str, Any]] | None:
+    payload = _decode_cached_payload(raw)
+    if payload is None or payload.get("relationships_v") != RELATIONSHIPS_CACHE_VERSION:
+        return None
+    relationships = payload.get("relationships")
+    if not isinstance(relationships, list):
+        return []
+    return [relationship for relationship in relationships if isinstance(relationship, dict)]
+
+
+def _close_graph_store(graph_store: Any) -> None:
+    close = getattr(graph_store, "close", None)
+    if callable(close):
+        close()
+
+
+def _sync_entities_to_graph(article: dict[str, Any], entities: list[dict[str, str]]) -> bool:
+    try:
+        graph_store = graph_store_from_env()
+    except GraphUnavailableError:
+        logger.exception("Neo4j graph store is configured but unavailable")
+        return False
+    if graph_store is None:
+        return False
+    try:
+        graph_store.sync_article_entities(article=article, entities=entities)
+    except Exception:
+        logger.exception("Failed to sync article %s entities to Neo4j", article.get("id"))
+        return False
+    finally:
+        _close_graph_store(graph_store)
+    return True
+
+
 def _store_entities(
-    article_id: int, entities: list[dict[str, str]], database_url: str | None
+    article: dict[str, Any],
+    entities: list[dict[str, str]],
+    database_url: str | None,
 ) -> None:
+    article_id = int(article["id"])
     payload = json.dumps({"v": ENTITIES_CACHE_VERSION, "entities": entities})
+    with connect(database_url=database_url) as conn:
+        conn.execute("UPDATE articles SET entities = %s WHERE id = %s", (payload, article_id))
+    _sync_entities_to_graph(article, entities)
+
+
+def _store_entity_relationships(
+    *,
+    article_id: int,
+    entities: list[dict[str, str]],
+    relationships: list[dict[str, Any]],
+    database_url: str | None,
+) -> None:
+    payload = json.dumps(
+        {
+            "v": ENTITIES_CACHE_VERSION,
+            "entities": entities,
+            "relationships_v": RELATIONSHIPS_CACHE_VERSION,
+            "relationships": relationships,
+        }
+    )
     with connect(database_url=database_url) as conn:
         conn.execute("UPDATE articles SET entities = %s WHERE id = %s", (payload, article_id))
 
@@ -164,7 +355,8 @@ def get_or_extract_entities(
         if user_id is not None:
             row = conn.execute(
                 """
-                SELECT a.id, a.title, a.summary, a.body, a.entities
+                SELECT a.id, a.url, a.title, a.source_slug, a.summary, a.body,
+                       a.entities, a.discovered_at
                 FROM articles a
                 JOIN sources src ON src.slug = a.source_slug
                 LEFT JOIN user_sources us_src
@@ -178,7 +370,11 @@ def get_or_extract_entities(
             ).fetchone()
         else:
             row = conn.execute(
-                "SELECT id, title, summary, body, entities FROM articles WHERE id = %s",
+                """
+                SELECT id, url, title, source_slug, summary, body, entities, discovered_at
+                FROM articles
+                WHERE id = %s
+                """,
                 (article_id,),
             ).fetchone()
 
@@ -190,7 +386,7 @@ def get_or_extract_entities(
         return cached
 
     entities = extract_entities(dict(row), user_id=user_id)
-    _store_entities(article_id, entities, database_url)
+    _store_entities(dict(row), entities, database_url)
     return entities
 
 
@@ -209,7 +405,7 @@ def extract_missing_entities(
     with connect(database_url=database_url) as conn:
         rows = conn.execute(
             """
-            SELECT id, title, summary, body
+            SELECT id, url, title, source_slug, summary, body, discovered_at
             FROM articles
             WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
               AND entities IS NULL
@@ -228,29 +424,140 @@ def extract_missing_entities(
         except Exception:
             logger.exception("Entity extraction failed for article %s", row["id"])
             continue
-        _store_entities(int(row["id"]), entities, database_url)
+        _store_entities(dict(row), entities, database_url)
         extracted += 1
     return extracted
+
+
+def sync_cached_entities_to_graph(
+    limit: int = 250,
+    days: int = 30,
+    database_url: str | None = None,
+) -> int:
+    """Backfill cached PostgreSQL entity JSON into Neo4j when graph storage is enabled."""
+    init_db(database_url=database_url)
+    try:
+        graph_store = graph_store_from_env()
+    except GraphUnavailableError:
+        logger.exception("Neo4j graph store is configured but unavailable")
+        return 0
+    if graph_store is None:
+        return 0
+
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, url, title, source_slug, entities, discovered_at
+            FROM articles
+            WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+              AND entities IS NOT NULL
+            ORDER BY discovered_at DESC
+            LIMIT %s
+            """,
+            (days, limit),
+        ).fetchall()
+
+    synced = 0
+    try:
+        for row in rows:
+            entities = _decode_cached(row["entities"])
+            if entities is None:
+                continue
+            try:
+                graph_store.sync_article_entities(article=dict(row), entities=entities)
+            except Exception:
+                logger.exception("Failed to backfill article %s entities to Neo4j", row["id"])
+                continue
+            synced += 1
+        return synced
+    finally:
+        _close_graph_store(graph_store)
+
+
+def extract_missing_entity_relationships(
+    limit: int = 50,
+    days: int = 7,
+    database_url: str | None = None,
+) -> int:
+    """Extract typed entity relationships for cached articles and sync them to Neo4j."""
+    init_db(database_url=database_url)
+    try:
+        graph_store = graph_store_from_env()
+    except GraphUnavailableError:
+        logger.exception("Neo4j graph store is configured but unavailable")
+        return 0
+    if graph_store is None:
+        return 0
+
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, title, summary, body, entities
+            FROM articles
+            WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+              AND entities IS NOT NULL
+            ORDER BY discovered_at DESC
+            LIMIT %s
+            """,
+            (days, limit),
+        ).fetchall()
+
+    synced = 0
+    try:
+        for row in rows:
+            article_id = int(row["id"])
+            entities = _decode_cached(row["entities"])
+            if entities is None or len(entities) < 2:
+                continue
+
+            cached_relationships = _decode_cached_relationships(row["entities"])
+            if cached_relationships is None:
+                try:
+                    relationships = extract_entity_relationships(dict(row), entities)
+                except EntitiesNotConfiguredError:
+                    logger.warning("Skipping entity relationship extraction; AI is not configured")
+                    return synced
+                except Exception:
+                    logger.exception(
+                        "Entity relationship extraction failed for article %s",
+                        row["id"],
+                    )
+                    continue
+                _store_entity_relationships(
+                    article_id=article_id,
+                    entities=entities,
+                    relationships=relationships,
+                    database_url=database_url,
+                )
+            else:
+                relationships = cached_relationships
+
+            if not relationships:
+                continue
+            try:
+                graph_store.sync_entity_relationships(
+                    article_id=article_id,
+                    relationships=relationships,
+                )
+            except Exception:
+                logger.exception("Failed to sync article %s relationships to Neo4j", row["id"])
+                continue
+            synced += 1
+        return synced
+    finally:
+        _close_graph_store(graph_store)
 
 
 def _entity_id(name: str, entity_type: str) -> str:
     return f"{entity_type}:{name.lower().replace(' ', '-')}"
 
 
-def knowledge_graph(
-    user_id: int | None = None,
-    days: int = 7,
-    max_nodes: int = 40,
-    database_url: str | None = None,
-) -> dict[str, Any]:
-    """Aggregate cached entities over recent visible articles into a graph.
-
-    Reads the cache only — never calls the LLM. ``pending_count`` reports how
-    many visible recent articles still lack extracted entities so the UI can
-    explain a sparse graph.
-    """
-    init_db(database_url=database_url)
-
+def _visible_graph_rows(
+    *,
+    user_id: int | None,
+    days: int,
+    database_url: str | None,
+) -> list[dict[str, Any]]:
     with connect(database_url=database_url) as conn:
         if user_id is None:
             rows = conn.execute(
@@ -263,35 +570,76 @@ def knowledge_graph(
                 """,
                 (days, _MAX_GRAPH_ARTICLES),
             ).fetchall()
-        else:
-            rows = conn.execute(
-                """
-                SELECT a.id, a.title, a.entities
-                FROM articles a
-                JOIN sources src ON src.slug = a.source_slug
-                LEFT JOIN user_sources us
-                  ON us.source_slug = src.slug AND us.user_id = %s
-                LEFT JOIN user_article_state uas
-                  ON uas.article_id = a.id AND uas.user_id = %s
-                WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
-                  AND COALESCE(uas.state, 'today') != 'archived'
-                  AND (
-                    (
-                      src.owner_user_id IS NULL
-                      AND COALESCE(us.enabled, TRUE) IS TRUE
-                    )
-                    OR (
-                      src.owner_user_id = %s
-                      AND src.enabled IS TRUE
-                    )
-                  )
-                ORDER BY a.discovered_at DESC
-                LIMIT %s
-                """,
-                (user_id, user_id, days, user_id, _MAX_GRAPH_ARTICLES),
-            ).fetchall()
+            return [dict(row) for row in rows]
 
-    pending_count = 0
+        rows = conn.execute(
+            """
+            SELECT a.id, a.title, a.entities
+            FROM articles a
+            JOIN sources src ON src.slug = a.source_slug
+            LEFT JOIN user_sources us
+              ON us.source_slug = src.slug AND us.user_id = %s
+            LEFT JOIN user_article_state uas
+              ON uas.article_id = a.id AND uas.user_id = %s
+            WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+              AND COALESCE(uas.state, 'today') != 'archived'
+              AND (
+                (
+                  src.owner_user_id IS NULL
+                  AND COALESCE(us.enabled, TRUE) IS TRUE
+                )
+                OR (
+                  src.owner_user_id = %s
+                  AND src.enabled IS TRUE
+                )
+              )
+            ORDER BY a.discovered_at DESC
+            LIMIT %s
+            """,
+            (user_id, user_id, days, user_id, _MAX_GRAPH_ARTICLES),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+
+def _pending_entity_count(rows: list[dict[str, Any]]) -> int:
+    return sum(1 for row in rows if _decode_cached(row["entities"]) is None)
+
+
+def _neo4j_knowledge_graph(
+    *,
+    rows: list[dict[str, Any]],
+    pending_count: int,
+    days: int = 7,
+    max_nodes: int = 40,
+) -> dict[str, Any] | None:
+    try:
+        graph_store = graph_store_from_env()
+    except GraphUnavailableError:
+        logger.exception("Neo4j graph store is configured but unavailable")
+        return None
+    if graph_store is None:
+        return None
+    try:
+        return graph_store.knowledge_graph(
+            articles=[{"id": int(row["id"]), "title": str(row["title"] or "")} for row in rows],
+            pending_count=pending_count,
+            days=days,
+            max_nodes=max_nodes,
+        )
+    except Exception:
+        logger.exception("Falling back to PostgreSQL entity cache for knowledge graph")
+        return None
+    finally:
+        _close_graph_store(graph_store)
+
+
+def _legacy_knowledge_graph(
+    *,
+    rows: list[dict[str, Any]],
+    pending_count: int,
+    days: int,
+    max_nodes: int,
+) -> dict[str, Any]:
     # node key -> {"id", "name", "type", "count", "article_ids"}
     node_map: dict[tuple[str, str], dict[str, Any]] = {}
     # article id -> list of node keys mentioned in it
@@ -301,7 +649,6 @@ def knowledge_graph(
     for row in rows:
         entities = _decode_cached(row["entities"])
         if entities is None:
-            pending_count += 1
             continue
         article_id = int(row["id"])
         keys: list[tuple[str, str]] = []
@@ -371,3 +718,35 @@ def knowledge_graph(
         "pending_count": pending_count,
         "days": days,
     }
+
+
+def knowledge_graph(
+    user_id: int | None = None,
+    days: int = 7,
+    max_nodes: int = 40,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate cached entities over recent visible articles into a graph.
+
+    Reads the cache only — never calls the LLM. ``pending_count`` reports how
+    many visible recent articles still lack extracted entities so the UI can
+    explain a sparse graph.
+    """
+    init_db(database_url=database_url)
+
+    rows = _visible_graph_rows(user_id=user_id, days=days, database_url=database_url)
+    pending_count = _pending_entity_count(rows)
+    neo4j_graph = _neo4j_knowledge_graph(
+        rows=rows,
+        pending_count=pending_count,
+        days=days,
+        max_nodes=max_nodes,
+    )
+    if neo4j_graph is not None:
+        return neo4j_graph
+    return _legacy_knowledge_graph(
+        rows=rows,
+        pending_count=pending_count,
+        days=days,
+        max_nodes=max_nodes,
+    )

--- a/backend/news_dashboard/graph_store.py
+++ b/backend/news_dashboard/graph_store.py
@@ -1,0 +1,373 @@
+"""Optional Neo4j boundary for knowledge-graph storage."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+logger = logging.getLogger(__name__)
+
+_ENTITY_TYPES = frozenset({"person", "org", "product", "place"})
+_DEFAULT_DATABASE = "neo4j"
+
+
+class GraphUnavailableError(Exception):
+    """Raised when Neo4j is configured incorrectly or cannot be reached."""
+
+
+class GraphResult(Protocol):
+    def single(self) -> dict[str, Any] | None: ...
+
+    def data(self) -> list[dict[str, Any]]: ...
+
+
+class GraphSession(Protocol):
+    def __enter__(self) -> GraphSession: ...
+
+    def __exit__(self, *_args: object) -> None: ...
+
+    def run(self, query: str, **params: Any) -> GraphResult: ...
+
+
+class GraphDriver(Protocol):
+    def session(self, **kwargs: Any) -> GraphSession: ...
+
+    def verify_connectivity(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class GraphConfig:
+    uri: str
+    username: str
+    password: str
+    database: str = _DEFAULT_DATABASE
+
+
+def graph_config_from_env() -> GraphConfig | None:
+    """Read optional Neo4j settings from the process environment."""
+    uri = os.getenv("NEO4J_URI", "").strip()
+    if not uri:
+        return None
+
+    username = os.getenv("NEO4J_USER", "").strip()
+    password = os.getenv("NEO4J_PASSWORD", "").strip()
+    missing = [
+        name
+        for name, value in (("NEO4J_USER", username), ("NEO4J_PASSWORD", password))
+        if not value
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        msg = f"Neo4j is configured with NEO4J_URI but missing {joined}"
+        raise GraphUnavailableError(msg)
+
+    database = os.getenv("NEO4J_DATABASE", "").strip() or _DEFAULT_DATABASE
+    return GraphConfig(uri=uri, username=username, password=password, database=database)
+
+
+def _entity_id(name: str, entity_type: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return f"{entity_type}:{slug}"
+
+
+def _confidence(value: Any) -> float:
+    try:
+        confidence = float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, confidence))
+
+
+def _normalize_entities(entities: list[dict[str, str]]) -> list[dict[str, str]]:
+    normalized: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for entity in entities:
+        name = str(entity.get("name") or "").strip()
+        entity_type = str(entity.get("type") or "").strip().lower()
+        if not name or entity_type not in _ENTITY_TYPES:
+            continue
+        key = (name.lower(), entity_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append({"id": _entity_id(name, entity_type), "name": name, "type": entity_type})
+    return normalized
+
+
+def _normalize_relationships(relationships: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for relationship in relationships:
+        source_name = str(relationship.get("source_name") or "").strip()
+        source_type = str(relationship.get("source_type") or "").strip().lower()
+        target_name = str(relationship.get("target_name") or "").strip()
+        target_type = str(relationship.get("target_type") or "").strip().lower()
+        relationship_type = str(relationship.get("relationship_type") or "").strip().lower()
+        label = str(relationship.get("label") or relationship_type.replace("_", " ")).strip()
+        if (
+            not source_name
+            or not target_name
+            or not relationship_type
+            or source_type not in _ENTITY_TYPES
+            or target_type not in _ENTITY_TYPES
+        ):
+            continue
+        source_id = _entity_id(source_name, source_type)
+        target_id = _entity_id(target_name, target_type)
+        key = (source_id, target_id, relationship_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(
+            {
+                "source_id": source_id,
+                "target_id": target_id,
+                "relationship_type": relationship_type,
+                "label": label,
+                "confidence": _confidence(relationship.get("confidence")),
+            }
+        )
+    return normalized
+
+
+class GraphStore:
+    """Small Neo4j client wrapper with a fakeable driver for unit tests."""
+
+    def __init__(self, config: GraphConfig, driver: GraphDriver | None = None) -> None:
+        self.config = config
+        self._driver = driver
+
+    @property
+    def driver(self) -> GraphDriver:
+        if self._driver is None:
+            try:
+                neo4j = importlib.import_module("neo4j")
+            except ImportError as exc:
+                msg = "Neo4j support requires the neo4j Python package"
+                raise GraphUnavailableError(msg) from exc
+            self._driver = cast(
+                "GraphDriver",
+                neo4j.GraphDatabase.driver(
+                    self.config.uri,
+                    auth=(self.config.username, self.config.password),
+                ),
+            )
+        return self._driver
+
+    def verify_connectivity(self) -> bool:
+        self.driver.verify_connectivity()
+        return True
+
+    def close(self) -> None:
+        if self._driver is not None:
+            self._driver.close()
+
+    def sync_article_entities(
+        self,
+        *,
+        article: dict[str, Any],
+        entities: list[dict[str, str]],
+    ) -> None:
+        """Upsert an Article node, Entity nodes, and MENTIONS relationships."""
+        normalized = _normalize_entities(entities)
+        article_id = int(article["id"])
+        query = """
+        MERGE (article:Article {id: $article_id})
+        SET article.title = $title,
+            article.url = $url,
+            article.source_slug = $source_slug,
+            article.discovered_at = $discovered_at
+        WITH article
+        UNWIND $entities AS entity_row
+        MERGE (entity:Entity {id: entity_row.id})
+        SET entity.name = entity_row.name,
+            entity.type = entity_row.type
+        MERGE (article)-[mention:MENTIONS]->(entity)
+        ON CREATE SET mention.created_at = datetime()
+        SET mention.updated_at = datetime()
+        """
+        with self.driver.session(database=self.config.database) as session:
+            session.run(
+                query,
+                article_id=article_id,
+                title=str(article.get("title") or ""),
+                url=str(article.get("url") or ""),
+                source_slug=str(article.get("source_slug") or ""),
+                discovered_at=str(article.get("discovered_at") or ""),
+                entities=normalized,
+            )
+
+    def sync_entity_relationships(
+        self,
+        *,
+        article_id: int,
+        relationships: list[dict[str, Any]],
+    ) -> None:
+        """Upsert typed entity relationships with article provenance."""
+        normalized = _normalize_relationships(relationships)
+        if not normalized:
+            return
+        query = """
+        UNWIND $relationships AS relationship
+        MATCH (source:Entity {id: relationship.source_id})
+        MATCH (target:Entity {id: relationship.target_id})
+        MERGE (source)-[edge:RELATED_TO {
+          article_id: $article_id,
+          relationship_type: relationship.relationship_type
+        }]->(target)
+        SET edge.article_id = $article_id,
+            edge.label = relationship.label,
+            edge.confidence = relationship.confidence,
+            edge.updated_at = datetime()
+        ON CREATE SET edge.created_at = datetime()
+        """
+        with self.driver.session(database=self.config.database) as session:
+            session.run(query, article_id=article_id, relationships=normalized)
+
+    def knowledge_graph(
+        self,
+        *,
+        articles: list[dict[str, Any]],
+        pending_count: int,
+        days: int,
+        max_nodes: int,
+    ) -> dict[str, Any]:
+        """Build the API graph response from Neo4j for already-visible articles."""
+        article_ids = [int(article["id"]) for article in articles]
+        if not article_ids:
+            return {
+                "nodes": [],
+                "edges": [],
+                "articles": [],
+                "article_count": 0,
+                "pending_count": pending_count,
+                "days": days,
+                "graph_store": "neo4j",
+            }
+
+        query = """
+        MATCH (article:Article)-[:MENTIONS]->(entity:Entity)
+        WHERE article.id IN $article_ids
+        WITH entity,
+             count(DISTINCT article) AS mentions,
+             collect(DISTINCT article.id) AS entity_articles
+        ORDER BY mentions DESC, entity.name ASC
+        LIMIT $max_nodes
+        WITH collect({
+          id: entity.id,
+          name: entity.name,
+          type: entity.type,
+          count: mentions,
+          article_ids: entity_articles
+        }) AS nodes
+        WITH nodes, [node IN nodes | node.id] AS node_ids
+        CALL {
+          WITH node_ids
+          MATCH (a:Article)-[:MENTIONS]->(source:Entity)
+          MATCH (a)-[:MENTIONS]->(target:Entity)
+          WHERE a.id IN $article_ids
+            AND source.id IN node_ids
+            AND target.id IN node_ids
+            AND source.id < target.id
+          WITH source,
+               target,
+               count(DISTINCT a) AS weight,
+               collect(DISTINCT a.id) AS edge_articles
+          RETURN collect({
+            source: source.id,
+            target: target.id,
+            weight: weight,
+            article_ids: edge_articles,
+            kind: 'cooccurrence',
+            label: 'co-mentioned'
+          }) AS cooccurrence_edges
+        }
+        CALL {
+          WITH node_ids
+          MATCH (source:Entity)-[relationship:RELATED_TO]->(target:Entity)
+          WHERE relationship.article_id IN $article_ids
+            AND source.id IN node_ids
+            AND target.id IN node_ids
+          RETURN collect({
+            source: source.id,
+            target: target.id,
+            weight: 1,
+            article_ids: [relationship.article_id],
+            kind: 'typed',
+            relationship_type: relationship.relationship_type,
+            label: relationship.label,
+            confidence: relationship.confidence
+          }) AS typed_edges
+        }
+        RETURN nodes, cooccurrence_edges + typed_edges AS edges
+        """
+        with self.driver.session(database=self.config.database) as session:
+            row = session.run(query, article_ids=article_ids, max_nodes=max_nodes).single()
+
+        nodes = list(row.get("nodes", [])) if row is not None else []
+        edges = list(row.get("edges", [])) if row is not None else []
+        titles = {int(article["id"]): str(article.get("title") or "") for article in articles}
+        return {
+            "nodes": nodes,
+            "edges": edges,
+            "articles": [
+                {"id": article_id, "title": titles[article_id]} for article_id in article_ids
+            ],
+            "article_count": len(articles),
+            "pending_count": pending_count,
+            "days": days,
+            "graph_store": "neo4j",
+        }
+
+    def ask_context(self, *, article_ids: list[int], max_items: int = 8) -> dict[str, Any] | None:
+        """Return bounded graph context for already-authorized Ask AI source articles."""
+        if not article_ids:
+            return None
+        query = """
+        MATCH (article:Article)-[:MENTIONS]->(entity:Entity)
+        WHERE article.id IN $article_ids
+        WITH collect(DISTINCT {
+          id: entity.id,
+          name: entity.name,
+          type: entity.type,
+          article_ids: [article.id]
+        })[0..$max_items] AS entities
+        OPTIONAL MATCH (source:Entity)-[edge:RELATED_TO]->(target:Entity)
+        WHERE edge.article_id IN $article_ids
+        RETURN entities,
+               collect({
+                 source: source.id,
+                 source_name: source.name,
+                 target: target.id,
+                 target_name: target.name,
+                 relationship_type: edge.relationship_type,
+                 label: edge.label,
+                 confidence: edge.confidence,
+                 article_ids: [edge.article_id]
+               })[0..$max_items] AS relationships
+        """
+        with self.driver.session(database=self.config.database) as session:
+            row = session.run(query, article_ids=article_ids, max_items=max_items).single()
+        if row is None:
+            return None
+        return {
+            "entities": list(row.get("entities", [])),
+            "relationships": [
+                relationship
+                for relationship in list(row.get("relationships", []))
+                if relationship.get("source") and relationship.get("target")
+            ],
+        }
+
+
+def graph_store_from_env() -> GraphStore | None:
+    config = graph_config_from_env()
+    if config is None:
+        return None
+    return GraphStore(config)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2060,10 +2060,13 @@ def list_scheduled_job_runs() -> dict[str, Any]:
 
 @api.get("/api/health/details", dependencies=_admin_dep)
 def health_details() -> dict[str, Any]:
+    from news_dashboard.system.service import graph_status
+
     init_db()
     return {
         "status": "ok",
         "database": describe_database(),
+        "graph": graph_status(),
         "next_ingest_at": get_next_ingest_at(),
     }
 

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -340,6 +340,19 @@ def _run_entity_extraction() -> tuple[str, str | None]:
     return "success", f"extracted {extracted} article(s)"
 
 
+def _run_entity_relationship_extraction() -> tuple[str, str | None]:
+    from news_dashboard.entities import extract_missing_entity_relationships
+
+    logger.info("Extracting entity relationships for recent articles…")
+    try:
+        extracted = extract_missing_entity_relationships()
+    except Exception as exc:
+        logger.exception("Entity relationship extraction failed")
+        return "failure", str(exc)[:500]
+    logger.info("Entity relationship extraction done: %d article(s).", extracted)
+    return "success", f"extracted relationships for {extracted} article(s)"
+
+
 def _run_reading_list_fetch() -> tuple[str, str | None] | None:
     from news_dashboard.reading_list import service
 
@@ -446,6 +459,10 @@ def _job_entity_extraction() -> None:
     _run_and_record("entity_extraction", _run_entity_extraction)
 
 
+def _job_entity_relationship_extraction() -> None:
+    _run_and_record("entity_relationship_extraction", _run_entity_relationship_extraction)
+
+
 def _job_weekly_recaps() -> None:
     _run_and_record("weekly_recaps", _run_weekly_recaps)
 
@@ -516,6 +533,14 @@ def _register_recurring_jobs(scheduler: Any) -> None:
         trigger="interval",
         minutes=int(os.getenv("ENTITY_EXTRACTION_INTERVAL_MINUTES", "30")),
         id="entity_extraction",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _job_entity_relationship_extraction,
+        trigger="interval",
+        minutes=int(os.getenv("ENTITY_RELATIONSHIP_EXTRACTION_INTERVAL_MINUTES", "60")),
+        id="entity_relationship_extraction",
         replace_existing=True,
     )
 

--- a/backend/news_dashboard/system/service.py
+++ b/backend/news_dashboard/system/service.py
@@ -34,6 +34,28 @@ def check_readiness() -> None:
         conn.execute("SELECT 1")
 
 
+def graph_status() -> dict[str, str]:
+    """Report optional Neo4j availability without making readiness depend on it."""
+    from news_dashboard.graph_store import GraphUnavailableError, graph_store_from_env
+
+    try:
+        graph_store = graph_store_from_env()
+    except GraphUnavailableError as exc:
+        return {"status": "unavailable", "detail": str(exc)}
+    if graph_store is None:
+        return {"status": "disabled"}
+    try:
+        graph_store.verify_connectivity()
+    except Exception as exc:
+        return {"status": "unavailable", "detail": str(exc)}
+    else:
+        return {"status": "ok"}
+    finally:
+        close = getattr(graph_store, "close", None)
+        if callable(close):
+            close()
+
+
 def public_config() -> dict[str, Any]:
     """Public, non-sensitive runtime config the SPA needs before login.
 

--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -42,6 +42,15 @@ def _manifest_for_kind(output: str, kind: str) -> str:
     raise AssertionError(msg)
 
 
+def _manifest_for_kind_and_name(output: str, kind: str, name: str) -> str:
+    for manifest in output.split("---"):
+        normalized = f"\n{manifest}\n"
+        if f"\nkind: {kind}\n" in normalized and f"\n  name: {name}\n" in normalized:
+            return manifest
+    msg = f"Rendered chart did not include {kind}/{name}"
+    raise AssertionError(msg)
+
+
 def _env_block(manifest: str) -> str:
     lines = manifest.splitlines()
     env_index = next(index for index, line in enumerate(lines) if line.strip() == "env:")
@@ -75,6 +84,8 @@ def _env_entry(env: str, name: str) -> str:
 def test_helm_template_default() -> None:
     output = _render_chart()
     assert "NEWS_DASHBOARD_DB" not in output
+    assert "NEO4J_URI" not in output
+    assert "news-dashboard-news-dashboard-neo4j" not in output
     # Check that it renders standard postgres config
     assert "name: POSTGRES_HOST" in output
     assert 'value: "news-dashboard-news-dashboard-postgres"' in output
@@ -84,6 +95,105 @@ def test_helm_template_default() -> None:
     assert "backoffLimit: 1" in output
     assert "successfulJobsHistoryLimit: 2" in output
     assert "failedJobsHistoryLimit: 3" in output
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_neo4j_can_use_existing_secret_and_claim() -> None:
+    output = _render_chart(
+        "neo4j.enabled=true",
+        "neo4j.auth.existingSecret=graph-secret",
+        "neo4j.auth.passwordKey=GRAPH_PASSWORD",
+        "neo4j.persistence.enabled=true",
+        "neo4j.persistence.existingClaim=graph-data",
+    )
+    deployment = _manifest_for_kind(output, "Deployment")
+    deployment_env = _env_block(deployment)
+    statefulset = _manifest_for_kind_and_name(
+        output,
+        "StatefulSet",
+        "news-dashboard-news-dashboard-neo4j",
+    )
+
+    assert 'claimName: "graph-data"' in statefulset
+    assert "stringData:\n  NEO4J_USER" not in output
+    assert 'name: "graph-secret"' in _env_entry(deployment_env, "NEO4J_PASSWORD")
+    assert 'key: "GRAPH_PASSWORD"' in _env_entry(deployment_env, "NEO4J_PASSWORD")
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_neo4j_disabled_by_default() -> None:
+    output = _render_chart()
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert "-neo4j" not in output
+    assert "NEO4J_URI" not in deployment_env
+    assert "NEO4J_USER" not in deployment_env
+    assert "NEO4J_PASSWORD" not in deployment_env
+    assert "NEO4J_DATABASE" not in deployment_env
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_neo4j_enabled_renders_graph_service_and_app_env() -> None:
+    output = _render_chart(
+        "neo4j.enabled=true",
+        "neo4j.image.repository=neo4j",
+        "neo4j.image.tag=5-community",
+        "neo4j.image.pullPolicy=Always",
+        "neo4j.auth.user=graph_user",
+        "neo4j.auth.password=dummy-neo4j-password-for-render-only",
+        "neo4j.auth.passwordKey=GRAPH_PASSWORD",
+        "neo4j.service.port=17687",
+        "neo4j.persistence.size=8Gi",
+        "neo4j.persistence.storageClassName=fast-storage",
+        "neo4j.resources.requests.cpu=100m",
+        "neo4j.resources.limits.memory=1Gi",
+    )
+
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+    service = _manifest_for_kind_and_name(
+        output,
+        "Service",
+        "news-dashboard-news-dashboard-neo4j",
+    )
+    statefulset = _manifest_for_kind_and_name(
+        output,
+        "StatefulSet",
+        "news-dashboard-news-dashboard-neo4j",
+    )
+    secret = _manifest_for_kind_and_name(
+        output,
+        "Secret",
+        "news-dashboard-news-dashboard-neo4j",
+    )
+    pvc = _manifest_for_kind_and_name(
+        output,
+        "PersistentVolumeClaim",
+        "news-dashboard-news-dashboard-neo4j",
+    )
+
+    assert "port: 17687" in service
+    assert "targetPort: bolt" in service
+    assert 'image: "neo4j:5-community"' in statefulset
+    assert "imagePullPolicy: Always" in statefulset
+    assert "name: bolt" in statefulset
+    assert "containerPort: 17687" in statefulset
+    assert "GRAPH_PASSWORD:" in secret
+    assert "NEO4J_AUTH:" in secret
+    assert "storage: 8Gi" in pvc
+    assert 'storageClassName: "fast-storage"' in pvc
+    assert "cpu: 100m" in statefulset
+    assert "memory: 1Gi" in statefulset
+
+    assert _env_entry(deployment_env, "NEO4J_URI") == (
+        '- name: NEO4J_URI\n  value: "bolt://news-dashboard-news-dashboard-neo4j:17687"'
+    )
+    assert _env_entry(deployment_env, "NEO4J_USER") == ('- name: NEO4J_USER\n  value: "graph_user"')
+    neo4j_password = _env_entry(deployment_env, "NEO4J_PASSWORD")
+    assert 'name: "news-dashboard-news-dashboard-neo4j"' in neo4j_password
+    assert 'key: "GRAPH_PASSWORD"' in neo4j_password
+    assert _env_entry(deployment_env, "NEO4J_DATABASE") == (
+        '- name: NEO4J_DATABASE\n  value: "neo4j"'
+    )
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -67,6 +67,27 @@ def test_articles_lists_rows() -> None:
     assert "[7] new Hello — Src" in result.stdout
 
 
+def test_graph_backfill_prints_synced_count() -> None:
+    with patch("news_dashboard.entities.sync_cached_entities_to_graph", return_value=12) as sync:
+        result = runner.invoke(app, ["graph-backfill", "--limit", "50", "--days", "14"])
+
+    assert result.exit_code == 0
+    sync.assert_called_once_with(limit=50, days=14)
+    assert "graph entities synced: 12" in result.stdout
+
+
+def test_graph_relationship_backfill_prints_synced_count() -> None:
+    with patch(
+        "news_dashboard.entities.extract_missing_entity_relationships",
+        return_value=4,
+    ) as sync:
+        result = runner.invoke(app, ["graph-relationship-backfill", "--limit", "25", "--days", "7"])
+
+    assert result.exit_code == 0
+    sync.assert_called_once_with(limit=25, days=7)
+    assert "graph relationships synced: 4" in result.stdout
+
+
 def test_rec_health_prints_snapshot() -> None:
     health = {
         "total_scores": 10,

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -232,3 +232,78 @@ def test_ask_endpoint_returns_503_when_embedding_unavailable(
     body = response.json()
     assert "temporarily unavailable" in body["detail"]
     assert "rate limited" not in body["detail"]
+
+
+def test_ask_includes_bounded_graph_context(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    init_db(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind)
+            VALUES ('ask-graph', 'AskGraph', 'https://example.test/feed.xml', 'tech', 'rss_feed')
+            ON CONFLICT(slug) DO NOTHING
+            """
+        )
+        for article_id in range(1, 6):
+            conn.execute(
+                """
+                INSERT INTO articles(
+                    id, url, canonical_url, title, source_slug, source_name,
+                    category, kind, status, importance_score, summary, reason,
+                    tags, embedding_vec
+                ) VALUES (%s, %s, %s, %s, 'ask-graph', 'AskGraph',
+                    'tech', 'rss_feed', 'saved', 0.5, %s, '', '', %s::vector)
+                """,
+                (
+                    article_id,
+                    f"https://example.test/{article_id}",
+                    f"https://example.test/{article_id}",
+                    f"Article {article_id}",
+                    f"Summary {article_id}",
+                    "[" + ",".join(["0.1"] * EMBEDDING_DIMENSIONS) + "]",
+                ),
+            )
+
+    captured: dict[str, str] = {}
+    graph_context = {
+        "entities": [{"id": "org:openai", "name": "OpenAI", "type": "org", "article_ids": [1]}],
+        "relationships": [
+            {
+                "source": "org:openai",
+                "source_name": "OpenAI",
+                "target": "person:sam-altman",
+                "target_name": "Sam Altman",
+                "label": "led by",
+                "relationship_type": "led_by",
+                "article_ids": [1],
+            }
+        ],
+    }
+
+    def fake_answer(
+        _system_prompt: str,
+        user_prompt: str,
+        **_kwargs: Any,
+    ) -> str:
+        captured["prompt"] = user_prompt
+        return "graph answer"
+
+    monkeypatch.setattr(embeddings_mod, "embed_all_eligible", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(embeddings_mod, "_embed", lambda _query: [0.1] * EMBEDDING_DIMENSIONS)
+    monkeypatch.setattr(embeddings_mod, "_answer", fake_answer)
+    monkeypatch.setattr(
+        embeddings_mod,
+        "graph_context_for_articles",
+        lambda article_ids: graph_context if article_ids else None,
+    )
+
+    result = embeddings_mod.ask("who leads OpenAI?", pg_clean)
+
+    assert result["answer"] == "graph answer"
+    assert result["graph_context"] == graph_context
+    assert "Knowledge graph:" in captured["prompt"]
+    assert "OpenAI led by Sam Altman" in captured["prompt"]
+    assert "articles [1]" in captured["prompt"]

--- a/backend/tests/test_entities.py
+++ b/backend/tests/test_entities.py
@@ -12,10 +12,14 @@ from news_dashboard.db import connect
 from news_dashboard.entities import (
     EntitiesNotConfiguredError,
     _parse_entities,
+    _parse_relationships,
     extract_entities,
+    extract_entity_relationships,
     extract_missing_entities,
+    extract_missing_entity_relationships,
     get_or_extract_entities,
     knowledge_graph,
+    sync_cached_entities_to_graph,
 )
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -121,6 +125,70 @@ def test_parse_entities_returns_empty_for_garbage() -> None:
     assert _parse_entities(json.dumps({"name": "x"})) == []
 
 
+def test_parse_relationships_validates_entities_and_dedupes() -> None:
+    raw = json.dumps(
+        [
+            {
+                "source_name": "OpenAI",
+                "source_type": "org",
+                "target_name": "Sam Altman",
+                "target_type": "person",
+                "relationship_type": "led_by",
+                "label": "led by",
+                "confidence": 0.9,
+            },
+            {
+                "source_name": "openai",
+                "source_type": "org",
+                "target_name": "Sam Altman",
+                "target_type": "person",
+                "relationship_type": "led_by",
+                "label": "duplicate",
+                "confidence": 0.7,
+            },
+            {
+                "source_name": "OpenAI",
+                "source_type": "org",
+                "target_name": "Unknown",
+                "target_type": "org",
+                "relationship_type": "mentions",
+            },
+        ]
+    )
+    entities = [{"name": "OpenAI", "type": "org"}, {"name": "Sam Altman", "type": "person"}]
+
+    assert _parse_relationships(raw, entities) == [
+        {
+            "source_name": "OpenAI",
+            "source_type": "org",
+            "target_name": "Sam Altman",
+            "target_type": "person",
+            "relationship_type": "led_by",
+            "label": "led by",
+            "confidence": 0.9,
+        }
+    ]
+
+
+def test_parse_relationships_clamps_malformed_confidence() -> None:
+    raw = json.dumps(
+        [
+            {
+                "source_name": "OpenAI",
+                "source_type": "org",
+                "target_name": "Sam Altman",
+                "target_type": "person",
+                "relationship_type": "led_by",
+                "label": "led by",
+                "confidence": "not-a-number",
+            }
+        ]
+    )
+    entities = [{"name": "OpenAI", "type": "org"}, {"name": "Sam Altman", "type": "person"}]
+
+    assert _parse_relationships(raw, entities)[0]["confidence"] == 0.0
+
+
 # ── extract_entities ──────────────────────────────────────────────────────────
 
 
@@ -144,6 +212,47 @@ def test_extract_entities_calls_llm_and_returns_parsed_list() -> None:
             {"id": 1, "title": "OpenAI ships", "summary": "OpenAI news", "body": "text"}
         )
     assert result == [{"name": "OpenAI", "type": "org"}]
+    client.chat.completions.create.assert_called_once()
+
+
+def test_extract_entity_relationships_calls_llm_with_bounded_entities() -> None:
+    client = _mock_llm(
+        json.dumps(
+            [
+                {
+                    "source_name": "OpenAI",
+                    "source_type": "org",
+                    "target_name": "Sam Altman",
+                    "target_type": "person",
+                    "relationship_type": "led_by",
+                    "label": "led by",
+                    "confidence": 0.8,
+                }
+            ]
+        )
+    )
+    entities = [{"name": "OpenAI", "type": "org"}, {"name": "Sam Altman", "type": "person"}]
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=client),
+    ):
+        result = extract_entity_relationships(
+            {"id": 1, "title": "OpenAI", "summary": "Sam Altman leads OpenAI.", "body": None},
+            entities,
+        )
+
+    assert result == [
+        {
+            "source_name": "OpenAI",
+            "source_type": "org",
+            "target_name": "Sam Altman",
+            "target_type": "person",
+            "relationship_type": "led_by",
+            "label": "led by",
+            "confidence": 0.8,
+        }
+    ]
     client.chat.completions.create.assert_called_once()
 
 
@@ -185,6 +294,33 @@ def test_get_or_extract_entities_extracts_and_caches_when_missing(pg_clean: str)
     stored = json.loads(row["entities"])
     assert stored["v"] == 1
     assert stored["entities"] == [{"name": "OpenAI", "type": "org"}]
+
+
+def test_get_or_extract_entities_syncs_fresh_entities_to_graph_store(pg_clean: str) -> None:
+    article_id = _seed_article(pg_clean, url_slug="graph-fresh", title="OpenAI ships a model")
+    synced: list[tuple[dict[str, Any], list[dict[str, str]]]] = []
+
+    class FakeGraphStore:
+        def sync_article_entities(
+            self, *, article: dict[str, Any], entities: list[dict[str, str]]
+        ) -> None:
+            synced.append((article, entities))
+
+    client = _mock_llm('[{"name": "OpenAI", "type": "org"}]')
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=client),
+        patch("news_dashboard.entities.graph_store_from_env", return_value=FakeGraphStore()),
+    ):
+        result = get_or_extract_entities(article_id, database_url=pg_clean)
+
+    assert result == [{"name": "OpenAI", "type": "org"}]
+    assert len(synced) == 1
+    article, entities = synced[0]
+    assert article["id"] == article_id
+    assert article["title"] == "OpenAI ships a model"
+    assert article["url"] == "https://ent-src.example/graph-fresh"
+    assert entities == [{"name": "OpenAI", "type": "org"}]
 
 
 def test_get_or_extract_entities_invisible_article_returns_empty(pg_clean: str) -> None:
@@ -232,6 +368,176 @@ def test_extract_missing_entities_respects_limit_and_survives_failures(pg_clean:
             "SELECT COUNT(*) AS n FROM articles WHERE entities IS NOT NULL"
         ).fetchone()
     assert row["n"] == 2
+
+
+def test_sync_cached_entities_to_graph_backfills_valid_cached_rows(pg_clean: str) -> None:
+    cached_id = _seed_article(
+        pg_clean,
+        url_slug="graph-cached",
+        title="Cached",
+        entities=_entities_json(("OpenAI", "org")),
+    )
+    _seed_article(pg_clean, url_slug="graph-pending", title="Pending")
+    _seed_article(pg_clean, url_slug="graph-invalid", title="Invalid", entities="not json")
+    synced: list[tuple[int, list[dict[str, str]]]] = []
+
+    class FakeGraphStore:
+        def sync_article_entities(
+            self, *, article: dict[str, Any], entities: list[dict[str, str]]
+        ) -> None:
+            synced.append((int(article["id"]), entities))
+
+    with patch("news_dashboard.entities.graph_store_from_env", return_value=FakeGraphStore()):
+        count = sync_cached_entities_to_graph(limit=10, database_url=pg_clean)
+
+    assert count == 1
+    assert synced == [(cached_id, [{"name": "OpenAI", "type": "org"}])]
+
+
+def test_sync_cached_entities_to_graph_skips_when_graph_disabled(pg_clean: str) -> None:
+    _seed_article(
+        pg_clean,
+        url_slug="graph-disabled",
+        title="Cached",
+        entities=_entities_json(("OpenAI", "org")),
+    )
+
+    with patch("news_dashboard.entities.graph_store_from_env", return_value=None):
+        assert sync_cached_entities_to_graph(limit=10, database_url=pg_clean) == 0
+
+
+def test_extract_missing_entity_relationships_writes_to_graph(pg_clean: str) -> None:
+    article_id = _seed_article(
+        pg_clean,
+        url_slug="graph-rels",
+        title="Relationships",
+        entities=_entities_json(("OpenAI", "org"), ("Sam Altman", "person")),
+    )
+    synced: list[tuple[int, list[dict[str, Any]]]] = []
+
+    class FakeGraphStore:
+        def sync_entity_relationships(
+            self, *, article_id: int, relationships: list[dict[str, Any]]
+        ) -> None:
+            synced.append((article_id, relationships))
+
+    relationships = [
+        {
+            "source_name": "OpenAI",
+            "source_type": "org",
+            "target_name": "Sam Altman",
+            "target_type": "person",
+            "relationship_type": "led_by",
+            "label": "led by",
+            "confidence": 0.8,
+        }
+    ]
+    with (
+        patch("news_dashboard.entities.graph_store_from_env", return_value=FakeGraphStore()),
+        patch("news_dashboard.entities.extract_entity_relationships", return_value=relationships),
+    ):
+        count = extract_missing_entity_relationships(limit=10, database_url=pg_clean)
+
+    assert count == 1
+    assert synced == [(article_id, relationships)]
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT entities FROM articles WHERE id = %s", (article_id,)).fetchone()
+    payload = json.loads(row["entities"])
+    assert payload["relationships_v"] == 1
+    assert payload["relationships"] == relationships
+
+
+def test_extract_missing_entity_relationships_reuses_cached_relationships(
+    pg_clean: str,
+) -> None:
+    cached_relationships = [
+        {
+            "source_name": "OpenAI",
+            "source_type": "org",
+            "target_name": "Sam Altman",
+            "target_type": "person",
+            "relationship_type": "led_by",
+            "label": "led by",
+            "confidence": 0.8,
+        }
+    ]
+    article_id = _seed_article(
+        pg_clean,
+        url_slug="graph-rels-cached",
+        title="Relationships",
+        entities=json.dumps(
+            {
+                "v": 1,
+                "entities": [
+                    {"name": "OpenAI", "type": "org"},
+                    {"name": "Sam Altman", "type": "person"},
+                ],
+                "relationships_v": 1,
+                "relationships": cached_relationships,
+            }
+        ),
+    )
+    synced: list[tuple[int, list[dict[str, Any]]]] = []
+
+    class FakeGraphStore:
+        def sync_entity_relationships(
+            self, *, article_id: int, relationships: list[dict[str, Any]]
+        ) -> None:
+            synced.append((article_id, relationships))
+
+    with (
+        patch("news_dashboard.entities.graph_store_from_env", return_value=FakeGraphStore()),
+        patch("news_dashboard.entities.extract_entity_relationships") as extracted,
+    ):
+        count = extract_missing_entity_relationships(limit=10, database_url=pg_clean)
+
+    assert count == 1
+    assert synced == [(article_id, cached_relationships)]
+    extracted.assert_not_called()
+
+
+def test_extract_missing_entity_relationships_marks_empty_results(pg_clean: str) -> None:
+    article_id = _seed_article(
+        pg_clean,
+        url_slug="graph-rels-empty",
+        title="Relationships",
+        entities=_entities_json(("OpenAI", "org"), ("Sam Altman", "person")),
+    )
+
+    class FakeGraphStore:
+        def sync_entity_relationships(
+            self, *, article_id: int, relationships: list[dict[str, Any]]
+        ) -> None:
+            assert article_id
+            assert relationships == []
+            msg = "empty relationship results should not sync"
+            raise AssertionError(msg)
+
+    with (
+        patch("news_dashboard.entities.graph_store_from_env", return_value=FakeGraphStore()),
+        patch("news_dashboard.entities.extract_entity_relationships", return_value=[]) as extracted,
+    ):
+        count = extract_missing_entity_relationships(limit=10, database_url=pg_clean)
+
+    assert count == 0
+    extracted.assert_called_once()
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT entities FROM articles WHERE id = %s", (article_id,)).fetchone()
+    payload = json.loads(row["entities"])
+    assert payload["relationships_v"] == 1
+    assert payload["relationships"] == []
+
+
+def test_extract_missing_entity_relationships_skips_when_graph_disabled(pg_clean: str) -> None:
+    _seed_article(
+        pg_clean,
+        url_slug="graph-rels-disabled",
+        title="Relationships",
+        entities=_entities_json(("OpenAI", "org"), ("Sam Altman", "person")),
+    )
+
+    with patch("news_dashboard.entities.graph_store_from_env", return_value=None):
+        assert extract_missing_entity_relationships(limit=10, database_url=pg_clean) == 0
 
 
 # ── knowledge_graph ───────────────────────────────────────────────────────────
@@ -317,3 +623,68 @@ def test_knowledge_graph_scopes_to_user_visible_articles(pg_clean: str) -> None:
     names = {n["name"] for n in result["nodes"]}
     assert "OpenAI" in names
     assert "Secret Corp" not in names
+
+
+def test_knowledge_graph_uses_graph_store_for_visible_article_ids(pg_clean: str) -> None:
+    user_id = _seed_user(pg_clean, "kg-neo4j")
+    other_id = _seed_user(pg_clean, "kg-neo4j-other")
+    _seed_source(pg_clean, "kg-neo4j-global")
+    _seed_source(pg_clean, "kg-neo4j-private", owner_user_id=other_id)
+    visible_id = _seed_article(
+        pg_clean,
+        slug="kg-neo4j-global",
+        url_slug="visible",
+        title="Visible",
+        entities=_entities_json(("OpenAI", "org")),
+    )
+    pending_id = _seed_article(
+        pg_clean,
+        slug="kg-neo4j-global",
+        url_slug="pending",
+        title="Pending",
+    )
+    _seed_article(
+        pg_clean,
+        slug="kg-neo4j-private",
+        url_slug="hidden",
+        title="Hidden",
+        entities=_entities_json(("Secret Corp", "org")),
+    )
+    calls: list[dict[str, Any]] = []
+
+    class FakeGraphStore:
+        def knowledge_graph(
+            self,
+            *,
+            articles: list[dict[str, Any]],
+            pending_count: int,
+            days: int,
+            max_nodes: int,
+        ) -> dict[str, Any]:
+            calls.append(
+                {
+                    "articles": articles,
+                    "pending_count": pending_count,
+                    "days": days,
+                    "max_nodes": max_nodes,
+                }
+            )
+            return {
+                "nodes": [{"id": "org:openai", "name": "OpenAI", "type": "org", "count": 1}],
+                "edges": [],
+                "articles": [{"id": visible_id, "title": "Visible"}],
+                "article_count": len(articles),
+                "pending_count": pending_count,
+                "days": days,
+                "graph_store": "neo4j",
+            }
+
+    with patch("news_dashboard.entities.graph_store_from_env", return_value=FakeGraphStore()):
+        result = knowledge_graph(user_id=user_id, days=14, max_nodes=5, database_url=pg_clean)
+
+    assert result["graph_store"] == "neo4j"
+    assert result["article_count"] == 2
+    assert calls[0]["pending_count"] == 1
+    assert calls[0]["days"] == 14
+    assert calls[0]["max_nodes"] == 5
+    assert {article["id"] for article in calls[0]["articles"]} == {visible_id, pending_id}

--- a/backend/tests/test_graph_store.py
+++ b/backend/tests/test_graph_store.py
@@ -1,0 +1,374 @@
+"""Tests for the optional Neo4j graph storage boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from news_dashboard.graph_store import (
+    GraphConfig,
+    GraphStore,
+    GraphUnavailableError,
+    graph_config_from_env,
+)
+
+_TEST_GRAPH_CREDENTIAL = "credential-for-tests"
+
+
+class FakeResult:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self._rows = rows or []
+
+    def single(self) -> dict[str, Any] | None:
+        return self._rows[0] if self._rows else None
+
+    def data(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class FakeSession:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows = rows or []
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __enter__(self) -> FakeSession:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def run(self, query: str, **params: Any) -> FakeResult:
+        self.calls.append((query, params))
+        return FakeResult(self.rows)
+
+
+class FakeDriver:
+    def __init__(self, session: FakeSession) -> None:
+        self.session_obj = session
+        self.verified = False
+        self.closed = False
+
+    def session(self, **_kwargs: Any) -> FakeSession:
+        return self.session_obj
+
+    def verify_connectivity(self) -> None:
+        self.verified = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_graph_config_from_env_is_disabled_without_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEO4J_URI", raising=False)
+    monkeypatch.delenv("NEO4J_USER", raising=False)
+    monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
+
+    assert graph_config_from_env() is None
+
+
+def test_graph_config_from_env_reads_connection_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEO4J_URI", "bolt://neo4j:7687")
+    monkeypatch.setenv("NEO4J_USER", "neo4j")
+    monkeypatch.setenv("NEO4J_PASSWORD", _TEST_GRAPH_CREDENTIAL)
+    monkeypatch.setenv("NEO4J_DATABASE", "news")
+
+    assert graph_config_from_env() == GraphConfig(
+        uri="bolt://neo4j:7687",
+        username="neo4j",
+        password=_TEST_GRAPH_CREDENTIAL,
+        database="news",
+    )
+
+
+def test_graph_config_from_env_rejects_partial_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEO4J_URI", "bolt://neo4j:7687")
+    monkeypatch.setenv("NEO4J_USER", "neo4j")
+    monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
+
+    with pytest.raises(GraphUnavailableError, match="NEO4J_PASSWORD"):
+        graph_config_from_env()
+
+
+def test_graph_store_verifies_connectivity_and_closes_driver() -> None:
+    session = FakeSession()
+    driver = FakeDriver(session)
+    store = GraphStore(
+        GraphConfig(
+            uri="bolt://neo4j:7687",
+            username="neo4j",
+            password=_TEST_GRAPH_CREDENTIAL,
+        ),
+        driver=driver,
+    )
+
+    assert store.verify_connectivity() is True
+    store.close()
+
+    assert driver.verified is True
+    assert driver.closed is True
+
+
+def test_graph_store_syncs_article_entities_idempotently() -> None:
+    session = FakeSession()
+    driver = FakeDriver(session)
+    store = GraphStore(
+        GraphConfig(
+            uri="bolt://neo4j:7687",
+            username="neo4j",
+            password=_TEST_GRAPH_CREDENTIAL,
+        ),
+        driver=driver,
+    )
+
+    store.sync_article_entities(
+        article={
+            "id": 42,
+            "title": "OpenAI ships",
+            "url": "https://example.test/openai",
+            "source_slug": "tech",
+            "discovered_at": "2026-07-09T00:00:00Z",
+        },
+        entities=[
+            {"name": "OpenAI", "type": "org"},
+            {"name": "OpenAI", "type": "org"},
+            {"name": "Sam Altman", "type": "person"},
+        ],
+    )
+
+    assert len(session.calls) == 1
+    query, params = session.calls[0]
+    assert "MERGE (article:Article {id: $article_id})" in query
+    assert "MERGE (entity:Entity {id: entity_row.id})" in query
+    assert "MERGE (article)-[mention:MENTIONS]->(entity)" in query
+    assert params["article_id"] == 42
+    assert params["title"] == "OpenAI ships"
+    assert params["entities"] == [
+        {"id": "org:openai", "name": "OpenAI", "type": "org"},
+        {"id": "person:sam-altman", "name": "Sam Altman", "type": "person"},
+    ]
+
+
+def test_graph_store_syncs_typed_relationships_with_article_provenance() -> None:
+    session = FakeSession()
+    driver = FakeDriver(session)
+    store = GraphStore(
+        GraphConfig(
+            uri="bolt://neo4j:7687",
+            username="neo4j",
+            password=_TEST_GRAPH_CREDENTIAL,
+        ),
+        driver=driver,
+    )
+
+    store.sync_entity_relationships(
+        article_id=42,
+        relationships=[
+            {
+                "source_name": "OpenAI",
+                "source_type": "org",
+                "target_name": "Sam Altman",
+                "target_type": "person",
+                "relationship_type": "led_by",
+                "label": "led by",
+                "confidence": 0.8,
+            }
+        ],
+    )
+
+    assert len(session.calls) == 1
+    query, params = session.calls[0]
+    assert "MATCH (source:Entity {id: relationship.source_id})" in query
+    assert "MERGE (source)-[edge:RELATED_TO" in query
+    assert "edge.article_id = $article_id" in query
+    assert params["article_id"] == 42
+    assert params["relationships"] == [
+        {
+            "source_id": "org:openai",
+            "target_id": "person:sam-altman",
+            "relationship_type": "led_by",
+            "label": "led by",
+            "confidence": 0.8,
+        }
+    ]
+
+
+def test_graph_store_coerces_malformed_relationship_confidence() -> None:
+    session = FakeSession()
+    store = GraphStore(
+        GraphConfig(
+            uri="bolt://neo4j:7687",
+            username="neo4j",
+            password=_TEST_GRAPH_CREDENTIAL,
+        ),
+        driver=FakeDriver(session),
+    )
+
+    store.sync_entity_relationships(
+        article_id=42,
+        relationships=[
+            {
+                "source_name": "OpenAI",
+                "source_type": "org",
+                "target_name": "Sam Altman",
+                "target_type": "person",
+                "relationship_type": "led_by",
+                "confidence": "not-a-number",
+            }
+        ],
+    )
+
+    assert session.calls[0][1]["relationships"][0]["confidence"] == 0.0
+
+
+def test_graph_store_builds_response_from_visible_articles() -> None:
+    session = FakeSession(
+        [
+            {
+                "nodes": [
+                    {
+                        "id": "org:openai",
+                        "name": "OpenAI",
+                        "type": "org",
+                        "count": 2,
+                        "article_ids": [1, 2],
+                    }
+                ],
+                "edges": [
+                    {
+                        "source": "org:openai",
+                        "target": "person:sam-altman",
+                        "weight": 1,
+                        "article_ids": [1],
+                        "kind": "cooccurrence",
+                        "label": "co-mentioned",
+                    },
+                    {
+                        "source": "org:openai",
+                        "target": "person:sam-altman",
+                        "weight": 1,
+                        "article_ids": [1],
+                        "kind": "typed",
+                        "relationship_type": "led_by",
+                        "label": "led by",
+                        "confidence": 0.8,
+                    },
+                ],
+            }
+        ]
+    )
+    store = GraphStore(
+        GraphConfig(
+            uri="bolt://neo4j:7687",
+            username="neo4j",
+            password=_TEST_GRAPH_CREDENTIAL,
+        ),
+        driver=FakeDriver(session),
+    )
+
+    result = store.knowledge_graph(
+        articles=[{"id": 1, "title": "One"}, {"id": 2, "title": "Two"}],
+        pending_count=3,
+        days=7,
+        max_nodes=40,
+    )
+
+    assert result == {
+        "nodes": [
+            {
+                "id": "org:openai",
+                "name": "OpenAI",
+                "type": "org",
+                "count": 2,
+                "article_ids": [1, 2],
+            }
+        ],
+        "edges": [
+            {
+                "source": "org:openai",
+                "target": "person:sam-altman",
+                "weight": 1,
+                "article_ids": [1],
+                "kind": "cooccurrence",
+                "label": "co-mentioned",
+            },
+            {
+                "source": "org:openai",
+                "target": "person:sam-altman",
+                "weight": 1,
+                "article_ids": [1],
+                "kind": "typed",
+                "relationship_type": "led_by",
+                "label": "led by",
+                "confidence": 0.8,
+            },
+        ],
+        "articles": [{"id": 1, "title": "One"}, {"id": 2, "title": "Two"}],
+        "article_count": 2,
+        "pending_count": 3,
+        "days": 7,
+        "graph_store": "neo4j",
+    }
+
+    query, params = session.calls[0]
+    assert "MATCH (article:Article)-[:MENTIONS]->(entity:Entity)" in query
+    assert "MATCH (source:Entity)-[relationship:RELATED_TO]->(target:Entity)" in query
+    assert params["article_ids"] == [1, 2]
+    assert params["max_nodes"] == 40
+
+
+def test_graph_store_ask_context_includes_relationship_display_names() -> None:
+    session = FakeSession(
+        [
+            {
+                "entities": [
+                    {"id": "org:openai", "name": "OpenAI", "type": "org", "article_ids": [1]}
+                ],
+                "relationships": [
+                    {
+                        "source": "org:openai",
+                        "source_name": "OpenAI",
+                        "target": "person:sam-altman",
+                        "target_name": "Sam Altman",
+                        "relationship_type": "led_by",
+                        "label": "led by",
+                        "article_ids": [1],
+                    }
+                ],
+            }
+        ]
+    )
+    store = GraphStore(
+        GraphConfig(
+            uri="bolt://neo4j:7687",
+            username="neo4j",
+            password=_TEST_GRAPH_CREDENTIAL,
+        ),
+        driver=FakeDriver(session),
+    )
+
+    context = store.ask_context(article_ids=[1], max_items=5)
+
+    assert context == {
+        "entities": [{"id": "org:openai", "name": "OpenAI", "type": "org", "article_ids": [1]}],
+        "relationships": [
+            {
+                "source": "org:openai",
+                "source_name": "OpenAI",
+                "target": "person:sam-altman",
+                "target_name": "Sam Altman",
+                "relationship_type": "led_by",
+                "label": "led by",
+                "article_ids": [1],
+            }
+        ],
+    }
+    query, params = session.calls[0]
+    assert "source_name: source.name" in query
+    assert "target_name: target.name" in query
+    assert params["article_ids"] == [1]
+    assert params["max_items"] == 5

--- a/backend/tests/test_health_endpoints.py
+++ b/backend/tests/test_health_endpoints.py
@@ -56,3 +56,27 @@ def test_ready_returns_503_when_db_unavailable() -> None:
     with patch("news_dashboard.system.service.connect", broken_connect):
         resp = _client().get("/api/ready")
     assert resp.status_code == 503
+
+
+def test_health_details_reports_graph_status() -> None:
+    from news_dashboard.auth import require_admin, require_auth
+
+    client = _client()
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 1,
+        "username": "admin",
+        "is_admin": True,
+    }
+    app.dependency_overrides[require_admin] = lambda: None
+    with (
+        patch("news_dashboard.main.init_db"),
+        patch("news_dashboard.main.describe_database", return_value="postgresql://db"),
+        patch("news_dashboard.main.get_next_ingest_at", return_value=None),
+        patch("news_dashboard.system.service.graph_status", return_value={"status": "disabled"}),
+    ):
+        resp = client.get("/api/health/details")
+    app.dependency_overrides.pop(require_admin, None)
+    app.dependency_overrides.pop(require_auth, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["graph"] == {"status": "disabled"}

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1094,6 +1094,16 @@ def test_start_scheduler_registers_entity_extraction_job(
     assert jobs["entity_extraction"]["minutes"] == 30
 
 
+def test_start_scheduler_registers_entity_relationship_extraction_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_sched = _start_with_env(monkeypatch)
+    jobs = {c.kwargs.get("id"): c.kwargs for c in mock_sched.add_job.call_args_list}
+    assert "entity_relationship_extraction" in jobs
+    assert jobs["entity_relationship_extraction"]["trigger"] == "interval"
+    assert jobs["entity_relationship_extraction"]["minutes"] == 60
+
+
 def test_start_scheduler_entity_extraction_interval_env_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1138,6 +1148,19 @@ def test_run_entity_extraction_reports_failure() -> None:
 
     assert status == "failure"
     assert "boom" in (message or "")
+
+
+def test_run_entity_relationship_extraction_reports_count() -> None:
+    from news_dashboard.scheduler import _run_entity_relationship_extraction
+
+    with patch(
+        "news_dashboard.entities.extract_missing_entity_relationships", return_value=2
+    ) as mock_extract:
+        status, message = _run_entity_relationship_extraction()
+
+    mock_extract.assert_called_once()
+    assert status == "success"
+    assert "2" in (message or "")
 
 
 def test_start_scheduler_registers_reading_list_fetch_job(

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,5 +11,6 @@ contributing, and end-user guides are published at
 | Doc | Description |
 |-----|--------------|
 | [SELF_HOSTING.md](SELF_HOSTING.md) | Running your own instance of News Dashboard. |
+| [knowledge-graph.md](knowledge-graph.md) | Neo4j knowledge graph architecture, data flow, backfill commands, and degraded behavior. |
 | [adr/](adr/README.md) | Architecture Decision Records — context and rationale behind significant technical decisions. |
 | [user-guide/](user-guide/README.md) | Markdown mirror of the end-user guide; the published version lives at [docs.lihor.ro/docs/user-guide](https://docs.lihor.ro/docs/user-guide). |

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -18,6 +18,7 @@ This guide explains how to deploy News Dashboard for production use using the pu
 - [Upgrading](#upgrading)
 - [Rolling Back](#rolling-back)
 - [Background Jobs](#background-jobs)
+- [Optional Graph Storage](#optional-graph-storage)
 - [Sizing](#sizing)
 - [Backups](#backups)
 - [Next Steps](#next-steps)
@@ -414,6 +415,10 @@ the app's own defaults. Sentry DSNs and other secret-bearing values are
 supplied via `app.sentry.existingSecret` (a pre-existing Secret), never
 committed to `values.yaml`.
 
+Neo4j is available as an optional Helm-managed graph store. See
+[Optional Graph Storage](#optional-graph-storage) for the values and backfill
+commands.
+
 ### Migration / Schema Updates
 
 The app calls `init_db()` on every startup, which creates missing tables and
@@ -483,6 +488,60 @@ If you see duplicate ingest runs, ensure only one scheduler is active.
 - **Disable the in-process scheduler**: set `INGEST_INTERVAL_SCHEDULER_ENABLED=false`
 - **Manual ingest**: call `POST /api/ingest` or run `news-dashboard ingest` from the CLI
 - **Scheduler admin**: authenticated admin users can pause, resume, and change the ingest interval via the `/api/scheduler/*` endpoints
+
+## Optional Graph Storage
+
+Neo4j support is off by default. In Helm installs, set `neo4j.enabled=true` to
+render a Neo4j StatefulSet, ClusterIP Service, credentials Secret, and
+persistent storage. The app still requires PostgreSQL for primary data storage.
+
+The most common values are:
+
+```yaml
+neo4j:
+  enabled: true
+  auth:
+    user: neo4j
+    password: "replace-with-a-long-random-password"
+  persistence:
+    size: 10Gi
+    storageClassName: fast-storage
+```
+
+Use `neo4j.auth.existingSecret` and `neo4j.auth.passwordKey` when credentials
+are managed outside Helm. The Secret must also include `NEO4J_AUTH` in
+`<user>/<password>` form so the Neo4j container can initialize authentication.
+
+For a chart-managed Neo4j Secret, pass a password at install or upgrade time:
+
+```bash
+helm upgrade news-dashboard ./helm/news-dashboard \
+  --reuse-values \
+  --set neo4j.enabled=true \
+  --set neo4j.auth.user=neo4j \
+  --set-string neo4j.auth.password='replace-with-a-long-random-password'
+```
+
+For a pre-existing Secret, create the password key used by the app and
+`NEO4J_AUTH` used by the Neo4j container:
+
+```bash
+kubectl -n news-dashboard create secret generic news-dashboard-neo4j-auth \
+  --from-literal=NEO4J_PASSWORD='replace-with-a-long-random-password' \
+  --from-literal=NEO4J_AUTH='neo4j/replace-with-a-long-random-password'
+
+helm upgrade news-dashboard ./helm/news-dashboard \
+  --reuse-values \
+  --set neo4j.enabled=true \
+  --set neo4j.auth.existingSecret=news-dashboard-neo4j-auth \
+  --set neo4j.auth.user=neo4j \
+  --set neo4j.auth.passwordKey=NEO4J_PASSWORD
+```
+
+Persistent storage is enabled by default when Neo4j is enabled. Tune it with
+`neo4j.persistence.size`, `neo4j.persistence.storageClassName`,
+`neo4j.persistence.existingClaim`, or `neo4j.persistence.hostPath`; set
+`neo4j.persistence.enabled=false` only for disposable test installs.
 
 ## Sizing
 

--- a/docs/knowledge-graph.md
+++ b/docs/knowledge-graph.md
@@ -1,0 +1,53 @@
+# Knowledge Graph Architecture
+
+News Dashboard keeps PostgreSQL as the application database. Articles, users,
+sources, workflow state, embeddings, briefings, auth, analytics, and scheduler
+history remain in PostgreSQL.
+
+Neo4j is optional graph storage for article/entity data:
+
+- `Article` nodes mirror article IDs and titles needed for graph provenance.
+- `Entity` nodes use stable IDs from canonical name and type, such as
+  `org:openai`.
+- `(:Article)-[:MENTIONS]->(:Entity)` records entity mentions.
+- `(:Entity)-[:RELATED_TO]->(:Entity)` records extracted typed relationships
+  with `relationship_type`, `label`, `confidence`, and `article_id`.
+
+When Neo4j is disabled or unavailable, the app falls back to the PostgreSQL
+`articles.entities` cache for the existing knowledge graph endpoint. Ask AI
+continues to work from article retrieval and simply omits graph context.
+
+## Data Flow
+
+1. Entity extraction stores validated JSON in `articles.entities`.
+2. If `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` are configured, the same
+   entities are written through to Neo4j.
+3. `news-dashboard graph-backfill` syncs existing cached entities into Neo4j.
+4. `news-dashboard graph-relationship-backfill` extracts typed relationships
+   from cached-entity articles and writes them to Neo4j.
+5. `/api/ai-stats/knowledge-graph` scopes visible articles in PostgreSQL first,
+   then asks Neo4j for graph edges only for those article IDs.
+6. Ask AI retrieves articles with pgvector as before, then adds bounded Neo4j
+   relationship context for those already-selected source articles.
+
+## Operations
+
+Run entity backfill after enabling Neo4j:
+
+```bash
+news-dashboard graph-backfill --limit 250 --days 30
+```
+
+Run relationship extraction after entities are synced:
+
+```bash
+news-dashboard graph-relationship-backfill --limit 50 --days 7
+```
+
+The scheduler also runs entity extraction and typed relationship extraction on
+intervals. Tune them with `ENTITY_EXTRACTION_INTERVAL_MINUTES` and
+`ENTITY_RELATIONSHIP_EXTRACTION_INTERVAL_MINUTES`.
+
+Back up Neo4j with the same storage discipline as PostgreSQL: snapshot the
+Neo4j PVC or host path while the pod is quiesced, or use Neo4j-admin tooling in
+your cluster runbook.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -13,6 +13,7 @@ core concepts and features so you can get the most out of your reading workflow.
 | [Search](search.md)                                               | Finding articles across your history                            |
 | [Briefings](briefings.md)                                         | The Current-Day Report, scheduled delivery, and podcast audio   |
 | [Recommendations](recommendations.md)                             | How the app learns what matters to you                          |
+| [Knowledge Graph](knowledge-graph.md)                              | Exploring entities, typed relationships, and Ask AI graph context |
 | [Saved & read history](saved-history.md)                          | Your personal reading archive and Reading DNA                   |
 | [Sharing articles](sharing.md)                                    | Sending articles to other users on the same instance            |
 

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -62,6 +62,15 @@ enable, or disable them.
 
 *Don't call it*: Feed filter, source state, channel.
 
+## Knowledge Graph
+
+An **entity relationship map** built from your visible articles. Entities are
+people, organizations, products, and places extracted from article text.
+Co-occurrence edges mean two entities appeared in the same article; typed
+relationship edges are explicit article-supported relationships.
+
+*Don't call it*: Global facts database, ontology, web search graph.
+
 ## Where these terms come from
 
 This terminology is defined in [`CONTEXT.md`](../../CONTEXT.md) and is the

--- a/docs/user-guide/knowledge-graph.md
+++ b/docs/user-guide/knowledge-graph.md
@@ -1,0 +1,19 @@
+# Knowledge Graph
+
+The Knowledge Graph in AI Stats shows named entities found in recent articles
+and how they connect.
+
+- Circles are entities such as people, organizations, products, and places.
+- Solid edges mean the entities appeared in the same article.
+- Dashed edges are typed relationships extracted from article text, such as
+  "led by" or "acquired".
+- Selecting an entity shows supporting articles and relationship provenance.
+
+Use the relationship filter to focus on all connections, co-occurrence only, or
+typed relationships. If Neo4j is not enabled on your instance, the graph still
+uses cached entity data where possible, but typed relationship exploration and
+Ask AI graph context may be unavailable.
+
+Ask AI can use graph context when it answers over retrieved articles. The answer
+still cites articles; graph context is shown separately so you can see which
+entity relationships influenced the response.

--- a/frontend/src/__tests__/ask.test.tsx
+++ b/frontend/src/__tests__/ask.test.tsx
@@ -113,6 +113,38 @@ describe('AskPage — citation click opens reader', () => {
       timeout: 2000,
     });
   });
+
+  it('shows graph context provenance when Ask AI used relationships', async () => {
+    vi.spyOn(api, 'askAI').mockResolvedValueOnce({
+      answer: 'Graph-aware answer [1].',
+      sources: [{ id: 42, title: 'Test Article', url: 'https://example.com/test' }],
+      trace_id: null,
+      graph_context: {
+        entities: [],
+        relationships: [
+          {
+            source: 'org:openai',
+            source_name: 'OpenAI',
+            target: 'person:sam-altman',
+            target_name: 'Sam Altman',
+            relationship_type: 'led_by',
+            label: 'led by',
+            article_ids: [42],
+          },
+        ],
+      },
+    });
+
+    renderAskPage();
+    const ta = screen.getByPlaceholderText(/Postgres/i);
+    await userEvent.type(ta, 'test question');
+    fireEvent.submit(ta.closest('form')!);
+
+    await waitFor(() => expect(screen.getByText('Knowledge graph context')).toBeTruthy(), {
+      timeout: 2000,
+    });
+    expect(screen.getByText(/OpenAI led by Sam Altman/i)).toBeTruthy();
+  });
 });
 
 // ─── Error states ─────────────────────────────────────────────────────────────

--- a/frontend/src/__tests__/knowledgeGraph.test.tsx
+++ b/frontend/src/__tests__/knowledgeGraph.test.tsx
@@ -30,7 +30,25 @@ const GRAPH: KnowledgeGraphResponse = {
     { id: 'person:sam-altman', name: 'Sam Altman', type: 'person', count: 2, article_ids: [1, 2] },
     { id: 'place:paris', name: 'Paris', type: 'place', count: 1, article_ids: [3] },
   ],
-  edges: [{ source: 'org:openai', target: 'person:sam-altman', weight: 2, article_ids: [1, 2] }],
+  edges: [
+    {
+      source: 'org:openai',
+      target: 'person:sam-altman',
+      weight: 2,
+      article_ids: [1, 2],
+      kind: 'cooccurrence',
+      label: 'co-mentioned',
+    },
+    {
+      source: 'org:openai',
+      target: 'person:sam-altman',
+      weight: 1,
+      article_ids: [1],
+      kind: 'typed',
+      relationship_type: 'led_by',
+      label: 'led by',
+    },
+  ],
   articles: [
     { id: 1, title: 'OpenAI and Altman' },
     { id: 2, title: 'Altman speaks' },
@@ -65,7 +83,7 @@ describe('knowledge graph section', () => {
     await waitFor(() => {
       expect(container.querySelectorAll('[data-testid="kg-node"]')).toHaveLength(3);
     });
-    expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(1);
+    expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(2);
     expect(screen.getByText('OpenAI')).toBeInTheDocument();
     expect(screen.getByText('Sam Altman')).toBeInTheDocument();
   });
@@ -80,9 +98,42 @@ describe('knowledge graph section', () => {
     )!;
     fireEvent.click(openai);
     await waitFor(() => {
-      expect(screen.getByText('OpenAI and Altman')).toBeInTheDocument();
+      expect(screen.getAllByText('OpenAI and Altman').length).toBeGreaterThan(0);
     });
     expect(screen.getByText('OpenAI in Paris')).toBeInTheDocument();
+  });
+
+  it('shows relationship summaries for the selected entity', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="kg-node"]')).toHaveLength(3);
+    });
+    const openai = [...container.querySelectorAll('[data-testid="kg-node"]')].find(
+      (n) => n.getAttribute('data-entity') === 'org:openai'
+    )!;
+    fireEvent.click(openai);
+
+    await waitFor(() => {
+      expect(screen.getByText('Relationships')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/led by Sam Altman/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/OpenAI and Altman/i).length).toBeGreaterThan(0);
+  });
+
+  it('filters the graph to typed relationships', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /typed relationships/i }));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(1);
+    });
+    expect(container.querySelector('[data-testid="kg-edge"]')?.getAttribute('data-kind')).toBe(
+      'typed'
+    );
   });
 
   it('explains pending extraction in the empty state', async () => {

--- a/frontend/src/components/aiStats/KnowledgeGraph.tsx
+++ b/frontend/src/components/aiStats/KnowledgeGraph.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 
 const CANVAS_W = 800;
 const CANVAS_H = 600;
+type EdgeFilter = 'all' | 'cooccurrence' | 'typed';
 
 const TYPE_COLORS: Record<EntityType, string> = {
   person: 'var(--color-chart-1)',
@@ -32,12 +33,17 @@ function isIncident(edge: KnowledgeGraphEdge, nodeId: string): boolean {
   return edge.source === nodeId || edge.target === nodeId;
 }
 
+function edgeKind(edge: KnowledgeGraphEdge): 'cooccurrence' | 'typed' {
+  return edge.kind ?? 'cooccurrence';
+}
+
 interface KnowledgeGraphProps {
   graph: KnowledgeGraphResponse;
 }
 
 export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [edgeFilter, setEdgeFilter] = useState<EdgeFilter>('all');
 
   // Mutable positions map (starts from forceLayout, updated by drag)
   const [positions, setPositions] = useState<Map<string, ForcePoint>>(() =>
@@ -141,11 +147,34 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
     [graph.nodes, selectedId]
   );
 
+  const nodeNameById = useMemo(
+    () => new Map(graph.nodes.map((node: KnowledgeGraphNode) => [node.id, node.name])),
+    [graph.nodes]
+  );
+
+  const visibleEdges = useMemo(
+    () => graph.edges.filter((edge) => edgeFilter === 'all' || edgeKind(edge) === edgeFilter),
+    [edgeFilter, graph.edges]
+  );
+
   const selectedArticles = useMemo(() => {
     if (!selected) return [];
     const wanted = new Set(selected.article_ids);
     return graph.articles.filter((a) => wanted.has(a.id));
   }, [graph.articles, selected]);
+
+  const selectedRelationships = useMemo(() => {
+    if (!selected) return [];
+    return visibleEdges.filter((edge) => isIncident(edge, selected.id));
+  }, [selected, visibleEdges]);
+
+  if (graph.graph_enabled === false) {
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        {graph.disabled_reason ?? 'Knowledge graph storage is not enabled.'}
+      </p>
+    );
+  }
 
   if (graph.nodes.length === 0) {
     return (
@@ -165,6 +194,28 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
 
   return (
     <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {[
+          ['all', 'All relationships'],
+          ['cooccurrence', 'Co-occurrence'],
+          ['typed', 'Typed relationships'],
+        ].map(([value, label]) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setEdgeFilter(value as EdgeFilter)}
+            className={cn(
+              'rounded px-2.5 py-1 text-xs transition-colors',
+              edgeFilter === value
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-surface-2 text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
       {/* Graph canvas */}
       <div className="relative overflow-hidden rounded-lg border border-border bg-surface-2">
         <svg
@@ -183,21 +234,27 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
           <rect x={0} y={0} width={CANVAS_W} height={CANVAS_H} fill="transparent" />
 
           <g transform={transform}>
-            {graph.edges.map((edge) => {
+            {visibleEdges.map((edge, index) => {
               const a = positions.get(edge.source);
               const b = positions.get(edge.target);
               if (!a || !b) return null;
               const dimmed = selectedId !== null && !isIncident(edge, selectedId);
+              const kind = edgeKind(edge);
               return (
                 <line
-                  key={`${edge.source}--${edge.target}`}
+                  key={`${edge.source}--${edge.target}--${kind}--${edge.relationship_type ?? index}`}
                   data-testid="kg-edge"
+                  data-kind={kind}
                   x1={a.x}
                   y1={a.y}
                   x2={b.x}
                   y2={b.y}
                   strokeWidth={Math.min(1 + edge.weight, 6)}
-                  className={cn('stroke-primary/30', dimmed && 'stroke-primary/10')}
+                  strokeDasharray={kind === 'typed' ? '5 4' : undefined}
+                  className={cn(
+                    kind === 'typed' ? 'stroke-accent-foreground/50' : 'stroke-primary/30',
+                    dimmed && 'stroke-primary/10'
+                  )}
                 />
               );
             })}
@@ -272,6 +329,8 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
             {type}
           </span>
         ))}
+        <span className="text-[11px] text-muted-foreground">solid: co-occurrence</span>
+        <span className="text-[11px] text-muted-foreground">dashed: typed relationship</span>
       </div>
 
       {/* Selected node detail */}
@@ -295,6 +354,52 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
               </li>
             ))}
           </ul>
+          {selectedRelationships.length > 0 && (
+            <div className="mt-4">
+              <h4 className="text-xs font-semibold text-muted-foreground">Relationships</h4>
+              <ul className="mt-2 grid gap-1.5">
+                {selectedRelationships.map((edge, index) => {
+                  const otherId = edge.source === selected.id ? edge.target : edge.source;
+                  const otherName = nodeNameById.get(otherId) ?? otherId;
+                  const label =
+                    edge.label ??
+                    (edge.kind === 'typed'
+                      ? (edge.relationship_type ?? 'related to').replace(/_/g, ' ')
+                      : 'co-mentioned with');
+                  const articles = graph.articles.filter((article) =>
+                    edge.article_ids.includes(article.id)
+                  );
+                  return (
+                    <li
+                      key={`${edge.source}--${edge.target}--${edge.relationship_type ?? index}`}
+                      className="text-xs text-muted-foreground"
+                    >
+                      <span className="font-medium text-foreground">
+                        {label} {otherName}
+                      </span>
+                      {articles.length > 0 && (
+                        <span>
+                          {' '}
+                          ·{' '}
+                          {articles.map((article, articleIndex) => (
+                            <span key={article.id}>
+                              {articleIndex > 0 ? ', ' : ''}
+                              <Link
+                                to={`/a/${article.id}`}
+                                className="text-foreground hover:text-primary hover:underline"
+                              >
+                                {article.title}
+                              </Link>
+                            </span>
+                          ))}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/AskPage.tsx
+++ b/frontend/src/pages/AskPage.tsx
@@ -352,6 +352,31 @@ export function AskPage() {
             </p>
           )}
 
+          {result.graph_context?.relationships && result.graph_context.relationships.length > 0 && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium mb-2">
+                Knowledge graph context
+              </div>
+              <ul className="space-y-1.5 rounded-md border border-border bg-surface-2 p-3">
+                {result.graph_context.relationships.slice(0, 5).map((relationship, index) => (
+                  <li
+                    key={`${relationship.source}-${relationship.target}-${relationship.relationship_type}-${index}`}
+                    className="text-xs text-muted-foreground"
+                  >
+                    <span className="font-medium text-foreground">
+                      {relationship.source_name ?? relationship.source}{' '}
+                      {relationship.label ?? relationship.relationship_type.replace(/_/g, ' ')}{' '}
+                      {relationship.target_name ?? relationship.target}
+                    </span>
+                    {relationship.article_ids.length > 0 && (
+                      <span> · articles {relationship.article_ids.join(', ')}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           {result.sources.length > 0 && (
             <div>
               <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium mb-2">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -241,6 +241,22 @@ export interface AskResponse {
   sources: AskSource[];
   /** Langfuse trace id for this answer; null when tracing is disabled. */
   trace_id: string | null;
+  graph_context?: AskGraphContext;
+}
+
+export interface AskGraphRelationship {
+  source: string;
+  source_name?: string;
+  target: string;
+  target_name?: string;
+  relationship_type: string;
+  label?: string;
+  article_ids: number[];
+}
+
+export interface AskGraphContext {
+  entities: KnowledgeGraphNode[];
+  relationships: AskGraphRelationship[];
 }
 
 export type AgentActionTool =
@@ -738,6 +754,10 @@ export interface KnowledgeGraphEdge {
   target: string;
   weight: number;
   article_ids: number[];
+  kind?: 'cooccurrence' | 'typed';
+  relationship_type?: string;
+  label?: string;
+  confidence?: number;
 }
 
 export interface KnowledgeGraphArticle {
@@ -752,6 +772,9 @@ export interface KnowledgeGraphResponse {
   article_count: number;
   pending_count: number;
   days: number;
+  graph_store?: 'postgres' | 'neo4j';
+  graph_enabled?: boolean;
+  disabled_reason?: string;
 }
 
 export interface OnboardingInterest {

--- a/helm/news-dashboard/templates/_helpers.tpl
+++ b/helm/news-dashboard/templates/_helpers.tpl
@@ -6,6 +6,30 @@
 {{- printf "%s-%s" .Release.Name (include "news-dashboard.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "news-dashboard.neo4jSecretName" -}}
+{{- default (printf "%s-neo4j" (include "news-dashboard.fullname" .)) .Values.neo4j.auth.existingSecret -}}
+{{- end -}}
+
+{{- define "news-dashboard.neo4jPasswordKey" -}}
+{{- default "NEO4J_PASSWORD" .Values.neo4j.auth.passwordKey -}}
+{{- end -}}
+
+{{- define "news-dashboard.neo4jEnv" -}}
+{{- if .Values.neo4j.enabled }}
+- name: NEO4J_URI
+  value: {{ printf "bolt://%s-neo4j:%v" (include "news-dashboard.fullname" .) .Values.neo4j.service.port | quote }}
+- name: NEO4J_USER
+  value: {{ .Values.neo4j.auth.user | quote }}
+- name: NEO4J_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "news-dashboard.neo4jSecretName" . | quote }}
+      key: {{ include "news-dashboard.neo4jPasswordKey" . | quote }}
+- name: NEO4J_DATABASE
+  value: {{ .Values.neo4j.database | quote }}
+{{- end }}
+{{- end -}}
+
 {{- define "news-dashboard.aiEnv" -}}
 {{- if .Values.app.ai.existingSecret }}
 - name: OPENAI_API_KEY

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
 {{- end }}
 {{ include "news-dashboard.aiEnv" . | indent 12 }}
 {{ include "news-dashboard.sentryEnv" . | indent 12 }}
+{{- if .Values.neo4j.enabled }}
+{{ include "news-dashboard.neo4jEnv" . | indent 12 }}
+{{- end }}
 {{- if .Values.app.push }}
 {{- if .Values.app.push.existingSecret }}
             - name: VAPID_PUBLIC_KEY

--- a/helm/news-dashboard/templates/neo4j-pvc.yaml
+++ b/helm/news-dashboard/templates/neo4j-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.neo4j.enabled .Values.neo4j.persistence.enabled (not .Values.neo4j.persistence.existingClaim) (not .Values.neo4j.persistence.hostPath) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "news-dashboard.fullname" . }}-neo4j
+  labels:
+    app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-neo4j
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.neo4j.persistence.size }}
+{{- if .Values.neo4j.persistence.storageClassName }}
+  storageClassName: {{ .Values.neo4j.persistence.storageClassName | quote }}
+{{- end }}
+{{- end }}

--- a/helm/news-dashboard/templates/neo4j-secret.yaml
+++ b/helm/news-dashboard/templates/neo4j-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.neo4j.enabled (not .Values.neo4j.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "news-dashboard.fullname" . }}-neo4j
+  labels:
+    app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-neo4j
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: Opaque
+stringData:
+  NEO4J_USER: {{ .Values.neo4j.auth.user | quote }}
+  {{ include "news-dashboard.neo4jPasswordKey" . }}: {{ required "neo4j.auth.password is required when neo4j.enabled=true and neo4j.auth.existingSecret is empty" .Values.neo4j.auth.password | quote }}
+  NEO4J_AUTH: {{ printf "%s/%s" .Values.neo4j.auth.user (required "neo4j.auth.password is required when neo4j.enabled=true and neo4j.auth.existingSecret is empty" .Values.neo4j.auth.password) | quote }}
+{{- end }}

--- a/helm/news-dashboard/templates/neo4j-statefulset.yaml
+++ b/helm/news-dashboard/templates/neo4j-statefulset.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.neo4j.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "news-dashboard.fullname" . }}-neo4j
+  labels:
+    app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-neo4j
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.neo4j.service.port }}
+      targetPort: bolt
+      name: bolt
+  selector:
+    app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-neo4j
+    app.kubernetes.io/instance: {{ .Release.Name }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "news-dashboard.fullname" . }}-neo4j
+  labels:
+    app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-neo4j
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  serviceName: {{ include "news-dashboard.fullname" . }}-neo4j
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-neo4j
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "news-dashboard.name" . }}-neo4j
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: neo4j
+          image: "{{ .Values.neo4j.image.repository }}:{{ .Values.neo4j.image.tag }}"
+          imagePullPolicy: {{ .Values.neo4j.image.pullPolicy }}
+          ports:
+            - name: bolt
+              containerPort: {{ .Values.neo4j.service.port }}
+          env:
+            - name: NEO4J_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "news-dashboard.neo4jSecretName" . | quote }}
+                  key: NEO4J_AUTH
+            - name: NEO4J_server_bolt_listen__address
+              value: {{ printf ":%v" .Values.neo4j.service.port | quote }}
+          volumeMounts:
+            - name: neo4j-data
+              mountPath: /data
+          {{- with .Values.neo4j.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+      volumes:
+        - name: neo4j-data
+{{- if .Values.neo4j.persistence.hostPath }}
+          hostPath:
+            path: {{ .Values.neo4j.persistence.hostPath | quote }}
+            type: DirectoryOrCreate
+{{- else if .Values.neo4j.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-neo4j" (include "news-dashboard.fullname" .)) .Values.neo4j.persistence.existingClaim | quote }}
+{{- else }}
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -252,6 +252,33 @@ postgresql:
         cpu: 200m
         memory: 128Mi
 
+neo4j:
+  # Optional graph storage. PostgreSQL remains the application database.
+  enabled: false
+  image:
+    repository: neo4j
+    tag: 5-community
+    pullPolicy: IfNotPresent
+  auth:
+    # Name of a pre-existing Secret containing the passwordKey below. When
+    # existingSecret is set, also include NEO4J_AUTH for the Neo4j container
+    # in the form "<user>/<password>".
+    existingSecret: ""
+    user: neo4j
+    # Required when neo4j.enabled=true and auth.existingSecret is empty.
+    password: ""
+    passwordKey: NEO4J_PASSWORD
+  service:
+    port: 7687
+  database: neo4j
+  persistence:
+    enabled: true
+    existingClaim: ""
+    size: 5Gi
+    storageClassName: ""
+    hostPath: ""
+  resources: {}
+
 ingress:
   enabled: false
   className: ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "defusedxml>=0.7.1",
   "prometheus-client>=0.21.0",
   "sentry-sdk>=2.0.0",
+  "neo4j>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -83,6 +92,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "alphashape"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "click-log" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "rtree" },
+    { name = "scipy" },
+    { name = "shapely" },
+    { name = "trimesh" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/83/67ff905694df5b34a777123b59fdfd05998d5a31766f188aafbf5b340055/alphashape-1.3.1.tar.gz", hash = "sha256:7a27340afc5f8ed301577acec46bb0cf2bada5410045f7289142e735ef6977ec", size = 26316, upload-time = "2021-04-16T17:47:19.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/ad/77fad9d6f974ec58d837cb49fb9b483d6227a420c4f908c3578633de1d47/alphashape-1.3.1-py2.py3-none-any.whl", hash = "sha256:96a5ddd5f09534a35f03a8916aeeaac00fe4d6bec2f9ad78f87f57be3007f795", size = 13122, upload-time = "2021-04-16T17:47:17.773Z" },
 ]
 
 [[package]]
@@ -237,6 +274,37 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -285,6 +353,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
 ]
 
 [[package]]
@@ -341,6 +428,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click-log"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/32/228be4f971e4bd556c33d52a22682bfe318ffe57a1ddb7a546f347a90260/click-log-0.4.0.tar.gz", hash = "sha256:3970f8570ac54491237bcdb3d8ab5e3eef6c057df29f8c3d1151a51a9c23b975", size = 9985, upload-time = "2022-03-13T11:10:15.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/5a/4f025bc751087833686892e17e7564828e409c43b632878afeae554870cd/click_log-0.4.0-py2.py3-none-any.whl", hash = "sha256:a43e394b528d52112af599f2fc9e4b7cf3c15f94e53581f74fa6867e68c91756", size = 4273, upload-time = "2022-03-13T11:10:17.594Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -386,6 +485,50 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
     { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
     { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
+name = "crawl4ai"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "aiosqlite" },
+    { name = "alphashape" },
+    { name = "anyio" },
+    { name = "beautifulsoup4" },
+    { name = "brotli" },
+    { name = "chardet" },
+    { name = "click" },
+    { name = "cssselect" },
+    { name = "fake-useragent" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "humanize" },
+    { name = "lark" },
+    { name = "lxml" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "patchright" },
+    { name = "pillow" },
+    { name = "playwright" },
+    { name = "playwright-stealth" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyopenssl" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rank-bm25" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "shapely" },
+    { name = "snowballstemmer" },
+    { name = "unclecode-litellm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/95/a307119201f09a5136be1e394282ee4d4d6e3816cbc3c73f370aaa4b5e56/crawl4ai-0.9.1.tar.gz", hash = "sha256:d04251f13ba180107324bb7bbe12029a63d95cc50248f05085743739f38404fc", size = 575249, upload-time = "2026-07-08T14:29:15.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/61/fd08ea5870bb7d5b3e028b784fb2e18343cc20b9aabdd4771df35c1a1642/crawl4ai-0.9.1-py3-none-any.whl", hash = "sha256:e154c3219d0cd46b4e06771a725bf35e6c31b19a5c2981afbcdba4574bd0a9dc", size = 479911, upload-time = "2026-07-08T14:29:14.038Z" },
 ]
 
 [[package]]
@@ -439,6 +582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/2e/cdfd8b01c37cbf4f9482eefd455853a3cf9c995029a46acd31dfaa9c1dd6/cssselect-1.4.0.tar.gz", hash = "sha256:fdaf0a1425e17dfe8c5cf66191d211b357cf7872ae8afc4c6762ddd8ac47fc92", size = 40589, upload-time = "2026-01-29T07:00:26.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/0c/7bb51e3acfafd16c48875bf3db03607674df16f5b6ef8d056586af7e2b8b/cssselect-1.4.0-py3-none-any.whl", hash = "sha256:c0ec5c0191c8ee39fcc8afc1540331d8b55b0183478c50e9c8a79d44dbceb1d8", size = 18540, upload-time = "2026-01-29T07:00:24.994Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -489,6 +641,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fake-useragent"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.138.2"
 source = { registry = "https://pypi.org/simple" }
@@ -502,6 +663,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/a9/9f8f7e00195c29836e9bf58bbbaf579e29878b8a67851efff93d9b6d4eb7/fastapi-0.138.2.tar.gz", hash = "sha256:6432359d067a432134620e7c5e4c6e5063e7f37815bbbbf20acef14b0d2e3fc8", size = 420423, upload-time = "2026-06-29T12:44:12.556Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/b3/38be2c074bdd0c986340db1d72d7b2321b805b1c5a68069aa00b5d31fd02/fastapi-0.138.2-py3-none-any.whl", hash = "sha256:db90c1ffb5517fba5d4a9f80e866daa008747e646310c9ce155c8c535f9d1615", size = 129271, upload-time = "2026-06-29T12:44:13.905Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
 ]
 
 [[package]]
@@ -567,6 +747,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -579,12 +768,105 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -646,6 +928,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ea/13a1ef3c12d12662905801495283530251918b70d62d368f1d2e0272c70d/humanize-4.16.0.tar.gz", hash = "sha256:7dc2244a2f84a4bfb1d36c37bac80cd78e35cdc5c119206d87b018e1445f3a3f", size = 89515, upload-time = "2026-06-30T16:17:29.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/aa/0b7365d30fed43e7a3449aba1fe20a0a7174d9cf13e282af4e69ac825441/humanize-4.16.0-py3-none-any.whl", hash = "sha256:353eb2f34c09d098b2880eee8bef21832eae6d174f48c5762fff7e5fcb74d01d", size = 137209, upload-time = "2026-06-30T16:17:28.36Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
 [[package]]
 name = "identify"
 version = "2.6.19"
@@ -665,6 +990,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -680,6 +1017,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -718,6 +1067,42 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "langfuse"
 version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -734,6 +1119,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/ba/3a969cad28bcef7f42e0fd052df4cf54004268a3a405108e3e2e03055678/langfuse-4.12.0.tar.gz", hash = "sha256:af4c12ae61f69726e0ac73d14a4ada1a119013d5558598828d382f2a238d7314", size = 348143, upload-time = "2026-06-25T11:57:12.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f3/da8f6972566cfb9eb701a0d6a48668ab3e5ba6ae4ffeabb85e24a10e02ac/langfuse-4.12.0-py3-none-any.whl", hash = "sha256:55f6231d1e64dc6e9debe776cb3f06eb93ca7afb51322ce54571fa7493ac05c9", size = 609201, upload-time = "2026-06-25T11:57:10.497Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -771,6 +1165,50 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -780,6 +1218,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -876,8 +1344,29 @@ wheels = [
 ]
 
 [[package]]
+name = "neo4j"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/aaa4ac19adae4b01bc742b63afd2672a77e7351566f02721e713e4b863ee/neo4j-6.2.0.tar.gz", hash = "sha256:e1e246b65b572bd8ea97f9e0e721b7d40a5ce53e53d0007c29aef63e4f9124d9", size = 241459, upload-time = "2026-05-04T07:35:41.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/cf/1c3795866cefaac6e648d4e98c373cafd97810f6e317c307371007ab4abb/neo4j-6.2.0-py3-none-any.whl", hash = "sha256:b87abdd13a5cc2e3bd51026926c2f20ac38fa3febe98c340520dce19e97388d0", size = 327824, upload-time = "2026-05-04T07:35:39.604Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "news-dashboard"
-version = "1.108.2"
+version = "1.122.9"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
@@ -888,6 +1377,7 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "langfuse" },
+    { name = "neo4j" },
     { name = "numpy" },
     { name = "openai" },
     { name = "prometheus-client" },
@@ -903,6 +1393,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+crawl4ai = [
+    { name = "crawl4ai" },
+]
 dev = [
     { name = "httpx" },
     { name = "mypy" },
@@ -923,6 +1416,7 @@ dev = [
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.11.3" },
     { name = "bcrypt", specifier = ">=4.0.0" },
+    { name = "crawl4ai", marker = "extra == 'crawl4ai'", specifier = ">=0.1.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = ">=0.138.2" },
     { name = "feedparser", specifier = ">=6.0.11" },
@@ -931,6 +1425,7 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
+    { name = "neo4j", specifier = ">=5.0.0" },
     { name = "numpy", specifier = ">=2.5.0" },
     { name = "openai", specifier = ">=2.44.0" },
     { name = "pillow", marker = "extra == 'dev'", specifier = ">=11.0.0" },
@@ -955,7 +1450,23 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
     { name = "webdriver-manager", specifier = ">=4.0.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["crawl4ai", "dev"]
+
+[[package]]
+name = "nltk"
+version = "3.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "defusedxml" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
+]
 
 [[package]]
 name = "nodeenv"
@@ -1117,6 +1628,25 @@ wheels = [
 ]
 
 [[package]]
+name = "patchright"
+version = "1.61.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/a76e2ea17dd4feccbf5ef6df017fb2e67f4b72a6f559f59d9aad1197f83a/patchright-1.61.2-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:43ae10cd2a3e46b222179a120ab39ba88f801f3a42aa41cab45fac9928f2103d", size = 43727572, upload-time = "2026-07-05T21:17:52.382Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e7/1ff89853c9aeaf26cd20559f401375ec71a40e4041cf7ace03d41a741f06/patchright-1.61.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a3da24d7890631255c7bef467b94ffe7f7bfa36f96fc72c10d5787d3cb396873", size = 42512921, upload-time = "2026-07-05T21:17:55.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/d730536a7fc43c3aaf2781518595ca71ffa1fc2f24e580c0d0cf04e00eca/patchright-1.61.2-py3-none-macosx_11_0_universal2.whl", hash = "sha256:edef852aa7d28791fa2d3f7ce135edfea2ce07a2bc5e0a74fb2dfe269af62223", size = 43727573, upload-time = "2026-07-05T21:17:59.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b5/c76dcda275cb0d9651321e343f3268609ae24cef196bff56751754ffba16/patchright-1.61.2-py3-none-manylinux1_x86_64.whl", hash = "sha256:545bdf2c0bb5f9ad78ab315e91c8c2990cc6a702e7f18650b71fe1071049b5c1", size = 47729338, upload-time = "2026-07-05T21:18:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ef/5de6feaedf47a6ba8efb9e8c4f8a42bad29cc59c35bbd088b1729a36b271/patchright-1.61.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1824da30cf6560749bc1bb4a7f002fec325d5b709090dd7c8c1b643899331cee", size = 47426969, upload-time = "2026-07-05T21:18:06.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6e/ce2c5d03a4c785ac8f3e0180bbf83ef85149cf41fdfa41c09bd8cbcfd945/patchright-1.61.2-py3-none-win32.whl", hash = "sha256:a5aaf4cec2bd38714f2447f84bcdfe7dcb592a16e9616bf6d2d872066d1c78af", size = 38155048, upload-time = "2026-07-05T21:18:09.938Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c8/fceb57b9d32ed078f53fc6a757c6e4b54cb117f59412938252a3359105e5/patchright-1.61.2-py3-none-win_amd64.whl", hash = "sha256:506bca9b72e609fd8fee35e2a3ad26e5d92e25337002f5c2cdad53d5cacb0b67", size = 38155052, upload-time = "2026-07-05T21:18:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/33/96/67a791c6b7cd76424b44d356beaf414ab97c3aef2d42fad4641e7905b41d/patchright-1.61.2-py3-none-win_arm64.whl", hash = "sha256:3dee1e2daada9f98653763831f688d39c924e0cf0eeb988e8047b703766cee73", size = 34268624, upload-time = "2026-07-05T21:18:15.966Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1182,6 +1712,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+]
+
+[[package]]
+name = "playwright-stealth"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/db/6ade5d539c7d151b9defc78fafa8b65aa52352617d0e7699b47008bd801f/playwright_stealth-2.0.3.tar.gz", hash = "sha256:1d8e488fbdd8f190f1269ea8cf5d57d14df3a9f1af1001c41ee3588b2aac3133", size = 25751, upload-time = "2026-04-04T02:50:33.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/10/607c409712c02a26c4cb794820514cb7fdaaeac15fb05bed917fb8a354b3/playwright_stealth-2.0.3-py3-none-any.whl", hash = "sha256:1887ade423ab7ff8ae16d363a30a38de0b5817e1e4a29d47b74bf3a0e3dbfcb4", size = 34385, upload-time = "2026-04-04T02:50:35.246Z" },
 ]
 
 [[package]]
@@ -1274,6 +1835,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
     { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
     { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1389,12 +1972,36 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b7/da07bae88f5a9506b4def6f2f4903cf4c3b8831e560dba8fa18ca08f758f/pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341", size = 182024, upload-time = "2026-06-12T20:28:07.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3", size = 56008, upload-time = "2026-06-12T20:28:05.999Z" },
 ]
 
 [[package]]
@@ -1500,6 +2107,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "pywebpush"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1555,6 +2171,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rank-bm25"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/21/f691fb2613100a62b3fa91e9988c991e9ca5b89ea31c0d3152a3210344f9/rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae", size = 8584, upload-time = "2022-02-16T12:10:50.626Z" },
+]
+
+[[package]]
 name = "rapidfuzz"
 version = "3.14.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1582,6 +2210,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
     { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
     { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.6.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/05/e4f219230e11e774a6c9987d2ab0d0c6b8573e13a17e143d0015bee710ef/regex-2026.6.28.tar.gz", hash = "sha256:3cb4b6c5cb3060cc31efdc1fbb27c25fb9b29044afd87e40601a1c4d9db54342", size = 416101, upload-time = "2026-06-28T19:56:55.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/fb/fad3b810a5bb1e09b9e5d6913fc6ba88cab738fdf283196827a3c59a4c10/regex-2026.6.28-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:f7c032b0c8a73739ff8ff1aaf30c281fa19c17bf7f1543256c8507390db7807c", size = 490407, upload-time = "2026-06-28T19:55:42.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/52/b8c79d12276d93e90e707e939b396034c04980caf1235312ef790f8e11fc/regex-2026.6.28-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f6710f512c57b84f127a23d0f59560a03b64136eff419ae1be5ab557577fe5e3", size = 291988, upload-time = "2026-06-28T19:55:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/6a911f18279daa8d7bb8b20d771ddb6ef31fabd35f5921f9d3ba21640e80/regex-2026.6.28-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0013958f427bd82509a186b9ff206d66cb8d60a81fc797a4c717afd18c5b0ba", size = 289704, upload-time = "2026-06-28T19:55:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/22/ad1955c47c669291a05804d53d7071cc0732dfdf166857be38003cedc2d1/regex-2026.6.28-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f06cdcd6421f8e194ad312ea608020381250df9b8a57661c1b57e9e5273878", size = 797017, upload-time = "2026-06-28T19:55:48.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/67/a83159ff8703ab4d0c2cf99e76ebf289b7b4a501623241d09f88f3614f80/regex-2026.6.28-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec9689392f7494ff4e3f8e7e8522f9158f11023f337eaaf04a64542fc45bbf26", size = 866112, upload-time = "2026-06-28T19:55:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/7bff2d6dbbd77421b3274aa51db1c887381cbc5b6eda93598c3e882ea345/regex-2026.6.28-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aa084684e6d2078bf6139e374d1fc2af5ddc1ac7122759a2db716d68169f6fd0", size = 911554, upload-time = "2026-06-28T19:55:53.707Z" },
+    { url = "https://files.pythonhosted.org/packages/29/44/ae59c3826e7ba492e56795cdf74ea2a7b5b7c5ea116afb79ee4956a5dff1/regex-2026.6.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40455e6840dc4e96a6fe50f4cedc957de2752c954d91e789812be55d49be199a", size = 800665, upload-time = "2026-06-28T19:55:55.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/19/6fd033d2ab00f35d445aaeaf3307c1e721424dcbfd48f6f65c857cb939cf/regex-2026.6.28-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:530b5c223b9ca5dd8370ac502e080aee0e4ded32be987c6564b425fb5523d581", size = 777243, upload-time = "2026-06-28T19:55:57.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9d/99730f26df4938049ab1e652ca75e967b4c6739444e18d9707bfdb8af20c/regex-2026.6.28-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e0ed273ecd1a89be84466c1749bfe58609cc2a32b5d5e05006c4625ba96411b", size = 785784, upload-time = "2026-06-28T19:56:00.072Z" },
+    { url = "https://files.pythonhosted.org/packages/48/49/105cd57162f5fc5c04cc917a1388a060cf8427e5c14353cd9044660fbf4d/regex-2026.6.28-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0ab0d5344311fc8e8667078942056c3b9c9b4a4b1cc99f2eb8a5af54554f4acc", size = 860914, upload-time = "2026-06-28T19:56:02.017Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/788245a95b69018f58bff2f4fd27d007cacaea088cdb390979743f1b2571/regex-2026.6.28-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:eacb79625323d9f7e7925366b917f492b8356fad58f5dc4fa12ff8c21d8f4ca9", size = 765915, upload-time = "2026-06-28T19:56:05.021Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/01/292065a39a004b05e67a337b18213670a7cb919d6856ac2d7df7f1a10dbb/regex-2026.6.28-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:20f4d87702702aa1d572721e146f301660c50eef6fd6cb596e48a22b0ace17db", size = 851404, upload-time = "2026-06-28T19:56:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9e/a93d865db0e13483ae1a01d81e2ce16d4a7fe2f9b9fe4aac4cc08590b136/regex-2026.6.28-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e693940a3b9e6d6e4dc2a54ecaa74b74934f77af1ef95f518a74261ef7cc1bc", size = 789373, upload-time = "2026-06-28T19:56:09.894Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0c/38b1685ad4017d78efbc8fa7dbbf96d8113b53750c8aa2d3609defd46605/regex-2026.6.28-cp314-cp314-win32.whl", hash = "sha256:234a51e20ebc18ab83b2c0600cf28f2e884560a0e00f743878f0b7d8e7c4cf03", size = 272496, upload-time = "2026-06-28T19:56:11.83Z" },
+    { url = "https://files.pythonhosted.org/packages/55/50/e19f261ff9ba9b50722a529e09b1743ecf65eb348be99d0fd2cd7fcede1c/regex-2026.6.28-cp314-cp314-win_amd64.whl", hash = "sha256:7b15c437bc4604f03ceb3f8d37eae2f8930e320e1bc556b259848c639d9eec1a", size = 280754, upload-time = "2026-06-28T19:56:13.758Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b8/c9e68f3a9e33be73f20990b2c065b144ff2d0aa242608a950d8c4f3b56e8/regex-2026.6.28-cp314-cp314-win_arm64.whl", hash = "sha256:c6e6f790d01380a74ad564f216c533b86504afb61bf66f2b2e11e7f1a3e287a7", size = 280979, upload-time = "2026-06-28T19:56:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e6/21c425a37880c650d007c4171c6a80325446d830d85f5fbf335e7205b1e7/regex-2026.6.28-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3527a72adcbe9e3600f1553b497d397c1a371d227580d41d96c3c5964109b65c", size = 494282, upload-time = "2026-06-28T19:56:18.049Z" },
+    { url = "https://files.pythonhosted.org/packages/07/50/6647a7ccf5ffff995ba955a0b7d766440f4e58ce1666549c8ee998f2b972/regex-2026.6.28-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:a644f6408692812f5ead82519eed680e08d5d546fddbd9f7d9514e3c73899aa5", size = 293977, upload-time = "2026-06-28T19:56:20.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/dc/a3e141a4eaf125e50f63105570c01fa477c06ac5259dcfa95e9b90760e84/regex-2026.6.28-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8e2fae6bb883648346f84db270dc9aafc29d8e895f62b88a75ccc83b09519820", size = 292432, upload-time = "2026-06-28T19:56:22.345Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ee/2ac1a6b9f167f8ff69f5a789938cc103b60cff41b24a6990daced8b88e34/regex-2026.6.28-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:debe623e09cee97ef9404575e936c610aac9bb08358c5099aaef14644a6871f2", size = 811877, upload-time = "2026-06-28T19:56:25.056Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7b/9a5505ee92180bcae300b1018b9ff3d3c19962436e66f2505f255e9fde35/regex-2026.6.28-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc579c91fb4605773483a8d940b136bcc5b854fff44fa14a1572a038f46563f1", size = 871212, upload-time = "2026-06-28T19:56:27.352Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4d/d61a702a9f9d1bd29b22cbef1aed6d477baa961232a7eb4d91b7775b0b3e/regex-2026.6.28-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e7c42be203d84ecf7d487ff23f8a61ef0eb0534fa0fc317a2fce8c065d20618f", size = 917507, upload-time = "2026-06-28T19:56:29.762Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/60/1308066f5966b65fbb6905b99ba37e9f1cd753dd0ac08485f8257334ee92/regex-2026.6.28-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8184b4e2fdaf9cdfe77e38f15a4d9dc149168c9c29eb0ea17c5481d3bb80546", size = 816389, upload-time = "2026-06-28T19:56:32.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5c/57ce2cb8d714ee0b7f11c7ee4cfe2af66df2b90f147feadcb538609a3a02/regex-2026.6.28-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:697f103104f5872d64078d8eeac59979960be8ee76115a2d3f31096312e2a400", size = 785890, upload-time = "2026-06-28T19:56:34.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fd/1d5350d3a8a327bff0fccacb911732baf7b5b6f5529c0e3fa602a23e7dad/regex-2026.6.28-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:714d2b1aa29beef0ddfcdc72ad0771c05326551a8bb0680b0ddf74bfaad87387", size = 801451, upload-time = "2026-06-28T19:56:36.749Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/79/3c9e4f8a0306e030ad5a43bbbc01625fb28d58a813bc52d42fd1cc63fb2e/regex-2026.6.28-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0f09f62e450cc2f113018cc8412aeea3a120a04e1ca7e801a0d441583f9a3b06", size = 866504, upload-time = "2026-06-28T19:56:38.994Z" },
+    { url = "https://files.pythonhosted.org/packages/65/12/f747de475b54f4709efb24dd0fbc8467c64cec91f5db0d047b079646ee78/regex-2026.6.28-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:731ea12d5aeb2577eaef2393d6428b995f76eb35f68a89e03e15a97719d1de19", size = 773047, upload-time = "2026-06-28T19:56:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3c/f02f860e0500c1b2d61a79dec7e214b37fb9656281dcddc92397edf96678/regex-2026.6.28-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:51e952c8783eabd4706d0f63922f219bcfc1bef9b8cb35941c0d1a0396578858", size = 856665, upload-time = "2026-06-28T19:56:43.466Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6c/28b3fa222513484be9dee26b7222bda109056c43ea28aa2314262ca48816/regex-2026.6.28-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43248fe4c0ab8fbb223588a0795b11268940072c97bba30ea8f9b49d8cdfde34", size = 803573, upload-time = "2026-06-28T19:56:45.791Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/8f86cf1a1fd85c5ab0c503c9fe4607ad4ad48978b2d8b435d94465e134c7/regex-2026.6.28-cp314-cp314t-win32.whl", hash = "sha256:fc1eddc25ad23c0f1344ab280d961ac595ead48292d7c779497975942373f493", size = 274515, upload-time = "2026-06-28T19:56:47.948Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/de/f8613c03b36786ddef2c930d28f9bcae861fcd541cc9203a870956cf1e83/regex-2026.6.28-cp314-cp314t-win_amd64.whl", hash = "sha256:ede8d8e53b6dde0a50f7eca902f0af76d87ab02a55aba7542da68ae3e5dfe83d", size = 283650, upload-time = "2026-06-28T19:56:50.614Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f3/f5ec86839bbabe33b6dee649b62ff9a445d43de6b0ad780cf6b83c56f61e/regex-2026.6.28-cp314-cp314t-win_arm64.whl", hash = "sha256:4da6f6a72f8700b97a1a765e837fb7d5750bfd9f13acea7bae498f573e3a70a8", size = 283338, upload-time = "2026-06-28T19:56:52.879Z" },
 ]
 
 [[package]]
@@ -1613,6 +2294,88 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "rtree"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/09/7302695875a019514de9a5dd17b8320e7a19d6e7bc8f85dcfb79a4ce2da3/rtree-1.4.1.tar.gz", hash = "sha256:c6b1b3550881e57ebe530cc6cffefc87cd9bf49c30b37b894065a9f810875e46", size = 52425, upload-time = "2025-08-13T19:32:01.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d9/108cd989a4c0954e60b3cdc86fd2826407702b5375f6dfdab2802e5fed98/rtree-1.4.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d672184298527522d4914d8ae53bf76982b86ca420b0acde9298a7a87d81d4a4", size = 468484, upload-time = "2025-08-13T19:31:50.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cf/2710b6fd6b07ea0aef317b29f335790ba6adf06a28ac236078ed9bd8a91d/rtree-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7e48d805e12011c2cf739a29d6a60ae852fb1de9fc84220bbcef67e6e595d7d", size = 436325, upload-time = "2025-08-13T19:31:52.367Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e1/4d075268a46e68db3cac51846eb6a3ab96ed481c585c5a1ad411b3c23aad/rtree-1.4.1-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa8c4496e31e9ad58ff6c7df89abceac7022d906cb64a3e18e4fceae6b77f65", size = 459789, upload-time = "2025-08-13T19:31:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/e5d44be90525cd28503e7f836d077ae6663ec0687a13ba7810b4114b3668/rtree-1.4.1-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12de4578f1b3381a93a655846900be4e3d5f4cd5e306b8b00aa77c1121dc7e8c", size = 507644, upload-time = "2025-08-13T19:31:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/85/b8684f769a142163b52859a38a486493b05bafb4f2fb71d4f945de28ebf9/rtree-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b558edda52eca3e6d1ee629042192c65e6b7f2c150d6d6cd207ce82f85be3967", size = 1454478, upload-time = "2025-08-13T19:31:56.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
@@ -1635,6 +2398,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
     { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
     { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
 ]
 
 [[package]]
@@ -1674,6 +2468,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/c4/3ce4c2d9b6aabd27d26ec988f08cb877ba9e6e96086eff81bfea93e688c7/shapely-2.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9a522f460d28e2bf4e12396240a5fc1518788b2fcd73535166d748399ef0c223", size = 1831290, upload-time = "2025-09-24T13:51:13.56Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ff629e00818033b8d71139565527ced7d776c269a49bd78c9df84e8f852190c", size = 1641463, upload-time = "2025-09-24T13:51:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/57/91d59ae525ca641e7ac5551c04c9503aee6f29b92b392f31790fcb1a4358/shapely-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f67b34271dedc3c653eba4e3d7111aa421d5be9b4c4c7d38d30907f796cb30df", size = 2970145, upload-time = "2025-09-24T13:51:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/4948be52ee1da6927831ab59e10d4c29baa2a714f599f1f0d1bc747f5777/shapely-2.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21952dc00df38a2c28375659b07a3979d22641aeb104751e769c3ee825aadecf", size = 3073806, upload-time = "2025-09-24T13:51:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/03/83/f768a54af775eb41ef2e7bec8a0a0dbe7d2431c3e78c0a8bdba7ab17e446/shapely-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f2f33f486777456586948e333a56ae21f35ae273be99255a191f5c1fa302eb4", size = 3980803, upload-time = "2025-09-24T13:51:20.37Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/559c7c195807c91c79d38a1f6901384a2878a76fbdf3f1048893a9b7534d/shapely-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cf831a13e0d5a7eb519e96f58ec26e049b1fad411fc6fc23b162a7ce04d9cffc", size = 4133301, upload-time = "2025-09-24T13:51:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cd/60d5ae203241c53ef3abd2ef27c6800e21afd6c94e39db5315ea0cbafb4a/shapely-2.1.2-cp314-cp314-win32.whl", hash = "sha256:61edcd8d0d17dd99075d320a1dd39c0cb9616f7572f10ef91b4b5b00c4aeb566", size = 1583247, upload-time = "2025-09-24T13:51:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/135684f342e909330e50d31d441ace06bf83c7dc0777e11043f99167b123/shapely-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:a444e7afccdb0999e203b976adb37ea633725333e5b119ad40b1ca291ecf311c", size = 1773019, upload-time = "2025-09-24T13:51:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/05/a44f3f9f695fa3ada22786dc9da33c933da1cbc4bfe876fe3a100bafe263/shapely-2.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5ebe3f84c6112ad3d4632b1fd2290665aa75d4cef5f6c5d77c4c95b324527c6a", size = 1834137, upload-time = "2025-09-24T13:51:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/4d57db45bf314573427b0a70dfca15d912d108e6023f623947fa69f39b72/shapely-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5860eb9f00a1d49ebb14e881f5caf6c2cf472c7fd38bd7f253bbd34f934eb076", size = 1642884, upload-time = "2025-09-24T13:51:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/4e29c0a55d6d14ad7422bf86995d7ff3f54af0eba59617eb95caf84b9680/shapely-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b705c99c76695702656327b819c9660768ec33f5ce01fa32b2af62b56ba400a1", size = 3018320, upload-time = "2025-09-24T13:51:29.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/bb/992e6a3c463f4d29d4cd6ab8963b75b1b1040199edbd72beada4af46bde5/shapely-2.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a1fd0ea855b2cf7c9cddaf25543e914dd75af9de08785f20ca3085f2c9ca60b0", size = 3094931, upload-time = "2025-09-24T13:51:32.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/82e65e21070e473f0ed6451224ed9fa0be85033d17e0c6e7213a12f59d12/shapely-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:df90e2db118c3671a0754f38e36802db75fe0920d211a27481daf50a711fdf26", size = 4030406, upload-time = "2025-09-24T13:51:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511, upload-time = "2025-09-24T13:51:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607, upload-time = "2025-09-24T13:51:37.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682, upload-time = "2025-09-24T13:51:39.233Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1692,12 +2513,30 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1", size = 86699, upload-time = "2021-11-16T18:38:38.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a", size = 93002, upload-time = "2021-11-16T18:38:34.792Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -1729,6 +2568,59 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1738,6 +2630,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
+]
+
+[[package]]
+name = "trimesh"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/37/5cb90f04990260d2caceb6093560c6cefafca1ec522c1e43be01ca658244/trimesh-4.12.2.tar.gz", hash = "sha256:c8ca31571ac00b112e4e160e66a2d4c3491df321f056bd33806be0485d1af9d9", size = 842220, upload-time = "2026-05-01T00:57:43.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/98/716a473cfb24750858ddd5d14e6527539dd206583a46408d08eeb2844a75/trimesh-4.12.2-py3-none-any.whl", hash = "sha256:b5b5afa63c5272345f2858f7676bc8c217dc8a89f4fadf6193fe10a81b5ff2aa", size = 741043, upload-time = "2026-05-01T00:57:40.763Z" },
 ]
 
 [[package]]
@@ -1860,6 +2764,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "unclecode-litellm"
+version = "1.81.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/c4/93ed52c49c2347184f908c692ebb7c1f06303805910774c3282ac68033db/unclecode_litellm-1.81.13.tar.gz", hash = "sha256:db70e34e3e859c0a07f02cb02eaa644f8fa4b4ecc5e2f3be9a58bd7d1c3feedc", size = 16678208, upload-time = "2026-03-24T14:46:31.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/85/7b1e0bc5827bcb23dc572b17c447fb5825340f36a9e4405d4b777b862e0c/unclecode_litellm-1.81.13-py3-none-any.whl", hash = "sha256:5e1fbedbed92333b48e7371e0bacf86d1288020451bf34351703c3b159591399", size = 18008619, upload-time = "2026-03-24T14:46:28.009Z" },
 ]
 
 [[package]]
@@ -2085,6 +3012,57 @@ wheels = [
 ]
 
 [[package]]
+name = "xxhash"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/63/71aa56b151a1b28770037a61bd4e461c2619cfc8866a4fcaf1548605e325/xxhash-3.8.1.tar.gz", hash = "sha256:b0de4bf3aa66363552d52c6a89003c479911f12098cd48a53d44a0f7a25f7c46", size = 86223, upload-time = "2026-07-06T10:49:58.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8b/df2ba04f22a6cd6b39f96a6577329a8471a55c90ef8d8e2f7c102363613f/xxhash-3.8.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:9db455cb649dcfe4504d6d68a6d83a7315a99a3ca59871dc3ff840671f99adba", size = 38430, upload-time = "2026-07-06T10:46:31.496Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4f/6a059e8ad3ca8deedc91dfe335b211204900895152212c03ebbe721de68b/xxhash-3.8.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:affb37f152e55b5e4494bb9d0107f7bb08515c6704fbed82d9f61214d74adc17", size = 36558, upload-time = "2026-07-06T10:46:33.078Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/95/40be178205acce092ae418feb20ac737b32a02c7b864926ed0717354c9f8/xxhash-3.8.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:460261045936975193bfd20549a0de1cd52a33b405cbb972f0d80940c42266cd", size = 31181, upload-time = "2026-07-06T10:46:34.793Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/89/2da4dbf051bafa156c0e3f12012db2b0ac3b84ff37ca1f021f6bfffcdfbb/xxhash-3.8.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:38c887aedb696ef8bca19983206d270848558cfae4a91afa6a2fb05dde58ffc5", size = 32192, upload-time = "2026-07-06T10:46:36.393Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4e/e000bbae3566bc8e0be771a8a0f294aa99075e3f0bc4ef43922ebffdebc8/xxhash-3.8.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:594131ce1aad18db3689781f806db1b065cdaa04f4df36b4c038d2013aefd0bf", size = 34691, upload-time = "2026-07-06T10:46:38.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4a/ea954aacc7d1c8711880ac2b55da94429a9b4296b151c4fc0966549ca1ee/xxhash-3.8.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:78c794b643d214f1522e7a288bcf5a2de120d26cd170516749a4009dc92722c9", size = 34807, upload-time = "2026-07-06T10:46:39.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/29/df598e738ff37558ac627264deb2e560902d9bf7f46d3bd5175c9eee593e/xxhash-3.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af0c9fedc4a2c24e8664953882fe8185f3790b8338c9c700f76f5ad660817711", size = 32410, upload-time = "2026-07-06T10:46:41.359Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9c/81ab40e7d33ada0b3df5d1bc884894d15dbf4f805cd645b685e4606bb8e0/xxhash-3.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:115772daeb71b2f3b9381177017f53e6cf3f3439c840737fdabd21aba6e54920", size = 220564, upload-time = "2026-07-06T10:46:43.463Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/62ae6f5c8606320a0e2a41c2dc8c6d91cc5d63d0f84dd9582e9543779dd8/xxhash-3.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:000435984a0469b0f822fe76f35bddea0f96a4d6521b3339a60a6428cdee1edc", size = 241462, upload-time = "2026-07-06T10:46:45.509Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a1/9c3a0ec6cb524396f551eddd102a76690a795494eb9784fc67542b0daa37/xxhash-3.8.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2f1c68394818e0595569c2ff3cbc1e6d5a36a434e796f5c526b987b80c8a8c62", size = 264491, upload-time = "2026-07-06T10:46:47.655Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/700a4674e4308eb59d2fdb973977e82eae231bea5044753fee5c9eec0e0c/xxhash-3.8.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:46b39976d008e2a845758650f0ff7136bca004f40da0c8798bd37ac37860154f", size = 242905, upload-time = "2026-07-06T10:46:49.857Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8a/72d9874375c8d4cbc64a8cd1d659d5695a8765c3db82efa82dc5bd9f14d0/xxhash-3.8.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d5006c65ec507a333479e76e00e2c368781f16c24ededa764763956b32a0e93e", size = 473873, upload-time = "2026-07-06T10:46:51.953Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f0/6db07590ed7e0a77f186ef0bcea8d52553bf1ba57833e09467a2411f0f2d/xxhash-3.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31a2649bcf1fe97cf11c79848d761df33ac46b3896942d31b640557b486ff6b", size = 220765, upload-time = "2026-07-06T10:46:55.41Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/10/00d12d8b8beabbf49a8bbc626fb9f40445145a8887eb41a6acfb69149ac4/xxhash-3.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8f759eed402448c2bdbb492e4fba1f20668ffe29688605ea61f0f67f9e4e386d", size = 310478, upload-time = "2026-07-06T10:46:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f9/12a82394eefb0f185d15a7f7b9f627c61c475a72dd83718436a5b84b42ac/xxhash-3.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5f97ecfede10d5b2870383620e2d25c8561e217c7bf9081073802b54248d2b", size = 238393, upload-time = "2026-07-06T10:46:59.87Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f3/53f963e320b9ce678337aa7273f39ce692ded8b99e3d22a866ec722159ab/xxhash-3.8.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1da930bbcac3e8fbe2191850e2abb57977a99348c12c4b385e1058ac1b0a9ecc", size = 268704, upload-time = "2026-07-06T10:47:01.806Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/50/5b5badbd87c82d9f9b5f58ac74a3f29ef08f6fc387b324b8fd482450b862/xxhash-3.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:747476436f6891b9773374ce8d48edcc8b12cb5b61b67c6fb6289633747d088f", size = 225015, upload-time = "2026-07-06T10:47:03.784Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/3ca68265afe7b4e69435e08a7b6a1d9d0f2a071e889da1f8041ed00fe878/xxhash-3.8.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4ef09bbc2519a93cd0f95f2ceb5f7b85919dffea643278e02362bf40e3c4bed1", size = 240951, upload-time = "2026-07-06T10:47:05.816Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/27e19670c40f46b5e76e11f2f4713d21054804568425d870670e757172ad/xxhash-3.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a5eed9d41995a83f3332b4e3396abb7f433cac584222bd7e305b606d8353861e", size = 300751, upload-time = "2026-07-06T10:47:07.95Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fb/b33e27689959fe7ed2ae0b830af41560d65213943983afa9db3a8d481bce/xxhash-3.8.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:53f3ed9118397074ff63a79b66b7fec1c84c782eecde35c5bc94e420a971c231", size = 443480, upload-time = "2026-07-06T10:47:10Z" },
+    { url = "https://files.pythonhosted.org/packages/26/60/0e0d973be5fe280753ef02fbc89349492ad6e903bf1dcb870b668f94b662/xxhash-3.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d247b34bf433c92b41689318fd25d246313cab2275a6a47e2efac178b80d6efe", size = 217657, upload-time = "2026-07-06T10:47:12.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/68/c9e3ecef4a9a417d464cb5bd200aa12f73192dee677901b9e08e0ad0d1bb/xxhash-3.8.1-cp314-cp314-win32.whl", hash = "sha256:d58ce8b6cfa9c4d2f230557f69caf7c06369e318015d0b19485095bc2c5963ab", size = 32690, upload-time = "2026-07-06T10:47:14.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/99/e9e44588c0b62837bbec5ba7927816de0afa03406b1a0b6c7a7e1d1a30a0/xxhash-3.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:6cee733fe4ccb1737e0997135283c82341e5cfa9cf214b165f9087fb663aaf4f", size = 33460, upload-time = "2026-07-06T10:47:16.021Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/64f36d86380b3657ad9031967ab814f3ef31307174650853f69c18932ebc/xxhash-3.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:58346024d47e84f7d8b3e7f5d6faa1d58acbbe49a8771497872059f58c1d8ea5", size = 30092, upload-time = "2026-07-06T10:47:17.81Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cb/18b64bff88c58a0ca209dc533e63cf02d7ae5aa6b1b9a9fd14e81b5dbd60/xxhash-3.8.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:01cab782f8a0a05ecad2c63d7ef10f7ab475f660e0d6419d069418c14d88de7c", size = 35024, upload-time = "2026-07-06T10:47:19.821Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1d/72d8a70520e5dcddb472ea0486d299da3240745a10658290cd7b5690ede2/xxhash-3.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:717b12fdc51819833704e85e6926d76981ffa3f780ef92e33ebb8b26d46bb230", size = 32697, upload-time = "2026-07-06T10:47:21.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b8/e041f555903c56db3d0a731b3d72a6575d75e0ed868b1bd2e5176111ca44/xxhash-3.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ec55d80e9b8a519d742669e0b49e8ce9e6747be42bf3c138158b6543a9c8e489", size = 226044, upload-time = "2026-07-06T10:47:23.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/7e/5cdcf06bf6ec4b5d2ac073feb23432ec1d603fd438864cbd2c09c7cb45e1/xxhash-3.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98d8ac1129b4dd39098cffed94d1284aceb61c3aa396757ccc736ac392e4cee5", size = 249899, upload-time = "2026-07-06T10:47:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c0/eb7e059cb5e1dba11fd30d2fdf882f56e5a417a3eaa43669d43623767f45/xxhash-3.8.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3bc0fa90830df1e1277f33cc6e55de9990b83c0319fd8c7412866cfde38b025e", size = 274892, upload-time = "2026-07-06T10:47:27.931Z" },
+    { url = "https://files.pythonhosted.org/packages/66/74/a600aaf7cd39957fd1510adeedb1749c1e7eb82bd632a1153d9c664c3135/xxhash-3.8.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c73b6f652f0745425aa6378319c331293b5341756262e9408ed3d45f183375e6", size = 252243, upload-time = "2026-07-06T10:47:30.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/04/78d88fa75a6763e5d09bf1b947a392a27988903381b219006f92f3c68fc8/xxhash-3.8.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6114692261eff4266386cdec0f7d87eee24e317ab397c218b7ae6a76b4c6339", size = 482191, upload-time = "2026-07-06T10:47:32.45Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/06/07a8aea1108d682de8791ce608cdf367d75ff4e7e57cd3c154bdc6f47b23/xxhash-3.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df57c0b161ec1b3ed0526a67b0db0914b557e86ee8aae51887aec941b261542", size = 226877, upload-time = "2026-07-06T10:47:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b5/86bade5618a524d2c06c4041aa2fe8e5749ce16e88afba60d67c1684a21f/xxhash-3.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9043877a917be88ccf230aa5667c1bd059bce80f4c2727e4defa1b29b7f48b08", size = 319794, upload-time = "2026-07-06T10:47:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/23/69/9b1a2b89b1621bb740fbcb7beb512f60f99480c1bdc680c0c90e1f56ff75/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:559e3cabe522231909f9de98ef06929edbd53782046bd21aae0c72db6f2a0775", size = 246202, upload-time = "2026-07-06T10:47:39.676Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ea/662ed6cb49f1d34078b6a3a3e0f3d29ff93fd7b5a03c0bc9ecfd9b2159c3/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:264710bd335016f303763ce1275c6486df30bb57c2245c91b224c983d7ac39b8", size = 275628, upload-time = "2026-07-06T10:47:41.99Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/49fc9e4c6728a5a3bd8fe639199d2fa67609b3a84f938aff6e8568dd3e4f/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e14800b9b10bb39d7a60ad4a310e403164d7b8988a27ae933d4e40618a44088e", size = 231390, upload-time = "2026-07-06T10:47:44.233Z" },
+    { url = "https://files.pythonhosted.org/packages/64/9d/3acaf8f599c0e0b30e910a3a11ba32929da53c86dc73c7c55fe6a010b4e9/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:ea6a3e734b0fd41b82784a400be946821900daebe610c050a5e0760838a34f99", size = 250600, upload-time = "2026-07-06T10:47:47.611Z" },
+    { url = "https://files.pythonhosted.org/packages/23/64/8acab4c5ec60dbe664b5b9858fd44c2413b07e535b09556a0a5022e78aa6/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cf399fac542a1c7a4734a435b93df2c55e858c7d31abf6c1bdf46f9ae67fbfd0", size = 310032, upload-time = "2026-07-06T10:47:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/56/47/a0288d7329b1fe63e2734a32d19d444a96ae2b4810f545bc61e561224917/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:44c89d915a75c11d2547eaee9098fcd80398987c4bff2974a0497a925bf92c07", size = 448882, upload-time = "2026-07-06T10:47:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e7/3071dfd3beb5c38204ce1cf56bf7749fce08de900fa92714b81d1d8ca1f2/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:358650d5bda9c635da699c53adf4e8134af492ecc79c960f917eebf088bb6799", size = 223728, upload-time = "2026-07-06T10:47:55.093Z" },
+    { url = "https://files.pythonhosted.org/packages/12/11/b99949f0ba2b07e9f9ffe83b9c86faa685f9080725dc21a916a607313be5/xxhash-3.8.1-cp314-cp314t-win32.whl", hash = "sha256:c240939e963653054fc7e4a17c382829cda4aa88a7daf0af841715dbded1b497", size = 33150, upload-time = "2026-07-06T10:47:57.274Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1c/09703eb341f8416e74e58d6c6732d4b5c46de59c942363203cb237cc95b0/xxhash-3.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:7258ee276e8772599bc19e14b36f6260306e21b637190cd7cb489a2449d48684", size = 34005, upload-time = "2026-07-06T10:47:59.434Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f9/6ed7251bb6a8af10ac73b1821c60583d2826e5b2064e45a979c935287c98/xxhash-3.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:8f454166c2ffed45636c8d501741e649851ba2f346c4eb73a64c07ac00428f20", size = 30239, upload-time = "2026-07-06T10:48:01.874Z" },
+]
+
+[[package]]
 name = "yarl"
 version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2130,4 +3108,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
     { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -6,6 +6,7 @@ The system is not a large microservice platform. It is best understood as a modu
 
 - `news-dashboard`: the FastAPI backend, which also serves the built React frontend in container and Kubernetes deployments.
 - `postgres`: the durable production database.
+- `neo4j`: optional graph storage for article/entity relationships.
 - `news-dashboard-ingest`: a Kubernetes CronJob batch workload that runs ingestion on a schedule.
 - Optional external integrations: RSS/Atom feeds, a scraped Anthropic News page, SMTP, GHCR, GitHub Actions, Keycloak SSO, and host-level Caddy.
 
@@ -18,6 +19,13 @@ PostgreSQL is the application database. Runtime code should be written directly 
 - Configure the app with `DATABASE_URL` or `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.
 - SQLite is allowed only as an input format for legacy migration tooling that imports old local data into PostgreSQL.
 - PostgreSQL must have the [pgvector](https://github.com/pgvector/pgvector) extension available (the `pgvector/pgvector:pg16` image, or `CREATE EXTENSION vector` on an external instance): article embeddings live in `articles.embedding_vec`, with similarity search (Ask AI, topic map, recommendations) running as SQL `<=>` queries over an HNSW index instead of a Python cosine loop.
+
+Neo4j is optional and scoped to graph-shaped data only. PostgreSQL remains the
+source of truth for article visibility, users, sources, workflow state,
+embeddings, auth, briefings, scheduler history, and analytics. The backend
+selects visible article IDs in PostgreSQL before querying Neo4j, so graph
+features inherit the same source ownership, disabled-source, and archived-state
+rules as the rest of the app.
 
 ## Runtime Topology
 

--- a/website/docs/architecture/product-spec.md
+++ b/website/docs/architecture/product-spec.md
@@ -14,7 +14,8 @@ A self-hosted, open-source news dashboard. It combines:
 3. **Summary archive** — stores contextual summaries and "why this matters" blurbs per article card.
 4. **Search** — full-text search across titles, summaries, tags, and sources.
 5. **Source health** — each feed shows last check time, success/error state, and item counts.
-6. **Future AI question layer** — ask Clau questions over saved/read history (see AI layer section).
+6. **AI question layer** — Ask AI answers over saved/read history with citations and optional graph context.
+7. **Knowledge graph** — entity and relationship exploration over recent visible articles.
 
 ## Source taxonomy
 
@@ -113,9 +114,10 @@ After ≥ 100 saved/read articles exist:
 - Enables semantic search and similarity grouping without adding a second runtime database.
 - Configure with `FREE_LLM_API_KEY` / `FREE_LLM_BASE_URL` (or the `OPENAI_API_KEY` / `OPENAI_BASE_URL` fallback); see `README.md` and `backend/news_dashboard/embeddings.py`.
 
-### Ask Clau endpoint (v1.3)
+### Ask AI endpoint and knowledge graph
 
-Scope: questions over articles with status `saved` or `read` only (not `new`/`skipped`/`archived`).
+Scope: questions over articles visible to the user. By default this is Starred
+and Done; users can include all non-archived articles.
 
 Proposed API:
 ```
@@ -125,9 +127,12 @@ POST /api/ask
 ```
 
 Implementation:
-1. Run `/api/search?q=<question_keywords>` to retrieve candidate articles.
-2. Bundle up to N articles (title + summary + date + source) into a prompt.
-3. Call OpenAI with the bundle and question.
+1. Use pgvector in PostgreSQL to retrieve candidate articles.
+2. Bundle bounded article context into the prompt.
+3. If Neo4j is enabled, add bounded entity relationship context for those same
+   candidate article IDs.
+4. Call the configured OpenAI-compatible LLM gateway and return article
+   citations plus graph context provenance.
 4. Return answer + article IDs used as citations.
 
 Privacy/security:

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -7,6 +7,7 @@ authentication, Caddy/HTTPS, and Postgres backups.
 - [HTTPS with Caddy](https-caddy)
 - [PostgreSQL Backup and Restore](postgres-backup)
 - [Newsletter ingestion via IMAP](newsletter-ingestion)
+- [Neo4j Knowledge Graph](neo4j-knowledge-graph)
 
 See the root [README](https://github.com/lihor-hub/news-dashboard#configuration)
 for the full environment variable reference.

--- a/website/docs/configuration/neo4j-knowledge-graph.md
+++ b/website/docs/configuration/neo4j-knowledge-graph.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 8
+---
+
+# Neo4j Knowledge Graph
+
+Neo4j is optional graph storage for entity and relationship data. PostgreSQL
+remains the application database.
+
+Enable the chart-managed Neo4j service:
+
+```bash
+helm upgrade news-dashboard ./helm/news-dashboard \
+  --reuse-values \
+  --set neo4j.enabled=true \
+  --set-string neo4j.auth.password='replace-with-a-long-random-password'
+```
+
+For externally managed credentials, create a Secret containing both the app
+password key and `NEO4J_AUTH` for the Neo4j container:
+
+```bash
+kubectl create secret generic news-dashboard-neo4j-auth \
+  --from-literal=NEO4J_PASSWORD='replace-with-a-long-random-password' \
+  --from-literal=NEO4J_AUTH='neo4j/replace-with-a-long-random-password'
+```
+
+Then install with:
+
+```bash
+helm upgrade news-dashboard ./helm/news-dashboard \
+  --reuse-values \
+  --set neo4j.enabled=true \
+  --set neo4j.auth.existingSecret=news-dashboard-neo4j-auth
+```
+
+Useful values:
+
+| Value | Purpose |
+| --- | --- |
+| `neo4j.enabled` | Renders the Neo4j StatefulSet, Service, Secret, and storage. |
+| `neo4j.auth.user` | Neo4j username, default `neo4j`. |
+| `neo4j.auth.password` | Chart-managed password; prefer a secret override in production. |
+| `neo4j.auth.existingSecret` | Existing Secret for credentials. |
+| `neo4j.persistence.size` | PVC size when using chart-managed storage. |
+| `neo4j.persistence.existingClaim` | Existing PVC name. |
+| `neo4j.persistence.hostPath` | Single-node host path storage. |
+
+After enabling Neo4j, backfill existing cached entities:
+
+```bash
+news-dashboard graph-backfill --limit 250 --days 30
+news-dashboard graph-relationship-backfill --limit 50 --days 7
+```

--- a/website/docs/contributing/index.md
+++ b/website/docs/contributing/index.md
@@ -52,6 +52,15 @@ placeholder translation layers, or generic multi-database SQL.
 SQLite may appear only in legacy migration tooling that reads an old SQLite
 database and writes into PostgreSQL.
 
+## Optional Neo4j graph store
+
+Graph features use Neo4j only when `NEO4J_URI`, `NEO4J_USER`, and
+`NEO4J_PASSWORD` are configured. Unit tests fake the graph boundary; do not
+require a live Neo4j instance for the normal test suite. When you change graph
+behavior, add tests around `backend/news_dashboard/graph_store.py`,
+`backend/news_dashboard/entities.py`, or the relevant frontend component, then
+run the targeted backend and Vitest suites.
+
 ## Opening a PR
 
 1. Pick or create an issue with clear acceptance criteria.

--- a/website/docs/user-guide/concepts.md
+++ b/website/docs/user-guide/concepts.md
@@ -48,3 +48,10 @@ not remove it from the day's report.
 A **source subscription** is the set of feeds available to your account. A
 source can be an RSS or Atom feed, a GitHub releases feed, a trending feed, or
 a custom scraped page.
+
+## Knowledge graph
+
+A **knowledge graph** is an entity relationship map built from your visible
+articles. Entities are people, organizations, products, and places extracted
+from article text. Co-occurrence edges mean two entities appeared in the same
+article; typed relationship edges are explicit article-supported relationships.

--- a/website/docs/user-guide/index.md
+++ b/website/docs/user-guide/index.md
@@ -13,6 +13,7 @@ search, briefings, and sharing.
 | [Search](search) | Finding articles across your history with PostgreSQL full-text search. |
 | [Briefings](briefings) | Current-Day Reports, scheduled delivery, and optional audio. |
 | [Recommendations](recommendations) | How personalized suggestions are scored and controlled. |
+| [Knowledge Graph](knowledge-graph) | Exploring entities, typed relationships, and Ask AI graph context. |
 | [Saved and read history](saved-history) | Later, Done, Starred, Archived, Reading DNA, and export behavior. |
 | [Sharing articles](sharing) | Sending articles to other users on the same instance. |
 

--- a/website/docs/user-guide/knowledge-graph.md
+++ b/website/docs/user-guide/knowledge-graph.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 9
+---
+
+# Knowledge Graph
+
+The Knowledge Graph in AI Stats shows named entities found in recent articles
+and how they connect.
+
+- Circles are entities such as people, organizations, products, and places.
+- Solid edges mean the entities appeared in the same article.
+- Dashed edges are typed relationships extracted from article text, such as
+  "led by" or "acquired".
+- Selecting an entity shows supporting articles and relationship provenance.
+
+Use the relationship filter to focus on all connections, co-occurrence only, or
+typed relationships. If graph storage is not enabled on your instance, the graph
+falls back to cached entity data where possible.
+
+Ask AI can use graph context when it answers over retrieved articles. The answer
+still cites articles; graph context is shown separately so you can audit which
+relationships influenced the response.


### PR DESCRIPTION
## Summary
- add optional Neo4j graph storage while keeping PostgreSQL as the application database and fallback graph source
- sync entities and typed relationships to Neo4j with CLI backfills, scheduler job, health details, and Ask AI graph context
- render typed graph relationships in the frontend and document Helm/self-hosting/user/privacy setup

## Verification
- PATH="$PWD/.venv/bin:$PATH" make lint typecheck helm-validate build
- PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_graph_store.py backend/tests/test_entities.py backend/tests/test_embeddings.py::test_ask_includes_bounded_graph_context backend/tests/test_health_endpoints.py::test_health_details_reports_graph_status -q
- npm run test:frontend -- --run frontend/src/__tests__/ask.test.tsx frontend/src/__tests__/knowledgeGraph.test.tsx
- npm run test:frontend --silent -- --run

Note: PATH="$PWD/.venv/bin:$PATH" make test hit existing xdist/shared-Postgres isolation failures in unrelated workflow/summary/quiz tests; the same 11 failing cases passed serially with pytest -n 0.

Closes #1098
Closes #1099
Closes #1100
Closes #1101
Closes #1102
Closes #1103
Closes #1104
Closes #1105
Closes #1106