### PR TITLE
Render structured lesson detail with read-worthiness verdict

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -640,6 +640,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
       author TEXT,
       published_at TEXT,
       source_content TEXT,
+      lesson_detail JSONB,
       generation_status TEXT NOT NULL DEFAULT 'pending'
         CHECK(generation_status IN ('pending','complete','failed')),
       generation_error TEXT,
@@ -648,6 +649,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
       UNIQUE(user_id, normalized_url)
     )
     """,
+    "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS lesson_detail JSONB",
     "CREATE INDEX IF NOT EXISTS idx_lessons_user_created ON lessons(user_id, created_at DESC)",
     """
     CREATE TABLE IF NOT EXISTS agent_action_runs (

--- a/backend/news_dashboard/learn_from_link/models.py
+++ b/backend/news_dashboard/learn_from_link/models.py
@@ -2,8 +2,42 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+NonEmptyText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+GistText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=280)]
 
 
 class LessonCreateRequest(BaseModel):
     url: str
+
+
+class LessonCitation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: NonEmptyText
+    snippet: NonEmptyText
+    source: NonEmptyText
+
+
+class ReadWorthiness(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    verdict: Literal["skip", "skim", "read", "study"]
+    rationale: NonEmptyText
+
+
+class LessonDetail(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    gist: GistText
+    explanation: NonEmptyText
+    key_claims: list[NonEmptyText] = Field(min_length=1)
+    prerequisite_concepts: list[NonEmptyText] = Field(min_length=1)
+    why_it_matters: NonEmptyText
+    read_worthiness: ReadWorthiness
+    who_should_read: list[NonEmptyText] = Field(min_length=1)
+    questions_to_keep_in_mind: list[NonEmptyText] = Field(min_length=1)
+    citations: list[LessonCitation] = Field(min_length=1)

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from psycopg.types.json import Jsonb
+from pydantic import ValidationError
+
 from news_dashboard.body_fetch import extract_body
 from news_dashboard.db import connect, init_db, row_to_dict
+from news_dashboard.learn_from_link.models import LessonDetail
 from news_dashboard.reading_list.metadata import fetch_url_metadata
 from news_dashboard.reading_list.service import normalize_url
 from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
@@ -21,6 +26,14 @@ class LessonUrlError(ValueError):
 
 class LessonNotFoundError(LookupError):
     """Raised when a lesson row cannot be found for the given user."""
+
+
+class LessonDetailValidationError(ValueError):
+    """Raised when generated lesson detail fails schema validation."""
+
+
+class LessonCitationValidationError(ValueError):
+    """Raised when lesson citations are not grounded in source content."""
 
 
 def _normalize_lesson_url(url: str) -> str:
@@ -73,6 +86,7 @@ def create_lesson(
                 author = NULL,
                 published_at = NULL,
                 source_content = NULL,
+                lesson_detail = NULL,
                 updated_at = NOW()
             RETURNING *
             """,
@@ -92,7 +106,7 @@ def _update_lesson_success(
     lesson_id: int,
     user_id: int,
     *,
-    lesson_fields: dict[str, str | None],
+    lesson_fields: dict[str, Any],
     database_url: str | None = None,
 ) -> dict[str, Any]:
     init_db(database_url=database_url)
@@ -105,6 +119,7 @@ def _update_lesson_success(
                 author = %s,
                 published_at = %s,
                 source_content = %s,
+                lesson_detail = %s::jsonb,
                 generation_status = 'complete',
                 generation_error = NULL,
                 updated_at = NOW()
@@ -117,6 +132,7 @@ def _update_lesson_success(
                 lesson_fields["author"],
                 lesson_fields["published_at"],
                 lesson_fields["source_content"],
+                Jsonb(lesson_fields["lesson_detail"]),
                 lesson_id,
                 user_id,
             ),
@@ -143,6 +159,7 @@ def _update_lesson_failure(
                 author = NULL,
                 published_at = NULL,
                 source_content = NULL,
+                lesson_detail = NULL,
                 updated_at = NOW()
             WHERE id = %s AND user_id = %s
             RETURNING *
@@ -150,6 +167,101 @@ def _update_lesson_failure(
             (error_message, lesson_id, user_id),
         ).fetchone()
     return _serialize_lesson(row)
+
+
+def _sentences(text: str) -> list[str]:
+    compact = re.sub(r"\s+", " ", text).strip()
+    if not compact:
+        return []
+    return [
+        sentence.strip() for sentence in re.split(r"(?<=[.!?])\s+", compact) if sentence.strip()
+    ]
+
+
+def _clip(text: str, limit: int) -> str:
+    compact = re.sub(r"\s+", " ", text).strip()
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 3].rstrip()}..."
+
+
+def _normalized_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def generate_structured_lesson_detail(lesson_fields: dict[str, Any]) -> dict[str, Any]:
+    source_content = str(lesson_fields["source_content"])
+    title = str(lesson_fields["title"] or lesson_fields["original_url"])
+    source_name = lesson_fields.get("source_name")
+    sentence_list = _sentences(source_content)
+    gist = sentence_list[0] if sentence_list else _clip(source_content, 180)
+    key_claims = sentence_list[:3] or [gist]
+    source_label = str(source_name or "the source")
+    if len(source_content) >= 2000:
+        verdict = "study"
+        rationale = "Study it closely: the source is substantial enough to reward careful notes."
+    elif len(source_content) >= 600:
+        verdict = "read"
+        rationale = "Read it: the source has enough depth to justify focused attention."
+    else:
+        verdict = "skim"
+        rationale = "Start with a skim: the source is short enough to inspect quickly."
+
+    return {
+        "gist": gist,
+        "explanation": source_content if len(source_content) <= 600 else _clip(source_content, 600),
+        "key_claims": key_claims,
+        "prerequisite_concepts": [f"Context from {source_label}"],
+        "why_it_matters": f"It helps you decide whether {title} deserves deeper reading.",
+        "read_worthiness": {
+            "verdict": verdict,
+            "rationale": rationale,
+        },
+        "who_should_read": ["Readers deciding whether to spend more time with this source."],
+        "questions_to_keep_in_mind": [
+            "What evidence does the source provide for its central claim?"
+        ],
+        "citations": [
+            {
+                "label": "1",
+                "snippet": gist,
+                "source": title,
+            }
+        ],
+    }
+
+
+def validate_structured_lesson_detail(
+    raw_detail: Any,
+    *,
+    lesson_fields: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        detail = LessonDetail.model_validate(raw_detail)
+    except ValidationError as exc:
+        raise LessonDetailValidationError from exc
+
+    source_context = _normalized_text(
+        "\n".join(
+            str(value)
+            for value in (
+                lesson_fields.get("title"),
+                lesson_fields.get("source_name"),
+                lesson_fields.get("author"),
+                lesson_fields.get("published_at"),
+                lesson_fields.get("original_url"),
+                lesson_fields.get("source_content"),
+            )
+            if value
+        )
+    )
+    for citation in detail.citations:
+        citation_snippet = _normalized_text(citation.snippet)
+        citation_source = _normalized_text(citation.source)
+        if citation_snippet not in source_context or citation_source not in source_context:
+            raise LessonCitationValidationError
+
+    return detail.model_dump(mode="json")
 
 
 def generate_lesson_from_url(
@@ -189,16 +301,49 @@ def generate_lesson_from_url(
             database_url=database_url,
         )
 
+    lesson_fields: dict[str, Any] = {
+        "original_url": lesson_url,
+        "title": str(metadata.get("title") or lesson_url),
+        "source_name": metadata.get("site_name"),
+        "author": metadata.get("author"),
+        "published_at": metadata.get("published_at"),
+        "source_content": body_text,
+    }
+    try:
+        raw_detail = generate_structured_lesson_detail(lesson_fields)
+        lesson_fields["lesson_detail"] = validate_structured_lesson_detail(
+            raw_detail,
+            lesson_fields=lesson_fields,
+        )
+    except LessonDetailValidationError:
+        logger.warning("lesson detail validation failed for lesson %d", lesson_id)
+        return _update_lesson_failure(
+            lesson_id,
+            user_id,
+            "Generated lesson detail was malformed.",
+            database_url=database_url,
+        )
+    except LessonCitationValidationError:
+        logger.warning("lesson citation validation failed for lesson %d", lesson_id)
+        return _update_lesson_failure(
+            lesson_id,
+            user_id,
+            "Generated lesson citations did not match source content.",
+            database_url=database_url,
+        )
+    except Exception as exc:
+        logger.warning("lesson detail generation failed for lesson %d: %s", lesson_id, exc)
+        return _update_lesson_failure(
+            lesson_id,
+            user_id,
+            "Generated lesson detail was malformed.",
+            database_url=database_url,
+        )
+
     return _update_lesson_success(
         lesson_id,
         user_id,
-        lesson_fields={
-            "title": str(metadata.get("title") or lesson_url),
-            "source_name": metadata.get("site_name"),
-            "author": metadata.get("author"),
-            "published_at": metadata.get("published_at"),
-            "source_content": body_text,
-        },
+        lesson_fields=lesson_fields,
         database_url=database_url,
     )
 

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -111,6 +111,28 @@ def test_create_lesson_completes_with_extracted_content(
     assert lesson["author"] == "Ada Writer"
     assert lesson["published_at"] == "2026-07-09"
     assert lesson["source_content"] == "Paragraph one.\n\nParagraph two."
+    assert lesson["lesson_detail"] == {
+        "gist": "Paragraph one.",
+        "explanation": "Paragraph one.\n\nParagraph two.",
+        "key_claims": ["Paragraph one.", "Paragraph two."],
+        "prerequisite_concepts": ["Context from Example Journal"],
+        "why_it_matters": "It helps you decide whether A careful article deserves deeper reading.",
+        "read_worthiness": {
+            "verdict": "skim",
+            "rationale": "Start with a skim: the source is short enough to inspect quickly.",
+        },
+        "who_should_read": ["Readers deciding whether to spend more time with this source."],
+        "questions_to_keep_in_mind": [
+            "What evidence does the source provide for its central claim?"
+        ],
+        "citations": [
+            {
+                "label": "1",
+                "snippet": "Paragraph one.",
+                "source": "A careful article",
+            }
+        ],
+    }
 
 
 def test_create_lesson_marks_failed_when_extraction_fails(
@@ -138,6 +160,155 @@ def test_create_lesson_marks_failed_when_extraction_fails(
     assert lesson["generation_error"] == "Could not extract readable article content."
     assert lesson["title"] is None
     assert lesson["source_content"] is None
+    assert lesson["lesson_detail"] is None
+
+
+def test_create_lesson_marks_failed_when_structured_detail_is_malformed(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    monkeypatch.setattr(
+        service,
+        "generate_structured_lesson_detail",
+        lambda _fields: {"gist": "Only one field is not enough."},
+        raising=False,
+    )
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    assert lesson["generation_error"] == "Generated lesson detail was malformed."
+    assert lesson["lesson_detail"] is None
+
+
+def test_create_lesson_marks_failed_when_structured_detail_generation_raises(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    def _boom(_fields: dict[str, object]) -> dict[str, object]:
+        message = "invalid generated json"
+        raise ValueError(message)
+
+    monkeypatch.setattr(service, "generate_structured_lesson_detail", _boom, raising=False)
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    assert lesson["generation_error"] == "Generated lesson detail was malformed."
+    assert lesson["lesson_detail"] is None
+
+
+def test_create_lesson_rejects_citations_not_found_in_source_context(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    monkeypatch.setattr(
+        service,
+        "generate_structured_lesson_detail",
+        lambda _fields: {
+            "gist": "A gist grounded in the article.",
+            "explanation": "A short explanation grounded in the article.",
+            "key_claims": ["A grounded claim."],
+            "prerequisite_concepts": ["Background context"],
+            "why_it_matters": "It matters because the source is useful.",
+            "read_worthiness": {"verdict": "read", "rationale": "The source is useful."},
+            "who_should_read": ["Curious readers"],
+            "questions_to_keep_in_mind": ["Which claims are supported?"],
+            "citations": [
+                {
+                    "label": "1",
+                    "snippet": "This invented quote is absent from the article.",
+                    "source": "Metadata title",
+                }
+            ],
+        },
+        raising=False,
+    )
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    assert lesson["generation_error"] == "Generated lesson citations did not match source content."
+    assert lesson["lesson_detail"] is None
+
+
+def test_create_lesson_rejects_citation_sources_not_found_in_source_context(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    monkeypatch.setattr(
+        service,
+        "generate_structured_lesson_detail",
+        lambda _fields: {
+            "gist": "Body for https://example.com/a",
+            "explanation": "Body for https://example.com/a",
+            "key_claims": ["Body for https://example.com/a"],
+            "prerequisite_concepts": ["Background context"],
+            "why_it_matters": "It matters because the source is useful.",
+            "read_worthiness": {"verdict": "read", "rationale": "The source is useful."},
+            "who_should_read": ["Curious readers"],
+            "questions_to_keep_in_mind": ["Which claims are supported?"],
+            "citations": [
+                {
+                    "label": "1",
+                    "snippet": "Body for https://example.com/a",
+                    "source": "Invented Source",
+                }
+            ],
+        },
+        raising=False,
+    )
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    assert lesson["generation_error"] == "Generated lesson citations did not match source content."
+    assert lesson["lesson_detail"] is None
+
+
+def test_create_lesson_rejects_structured_detail_with_extra_blank_or_long_fields(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    monkeypatch.setattr(
+        service,
+        "generate_structured_lesson_detail",
+        lambda _fields: {
+            "gist": "x" * 281,
+            "unexpected_extra_field": "not part of the contract",
+            "explanation": "Body for https://example.com/a",
+            "key_claims": [""],
+            "prerequisite_concepts": ["Background context"],
+            "why_it_matters": "It matters because the source is useful.",
+            "read_worthiness": {"verdict": "read", "rationale": "The source is useful."},
+            "who_should_read": ["Curious readers"],
+            "questions_to_keep_in_mind": ["Which claims are supported?"],
+            "citations": [
+                {
+                    "label": "1",
+                    "snippet": "Body for https://example.com/a",
+                    "source": "Title for https://example.com/a",
+                }
+            ],
+        },
+        raising=False,
+    )
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    assert lesson["generation_error"] == "Generated lesson detail was malformed."
+    assert lesson["lesson_detail"] is None
 
 
 def test_create_lesson_ignores_metadata_failure_when_body_succeeds(
@@ -313,6 +484,28 @@ def test_create_lesson_endpoint_returns_completed_lesson(
                 "author": "Robin Reporter",
                 "published_at": "2026-07-09",
                 "source_content": "API body text.",
+                "lesson_detail": {
+                    "gist": "API body text.",
+                    "explanation": "API body text.",
+                    "key_claims": ["API body text."],
+                    "prerequisite_concepts": ["Context from API Source"],
+                    "why_it_matters": (
+                        "It helps you decide whether API article deserves deeper reading."
+                    ),
+                    "read_worthiness": {
+                        "verdict": "skim",
+                        "rationale": "Start with a skim.",
+                    },
+                    "who_should_read": ["Curious readers"],
+                    "questions_to_keep_in_mind": ["Which claim is supported?"],
+                    "citations": [
+                        {
+                            "label": "1",
+                            "snippet": "API body text.",
+                            "source": "API article",
+                        }
+                    ],
+                },
             },
             database_url=pg_clean,
         )

--- a/frontend/src/__tests__/learnPage.test.tsx
+++ b/frontend/src/__tests__/learnPage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LearnPage } from '../pages/LearnPage';
 import { HttpError, createLessonFromLink, fetchLesson } from '../api';
+import type { Lesson } from '../api';
 import * as api from '../api';
 
 const { translationSpy } = vi.hoisted(() => ({
@@ -40,7 +41,7 @@ vi.mock('react-i18next', () => ({
 
 vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-const COMPLETE_LESSON = {
+const COMPLETE_LESSON: Lesson = {
   id: 7,
   user_id: 1,
   original_url: 'https://example.com/article',
@@ -52,11 +53,39 @@ const COMPLETE_LESSON = {
   source_content: 'A compact but useful article body preview.',
   generation_status: 'complete',
   generation_error: null,
+  lesson_detail: {
+    gist: 'The article argues that strong source selection matters more than raw volume.',
+    explanation:
+      'It walks through how the author chose a small set of high-signal sources and why that improves review quality.',
+    key_claims: [
+      'A short reading stack can outperform a broad feed when the goal is comprehension.',
+      'Editorial filtering reduces noise and makes follow-up questions sharper.',
+    ],
+    prerequisite_concepts: ['Signal-to-noise ratio', 'Editorial curation'],
+    why_it_matters:
+      'Knowing when to skim versus study helps the reader spend attention where it compounds.',
+    read_worthiness: {
+      verdict: 'study',
+      rationale: 'It introduces a repeatable framework for deciding how deeply to read a piece.',
+    },
+    who_should_read: ['People building reading workflows', 'Editors evaluating article quality'],
+    questions_to_keep_in_mind: [
+      'What filtering rule is being applied?',
+      'Which audience is this lesson aiming at?',
+    ],
+    citations: [
+      {
+        label: 'Filtering principle',
+        snippet: 'Choose fewer, higher-signal sources when the goal is durable understanding.',
+        source: 'Example Journal',
+      },
+    ],
+  },
   created_at: '2026-07-08T10:00:00Z',
   updated_at: '2026-07-08T10:01:00Z',
-} as const;
+};
 
-const PENDING_LESSON = {
+const PENDING_LESSON: Lesson = {
   ...COMPLETE_LESSON,
   id: 8,
   title: null,
@@ -65,9 +94,10 @@ const PENDING_LESSON = {
   published_at: null,
   source_content: null,
   generation_status: 'pending',
-} as const;
+  lesson_detail: null,
+};
 
-const FAILED_LESSON = {
+const FAILED_LESSON: Lesson = {
   ...COMPLETE_LESSON,
   id: 9,
   title: null,
@@ -77,7 +107,8 @@ const FAILED_LESSON = {
   source_content: null,
   generation_status: 'failed',
   generation_error: 'Could not extract readable article content.',
-} as const;
+  lesson_detail: null,
+};
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -160,13 +191,55 @@ describe('LearnPage', () => {
 
     await screen.findByText(/lesson generated/i);
     expect(screen.getByText(/A careful article/i)).toBeInTheDocument();
-    expect(screen.getByText(/Example Journal/i)).toBeInTheDocument();
+    expect(screen.getByText(/Example Journal/i, { selector: 'span' })).toBeInTheDocument();
     expect(screen.getByText(/Jane Example/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /open original article/i })).toHaveAttribute(
       'href',
       'https://example.com/article'
     );
     expect(screen.getByText(/A compact but useful article body preview\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Study/i, { selector: 'div' })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /It introduces a repeatable framework for deciding how deeply to read a piece\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /The article argues that strong source selection matters more than raw volume\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /It walks through how the author chose a small set of high-signal sources and why that improves review quality\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /A short reading stack can outperform a broad feed when the goal is comprehension\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Editorial filtering reduces noise and makes follow-up questions sharper\./i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Signal-to-noise ratio/i)).toBeInTheDocument();
+    expect(screen.getByText(/Editorial curation/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Knowing when to skim versus study helps the reader spend attention where it compounds\./i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/People building reading workflows/i)).toBeInTheDocument();
+    expect(screen.getByText(/Editors evaluating article quality/i)).toBeInTheDocument();
+    expect(screen.getByText(/What filtering rule is being applied\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/Which audience is this lesson aiming at\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/Filtering principle/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Choose fewer, higher-signal sources when the goal is durable understanding\./i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Example Journal/i, { selector: 'div' })).toBeInTheDocument();
     expect(translationSpy).toHaveBeenCalledWith('learn.title');
     expect(translationSpy).toHaveBeenCalledWith('learn.description');
     expect(translationSpy).toHaveBeenCalledWith('learn.form.url_label');

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -1,5 +1,28 @@
 import { requestJson } from './core';
 
+export interface LessonReadWorthiness {
+  verdict: 'skip' | 'skim' | 'read' | 'study';
+  rationale: string;
+}
+
+export interface LessonCitation {
+  label: string;
+  snippet: string;
+  source: string;
+}
+
+export interface LessonDetail {
+  gist: string;
+  explanation: string;
+  key_claims: string[];
+  prerequisite_concepts: string[];
+  why_it_matters: string;
+  read_worthiness: LessonReadWorthiness;
+  who_should_read: string[];
+  questions_to_keep_in_mind: string[];
+  citations: LessonCitation[];
+}
+
 export interface Lesson {
   id: number;
   user_id: number;
@@ -12,6 +35,7 @@ export interface Lesson {
   source_content: string | null;
   generation_status: 'pending' | 'complete' | 'failed';
   generation_error: string | null;
+  lesson_detail: LessonDetail | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -5,7 +5,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { createLessonFromLink, fetchLesson, HttpError, type Lesson } from '@/api';
+import {
+  createLessonFromLink,
+  fetchLesson,
+  HttpError,
+  type Lesson,
+  type LessonDetail,
+} from '@/api';
 
 function formatPublishedDate(value: string | null): string | null {
   if (!value) return null;
@@ -24,6 +30,32 @@ function statusBadgeVariant(
   if (status === 'complete') return 'default';
   if (status === 'failed') return 'destructive';
   return 'secondary';
+}
+
+function verdictBadgeVariant(
+  verdict: LessonDetail['read_worthiness']['verdict']
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (verdict === 'study') return 'default';
+  if (verdict === 'read') return 'secondary';
+  if (verdict === 'skim') return 'outline';
+  return 'destructive';
+}
+
+function capitalizeLabel(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function renderBulletList(items: string[]) {
+  return (
+    <ul className="space-y-1.5">
+      {items.map((item) => (
+        <li key={item} className="flex items-start gap-2 text-sm leading-6 text-foreground">
+          <span className="mt-0.5 shrink-0 text-accent">-</span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
 }
 
 export function LearnPage() {
@@ -95,6 +127,8 @@ export function LearnPage() {
   const isPendingLesson = lesson?.generation_status === 'pending';
   const isFailedLesson = lesson?.generation_status === 'failed';
   const isCompleteLesson = lesson?.generation_status === 'complete';
+  const lessonDetail = lesson?.lesson_detail ?? null;
+  const hasLessonDetail = isCompleteLesson && lessonDetail !== null;
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
@@ -197,6 +231,74 @@ export function LearnPage() {
               <Skeleton className="h-4 w-full" />
               <Skeleton className="h-4 w-11/12" />
               <Skeleton className="h-4 w-10/12" />
+            </div>
+          ) : null}
+
+          {hasLessonDetail && lessonDetail ? (
+            <div className="space-y-4 rounded-lg border border-border bg-background p-4">
+              <div className="flex flex-wrap items-start gap-3">
+                <Badge variant={verdictBadgeVariant(lessonDetail.read_worthiness.verdict)}>
+                  {capitalizeLabel(lessonDetail.read_worthiness.verdict)}
+                </Badge>
+                <div className="min-w-0 text-sm text-muted-foreground">
+                  {lessonDetail.read_worthiness.rationale}
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold text-foreground">Gist</h3>
+                  <p className="text-sm leading-6 text-foreground">{lessonDetail.gist}</p>
+                </section>
+
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold text-foreground">Why it matters</h3>
+                  <p className="text-sm leading-6 text-foreground">{lessonDetail.why_it_matters}</p>
+                </section>
+
+                <section className="space-y-2 md:col-span-2">
+                  <h3 className="text-sm font-semibold text-foreground">Explanation</h3>
+                  <p className="text-sm leading-6 text-foreground">{lessonDetail.explanation}</p>
+                </section>
+
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold text-foreground">Key claims</h3>
+                  {renderBulletList(lessonDetail.key_claims)}
+                </section>
+
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold text-foreground">Prerequisite concepts</h3>
+                  {renderBulletList(lessonDetail.prerequisite_concepts)}
+                </section>
+
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold text-foreground">Who should read</h3>
+                  {renderBulletList(lessonDetail.who_should_read)}
+                </section>
+
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold text-foreground">
+                    Questions to keep in mind
+                  </h3>
+                  {renderBulletList(lessonDetail.questions_to_keep_in_mind)}
+                </section>
+
+                <section className="space-y-2 md:col-span-2">
+                  <h3 className="text-sm font-semibold text-foreground">Citations</h3>
+                  <ul className="space-y-3">
+                    {lessonDetail.citations.map((citation) => (
+                      <li
+                        key={`${citation.label}-${citation.source}-${citation.snippet}`}
+                        className="space-y-1"
+                      >
+                        <div className="text-sm font-medium text-foreground">{citation.label}</div>
+                        <p className="text-sm leading-6 text-foreground">{citation.snippet}</p>
+                        <div className="text-xs text-muted-foreground">{citation.source}</div>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              </div>
             </div>
           ) : null}
 


### PR DESCRIPTION
Closes #1117
Closes #1144
Closes #1145
Closes #1146

## Summary

- Adds a structured `lesson_detail` JSONB artifact for completed Learn-from-Link lessons.
- Validates generated lesson detail with a Pydantic schema before persistence, including read-worthiness verdicts, gist/explanation, claims, prerequisites, audience, guiding questions, and citations.
- Grounds citation snippets and displayed source labels against fetched lesson source context before saving.
- Renders the structured lesson detail on the Learn page, including verdict, rationale, citations, intended readers, and questions.

## Verification

- `make lint`
- `make typecheck`
- `dotenv run -- pytest backend/tests/test_learn_from_link.py -q` -> 18 passed
- `npm run test:frontend` -> 87 files / 877 tests passed
- `npm run build`
- Final re-review found no remaining blocking issues.

## Local full-suite note

- `dotenv run -- make test` currently fails outside this slice in legacy/body-fetch/search/stats/workflow tests, including `test_body_fetch.py`, `test_quiz.py`, `test_search_filters.py`, `test_summary_user_scoped.py`, `test_source_subscriptions.py`, `test_stats.py`, and `test_workflow_state.py`. The failures show existing local-suite isolation/env issues such as `db_path` tests colliding with `.env` PostgreSQL rows and body-fetch tests bypassing patches to hit Crawl4AI. Focused lesson tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
