### PR TITLE
fix: repair broken news-fetching sources (redirects, scrapers, 429, nitter)

### DIFF
--- a/backend/news_dashboard/ingest.py
+++ b/backend/news_dashboard/ingest.py
@@ -417,6 +417,7 @@ def sync_sources(db_path: Path | str | None = None) -> None:
 # community-run and can go offline — update this list if the top one breaks.
 # See https://github.com/zedeus/nitter/wiki/Instances for current options.
 _NITTER_INSTANCES: tuple[str, ...] = (
+    "xcancel.com",
     "nitter.poast.org",
     "nitter.privacydev.net",
     "nitter.net",
@@ -427,10 +428,53 @@ FEED_FETCH_TIMEOUT_SECS = 15
 # RSS/Atom feeds are rarely more than a few hundred KB; 2 MiB leaves headroom
 # for verbose feeds while bounding memory use and parse time for bad actors.
 FEED_FETCH_MAX_BYTES = 2 * 1024 * 1024
+# Some hosts (notably Reddit) rate-limit shared IPs and answer 429/503
+# transiently; a couple of backed-off retries usually clears it.
+_RETRYABLE_STATUS: frozenset[int] = frozenset({429, 503})
+FEED_FETCH_MAX_RETRIES = 2
+FEED_FETCH_RETRY_BACKOFF_SECS = 2.0
+# Cap honored Retry-After so a hostile/huge value can't stall a run.
+FEED_FETCH_RETRY_MAX_WAIT_SECS = 30.0
+
+
+def _retry_after_seconds(exc: urllib.error.HTTPError) -> float | None:
+    """Parse a numeric Retry-After header, capped; ignore HTTP-date form."""
+    headers = getattr(exc, "headers", None)
+    value = headers.get("Retry-After") if headers else None
+    if not value:
+        return None
+    try:
+        secs = float(value)
+    except (TypeError, ValueError):
+        return None
+    if secs < 0:
+        return None
+    return min(secs, FEED_FETCH_RETRY_MAX_WAIT_SECS)
+
+
+def _read_feed_response(url: str, req: urllib.request.Request) -> bytes:
+    """Perform one feed fetch, enforcing the size cap. Raises on HTTP/network errors."""
+    with open_server_fetch_url(req, timeout=FEED_FETCH_TIMEOUT_SECS) as resp:
+        content_length = resp.headers.get("Content-Length")
+        if content_length is not None:
+            # Content-Length is attacker-controlled and may be non-numeric;
+            # ignore malformed values rather than failing the fetch on them.
+            with contextlib.suppress(ValueError):
+                if int(content_length) > FEED_FETCH_MAX_BYTES:
+                    msg = (
+                        f"Feed response too large ({content_length} bytes, "
+                        f"max {FEED_FETCH_MAX_BYTES}): {url}"
+                    )
+                    raise FeedFetchError(msg)
+        content: bytes = resp.read(FEED_FETCH_MAX_BYTES + 1)
+    if len(content) > FEED_FETCH_MAX_BYTES:
+        msg = f"Feed response exceeded {FEED_FETCH_MAX_BYTES} byte limit: {url}"
+        raise FeedFetchError(msg)
+    return content
 
 
 def _fetch_feed_content(url: str) -> bytes:
-    """Fetch raw feed bytes with an explicit timeout and size cap.
+    """Fetch raw feed bytes with a timeout, size cap, and 429/503 retry.
 
     Raises FeedFetchError on failure.
     """
@@ -439,30 +483,34 @@ def _fetch_feed_content(url: str) -> bytes:
     except UnsafeUrlError as exc:
         raise FeedFetchError(str(exc)) from exc
     req = urllib.request.Request(url, headers={"User-Agent": _FEED_AGENT})  # noqa: S310
-    try:
-        with open_server_fetch_url(req, timeout=FEED_FETCH_TIMEOUT_SECS) as resp:
-            content_length = resp.headers.get("Content-Length")
-            if content_length is not None:
-                # Content-Length is attacker-controlled and may be non-numeric;
-                # ignore malformed values rather than failing the fetch on them.
-                with contextlib.suppress(ValueError):
-                    if int(content_length) > FEED_FETCH_MAX_BYTES:
-                        msg = (
-                            f"Feed response too large ({content_length} bytes, "
-                            f"max {FEED_FETCH_MAX_BYTES}): {url}"
-                        )
-                        raise FeedFetchError(msg)
-            content: bytes = resp.read(FEED_FETCH_MAX_BYTES + 1)
-    except TimeoutError as exc:
-        msg = f"Feed fetch timed out after {FEED_FETCH_TIMEOUT_SECS}s: {url}"
-        raise FeedFetchError(msg) from exc
-    except urllib.error.URLError as exc:
-        msg = f"Feed fetch network error: {exc.reason}"
-        raise FeedFetchError(msg) from exc
-    if len(content) > FEED_FETCH_MAX_BYTES:
-        msg = f"Feed response exceeded {FEED_FETCH_MAX_BYTES} byte limit: {url}"
-        raise FeedFetchError(msg)
-    return content
+    attempt = 0
+    while True:
+        try:
+            return _read_feed_response(url, req)
+        except urllib.error.HTTPError as exc:
+            if exc.code in _RETRYABLE_STATUS and attempt < FEED_FETCH_MAX_RETRIES:
+                attempt += 1
+                delay = _retry_after_seconds(exc)
+                if delay is None:
+                    delay = FEED_FETCH_RETRY_BACKOFF_SECS * attempt
+                logger.warning(
+                    "Feed %s returned HTTP %s; retry %d/%d in %.1fs",
+                    url,
+                    exc.code,
+                    attempt,
+                    FEED_FETCH_MAX_RETRIES,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+            msg = f"Feed fetch network error: {exc.reason}"
+            raise FeedFetchError(msg) from exc
+        except TimeoutError as exc:
+            msg = f"Feed fetch timed out after {FEED_FETCH_TIMEOUT_SECS}s: {url}"
+            raise FeedFetchError(msg) from exc
+        except urllib.error.URLError as exc:
+            msg = f"Feed fetch network error: {exc.reason}"
+            raise FeedFetchError(msg) from exc
 
 
 def _parse_feed_url(url: str) -> list[dict[str, Any]]:
@@ -547,10 +595,21 @@ def _fetch_nitter_feed(source: SourceDefinition) -> list[dict[str, Any]]:
     last_exc: Exception | None = None
     for instance in _NITTER_INSTANCES:
         try:
-            return _parse_feed_url(f"https://{instance}/{handle}/rss")
+            entries = _parse_feed_url(f"https://{instance}/{handle}/rss")
         except FeedFetchError as exc:
             logger.warning("Nitter %s failed for @%s: %s", instance, handle, exc)
             last_exc = exc
+            continue
+        # Nitter tweet entries always link to /<user>/status/<id>. Some instances
+        # answer with a placeholder item ("RSS reader not yet whitelisted!") or a
+        # block page instead; those carry no status links, so treat the instance
+        # as failed and try the next rather than ingesting the placeholder.
+        tweets = [e for e in entries if "/status/" in (e.get("url") or "")]
+        if tweets:
+            return tweets
+        msg = f"Nitter {instance} returned no tweets for @{handle} (placeholder or blocked)"
+        logger.warning(msg)
+        last_exc = FeedFetchError(msg)
     msg = f"All Nitter instances failed for @{handle}"
     raise FeedFetchError(msg) from last_exc
 

--- a/backend/news_dashboard/scraper.py
+++ b/backend/news_dashboard/scraper.py
@@ -11,6 +11,7 @@ import re
 import urllib.request
 from html.parser import HTMLParser
 from typing import Any
+from urllib.parse import urljoin, urlparse
 
 from news_dashboard.url_safety import open_server_fetch_url, validate_server_fetch_url
 
@@ -119,11 +120,123 @@ def _scrape_anthropic(_url: str) -> list[dict[str, Any]]:
 
 
 # ──────────────────────────────────────────────
+# Generic listing-page scraper
+# ──────────────────────────────────────────────
+
+
+def _slug_title(url: str) -> str:
+    """Fallback title derived from the final path segment of an article URL."""
+    slug = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1]
+    return slug.replace("-", " ").strip().title() or "Untitled"
+
+
+# Card layouts wrap several anchors around one post URL (a badge, a "Learn more"
+# CTA, the heading). The heading is reliably the longest, so keep the longest
+# text per URL. Titles often carry a trailing "<Mon> <D>, <YYYY> … min read"
+# byline from the card chrome — strip it so stored titles stay clean.
+_CARD_BYLINE_RE = re.compile(
+    r"\s+[A-Z][a-z]{2,8}\s+\d{1,2},\s+\d{4}\b.*?\bmin read\b\s*$",
+    re.IGNORECASE,
+)
+
+
+class _LinkListParser(HTMLParser):
+    """Extract article links from a blog/news listing page.
+
+    Collects anchors whose (resolved) path matches ``path_pattern`` and keeps,
+    per URL, the longest anchor text seen — which is the post title rather than a
+    badge or CTA that links to the same post. Anchors do not nest in valid HTML,
+    so a simple in-anchor flag is robust to void elements (``<img>``) inside a
+    card, unlike depth counting.
+    """
+
+    def __init__(self, base_url: str, path_pattern: str) -> None:
+        super().__init__()
+        self._base = base_url
+        self._base_host = urlparse(base_url).netloc
+        self._path_re = re.compile(path_pattern)
+        self._titles: dict[str, str] = {}
+        self._order: list[str] = []
+        self._href: str = ""
+        self._text: str = ""
+        self._capturing: bool = False
+
+    def _resolve(self, href: str) -> str:
+        """Return the absolute, query-stripped URL if it matches the pattern, else ''."""
+        if not href:
+            return ""
+        absolute = urljoin(self._base, href)
+        parsed = urlparse(absolute)
+        if parsed.scheme not in {"http", "https"}:
+            return ""
+        if parsed.netloc != self._base_host:
+            return ""
+        clean = parsed._replace(query="", fragment="").geturl()
+        if not self._path_re.match(parsed.path):
+            return ""
+        return clean
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        resolved = self._resolve(dict(attrs).get("href") or "")
+        self._capturing = bool(resolved)
+        self._href = resolved
+        self._text = ""
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag != "a" or not self._capturing:
+            return
+        text = re.sub(r"\s+", " ", self._text).strip()
+        text = _CARD_BYLINE_RE.sub("", text).strip()
+        if self._href not in self._titles:
+            self._order.append(self._href)
+        if len(text) > len(self._titles.get(self._href, "")):
+            self._titles[self._href] = text
+        self._capturing = False
+        self._href = ""
+        self._text = ""
+
+    def handle_data(self, data: str) -> None:
+        if self._capturing:
+            self._text += data
+
+    @property
+    def entries(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "url": url,
+                "title": self._titles.get(url) or _slug_title(url),
+                "description": "",
+                "date": None,
+            }
+            for url in self._order
+        ]
+
+
+def _scrape_link_list(page_url: str, path_pattern: str, *, limit: int = 30) -> list[dict[str, Any]]:
+    html = _fetch_html(page_url)
+    parser = _LinkListParser(page_url, path_pattern)
+    parser.feed(html)
+    return parser.entries[:limit]
+
+
+def _scrape_cohere(_url: str) -> list[dict[str, Any]]:
+    return _scrape_link_list("https://cohere.com/blog", r"^/blog/[^/]+$")
+
+
+def _scrape_meta(_url: str) -> list[dict[str, Any]]:
+    return _scrape_link_list("https://ai.meta.com/blog/", r"^/blog/[^/]+/?$")
+
+
+# ──────────────────────────────────────────────
 # Dispatch table — add new scrapers here
 # ──────────────────────────────────────────────
 
 _SCRAPERS: dict[str, Any] = {
     "anthropic-news": _scrape_anthropic,
+    "cohere-blog": _scrape_cohere,
+    "meta-ai-blog": _scrape_meta,
 }
 
 

--- a/backend/news_dashboard/sources.py
+++ b/backend/news_dashboard/sources.py
@@ -127,10 +127,9 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
     SourceDefinition(
         "deepmind-blog",
         "Google DeepMind Blog",
-        "https://deepmind.google/blog/",
+        "https://deepmind.google/blog/rss.xml",
         "ai-llm",
-        "scraped_page",
-        85,
+        priority=85,
         interest_tags=("agents", "model-releases", "evals", "product-news"),
     ),
     SourceDefinition(
@@ -210,10 +209,9 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
     SourceDefinition(
         "mistral-ai-news",
         "Mistral AI News",
-        "https://mistral.ai/news/",
+        "https://mistral.ai/rss.xml",
         "ai-llm",
-        "scraped_page",
-        80,
+        priority=80,
         interest_tags=("agents", "model-releases", "product-news"),
     ),
     SourceDefinition(
@@ -288,7 +286,9 @@ DEFAULT_SOURCES: list[SourceDefinition] = [
     SourceDefinition(
         "google-project-zero",
         "Google Project Zero",
-        "https://googleprojectzero.blogspot.com/feeds/posts/default",
+        # Summary feed with a post cap: the default feed embeds full post bodies
+        # and exceeds the 2 MiB fetch cap (~13 MiB); the summary feed is a few KB.
+        "https://googleprojectzero.blogspot.com/feeds/posts/summary?alt=rss&max-results=25",
         "security",
         priority=82,
         interest_tags=("security", "research"),

--- a/backend/news_dashboard/url_safety.py
+++ b/backend/news_dashboard/url_safety.py
@@ -61,7 +61,17 @@ def validate_server_fetch_url(url: str) -> None:
             raise UnsafeUrlError(msg)
 
 
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow redirects only after re-validating each hop against SSRF rules.
+
+    urllib validates the *initial* fetch target, but a 3xx response can point
+    anywhere — including localhost or a cloud metadata endpoint. Re-validate
+    every redirect target before following it. Returning ``None`` for an unsafe
+    hop makes urllib raise the underlying ``HTTPError`` instead of chasing the
+    redirect, so the caller sees a fetch failure rather than reaching a private
+    host. urllib's built-in redirect cap (``max_redirections``) still applies.
+    """
+
     def redirect_request(
         self,
         req: urllib.request.Request,
@@ -71,14 +81,17 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         headers: HTTPMessage,
         newurl: str,
     ) -> urllib.request.Request | None:
-        _ = (req, fp, code, msg, headers, newurl)
-        return None
+        try:
+            validate_server_fetch_url(newurl)
+        except UnsafeUrlError:
+            return None
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
 def open_server_fetch_url(request: urllib.request.Request, *, timeout: float) -> Any:
-    """Open a prevalidated server-side fetch request without following redirects."""
+    """Open a prevalidated server-side fetch request, following only safe redirects."""
     validate_server_fetch_url(request.full_url)
-    opener = urllib.request.build_opener(_NoRedirectHandler)
+    opener = urllib.request.build_opener(_ValidatingRedirectHandler)
     return opener.open(request, timeout=timeout)
 
 

--- a/backend/tests/test_deepmind_blog_source.py
+++ b/backend/tests/test_deepmind_blog_source.py
@@ -20,9 +20,9 @@ def test_deepmind_blog_metadata() -> None:
     """deepmind-blog has the expected metadata fields."""
     src = next(s for s in DEFAULT_SOURCES if s.slug == "deepmind-blog")
     assert src.name == "Google DeepMind Blog"
-    assert src.url == "https://deepmind.google/blog/"
+    assert src.url == "https://deepmind.google/blog/rss.xml"
     assert src.category == "ai-llm"
-    assert src.kind == "scraped_page"
+    assert src.kind == "rss_feed"
     assert src.priority == 85
     assert src.enabled is True
     assert src.lang == "en"
@@ -37,10 +37,11 @@ def test_deepmind_blog_interest_tags() -> None:
     assert "product-news" in src.interest_tags
 
 
-def test_deepmind_blog_routes_to_scraped_page() -> None:
-    """deepmind-blog kind is scraped_page, which ingest routes correctly."""
+def test_deepmind_blog_routes_to_rss_feed() -> None:
+    """deepmind-blog is served by a real RSS feed, not a scraper."""
     src = next(s for s in DEFAULT_SOURCES if s.slug == "deepmind-blog")
-    assert src.kind == "scraped_page"
+    assert src.kind == "rss_feed"
+    assert src.url.endswith("rss.xml")
 
 
 # ── Integration tests (PostgreSQL) ────────────────────────────────────────
@@ -62,9 +63,9 @@ def test_deepmind_blog_sync_persists_row(pg_clean: str, monkeypatch: pytest.Monk
     assert row is not None, "deepmind-blog row missing from sources table"
     assert row["slug"] == "deepmind-blog"
     assert row["name"] == "Google DeepMind Blog"
-    assert row["url"] == "https://deepmind.google/blog/"
+    assert row["url"] == "https://deepmind.google/blog/rss.xml"
     assert row["category"] == "ai-llm"
-    assert row["kind"] == "scraped_page"
+    assert row["kind"] == "rss_feed"
     assert row["priority"] == 85
     assert row["enabled"] is True
 

--- a/backend/tests/test_google_project_zero_source.py
+++ b/backend/tests/test_google_project_zero_source.py
@@ -22,7 +22,10 @@ def test_google_project_zero_metadata() -> None:
     """google-project-zero has the expected metadata fields."""
     src = next(s for s in DEFAULT_SOURCES if s.slug == "google-project-zero")
     assert src.name == "Google Project Zero"
-    assert src.url == "https://googleprojectzero.blogspot.com/feeds/posts/default"
+    assert (
+        src.url
+        == "https://googleprojectzero.blogspot.com/feeds/posts/summary?alt=rss&max-results=25"
+    )
     assert src.category == "security"
     assert src.kind == "rss_feed"
     assert src.priority == 82
@@ -64,7 +67,10 @@ def test_google_project_zero_sync_persists_row(
     assert row is not None, "google-project-zero row missing from sources table"
     assert row["slug"] == "google-project-zero"
     assert row["name"] == "Google Project Zero"
-    assert row["url"] == "https://googleprojectzero.blogspot.com/feeds/posts/default"
+    assert (
+        row["url"]
+        == "https://googleprojectzero.blogspot.com/feeds/posts/summary?alt=rss&max-results=25"
+    )
     assert row["category"] == "security"
     assert row["kind"] == "rss_feed"
     assert row["priority"] == 82

--- a/backend/tests/test_mistral_ai_news_source.py
+++ b/backend/tests/test_mistral_ai_news_source.py
@@ -22,9 +22,9 @@ def test_mistral_ai_news_metadata() -> None:
     """mistral-ai-news has the expected metadata fields."""
     src = next(s for s in DEFAULT_SOURCES if s.slug == "mistral-ai-news")
     assert src.name == "Mistral AI News"
-    assert src.url == "https://mistral.ai/news/"
+    assert src.url == "https://mistral.ai/rss.xml"
     assert src.category == "ai-llm"
-    assert src.kind == "scraped_page"
+    assert src.kind == "rss_feed"
     assert src.priority == 80
     assert src.enabled is True
     assert src.lang == "en"
@@ -38,10 +38,11 @@ def test_mistral_ai_news_interest_tags() -> None:
     assert "product-news" in src.interest_tags
 
 
-def test_mistral_ai_news_routes_to_scraped_page() -> None:
-    """mistral-ai-news kind is scraped_page, which ingest routes correctly."""
+def test_mistral_ai_news_routes_to_rss_feed() -> None:
+    """mistral-ai-news is served by a real RSS feed, not a scraper."""
     src = next(s for s in DEFAULT_SOURCES if s.slug == "mistral-ai-news")
-    assert src.kind == "scraped_page"
+    assert src.kind == "rss_feed"
+    assert src.url.endswith("rss.xml")
 
 
 # ── Integration tests (PostgreSQL) ────────────────────────────────────────
@@ -63,9 +64,9 @@ def test_mistral_ai_news_sync_persists_row(pg_clean: str, monkeypatch: pytest.Mo
     assert row is not None, "mistral-ai-news row missing from sources table"
     assert row["slug"] == "mistral-ai-news"
     assert row["name"] == "Mistral AI News"
-    assert row["url"] == "https://mistral.ai/news/"
+    assert row["url"] == "https://mistral.ai/rss.xml"
     assert row["category"] == "ai-llm"
-    assert row["kind"] == "scraped_page"
+    assert row["kind"] == "rss_feed"
     assert row["priority"] == 80
     assert row["enabled"] is True
 

--- a/backend/tests/test_nitter_feed.py
+++ b/backend/tests/test_nitter_feed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import urllib.error
+from http.client import HTTPMessage
 from typing import ClassVar
 
 import pytest
@@ -11,6 +12,7 @@ from news_dashboard.ingest import (
     _FEED_AGENT,
     _NITTER_INSTANCES,
     FEED_FETCH_MAX_BYTES,
+    FEED_FETCH_MAX_RETRIES,
     FEED_FETCH_TIMEOUT_SECS,
     FeedFetchError,
     _fetch_feed_content,
@@ -140,6 +142,82 @@ def test_fetch_feed_content_converts_url_error(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
     with pytest.raises(FeedFetchError, match="network error"):
         _fetch_feed_content("https://example.com/feed.xml")
+
+
+# ── 429/503 retry ─────────────────────────────────────────────────────────────
+
+
+def _http_error(code: int, retry_after: str | None = None) -> urllib.error.HTTPError:
+    headers = HTTPMessage()
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    return urllib.error.HTTPError("https://example.com/feed.xml", code, "err", headers, None)
+
+
+def test_fetch_feed_content_retries_429_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = b"<rss>ok</rss>"
+    attempts = {"n": 0}
+
+    def fake_open(_req: object, *, timeout: float) -> _SizedFakeResp:
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise _http_error(429)
+        return _SizedFakeResp(body)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
+    monkeypatch.setattr("news_dashboard.ingest.time.sleep", sleeps.append)
+
+    assert _fetch_feed_content("https://example.com/feed.xml") == body
+    assert attempts["n"] == 2
+    assert sleeps, "expected a backoff sleep between attempts"
+
+
+def test_fetch_feed_content_gives_up_after_max_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"n": 0}
+
+    def fake_open(_req: object, *, timeout: float) -> None:
+        attempts["n"] += 1
+        raise _http_error(429)
+
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
+    monkeypatch.setattr("news_dashboard.ingest.time.sleep", lambda _s: None)
+
+    with pytest.raises(FeedFetchError, match="network error"):
+        _fetch_feed_content("https://example.com/feed.xml")
+    assert attempts["n"] == FEED_FETCH_MAX_RETRIES + 1
+
+
+def test_fetch_feed_content_honors_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"n": 0}
+
+    def fake_open(_req: object, *, timeout: float) -> _SizedFakeResp:
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise _http_error(429, retry_after="7")
+        return _SizedFakeResp(b"<rss/>")
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
+    monkeypatch.setattr("news_dashboard.ingest.time.sleep", sleeps.append)
+
+    _fetch_feed_content("https://example.com/feed.xml")
+    assert sleeps == [7.0]
+
+
+def test_fetch_feed_content_does_not_retry_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"n": 0}
+
+    def fake_open(_req: object, *, timeout: float) -> None:
+        attempts["n"] += 1
+        raise _http_error(404)
+
+    monkeypatch.setattr("news_dashboard.ingest.open_server_fetch_url", fake_open)
+    monkeypatch.setattr("news_dashboard.ingest.time.sleep", lambda _s: None)
+
+    with pytest.raises(FeedFetchError, match="network error"):
+        _fetch_feed_content("https://example.com/feed.xml")
+    assert attempts["n"] == 1
 
 
 # ── size cap ──────────────────────────────────────────────────────────────────
@@ -290,6 +368,37 @@ def test_fetch_nitter_raises_when_all_instances_fail(monkeypatch: pytest.MonkeyP
         _fetch_nitter_feed(_make_source("ylecun"))
 
 
+def test_fetch_nitter_skips_placeholder_without_status_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 'not whitelisted' placeholder (no /status/ links) is treated as a failure."""
+    calls: list[str] = []
+
+    def fake_parse_url(url: str) -> list[dict[str, object]]:
+        calls.append(url)
+        if _NITTER_INSTANCES[0] in url:
+            # xcancel-style placeholder: one item linking back to the RSS URL.
+            return _ok_entries(
+                [{"link": "https://rss.xcancel.com/xai/rss", "title": "Not whitelisted!"}]
+            )
+        return _ok_entries([{"link": "https://x.com/xai/status/9", "title": "Real tweet"}])
+
+    monkeypatch.setattr("news_dashboard.ingest._parse_feed_url", fake_parse_url)
+    entries = _fetch_nitter_feed(_make_source("xai"))
+
+    assert len(calls) == 2, "should skip the placeholder instance and try the next"
+    assert [e["title"] for e in entries] == ["Real tweet"]
+
+
+def test_fetch_nitter_raises_when_only_placeholders(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_parse_url(url: str) -> list[dict[str, object]]:
+        return _ok_entries([{"link": url, "title": "RSS reader not yet whitelisted!"}])
+
+    monkeypatch.setattr("news_dashboard.ingest._parse_feed_url", fake_parse_url)
+    with pytest.raises(FeedFetchError, match="All Nitter instances failed for @xai"):
+        _fetch_nitter_feed(_make_source("xai"))
+
+
 def test_fetch_nitter_tries_all_instances_before_failing(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
@@ -313,6 +422,11 @@ def test_nitter_instances_has_at_least_two() -> None:
 
 def test_nitter_instances_are_unique() -> None:
     assert len(_NITTER_INSTANCES) == len(set(_NITTER_INSTANCES))
+
+
+def test_nitter_instances_include_working_xcancel() -> None:
+    """xcancel.com is the currently-reachable instance and should be tried first."""
+    assert _NITTER_INSTANCES[0] == "xcancel.com"
 
 
 # ── DEFAULT_SOURCES sanity checks ─────────────────────────────────────────────

--- a/backend/tests/test_scraper.py
+++ b/backend/tests/test_scraper.py
@@ -11,6 +11,7 @@ from news_dashboard.scraper import (
     ScrapeFetchError,
     _AnthropicParser,
     _fetch_html,
+    _LinkListParser,
     scrape_source,
 )
 from news_dashboard.sources import SourceDefinition
@@ -97,12 +98,99 @@ def test_fetch_html_rejects_private_network_url(monkeypatch: pytest.MonkeyPatch)
     assert called is False
 
 
+# Mimics Meta AI / Cohere card layout: several anchors around one post URL
+# (badge, heading, CTA), some with a trailing byline of date + read time.
+LINK_LIST_FIXTURE = """
+<!DOCTYPE html>
+<html><body>
+  <a href="/blog?page=2">Next page</a>
+  <a href="/blog">All posts</a>
+  <div class="card">
+    <a href="/blog/muse-spark-1-1"><span>FEATURED</span></a>
+    <a href="/blog/muse-spark-1-1"><h4>Introducing Muse Spark 1.1</h4></a>
+    <a href="/blog/muse-spark-1-1">Learn More</a>
+  </div>
+  <div class="card">
+    <a href="/blog/north-mini-code?ref=home">Learn more</a>
+    <a href="/blog/north-mini-code">
+      <img src="/x.png" alt="">
+      Introducing North Mini Code: Cohere's first model Jun 09, 2026 3 min read
+    </a>
+  </div>
+  <a href="https://external.example.com/blog/other">Off-site post</a>
+  <a href="/blog/no-title-here"><img src="/y.png" alt=""></a>
+</body></html>
+"""
+
+
+def test_link_list_parser_keeps_longest_title_per_url() -> None:
+    parser = _LinkListParser("https://ai.meta.com/blog/", r"^/blog/[^/]+/?$")
+    parser.feed(LINK_LIST_FIXTURE)
+    by_url = {e["url"]: e["title"] for e in parser.entries}
+    assert by_url["https://ai.meta.com/blog/muse-spark-1-1"] == "Introducing Muse Spark 1.1"
+
+
+def test_link_list_parser_strips_card_byline() -> None:
+    parser = _LinkListParser("https://cohere.com/blog", r"^/blog/[^/]+$")
+    parser.feed(LINK_LIST_FIXTURE)
+    by_url = {e["url"]: e["title"] for e in parser.entries}
+    assert (
+        by_url["https://cohere.com/blog/north-mini-code"]
+        == "Introducing North Mini Code: Cohere's first model"
+    )
+
+
+def test_link_list_parser_dedupes_and_strips_query() -> None:
+    parser = _LinkListParser("https://cohere.com/blog", r"^/blog/[^/]+$")
+    parser.feed(LINK_LIST_FIXTURE)
+    urls = [e["url"] for e in parser.entries]
+    assert urls == sorted(set(urls), key=urls.index), "entries should be deduped by URL"
+    assert "https://cohere.com/blog/north-mini-code" in urls
+    assert all("?" not in u for u in urls), "query strings should be stripped"
+
+
+def test_link_list_parser_excludes_listing_and_offsite_links() -> None:
+    parser = _LinkListParser("https://ai.meta.com/blog/", r"^/blog/[^/]+/?$")
+    parser.feed(LINK_LIST_FIXTURE)
+    urls = {e["url"] for e in parser.entries}
+    assert "https://ai.meta.com/blog/" not in urls
+    assert not any("external.example.com" in u for u in urls)
+    assert not any(u.endswith("/blog") for u in urls)
+
+
+def test_link_list_parser_falls_back_to_slug_title() -> None:
+    parser = _LinkListParser("https://ai.meta.com/blog/", r"^/blog/[^/]+/?$")
+    parser.feed(LINK_LIST_FIXTURE)
+    by_url = {e["url"]: e["title"] for e in parser.entries}
+    assert by_url["https://ai.meta.com/blog/no-title-here"] == "No Title Here"
+
+
+@pytest.mark.parametrize("slug", ["cohere-blog", "meta-ai-blog"])
+def test_registered_scrapers_use_fetch(slug: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SourceDefinition(slug, slug, "https://example.com", "ai-llm", "scraped_page", 80)
+    monkeypatch.setattr("news_dashboard.scraper._fetch_html", lambda _url: LINK_LIST_FIXTURE)
+    entries = scrape_source(source)
+    assert entries, "expected at least one scraped entry"
+    assert all(e["title"] for e in entries)
+
+
 def test_scrape_source_unknown_slug_raises() -> None:
     source = SourceDefinition(
         "no-scraper", "No Scraper", "https://example.com", "python", "scraped_page", 50
     )
     with pytest.raises(NotImplementedError, match="no-scraper"):
         scrape_source(source)
+
+
+def test_every_scraped_page_source_has_a_registered_scraper() -> None:
+    """Guard against re-adding a scraped_page source with no scraper (issue #1142)."""
+    from news_dashboard.scraper import _SCRAPERS
+    from news_dashboard.sources import DEFAULT_SOURCES
+
+    missing = [
+        s.slug for s in DEFAULT_SOURCES if s.kind == "scraped_page" and s.slug not in _SCRAPERS
+    ]
+    assert not missing, f"scraped_page sources without a scraper: {missing}"
 
 
 class _FakeHeaders:

--- a/backend/tests/test_url_safety.py
+++ b/backend/tests/test_url_safety.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import io
 import socket
+import urllib.request
+from http.client import HTTPMessage
 
 import pytest
 
-from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
+from news_dashboard.url_safety import (
+    UnsafeUrlError,
+    _ValidatingRedirectHandler,
+    validate_server_fetch_url,
+)
 
 
 def _fake_getaddrinfo(addresses: list[str]) -> object:
@@ -53,3 +60,35 @@ def test_validate_server_fetch_url_rejects_any_unsafe_resolved_address(
 
     with pytest.raises(UnsafeUrlError):
         validate_server_fetch_url("https://example.com/feed.xml")
+
+
+def test_redirect_handler_follows_safe_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo(["93.184.216.34"]))
+    handler = _ValidatingRedirectHandler()
+    req = urllib.request.Request("https://example.com/feed.xml")
+
+    result = handler.redirect_request(
+        req,
+        io.BytesIO(),
+        301,
+        "Moved Permanently",
+        HTTPMessage(),
+        "https://example.com/new-feed.xml",
+    )
+
+    assert result is not None
+    assert result.full_url == "https://example.com/new-feed.xml"
+
+
+def test_redirect_handler_blocks_redirect_to_private_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo(["169.254.169.254"]))
+    handler = _ValidatingRedirectHandler()
+    req = urllib.request.Request("https://example.com/feed.xml")
+
+    result = handler.redirect_request(
+        req, io.BytesIO(), 302, "Found", HTTPMessage(), "http://169.254.169.254/latest/meta-data"
+    )
+
+    assert result is None


### PR DESCRIPTION
Closes #1142

Diagnosed every failing ingestion path against live endpoints and fixed them.

## Redirects (was: "Moved Permanently" / "Found")
`open_server_fetch_url` refused all 3xx. Now it follows redirects but re-validates
every hop against the existing SSRF rules — unsafe redirect targets (localhost,
metadata IPs) are still blocked. Fixes pytorch-blog, google-ai-blog,
trail-of-bits-blog, docker-blog, web-dev-blog.

## `scraped_page` sources with no scraper (was: "No scraper registered")
- **deepmind-blog**, **mistral-ai-news** expose real RSS → converted to `rss_feed`.
- **cohere-blog**, **meta-ai-blog** have no feed → new generic listing-page scraper
  (longest anchor text per post URL, card date/"min read" byline stripped, same-host
  only). Added a guard test that every `scraped_page` source has a registered scraper.

## Reddit 429 (was: "Too Many Requests")
Transient IP rate-limiting. `_fetch_feed_content` now retries 429/503 with
`Retry-After`-aware backoff (capped at 30s, 2 retries).

## Nitter @xai (was: "All Nitter instances failed")
Added `xcancel.com` (currently the only reachable instance). It gates RSS behind
whitelisting and returns a placeholder item; a new guard rejects any Nitter reply
with no `/status/` tweet links so placeholders/block-pages are never ingested and
the fetch fails cleanly instead. Nitter remains effectively dead for public use —
this makes the failure clean and auto-recovers if any instance serves real tweets.

## Google Project Zero (was: "Found", then oversized)
The blogspot default feed embeds full post bodies (~13 MiB) and blows the 2 MiB
cap. Pointed the source at the summary feed (`?alt=rss&max-results=25`, a few KB).

## Verification
- `test_url_safety`, `test_scraper`, `test_nitter_feed`, and the affected source
  tests: 92 passing; ruff + mypy + ty + pyrefly green.
- Live end-to-end via `preview_source_entries`: all six redirect feeds, both new
  scrapers, both converted RSS sources, and Project Zero now return entries; @xai
  fails cleanly with no placeholder ingested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)