### PR TITLE
perf: reduce frontend production chunk sizes

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -8,20 +8,36 @@ import { RequireAuth } from './components/RequireAuth';
 import { AppShell } from './components/AppShell';
 import { LoginPage } from './pages/LoginPage';
 import { BriefPage } from './pages/BriefPage';
-import { InboxPage } from './pages/InboxPage';
-import { SharedPage } from './pages/SharedPage';
-import { SharedDetailPage } from './pages/SharedDetailPage';
-import { LaterPage } from './pages/LaterPage';
-import { StarredPage } from './pages/StarredPage';
 import { FeedsPage } from './pages/FeedsPage';
-import { SourcesPage } from './pages/SourcesPage';
-import { ArchivePage } from './pages/ArchivePage';
-import { CollectionsPage } from './pages/CollectionsPage';
-import { CollectionDetailPage } from './pages/CollectionDetailPage';
-import { ShareTargetPage } from './pages/ShareTargetPage';
 import { useAuth } from './contexts/auth';
 import { ShieldAlert } from 'lucide-react';
 
+const InboxPage = lazy(() => import('./pages/InboxPage').then((m) => ({ default: m.InboxPage })));
+const SharedPage = lazy(() =>
+  import('./pages/SharedPage').then((m) => ({ default: m.SharedPage }))
+);
+const SharedDetailPage = lazy(() =>
+  import('./pages/SharedDetailPage').then((m) => ({ default: m.SharedDetailPage }))
+);
+const LaterPage = lazy(() => import('./pages/LaterPage').then((m) => ({ default: m.LaterPage })));
+const StarredPage = lazy(() =>
+  import('./pages/StarredPage').then((m) => ({ default: m.StarredPage }))
+);
+const SourcesPage = lazy(() =>
+  import('./pages/SourcesPage').then((m) => ({ default: m.SourcesPage }))
+);
+const ArchivePage = lazy(() =>
+  import('./pages/ArchivePage').then((m) => ({ default: m.ArchivePage }))
+);
+const CollectionsPage = lazy(() =>
+  import('./pages/CollectionsPage').then((m) => ({ default: m.CollectionsPage }))
+);
+const CollectionDetailPage = lazy(() =>
+  import('./pages/CollectionDetailPage').then((m) => ({ default: m.CollectionDetailPage }))
+);
+const ShareTargetPage = lazy(() =>
+  import('./pages/ShareTargetPage').then((m) => ({ default: m.ShareTargetPage }))
+);
 const SearchPage = lazy(() =>
   import('./pages/SearchPage').then((m) => ({ default: m.SearchPage }))
 );
