### PR TITLE
feat: migrate knowledge graph to React Flow

### DIFF
--- a/frontend/src/__tests__/knowledgeGraph.test.tsx
+++ b/frontend/src/__tests__/knowledgeGraph.test.tsx
@@ -78,10 +78,11 @@ beforeEach(() => {
 });
 
 describe('knowledge graph section', () => {
-  it('renders a node per entity and an edge per co-occurrence', async () => {
+  it('renders the graph with React Flow nodes and edges', async () => {
     const { container } = renderPage();
     await waitFor(() => {
-      expect(container.querySelectorAll('[data-testid="kg-node"]')).toHaveLength(3);
+      expect(container.querySelector('.react-flow')).toBeInTheDocument();
+      expect(container.querySelectorAll('.react-flow__node')).toHaveLength(3);
     });
     expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(2);
     expect(screen.getByText('OpenAI')).toBeInTheDocument();
@@ -126,11 +127,13 @@ describe('knowledge graph section', () => {
       expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(2);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /typed relationships/i }));
+    const typedFilter = screen.getByRole('button', { name: /typed relationships/i });
+    fireEvent.click(typedFilter);
 
     await waitFor(() => {
       expect(container.querySelectorAll('[data-testid="kg-edge"]')).toHaveLength(1);
     });
+    expect(typedFilter).toHaveAttribute('aria-pressed', 'true');
     expect(container.querySelector('[data-testid="kg-edge"]')?.getAttribute('data-kind')).toBe(
       'typed'
     );

--- a/frontend/src/components/aiStats/KnowledgeGraph.tsx
+++ b/frontend/src/components/aiStats/KnowledgeGraph.tsx
@@ -1,4 +1,19 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Background,
+  BaseEdge,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  applyNodeChanges,
+  getStraightPath,
+  type Edge,
+  type EdgeProps,
+  type Node,
+  type NodeProps,
+  type OnNodesChange,
+} from '@xyflow/react';
 import { Link } from 'react-router-dom';
 import type {
   EntityType,
@@ -7,8 +22,6 @@ import type {
   KnowledgeGraphResponse,
 } from '@/types';
 import { forceLayout } from '@/lib/forceLayout';
-import type { ForcePoint } from '@/lib/forceLayout';
-import { useInteractiveViewport } from '@/lib/useInteractiveViewport';
 import { cn } from '@/lib/utils';
 
 const CANVAS_W = 800;
@@ -26,7 +39,7 @@ function nodeRadius(count: number): number {
   return 6 + 3 * Math.sqrt(count);
 }
 
-/** Generous upper bound for margin so nodes never clip at the SVG boundary */
+/** Generous upper bound for margin so nodes never clip at the viewport boundary */
 const MAX_RADIUS = nodeRadius(50);
 
 function isIncident(edge: KnowledgeGraphEdge, nodeId: string): boolean {
@@ -37,6 +50,143 @@ function edgeKind(edge: KnowledgeGraphEdge): 'cooccurrence' | 'typed' {
   return edge.kind ?? 'cooccurrence';
 }
 
+type KnowledgeFlowNodeData = Record<string, unknown> & {
+  entity: KnowledgeGraphNode;
+  color: string;
+  dimmed: boolean;
+  radius: number;
+};
+
+type KnowledgeFlowEdgeData = Record<string, unknown> & {
+  kind: 'cooccurrence' | 'typed';
+};
+
+type KnowledgeFlowNode = Node<KnowledgeFlowNodeData, 'entity'>;
+type KnowledgeFlowEdge = Edge<KnowledgeFlowEdgeData, 'relationship'>;
+
+function EntityNode({ data }: NodeProps<KnowledgeFlowNode>) {
+  const diameter = data.radius * 2;
+  return (
+    <div className="relative flex items-center justify-center">
+      <Handle type="target" position={Position.Left} className="opacity-0" />
+      <div
+        data-testid="kg-node"
+        data-entity={data.entity.id}
+        title={`${data.entity.name} - ${data.entity.count} article${
+          data.entity.count !== 1 ? 's' : ''
+        }`}
+        className={cn(
+          'grid place-items-center rounded-full border-[1.5px] border-background text-[10px] font-semibold text-background shadow-sm transition-opacity',
+          data.dimmed ? 'opacity-30' : 'opacity-90'
+        )}
+        style={{
+          width: diameter,
+          height: diameter,
+          backgroundColor: data.color,
+        }}
+      />
+      <span
+        className={cn(
+          'pointer-events-none absolute left-1/2 top-0 max-w-28 -translate-x-1/2 -translate-y-full select-none truncate pb-1 text-[11px] font-medium text-foreground',
+          data.dimmed && 'opacity-30'
+        )}
+      >
+        {data.entity.name}
+      </span>
+      <Handle type="source" position={Position.Right} className="opacity-0" />
+    </div>
+  );
+}
+
+function RelationshipEdge({
+  data,
+  id,
+  sourceX,
+  sourceY,
+  style,
+  targetX,
+  targetY,
+}: EdgeProps<KnowledgeFlowEdge>) {
+  const [edgePath] = getStraightPath({ sourceX, sourceY, targetX, targetY });
+  const kind = data?.kind ?? 'cooccurrence';
+  return <BaseEdge id={id} data-testid="kg-edge" data-kind={kind} path={edgePath} style={style} />;
+}
+
+const NODE_TYPES = { entity: EntityNode };
+const EDGE_TYPES = { relationship: RelationshipEdge };
+
+function makeNode(
+  entity: KnowledgeGraphNode,
+  position: { x: number; y: number },
+  selectedId: string | null
+): KnowledgeFlowNode {
+  const radius = nodeRadius(entity.count);
+  const diameter = radius * 2;
+  return {
+    id: entity.id,
+    type: 'entity',
+    position,
+    width: diameter,
+    height: diameter,
+    initialWidth: diameter,
+    initialHeight: diameter,
+    origin: [0.5, 0.5],
+    sourcePosition: Position.Right,
+    targetPosition: Position.Left,
+    handles: [
+      {
+        id: null,
+        type: 'target',
+        position: Position.Left,
+        x: 0,
+        y: radius,
+        width: 1,
+        height: 1,
+      },
+      {
+        id: null,
+        type: 'source',
+        position: Position.Right,
+        x: diameter,
+        y: radius,
+        width: 1,
+        height: 1,
+      },
+    ],
+    data: {
+      entity,
+      color: TYPE_COLORS[entity.type],
+      dimmed: selectedId !== null && selectedId !== entity.id,
+      radius,
+    },
+    draggable: true,
+    focusable: true,
+    selectable: false,
+  };
+}
+
+function makeEdge(edge: KnowledgeGraphEdge, index: number, selectedId: string | null) {
+  const kind = edgeKind(edge);
+  const dimmed = selectedId !== null && !isIncident(edge, selectedId);
+  return {
+    id: `${edge.source}--${edge.target}--${kind}--${edge.relationship_type ?? index}`,
+    source: edge.source,
+    target: edge.target,
+    type: 'relationship',
+    data: { kind },
+    selectable: false,
+    style: {
+      stroke:
+        kind === 'typed'
+          ? 'color-mix(in oklch, var(--color-accent-foreground) 50%, transparent)'
+          : 'color-mix(in oklch, var(--color-primary) 30%, transparent)',
+      strokeDasharray: kind === 'typed' ? '5 4' : undefined,
+      strokeWidth: Math.min(1 + edge.weight, 6),
+      opacity: dimmed ? 0.35 : 1,
+    },
+  } satisfies KnowledgeFlowEdge;
+}
+
 interface KnowledgeGraphProps {
   graph: KnowledgeGraphResponse;
 }
@@ -44,103 +194,34 @@ interface KnowledgeGraphProps {
 export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [edgeFilter, setEdgeFilter] = useState<EdgeFilter>('all');
+  const [flowNodes, setFlowNodes] = useState<KnowledgeFlowNode[]>([]);
 
-  // Mutable positions map (starts from forceLayout, updated by drag)
-  const [positions, setPositions] = useState<Map<string, ForcePoint>>(() =>
-    forceLayout(graph.nodes, graph.edges, CANVAS_W, CANVAS_H, MAX_RADIUS)
-  );
-
-  // Re-run layout when graph data identity changes
   useEffect(() => {
-    setPositions(forceLayout(graph.nodes, graph.edges, CANVAS_W, CANVAS_H, MAX_RADIUS));
+    const positions = forceLayout(graph.nodes, graph.edges, CANVAS_W, CANVAS_H, MAX_RADIUS);
+    setFlowNodes(
+      graph.nodes.map((entity) =>
+        makeNode(entity, positions.get(entity.id) ?? { x: CANVAS_W / 2, y: CANVAS_H / 2 }, null)
+      )
+    );
+    setSelectedId(null);
   }, [graph.nodes, graph.edges]);
 
-  const { viewport, svgRef, svgProps, isPanning, resetViewport } = useInteractiveViewport({
-    width: CANVAS_W,
-    height: CANVAS_H,
-  });
+  useEffect(() => {
+    setFlowNodes((nodes) =>
+      nodes.map((node) => ({
+        ...node,
+        data: {
+          ...node.data,
+          dimmed: selectedId !== null && selectedId !== node.id,
+        },
+      }))
+    );
+  }, [selectedId]);
 
-  // Track which node is being dragged (null = none) — kept in state so cursor updates
-  const [draggingNodeId, setDraggingNodeId] = useState<string | null>(null);
-
-  // Mutable drag-start data (not state — no re-render needed on update)
-  const dragData = useRef<{
-    startClientX: number;
-    startClientY: number;
-    startX: number;
-    startY: number;
-  } | null>(null);
-
-  const handleNodeMouseDown = useCallback(
-    (e: React.MouseEvent<SVGCircleElement>, nodeId: string) => {
-      e.stopPropagation();
-      const p = positions.get(nodeId);
-      if (!p) return;
-      dragData.current = {
-        startClientX: e.clientX,
-        startClientY: e.clientY,
-        startX: p.x,
-        startY: p.y,
-      };
-      setDraggingNodeId(nodeId);
-    },
-    [positions]
+  const onNodesChange = useCallback<OnNodesChange<KnowledgeFlowNode>>(
+    (changes) => setFlowNodes((nodes) => applyNodeChanges(changes, nodes)),
+    []
   );
-
-  const handleSvgMouseMove = useCallback(
-    (e: React.MouseEvent<SVGSVGElement>) => {
-      if (dragData.current && draggingNodeId !== null) {
-        e.stopPropagation();
-        const svg = svgRef.current;
-        if (!svg) return;
-        const rect = svg.getBoundingClientRect();
-        const scaleX = CANVAS_W / rect.width;
-        const scaleY = CANVAS_H / rect.height;
-        const dx = ((e.clientX - dragData.current.startClientX) * scaleX) / viewport.scale;
-        const dy = ((e.clientY - dragData.current.startClientY) * scaleY) / viewport.scale;
-        const newX = Math.max(
-          MAX_RADIUS,
-          Math.min(CANVAS_W - MAX_RADIUS, dragData.current.startX + dx)
-        );
-        const newY = Math.max(
-          MAX_RADIUS,
-          Math.min(CANVAS_H - MAX_RADIUS, dragData.current.startY + dy)
-        );
-        setPositions((prev) => {
-          const next = new Map(prev);
-          next.set(draggingNodeId, { x: newX, y: newY });
-          return next;
-        });
-      } else {
-        svgProps.onMouseMove(e);
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [draggingNodeId, svgProps, viewport.scale]
-  );
-
-  const handleSvgMouseUp = useCallback(() => {
-    if (draggingNodeId !== null) {
-      dragData.current = null;
-      setDraggingNodeId(null);
-    } else {
-      svgProps.onMouseUp();
-    }
-  }, [draggingNodeId, svgProps]);
-
-  const handleSvgMouseLeave = useCallback(() => {
-    if (draggingNodeId !== null) {
-      dragData.current = null;
-      setDraggingNodeId(null);
-    } else {
-      svgProps.onMouseLeave();
-    }
-  }, [draggingNodeId, svgProps]);
-
-  const handleNodeClick = useCallback((e: React.MouseEvent, nodeId: string) => {
-    e.stopPropagation();
-    setSelectedId((prev) => (prev === nodeId ? null : nodeId));
-  }, []);
 
   const selected = useMemo(
     () => graph.nodes.find((n: KnowledgeGraphNode) => n.id === selectedId) ?? null,
@@ -157,6 +238,11 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
     [edgeFilter, graph.edges]
   );
 
+  const flowEdges = useMemo(
+    () => visibleEdges.map((edge, index) => makeEdge(edge, index, selectedId)),
+    [selectedId, visibleEdges]
+  );
+
   const selectedArticles = useMemo(() => {
     if (!selected) return [];
     const wanted = new Set(selected.article_ids);
@@ -167,6 +253,10 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
     if (!selected) return [];
     return visibleEdges.filter((edge) => isIncident(edge, selected.id));
   }, [selected, visibleEdges]);
+
+  const handleNodeClick = useCallback((_event: React.MouseEvent, node: KnowledgeFlowNode) => {
+    setSelectedId((prev) => (prev === node.id ? null : node.id));
+  }, []);
 
   if (graph.graph_enabled === false) {
     return (
@@ -180,17 +270,13 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
     return (
       <p className="py-10 text-center text-sm text-muted-foreground">
         {graph.pending_count > 0
-          ? `No entities yet — extraction is still running for ${graph.pending_count} article${
+          ? `No entities yet - extraction is still running for ${graph.pending_count} article${
               graph.pending_count !== 1 ? 's' : ''
             }.`
-          : 'No entities yet — the graph fills in as articles are analyzed.'}
+          : 'No entities yet - the graph fills in as articles are analyzed.'}
       </p>
     );
   }
-
-  const isDraggingNode = draggingNodeId !== null;
-  const cursorClass = isDraggingNode || isPanning ? 'cursor-grabbing' : 'cursor-grab';
-  const transform = `translate(${viewport.tx} ${viewport.ty}) scale(${viewport.scale})`;
 
   return (
     <div className="flex flex-col gap-3">
@@ -203,6 +289,7 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
           <button
             key={value}
             type="button"
+            aria-pressed={edgeFilter === value}
             onClick={() => setEdgeFilter(value as EdgeFilter)}
             className={cn(
               'rounded px-2.5 py-1 text-xs transition-colors',
@@ -216,109 +303,32 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
         ))}
       </div>
 
-      {/* Graph canvas */}
-      <div className="relative overflow-hidden rounded-lg border border-border bg-surface-2">
-        <svg
-          ref={svgRef}
-          viewBox={`0 0 ${CANVAS_W} ${CANVAS_H}`}
-          className={cn('h-auto w-full', cursorClass)}
-          role="img"
-          onMouseDown={svgProps.onMouseDown}
-          onMouseMove={handleSvgMouseMove}
-          onMouseUp={handleSvgMouseUp}
-          onMouseLeave={handleSvgMouseLeave}
-          onWheel={svgProps.onWheel}
+      <div className="relative h-[28rem] w-full overflow-hidden rounded-lg border border-border bg-surface-2">
+        <ReactFlow<KnowledgeFlowNode, KnowledgeFlowEdge>
+          className="h-full w-full"
+          nodes={flowNodes}
+          edges={flowEdges}
+          nodeTypes={NODE_TYPES}
+          edgeTypes={EDGE_TYPES}
+          onNodeClick={handleNodeClick}
+          onNodesChange={onNodesChange}
+          fitView
+          minZoom={0.35}
+          maxZoom={2.5}
+          nodesConnectable={false}
+          edgesFocusable={false}
+          panOnScroll
+          proOptions={{ hideAttribution: true }}
         >
-          <title>Knowledge graph of entities in recent news</title>
-          {/* Transparent backdrop to capture pan clicks */}
-          <rect x={0} y={0} width={CANVAS_W} height={CANVAS_H} fill="transparent" />
+          <Background color="var(--color-border)" gap={24} />
+          <Controls position="bottom-right" showInteractive={false} />
+        </ReactFlow>
 
-          <g transform={transform}>
-            {visibleEdges.map((edge, index) => {
-              const a = positions.get(edge.source);
-              const b = positions.get(edge.target);
-              if (!a || !b) return null;
-              const dimmed = selectedId !== null && !isIncident(edge, selectedId);
-              const kind = edgeKind(edge);
-              return (
-                <line
-                  key={`${edge.source}--${edge.target}--${kind}--${edge.relationship_type ?? index}`}
-                  data-testid="kg-edge"
-                  data-kind={kind}
-                  x1={a.x}
-                  y1={a.y}
-                  x2={b.x}
-                  y2={b.y}
-                  strokeWidth={Math.min(1 + edge.weight, 6)}
-                  strokeDasharray={kind === 'typed' ? '5 4' : undefined}
-                  className={cn(
-                    kind === 'typed' ? 'stroke-accent-foreground/50' : 'stroke-primary/30',
-                    dimmed && 'stroke-primary/10'
-                  )}
-                />
-              );
-            })}
-            {graph.nodes.map((node: KnowledgeGraphNode) => {
-              const p = positions.get(node.id);
-              if (!p) return null;
-              const dimmed = selectedId !== null && selectedId !== node.id;
-              const r = nodeRadius(node.count);
-              const isThisNodeDragging = draggingNodeId === node.id;
-              return (
-                <g key={node.id}>
-                  <circle
-                    data-testid="kg-node"
-                    data-entity={node.id}
-                    cx={p.x}
-                    cy={p.y}
-                    r={r}
-                    fill={TYPE_COLORS[node.type]}
-                    fillOpacity={dimmed ? 0.3 : 0.85}
-                    className={cn(
-                      'stroke-background stroke-[1.5] transition-opacity',
-                      isThisNodeDragging ? 'cursor-grabbing' : 'cursor-pointer hover:stroke-[2.5]'
-                    )}
-                    onMouseDown={(e) => handleNodeMouseDown(e, node.id)}
-                    onClick={(e) => handleNodeClick(e, node.id)}
-                  >
-                    <title>{`${node.name} — ${node.count} article${node.count !== 1 ? 's' : ''}`}</title>
-                  </circle>
-                  <text
-                    x={p.x}
-                    y={p.y - r - 4}
-                    textAnchor="middle"
-                    className={cn(
-                      'pointer-events-none select-none fill-foreground text-[11px] font-medium',
-                      dimmed && 'opacity-30'
-                    )}
-                  >
-                    {node.name}
-                  </text>
-                </g>
-              );
-            })}
-          </g>
-        </svg>
-
-        {/* Controls overlay */}
-        <div className="absolute bottom-2 right-2 flex gap-1">
-          <button
-            type="button"
-            title="Reset view"
-            onClick={resetViewport}
-            className="rounded-md bg-background/80 px-2 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur hover:text-foreground"
-          >
-            Reset
-          </button>
-        </div>
-
-        {/* Hint */}
-        <p className="absolute bottom-2 left-2 select-none text-[10px] text-muted-foreground/50">
-          Scroll to zoom · Drag background to pan · Drag node to move
+        <p className="pointer-events-none absolute bottom-2 left-2 select-none text-[10px] text-muted-foreground/50">
+          Scroll to zoom · Drag background to pan · Drag nodes to move
         </p>
       </div>
 
-      {/* Legend */}
       <div className="flex flex-wrap gap-x-4 gap-y-1">
         {(Object.keys(TYPE_COLORS) as EntityType[]).map((type) => (
           <span key={type} className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
@@ -333,7 +343,6 @@ export function KnowledgeGraph({ graph }: KnowledgeGraphProps) {
         <span className="text-[11px] text-muted-foreground">dashed: typed relationship</span>
       </div>
 
-      {/* Selected node detail */}
       {selected && (
         <div className="rounded-xl border border-border bg-surface-2 p-4">
           <h3 className="text-sm font-semibold">

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -3,6 +3,7 @@
 @import '@fontsource-variable/inter/wght.css';
 @import '@fontsource-variable/jetbrains-mono/wght.css';
 @import '@fontsource-variable/source-serif-4/wght.css';
+@import '@xyflow/react/dist/style.css';
 
 /* Map Tailwind's dark: variant to [data-theme=dark] */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tailwindcss/vite": "^4.3.2",
         "@tanstack/react-query": "^5.101.2",
         "@vitejs/plugin-react": "^6.0.3",
+        "@xyflow/react": "^12.11.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -4842,6 +4843,15 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
@@ -4872,6 +4882,12 @@
         "@types/d3-time": "*"
       }
     },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
@@ -4892,6 +4908,25 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -5400,6 +5435,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5843,6 +5920,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5993,6 +6076,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -6048,6 +6153,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -6089,6 +6203,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -11535,6 +11684,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@tailwindcss/vite": "^4.3.2",
     "@tanstack/react-query": "^5.101.2",
     "@vitejs/plugin-react": "^6.0.3",
+    "@xyflow/react": "^12.11.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
Closes #1113

## Summary
- Move the AI stats knowledge graph renderer from custom SVG/pan-drag code to @xyflow/react.
- Keep the deterministic force layout as initial node placement while React Flow handles viewport controls and node dragging.
- Preserve relationship filtering, selected entity articles, relationship summaries, legend behavior, empty states, and disabled graph messaging.

## Verification
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:frontend -- frontend/src/__tests__/knowledgeGraph.test.tsx
- npm run test:frontend
- npm run build
- Playwright smoke against http://localhost:5173/ai-stats with mocked API data: React Flow nodes/edges, selection details, typed filter, controls placement, and no React Flow console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)