### PR TITLE
test: guard against duplicate Docusaurus .js/.tsx source pairs (#1091)

### DIFF
--- a/scripts/test_repo_metadata.py
+++ b/scripts/test_repo_metadata.py
@@ -61,6 +61,41 @@ class TestVultureWhitelistExists(unittest.TestCase):
         )
 
 
+class TestNoDuplicateDocusaurusSourceFiles(unittest.TestCase):
+    """A compiled/generated ``.js`` file checked in beside its ``.tsx`` source under
+    ``website/src`` makes Docusaurus register the same page or component twice
+    (e.g. a duplicate `/` route warning) because both files export a component
+    for the same route or import path. Guard against that pairing recurring.
+    """
+
+    _SOURCE_DIRS: ClassVar[list[str]] = ["pages", "components"]
+    _JS_EXTENSIONS: ClassVar[set[str]] = {".js", ".jsx"}
+    _TS_EXTENSIONS: ClassVar[set[str]] = {".ts", ".tsx"}
+
+    def test_no_js_and_ts_pair_share_a_basename(self) -> None:
+        website_src = ROOT / "website" / "src"
+        violations: list[str] = []
+        for subdir in self._SOURCE_DIRS:
+            base = website_src / subdir
+            if not base.is_dir():
+                continue
+            for path in base.rglob("*"):
+                if not path.is_file() or path.suffix not in self._JS_EXTENSIONS:
+                    continue
+                stem_dir = path.parent
+                for ts_ext in self._TS_EXTENSIONS:
+                    ts_sibling = stem_dir / f"{path.stem}{ts_ext}"
+                    if ts_sibling.is_file():
+                        violations.append(
+                            f"{path.relative_to(ROOT)} duplicates {ts_sibling.relative_to(ROOT)}"
+                        )
+        assert not violations, (
+            "Docusaurus source files must not have both a compiled .js/.jsx and a "
+            ".ts/.tsx file with the same name (causes duplicate route/component "
+            "registration):\n" + "\n".join(violations)
+        )
+
+
 class TestNoPrivatePersonalPhrases(unittest.TestCase):
     _FORBIDDEN: ClassVar[list[str]] = ["private personal", "for Ioachim"]
     _EXTENSIONS: ClassVar[set[str]] = {".py", ".md", ".toml", ".ts", ".tsx", ".txt", ".rst"}


### PR DESCRIPTION
## Summary

Closes #1091.

The issue reported that `website/src/pages/index.js` and `index.tsx` (and the matching `HomepageFeatures` pair) both existed and produced a Docusaurus "Duplicate routes found!" warning for `/`.

On the current `main`, that pairing does not exist: there is only `website/src/pages/index.tsx` and `website/src/components/HomepageFeatures/index.tsx`, no `.js`/`.jsx` counterparts. `npm run build` completes with no duplicate-route warning and `npm run typecheck` passes.

Since the acceptance criteria are already met (single source file per route/component, clean build, clean typecheck), this PR adds the "repo check" guard the issue asked for so the duplicate-source-file bug can't silently reappear: `scripts/test_repo_metadata.py::TestNoDuplicateDocusaurusSourceFiles` fails the build if a `.js`/`.jsx` file and a `.ts`/`.tsx` file with the same basename ever coexist under `website/src/pages` or `website/src/components`.

## Test plan

- [x] `python3 -m pytest scripts/test_repo_metadata.py -v` — all 6 tests pass, including the new guard
- [x] Verified the guard actually fails: temporarily copied `index.tsx` to `index.js` and confirmed the new test catches it, then removed the temp file
- [x] `cd website && npm ci && npm run typecheck && npm run build` — no duplicate route warning, typecheck clean
- [x] Pre-commit hooks (ruff, mypy, ty, pyrefly, vulture) pass on the changed file