### PR TITLE
fix: isolate each ingest entry so one DB error doesn't fail the whole source

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -18,6 +18,7 @@ from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import feedparser
+import psycopg
 
 from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.db import connect, init_db, insert_article_sql, placeholders, row_to_dict
@@ -766,6 +767,103 @@ def preview_source_entries(source: SourceDefinition) -> list[dict[str, Any]]:
     return _fetch_entries_by_kind(source)
 
 
+def _persist_entry(  # noqa: PLR0913
+    conn: Any,
+    source: SourceDefinition,
+    entry: dict[str, Any],
+    url: str,
+    translated_title: str,
+    original_title: str | None,
+    detected_lang: str | None,
+    summary: str,
+    reason: str,
+    score: int,
+    tags: str,
+) -> int:
+    """Insert one article (or its archived-duplicate form) and return rows added.
+
+    Each entry's writes run in their own savepoint so one failing entry — e.g. a
+    duplicate-key/unique violation the ``ON CONFLICT`` clauses don't cover, or
+    any other DB error — rolls back only itself and is skipped, instead of
+    aborting and losing every other article already staged for this source.
+    Returns 0 for a deduped/archived entry, a URL that already exists, or a
+    skipped entry.
+    """
+    try:
+        with conn.transaction():
+            # Deduplication: check if this article is a duplicate of an existing canonical
+            canonical_id = _find_canonical(conn, url, translated_title, source.owner_user_id)
+            if canonical_id is not None:
+                # Insert as archived duplicate pointing to canonical
+                conn.execute(
+                    """INSERT INTO articles(
+                         url, canonical_url, title, source_slug, source_name, category, kind,
+                         published_at, summary, reason, importance_score, tags,
+                         status, canonical_id, original_title, detected_lang
+                       ) VALUES (
+                         %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                         'archived', %s, %s, %s
+                       )
+                       ON CONFLICT (url) DO NOTHING""",
+                    (
+                        url,
+                        url,
+                        translated_title,
+                        source.slug,
+                        source.name,
+                        source.category,
+                        source.kind,
+                        entry.get("date"),
+                        summary,
+                        reason,
+                        score,
+                        tags,
+                        canonical_id,
+                        original_title,
+                        detected_lang,
+                    ),
+                )
+                # Tag canonical article's source list (stored in reason prefix)
+                conn.execute(
+                    """
+                    UPDATE articles
+                       SET updated_at=%s
+                     WHERE id=%s AND canonical_id IS NULL
+                    """,
+                    (now_iso(), canonical_id),
+                )
+                return 0
+            cursor = conn.execute(
+                insert_article_sql(),
+                (
+                    url,
+                    url,
+                    translated_title,
+                    source.slug,
+                    source.name,
+                    source.category,
+                    source.kind,
+                    entry.get("date"),
+                    summary,
+                    reason,
+                    score,
+                    tags,
+                    original_title,
+                    None,
+                    detected_lang,
+                ),
+            )
+            return int(cursor.rowcount)
+    except psycopg.Error as exc:
+        logger.warning(
+            "Skipping article %s for source %s after DB error: %s",
+            url,
+            source.slug,
+            exc,
+        )
+        return 0
+
+
 def _ingest_source(
     source: SourceDefinition, db_path: Path | str | None = None
 ) -> SourceIngestOutcome:
@@ -828,70 +926,19 @@ def _ingest_source(
                         translated_title, translated_desc, source
                     )
 