@@ -148,18 +164,18 @@ export const routes: RouteObject[] = [
     ),
     children: [
       { index: true, element: <BriefPage /> },
-      { path: 'today', element: <InboxPage /> },
-      { path: 'later', element: <LaterPage /> },
-      { path: 'starred', element: <StarredPage /> },
-      { path: 'shared', element: <SharedPage /> },
-      { path: 'shared/:shareId', element: <SharedDetailPage /> },
+      { path: 'today', element: withSuspense(InboxPage) },
+      { path: 'later', element: withSuspense(LaterPage) },
+      { path: 'starred', element: withSuspense(StarredPage) },
+      { path: 'shared', element: withSuspense(SharedPage) },
+      { path: 'shared/:shareId', element: withSuspense(SharedDetailPage) },
       { path: 'search', element: withSuspense(SearchPage) },
       { path: 'ask', element: withSuspense(AskPage) },
       {
         path: 'feeds',
         element: <FeedsPage />,
         children: [
-          { index: true, element: <SourcesPage /> },
+          { index: true, element: withSuspense(SourcesPage) },
           {
             path: 'schedule',
             element: (
@@ -210,11 +226,11 @@ export const routes: RouteObject[] = [
       { path: 'reading-list', element: withSuspense(ReadingListPage) },
       { path: 'offline-saved', element: withSuspense(OfflineSavedPage) },
       { path: 'recap', element: withSuspense(WeeklyRecapPage) },
-      { path: 'archive', element: <ArchivePage /> },
-      { path: 'collections', element: <CollectionsPage /> },
-      { path: 'collections/:tagId', element: <CollectionDetailPage /> },
+      { path: 'archive', element: withSuspense(ArchivePage) },
+      { path: 'collections', element: withSuspense(CollectionsPage) },
+      { path: 'collections/:tagId', element: withSuspense(CollectionDetailPage) },
       { path: 'settings', element: withSuspense(SettingsPage) },
-      { path: 'share-target', element: <ShareTargetPage /> },
+      { path: 'share-target', element: withSuspense(ShareTargetPage) },
       { path: 'admin', element: withSuspense(AdminPage) },
       {
         path: 'analytics',

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,15 +1,11 @@
 import { useLocation, useNavigate, Outlet, Link } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { LogOut, MoreHorizontal, Search, WifiOff } from 'lucide-react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { AppLogo } from './AppLogo';
 import { ErrorBoundary } from './ErrorBoundary';
-import { CommandPalette } from './CommandPalette';
-import { ShortcutOverlay } from './ShortcutOverlay';
-import { WhatsNewDialog } from './WhatsNewDialog';
-import { OnboardingWizard } from './OnboardingWizard';
 import { ListenQueuePlayer } from './ListenQueuePlayer';
 import { NavLink } from './NavLink';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
@@ -30,6 +26,19 @@ import {
   secondaryNavigationItemsFor,
   type NavigationItem,
 } from '@/lib/navigation';
+
+const CommandPalette = lazy(() =>
+  import('./CommandPalette').then((m) => ({ default: m.CommandPalette }))
+);
+const ShortcutOverlay = lazy(() =>
+  import('./ShortcutOverlay').then((m) => ({ default: m.ShortcutOverlay }))
+);
+const WhatsNewDialog = lazy(() =>
+  import('./WhatsNewDialog').then((m) => ({ default: m.WhatsNewDialog }))
+);
+const OnboardingWizard = lazy(() =>
+  import('./OnboardingWizard').then((m) => ({ default: m.OnboardingWizard }))
+);
 
 function useNavCounts() {
   const { data } = useQuery({
@@ -197,15 +206,17 @@ export function AppShell() {
         <ErrorBoundary>
           <Outlet />
         </ErrorBoundary>
-        <CommandPalette
-          open={paletteOpen}
-          onOpenChange={setPaletteOpen}
-          onShortcuts={() => {
-            setPaletteOpen(false);
-            setShortcutsOpen(true);
-          }}
-        />
-        <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+        <Suspense fallback={null}>
+          <CommandPalette
+            open={paletteOpen}
+            onOpenChange={setPaletteOpen}
+            onShortcuts={() => {
+              setPaletteOpen(false);
+              setShortcutsOpen(true);
+            }}
+          />
+          <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+        </Suspense>
       </>
     );
   }
@@ -327,17 +338,19 @@ export function AppShell() {
         </div>
       </nav>
 
-      <CommandPalette
-        open={paletteOpen}
-        onOpenChange={setPaletteOpen}
-        onShortcuts={() => {
-          setPaletteOpen(false);
-          setShortcutsOpen(true);
-        }}
-      />
-      <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
-      <WhatsNewDialog state={whatsNew} />
-      <OnboardingWizard open={onboarding.open} onClose={onboarding.skip} />
+      <Suspense fallback={null}>
+        <CommandPalette
+          open={paletteOpen}
+          onOpenChange={setPaletteOpen}
+          onShortcuts={() => {
+            setPaletteOpen(false);
+            setShortcutsOpen(true);
+          }}
+        />
+        <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+        <WhatsNewDialog state={whatsNew} />
+        <OnboardingWizard open={onboarding.open} onClose={onboarding.skip} />
+      </Suspense>
       <ListenQueuePlayer />
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "dev": "vite --host 0.0.0.0",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/check-bundle-budget.mjs",
     "preview": "vite preview --host 0.0.0.0",
     "typecheck": "tsc -b --noEmit",
     "lint": "eslint . --max-warnings 0",

--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Fails the build if any emitted JS chunk exceeds the configured budget, so
+// bundle-size regressions are caught in CI instead of discovered later in
+// production first-load metrics. Mirrors Vite's own chunkSizeWarningLimit
+// (500 kB) but turns it into a hard failure rather than a build-log warning.
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ASSETS_DIR = 'frontend/dist/assets';
+const BUDGET_BYTES = 500 * 1024;
+
+let files;
+try {
+  files = readdirSync(ASSETS_DIR).filter((f) => f.endsWith('.js'));
+} catch (err) {
+  console.error(`check-bundle-budget: could not read ${ASSETS_DIR}: ${err.message}`);
+  process.exit(1);
+}
+
+const overBudget = files
+  .map((name) => ({ name, size: statSync(join(ASSETS_DIR, name)).size }))
+  .filter(({ size }) => size > BUDGET_BYTES)
+  .sort((a, b) => b.size - a.size);
+
+if (overBudget.length > 0) {
+  console.error(
+    `check-bundle-budget: ${overBudget.length} chunk(s) exceed the ${(BUDGET_BYTES / 1024).toFixed(0)} kB budget:`
+  );
+  for (const { name, size } of overBudget) {
+    console.error(`  ${name}: ${(size / 1024).toFixed(1)} kB`);
+  }
+  console.error(
+    'Split the offending route/component with a dynamic import(), or if the growth is ' +
+      'justified (e.g. an isolated, lazy-loaded vendor library), raise BUDGET_BYTES in ' +
+      'scripts/check-bundle-budget.mjs with a comment explaining why.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check-bundle-budget: all ${files.length} JS chunks are within the ${(BUDGET_BYTES / 1024).toFixed(0)} kB budget.`
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,6 +97,23 @@ export default defineConfig({
   build: {
     outDir: 'frontend/dist',
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        // Stable, always-needed-on-first-paint libraries get their own chunk
+        // (independent from route/app code) so it caches across deploys and
+        // stays under Vite's per-chunk size warning instead of ballooning
+        // the app-shell "index" chunk every time application code changes.
+        manualChunks(id) {
+          if (
+            /node_modules\/(react|react-dom|react-router-dom|i18next|react-i18next|i18next-browser-languagedetector|@tanstack\/react-query|sonner)\//.test(
+              id
+            )
+          ) {
+            return 'vendor';
+          }
+        },
+      },
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
Closes #1093

## Summary
- Lazy-load the remaining eagerly-bundled routes in `frontend/src/AppRouter.tsx`: inbox, shared, shared-detail, later, starred, sources, archive, collections, collection-detail, share-target.
- Lazy-load `AppShell`'s overlay/dialog components (command palette, shortcut overlay, what's-new dialog, onboarding wizard) — they're not needed for first paint since they're closed by default.
- Add a `manualChunks` split in `vite.config.ts` that groups stable, always-needed vendor libraries (`react`, `react-dom`, `react-router-dom`, `i18next`, `react-i18next`, `i18next-browser-languagedetector`, `@tanstack/react-query`, `sonner`) into their own cacheable `vendor` chunk, separate from application/route code.
- Add `scripts/check-bundle-budget.mjs`, wired into `npm run build`, which fails the build if any emitted JS chunk exceeds 500 kB — turning Vite's existing warning into a hard CI failure so future regressions are caught automatically.

Charting (`recharts`) and error-tracking (`@sentry/react`) code were already isolated in their own route-gated / dynamically-imported chunks and are unchanged.

## Before/after chunk summary

| | Before | After |
|---|---|---|
| Initial app-shell `index` chunk | 622.63 kB | 249.69 kB |
| Vite chunk-size warning | yes (`index` > 500 kB) | none |
| New `vendor` chunk (react/router/i18n/query/sonner) | n/a | 307.28 kB (separately cacheable) |
| `AreaChart` (recharts, route-gated) | 359.28 kB | 359.29 kB (unchanged) |
| `esm` (Sentry, dynamic-import gated) | 472.06 kB | 472.10 kB (unchanged) |

## Test plan
- [x] `npm run build` — no Vite chunk-size warnings; `check-bundle-budget.mjs` passes ("all 99 JS chunks are within the 500 kB budget")
- [x] `npm run test:frontend:smoke` — 59 passed
- [x] `npm run test:frontend` — 863 passed (85 files)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] PWA precache generation still succeeds (133 entries, 2587.88 KiB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)