### PR TITLE
fix: avoid cross-user slug collisions for private sources (#1090)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -511,6 +511,18 @@ class CreateSourceRequest(BaseModel):
         return slug
 
 
+def _private_source_slug(owner_user_id: int, slug: str) -> str:
+    """Namespace a requested slug to the owning user's private source rows.
+
+    ``sources.slug`` is a global primary key, so two users requesting the same
+    human-friendly slug (e.g. "my-blog") would otherwise collide with a 409 even
+    though each source is private to its owner. Namespacing the stored slug by
+    owner keeps the requested name available to every user while the primary
+    key stays globally unique.
+    """
+    return f"u{owner_user_id}-{slug}"[:120]
+
+
 class PreviewSourceRequest(BaseModel):
     url: str
     kind: str = "rss_feed"
@@ -1553,13 +1565,16 @@ def create_source(
     except UnsafeUrlError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    slug = payload.validated_slug(payload.name)
+    requested_slug = payload.validated_slug(payload.name)
+    slug = _private_source_slug(uid, requested_slug)
 
     init_db()
     with connect() as conn:
         existing = conn.execute("SELECT 1 FROM sources WHERE slug = %s", (slug,)).fetchone()
         if existing:
-            raise HTTPException(status_code=409, detail=f"source slug '{slug}' already exists")
+            raise HTTPException(
+                status_code=409, detail=f"source slug '{requested_slug}' already exists"
+            )
         conn.execute(
             """
             INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
@@ -1809,15 +1824,16 @@ def import_opml(
                 url=xml_url, name=name, category=category, kind="rss_feed"
             )
             try:
-                slug = payload.validated_slug(name)
+                slug = _private_source_slug(uid, payload.validated_slug(name))
             except HTTPException:
                 failed.append({"url": xml_url, "error": "could not derive a valid slug"})
                 continue
 
-            # Skip duplicates: slug is globally unique (primary key), so a slug collision
-            # with anyone's source would fail the insert. For the URL, only match sources
-            # already visible to this user (their own, or a global default) — a different
-            # user's private source sharing the same URL is not a duplicate for this user.
+            # Skip duplicates: the namespaced slug is only reused if this same user already
+            # imported it, so it never collides with another user's private source. For the
+            # URL, only match sources already visible to this user (their own, or a global
+            # default) — a different user's private source sharing the same URL is not a
+            # duplicate for this user.
             existing = conn.execute(
                 """
                 SELECT 1 FROM sources

--- a/backend/tests/test_opml.py
+++ b/backend/tests/test_opml.py
@@ -178,6 +178,48 @@ def test_import_opml_skips_duplicates(client: TestClient, pg_clean: str) -> None
     assert data["skipped"][0]["reason"] == "duplicate"
 
 
+def test_import_opml_allows_cross_user_slug_reuse(pg_clean: str) -> None:
+    """A different user importing the same feed name should not be skipped as a
+    duplicate just because another user already owns a private source with the
+    same requested slug."""
+    from news_dashboard.auth import require_admin, require_auth
+
+    _seed_sources(pg_clean)  # owner_user_id=1 already owns slug 'arxiv' ("ArXiv AI")
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO users(id, username, password_hash, is_admin)"
+            " VALUES (2, 'reader2', 'x', FALSE)"
+        )
+
+    other_user = {"id": 2, "username": "reader2", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: other_user
+    app.dependency_overrides[require_admin] = lambda: other_user
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client2:
+            opml_same_name = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>User2 feeds</title></head>
+  <body>
+    <outline type="rss" text="ArXiv AI" xmlUrl="https://example.com/user2-arxiv-rss" />
+  </body>
+</opml>
+"""
+            response = client2.post(
+                "/api/sources/import",
+                files={"file": ("subs.opml", BytesIO(opml_same_name.encode()), "application/xml")},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["added"]) == 1
+    assert len(data["skipped"]) == 0
+    assert data["added"][0]["owner_user_id"] == 2
+
+
 def test_import_opml_rejects_malformed_xml(client: TestClient, pg_clean: str) -> None:
     init_db(database_url=pg_clean)
     with connect(database_url=pg_clean) as conn:

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -224,13 +224,16 @@ def test_api_create_private_source(pg_clean: str, monkeypatch: pytest.MonkeyPatc
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["slug"] == "my-blog"
+        # The stored slug is namespaced per-owner (see _private_source_slug) so it
+        # doesn't collide with another user's source requesting the same slug.
+        assert data["slug"] != "my-blog"
+        assert data["slug"].endswith("my-blog")
         assert data["owner_user_id"] == uid
 
         # Verify it appears in the source list for this user
         resp2 = client.get("/api/sources")
         slugs = [i["slug"] for i in resp2.json()["items"]]
-        assert "my-blog" in slugs
+        assert data["slug"] in slugs
 
 
 @pytest.mark.parametrize(
@@ -259,7 +262,7 @@ def test_api_create_private_source_accepts_supported_kinds(
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["slug"] == slug
+    assert data["slug"].endswith(slug)
     assert data["kind"] == kind
     assert data["owner_user_id"] == uid
 
@@ -349,7 +352,7 @@ def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.Monkey
     uid = _make_user(pg_clean)
 
     with _api_client(pg_clean, uid) as client:
-        client.post(
+        create_resp = client.post(
             "/api/sources",
             json={
                 "url": "https://example.com/delete-feed.xml",
@@ -357,7 +360,8 @@ def test_api_delete_own_private_source(pg_clean: str, monkeypatch: pytest.Monkey
                 "slug": "to-delete",
             },
         )
-        resp = client.delete("/api/sources/to-delete")
+        slug = create_resp.json()["slug"]
+        resp = client.delete(f"/api/sources/{slug}")
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
 
@@ -406,7 +410,7 @@ def test_api_delete_private_source_no_articles_still_soft_deletes(
     uid = _make_user(pg_clean)
 
     with _api_client(pg_clean, uid) as client:
-        client.post(
+        create_resp = client.post(
             "/api/sources",
             json={
                 "url": "https://example.com/empty-feed.xml",
@@ -414,7 +418,8 @@ def test_api_delete_private_source_no_articles_still_soft_deletes(
                 "slug": "empty-src",
             },
         )
-        resp = client.delete("/api/sources/empty-src")
+        slug = create_resp.json()["slug"]
+        resp = client.delete(f"/api/sources/{slug}")
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
 
@@ -422,7 +427,7 @@ def test_api_delete_private_source_no_articles_still_soft_deletes(
         with connect(pg_clean) as conn:
             row = conn.execute(
                 "SELECT slug, deleted_at IS NOT NULL as is_deleted FROM sources WHERE slug = %s",
-                ("empty-src",),
+                (slug,),
             ).fetchone()
             assert row is not None
             assert row["is_deleted"] is True
@@ -430,7 +435,7 @@ def test_api_delete_private_source_no_articles_still_soft_deletes(
         # Source not in listing
         resp2 = client.get("/api/sources")
         slugs = [i["slug"] for i in resp2.json()["items"]]
-        assert "empty-src" not in slugs
+        assert slug not in slugs
 
 
 def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -440,7 +445,7 @@ def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.Monk
     uid_b = _make_user(pg_clean, "bob")
 
     with _api_client(pg_clean, uid_a) as client_a:
-        client_a.post(
+        create_resp = client_a.post(
             "/api/sources",
             json={
                 "url": "https://example.com/alices-feed.xml",
@@ -448,9 +453,10 @@ def test_api_cannot_delete_others_source(pg_clean: str, monkeypatch: pytest.Monk
                 "slug": "alice-src",
             },
         )
+        slug = create_resp.json()["slug"]
 
     with _api_client(pg_clean, uid_b) as client_b:
-        resp = client_b.delete("/api/sources/alice-src")
+        resp = client_b.delete(f"/api/sources/{slug}")
         assert resp.status_code == 403
 
 
@@ -538,6 +544,70 @@ def test_api_create_source_duplicate_slug_returns_409(
         resp1 = client.post("/api/sources", json=payload)
         assert resp1.status_code == 200
         resp2 = client.post("/api/sources", json=payload)
+        assert resp2.status_code == 409
+        assert "already exists" in resp2.json()["detail"]
+
+
+def test_api_create_source_allows_cross_user_slug_reuse(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Different users can each create a private source with the same requested slug."""
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+
+    with _api_client(pg_clean, alice) as client:
+        resp = client.post(
+            "/api/sources",
+            json={"url": "https://example.com/alice-feed", "name": "My Blog", "slug": "my-blog"},
+        )
+        assert resp.status_code == 200
+        alice_slug = resp.json()["slug"]
+
+    with _api_client(pg_clean, bob) as client:
+        resp = client.post(
+            "/api/sources",
+            json={"url": "https://example.com/bob-feed", "name": "My Blog", "slug": "my-blog"},
+        )
+        assert resp.status_code == 200
+        bob_slug = resp.json()["slug"]
+
+    assert alice_slug != bob_slug
+
+    # Alice still can't see Bob's private source, and vice versa.
+    with _api_client(pg_clean, alice) as client:
+        resp = client.get("/api/sources")
+        slugs = {item["slug"] for item in resp.json()["items"]}
+        assert alice_slug in slugs
+        assert bob_slug not in slugs
+
+    with _api_client(pg_clean, bob) as client:
+        resp = client.get("/api/sources")
+        slugs = {item["slug"] for item in resp.json()["items"]}
+        assert bob_slug in slugs
+        assert alice_slug not in slugs
+
+
+def test_api_create_source_still_rejects_same_user_duplicate_slug(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user still gets 409 when re-using their own existing private slug."""
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        payload = {"url": "https://example.com/feed", "name": "My Blog", "slug": "my-blog"}
+        resp1 = client.post("/api/sources", json=payload)
+        assert resp1.status_code == 200
+
+        other_payload = {
+            "url": "https://example.com/other-feed",
+            "name": "My Blog Again",
+            "slug": "my-blog",
+        }
+        resp2 = client.post("/api/sources", json=other_payload)
         assert resp2.status_code == 409
         assert "already exists" in resp2.json()["detail"]
 


### PR DESCRIPTION
Fixes #1090

## Summary
- Private custom sources are user-owned, but `sources.slug` is a global primary key, so one user's private source slug (e.g. `my-blog`) blocked every other user from creating or importing an unrelated private source requesting the same name.
- Added `_private_source_slug(owner_user_id, slug)` in `backend/news_dashboard/main.py`, which namespaces the *stored* slug as `u{owner_user_id}-{slug}` for private sources — the same deterministic-namespacing pattern already used for newsletter sources (`newsletter-{owner_user_id}-{slug}` in `newsletter_ingest.py`).
- `create_source` (`POST /api/sources`) and the OPML import duplicate-detection path now namespace the slug before checking for an existing row and before insert, so:
  - Different users can each create/import a private source requesting the same slug/name without a 409, and without seeing each other's source.
  - A user re-using their *own* existing private slug still gets 409.
  - Global/default source slug uniqueness and scoping by `owner_user_id` are unchanged — every other endpoint (`delete_source`, `set_source_enabled`, listing, health, article visibility) already operates on whatever slug is returned from the DB, so no other call sites needed changes.
- Updated existing tests that hard-coded the requested slug as the expected returned `slug` — they now read the actual returned slug back from the response (matching the pattern `test_api_create_source_auto_generates_slug` already used) since the *stored* slug is now an internal, namespaced value rather than a literal echo of user input. The frontend already treats `slug` as an opaque identifier (never displayed, always round-tripped from API responses), so this is not a behavior change for the UI.
- Added new tests:
  - `test_api_create_source_allows_cross_user_slug_reuse` / `test_api_create_source_still_rejects_same_user_duplicate_slug` in `backend/tests/test_source_subscriptions.py`
  - `test_import_opml_allows_cross_user_slug_reuse` in `backend/tests/test_opml.py`

## Test plan
- [x] `pytest backend/tests/test_source_subscriptions.py backend/tests/test_opml.py` — 40 passed
- [x] `pytest backend/tests/test_demo.py backend/tests/test_personalization_nudges.py backend/tests/test_postgres_types.py backend/tests/test_source_health.py backend/tests/test_source_preview.py` — 77 passed
- [x] Full backend suite (`pytest backend/`) — 1867 passed, 12 pre-existing xdist-parallelism flakes in unrelated files (`test_body_fetch.py`, `test_workflow_state.py`, `test_per_user_article_state.py`) that all pass when re-run without parallelism (`-n0`), confirming they're unrelated to this change
- [x] `ruff check` / `ruff format --check` / `ty check` on changed files — clean
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) — passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)