### PR TITLE
test: isolate body fetch fallback tests

### DIFF
--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -188,7 +188,10 @@ def test_fetch_and_cache_body_fetch_error(tmp_path: Path) -> None:
     db_path = _db(tmp_path)
     article_id = _seed_article(db_path)
 
-    with patch("news_dashboard.body_fetch.extract_body", return_value=("", "error")):
+    with (
+        patch("news_dashboard.body_fetch.extract_body", return_value=("", "error")),
+        patch("news_dashboard.body_fetch._crawl4ai_extract_body", return_value=("", "error")),
+    ):
         result = fetch_and_cache_body(article_id, db_path=db_path)
 
     assert result is not None
@@ -674,6 +677,7 @@ def test_fetch_and_cache_body_uses_ai_fallback_when_scraper_fails(tmp_path: Path
 
     with (
         patch("news_dashboard.body_fetch.extract_body", return_value=("", "error")),
+        patch("news_dashboard.body_fetch._crawl4ai_extract_body", return_value=("", "error")),
         patch(
             "news_dashboard.body_fetch._ai_extract_body",
             return_value=("AI extracted text", "ok"),
@@ -718,6 +722,7 @@ def test_fetch_and_cache_body_ai_fallback_result_is_cached(tmp_path: Path) -> No
 
     with (
         patch("news_dashboard.body_fetch.extract_body", return_value=("", "error")),
+        patch("news_dashboard.body_fetch._crawl4ai_extract_body", return_value=("", "error")),
         patch("news_dashboard.body_fetch._ai_extract_body", side_effect=fake_ai),
     ):
         result1 = fetch_and_cache_body(article_id, db_path=db_path)


### PR DESCRIPTION
## Summary
- Stabilize body fetch fallback tests by explicitly disabling the Crawl4AI fallback in tests that are meant to exercise fetch-error and AI-fallback behavior.
- Follow-up from the Learn from Link verification pass; the full Learn from Link flow for #1116 has already merged in #1140.
- Closed duplicate child issues #1132, #1133, and #1134 as superseded by #1140 / canonical child issues #1136-#1138.

## Tests
- `PATH="$PWD/.venv/bin:$PATH" ruff check backend/tests/test_body_fetch.py`
- `PATH="$PWD/.venv/bin:$PATH" ruff format --check backend/tests/test_body_fetch.py`
- `PATH="$PWD/.venv/bin:$PATH" dotenv -f .env run -- pytest -q backend/tests/test_body_fetch.py::test_fetch_and_cache_body_fetch_error backend/tests/test_body_fetch.py::test_fetch_and_cache_body_uses_ai_fallback_when_scraper_fails backend/tests/test_body_fetch.py::test_fetch_and_cache_body_ai_fallback_result_is_cached`

## Verification note
- Full local `make check` was attempted after rebasing. Backend xdist/Postgres integration tests failed with shared-state/lock-pressure symptoms (`UniqueViolation` in unrelated seeded tests and `out of shared memory` during `pg_clean` truncation). Representative failing tests passed when rerun directly with `-n 0`, so this PR keeps scope to the deterministic test isolation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)