-                # Deduplication: check if this article is a duplicate of an existing canonical
-                canonical_id = _find_canonical(conn, url, translated_title, source.owner_user_id)
-                if canonical_id is not None:
-                    # Insert as archived duplicate pointing to canonical
-                    conn.execute(
-                        """INSERT INTO articles(
-                             url, canonical_url, title, source_slug, source_name, category, kind,
-                             published_at, summary, reason, importance_score, tags,
-                             status, canonical_id, original_title, detected_lang
-                           ) VALUES (
-                             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                             'archived', %s, %s, %s
-                           )
-                           ON CONFLICT (url) DO NOTHING""",
-                        (
-                            url,
-                            url,
-                            translated_title,
-                            source.slug,
-                            source.name,
-                            source.category,
-                            source.kind,
-                            entry.get("date"),
-                            summary,
-                            reason,
-                            score,
-                            tags,
-                            canonical_id,
-                            original_title,
-                            detected_lang,
-                        ),
-                    )
-                    # Tag canonical article's source list (stored in reason prefix)
-                    conn.execute(
-                        """
-                        UPDATE articles
-                           SET updated_at=%s
-                         WHERE id=%s AND canonical_id IS NULL
-                        """,
-                        (now_iso(), canonical_id),
-                    )
-                else:
-                    sql = insert_article_sql()
-                    cursor = conn.execute(
-                        sql,
-                        (
-                            url,
-                            url,
-                            translated_title,
-                            source.slug,
-                            source.name,
-                            source.category,
-                            source.kind,
-                            entry.get("date"),
-                            summary,
-                            reason,
-                            score,
-                            tags,
-                            original_title,
-                            None,
-                            detected_lang,
-                        ),
-                    )
-                    inserted += cursor.rowcount
+                inserted += _persist_entry(
+                    conn,
+                    source,
+                    entry,
+                    url,
+                    translated_title,
+                    original_title,
+                    detected_lang,
+                    summary,
+                    reason,
+                    score,
+                    tags,
+                )
 
             conn.execute(
                 """UPDATE sources SET

--- a/backend/tests/test_ingest_runs.py
+++ b/backend/tests/test_ingest_runs.py
@@ -96,6 +96,72 @@ def test_ingest_all_records_source_errors(tmp_path: Path, monkeypatch: Any) -> N
     )
 
 
+def test_ingest_source_skips_entry_that_raises_and_keeps_the_rest(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    # A single entry that trips a DB error (e.g. a unique violation on
+    # articles_url_key) must not abort the whole source: the other entries for
+    # that source should still be committed, and the source should not report a
+    # total failure.
+    db_path = tmp_path / "resilient.db"
+    source = SourceDefinition("mixed-feed", "Mixed Feed", "https://example.com/mixed.xml", "python")
+    ingest_events.reset_for_tests()
+    monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [source])
+
+    def fake_parse_url(_url: str) -> list[dict[str, object]]:
+        return [
+            {
+                "url": "https://example.com/good",
+                "title": "Good release notes",
+                "description": "A useful release summary.",
+                "date": None,
+            },
+            {
+                "url": "https://example.com/bad",
+                "title": "Bad release notes",
+                "description": "Another useful release summary.",
+                "date": None,
+            },
+        ]
+
+    monkeypatch.setattr(ingest_module, "_parse_feed_url", fake_parse_url)
+
+    # Reproduce a per-entry DB failure that poisons the transaction the way a
+    # real duplicate-key violation would: for the "bad" entry, insert the same
+    # url twice so the second insert raises a unique violation.
+    real_find_canonical = ingest_module._find_canonical
+
+    def flaky_find_canonical(conn: Any, url: str, title: str, owner: Any = None) -> Any:
+        if "bad" in url:
+            collide = "https://example.com/collide"
+            for _ in range(2):
+                conn.execute(
+                    "INSERT INTO articles(url, canonical_url, title, source_slug,"
+                    " source_name, category, kind)"
+                    " VALUES (%s, %s, 'dup', %s, %s, 'python', 'rss_feed')",
+                    (collide, collide, source.slug, source.name),
+                )
+        return real_find_canonical(conn, url, title, owner)
+
+    monkeypatch.setattr(ingest_module, "_find_canonical", flaky_find_canonical)
+
+    result = ingest_all(db_path)
+
+    # The good entry survives and the source is not reported as a total failure.
+    assert result.total_errors == 0
+    assert result.results == {"mixed-feed": 1}
+
+    with connect(db_path) as conn:
+        urls = {row["url"] for row in conn.execute("SELECT url FROM articles").fetchall()}
+        source_row = conn.execute("SELECT * FROM ingest_run_sources").fetchone()
+
+    assert "https://example.com/good" in urls
+    # The failing entry's rolled-back insert must leave no trace.
+    assert "https://example.com/collide" not in urls
+    assert source_row["error_message"] is None
+    assert source_row["articles_new"] == 1
+
+
 def test_ingest_stream_route_is_registered() -> None:
     # url_path_for raises NoMatchFound (KeyError) if the route isn't registered.
     # Using url_path_for is robust across FastAPI versions (0.137+ stores included


### PR DESCRIPTION
Closes #1139

## Problem

`_ingest_source` processed **all** of a source's entries inside one transaction (`with connect() … ` → single `commit()`). A single per-entry DB error — e.g. a `duplicate key value violates unique constraint "articles_url_key"` — aborted the whole transaction, so the `except` rolled back **every** entry for that source, reported the source as fully failed (`✗ …`), and lost the genuinely-new articles. Seen in ingest run #1030 where whole sources failed on one duplicate URL.

## Fix

Extract the per-entry dedup/insert into `_persist_entry`, wrapped in its own savepoint (`conn.transaction()`) with a `psycopg.Error` handler. A failing entry now rolls back only itself and is skipped (logged at WARNING) while the remaining entries for the source still commit. Both article-insert sites keep their `ON CONFLICT (url) DO NOTHING`; this adds defense-in-depth so ingest continues past *any* per-entry failure.

## Test

`test_ingest_source_skips_entry_that_raises_and_keeps_the_rest` drives a source with a good entry plus one entry that raises a real transaction-poisoning `UniqueViolation`, and asserts the good article lands, the poisoned insert leaves no trace, and the source reports success (`total_errors == 0`) rather than a total failure. Fails on `main`, passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)