### PR TITLE
test: guard frontend tests against accidental real network calls (#1094)

### DIFF
--- a/frontend/src/__tests__/testSetupFetchGuard.test.ts
+++ b/frontend/src/__tests__/testSetupFetchGuard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+describe('test-setup fetch guard', () => {
+  it('rejects an unmocked fetch call, naming the requested URL', async () => {
+    await expect(fetch('/api/definitely-not-mocked')).rejects.toThrow('/api/definitely-not-mocked');
+  });
+
+  it('rejects an unmocked fetch call given a Request object, naming its URL', async () => {
+    const request = new Request('https://example.test/api/thing');
+    await expect(fetch(request)).rejects.toThrow('https://example.test/api/thing');
+  });
+});

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,4 +1,34 @@
 import '@testing-library/jest-dom';
+import { afterEach, beforeEach, vi } from 'vitest';
+
+// Guard against accidental real network calls: any test that doesn't stub `fetch`
+// itself (via vi.stubGlobal, vi.spyOn on an api function, etc.) gets this default,
+// which rejects with an actionable message instead of hitting the real network.
+// Tests that install their own fetch mock in a `beforeEach` run after this one and
+// simply override it.
+function unmockedFetchUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function unmockedFetch(input: RequestInfo | URL): Promise<never> {
+  const url = unmockedFetchUrl(input);
+  return Promise.reject(
+    new Error(
+      `Unmocked fetch() call to "${url}" in a test. Stub this request explicitly ` +
+        `(e.g. vi.stubGlobal('fetch', ...) or vi.spyOn(api, '...')).`
+    )
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(unmockedFetch));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // Node.js v26 provides an experimental localStorage global that is non-functional
 // without --localstorage-file. Replace it with an in-memory implementation so


### PR DESCRIPTION
## Summary
Fixes #1094.

- `frontend/src/test-setup.ts` now installs a default `fetch` stub (in a global `beforeEach`) that rejects with an actionable error naming the requested URL, instead of leaving `fetch` unmocked and hitting the real network.
- Tests that intentionally stub `fetch` themselves (via `vi.stubGlobal('fetch', ...)` in their own `beforeEach`/test body, e.g. `analytics.test.ts`, `api.test.ts`) run after the setup-file hook and simply override the default — no changes needed there.
- Added `frontend/src/__tests__/testSetupFetchGuard.test.ts` to directly verify the guard's behavior (rejects with the URL for both string and `Request` inputs).

Root cause: `AppShell` fetches analytics settings on mount (`fetchAnalyticsSettings()` → `GET /api/settings/analytics`), and several suites (`routing.test.tsx`, `articleReader.test.tsx`, `briefingsHistory.test.tsx`, etc.) render `AppShell`/related components without mocking that call, so Vitest attempted a real relative fetch to `localhost:3000` and printed repeated `ECONNREFUSED` `AggregateError`s even though all tests passed.

## Test plan
- [x] `npm run test:frontend` — 865 passed, 0 `ECONNREFUSED`/`AggregateError` output (previously 863 passed with hundreds of `ECONNREFUSED` lines across 9 suites).
- [x] `npx eslint frontend/src/test-setup.ts frontend/src/__tests__/testSetupFetchGuard.test.ts` — clean.
- [x] `npm run typecheck` — clean.
- [x] Full `make test` was also run locally; the 63 backend failures observed there are `psycopg.errors.UniqueViolation` races caused by concurrent `make test` runs in sibling worktrees sharing the same local `nd-test-pg` Postgres container (a known local-environment issue, unrelated to this frontend-only change — see the diff, which touches only `frontend/src/test-setup.ts` and adds one new frontend test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)