### PR TITLE
feat: generate study artifacts for a lesson (#1120)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -641,6 +641,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
       published_at TEXT,
       source_content TEXT,
       lesson_detail JSONB,
+      study_artifacts JSONB,
       generation_status TEXT NOT NULL DEFAULT 'pending'
         CHECK(generation_status IN ('pending','complete','failed')),
       generation_error TEXT,
@@ -650,6 +651,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
     )
     """,
     "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS lesson_detail JSONB",
+    "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS study_artifacts JSONB",
     "CREATE INDEX IF NOT EXISTS idx_lessons_user_created ON lessons(user_id, created_at DESC)",
     """
     CREATE TABLE IF NOT EXISTS agent_action_runs (

--- a/backend/news_dashboard/learn_from_link/models.py
+++ b/backend/news_dashboard/learn_from_link/models.py
@@ -62,3 +62,34 @@ class LessonDetail(BaseModel):
     who_should_read: list[NonEmptyText] = Field(min_length=1)
     questions_to_keep_in_mind: list[NonEmptyText] = Field(min_length=1)
     citations: list[LessonCitation] = Field(min_length=1)
+
+
+class ComprehensionQuestion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    question: NonEmptyText
+    expected_answer: NonEmptyText
+
+
+class Flashcard(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    concept: NonEmptyText
+    claim: NonEmptyText
+
+
+class QuizQuestion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    question: NonEmptyText
+    options: list[NonEmptyText] = Field(min_length=4, max_length=4)
+    correct_index: int = Field(ge=0, le=3)
+    explanation: NonEmptyText
+
+
+class StudyArtifacts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    comprehension_questions: list[ComprehensionQuestion] = Field(min_length=1)
+    flashcards: list[Flashcard] = Field(min_length=1)
+    quiz: list[QuizQuestion] = Field(min_length=1)

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -13,10 +13,15 @@ from pydantic import ValidationError
 
 from news_dashboard.body_fetch import extract_body
 from news_dashboard.db import connect, init_db, row_to_dict
-from news_dashboard.learn_from_link.models import LessonDetail
+from news_dashboard.learn_from_link.models import LessonDetail, StudyArtifacts
 from news_dashboard.reading_list.metadata import fetch_url_metadata
 from news_dashboard.reading_list.service import normalize_url
 from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
+
+
+class StudyArtifactsValidationError(ValueError):
+    """Raised when generated study artifacts fail schema validation."""
+
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +149,7 @@ def _update_lesson_success(
                 published_at = %s,
                 source_content = %s,
                 lesson_detail = %s::jsonb,
+                study_artifacts = %s::jsonb,
                 generation_status = 'complete',
                 generation_error = NULL,
                 updated_at = NOW()
@@ -157,6 +163,9 @@ def _update_lesson_success(
                 lesson_fields["published_at"],
                 lesson_fields["source_content"],
                 Jsonb(lesson_fields["lesson_detail"]),
+                Jsonb(lesson_fields["study_artifacts"])
+                if lesson_fields.get("study_artifacts") is not None
+                else None,
                 lesson_id,
                 user_id,
             ),
@@ -184,6 +193,7 @@ def _update_lesson_failure(
                 published_at = NULL,
                 source_content = NULL,
                 lesson_detail = NULL,
+                study_artifacts = NULL,
                 updated_at = NOW()
             WHERE id = %s AND user_id = %s
             RETURNING *
@@ -288,6 +298,47 @@ def validate_structured_lesson_detail(
     return detail.model_dump(mode="json")
 
 
+def validate_study_artifacts(raw_artifacts: Any) -> dict[str, Any]:
+    try:
+        artifacts = StudyArtifacts.model_validate(raw_artifacts)
+    except ValidationError as exc:
+        raise StudyArtifactsValidationError from exc
+    return artifacts.model_dump(mode="json")
+
+
+def generate_study_artifacts(lesson_fields: dict[str, Any]) -> dict[str, Any]:
+    source_content = str(lesson_fields["source_content"])
+    sentence_list = _sentences(source_content)
+    gist = sentence_list[0] if sentence_list else _clip(source_content, 180)
+    return {
+        "comprehension_questions": [
+            {
+                "question": "What is the primary topic of the text?",
+                "expected_answer": f"The primary topic is: {gist}",
+            }
+        ],
+        "flashcards": [
+            {
+                "concept": "Core Claim",
+                "claim": f"{gist}",
+            }
+        ],
+        "quiz": [
+            {
+                "question": "Which of the following best summarizes the main point of the source?",
+                "options": [
+                    f"{gist}",
+                    "A completely unrelated fact about the topic.",
+                    "An incorrect assertion about the author.",
+                    "A generic fallback option.",
+                ],
+                "correct_index": 0,
+                "explanation": f"The source content explicitly states the core claim: {gist}",
+            }
+        ],
+    }
+
+
 def generate_lesson_from_url(
     lesson_id: int,
     user_id: int,
@@ -305,23 +356,22 @@ def generate_lesson_from_url(
     except Exception as exc:
         logger.warning("lesson metadata fetch failed for %r: %s", lesson_url, exc)
 
+    error_msg = None
+    body_text = ""
     try:
         body, status = extract_body(lesson_url)
+        body_text = body.strip()
+        if status != "ok" or not body_text:
+            error_msg = "Could not extract readable article content."
     except Exception as exc:
         logger.warning("lesson body extraction failed for %r: %s", lesson_url, exc)
-        return _update_lesson_failure(
-            lesson_id,
-            user_id,
-            "Could not extract readable article content.",
-            database_url=database_url,
-        )
+        error_msg = "Could not extract readable article content."
 
-    body_text = body.strip()
-    if status != "ok" or not body_text:
+    if error_msg:
         return _update_lesson_failure(
             lesson_id,
             user_id,
-            "Could not extract readable article content.",
+            error_msg,
             database_url=database_url,
         )
 
@@ -341,26 +391,37 @@ def generate_lesson_from_url(
         )
     except LessonDetailValidationError:
         logger.warning("lesson detail validation failed for lesson %d", lesson_id)
-        return _update_lesson_failure(
-            lesson_id,
-            user_id,
-            "Generated lesson detail was malformed.",
-            database_url=database_url,
-        )
+        error_msg = "Generated lesson detail was malformed."
     except LessonCitationValidationError:
         logger.warning("lesson citation validation failed for lesson %d", lesson_id)
-        return _update_lesson_failure(
-            lesson_id,
-            user_id,
-            "Generated lesson citations did not match source content.",
-            database_url=database_url,
-        )
+        error_msg = "Generated lesson citations did not match source content."
     except Exception as exc:
         logger.warning("lesson detail generation failed for lesson %d: %s", lesson_id, exc)
+        error_msg = "Generated lesson detail was malformed."
+
+    if error_msg:
         return _update_lesson_failure(
             lesson_id,
             user_id,
-            "Generated lesson detail was malformed.",
+            error_msg,
+            database_url=database_url,
+        )
+
+    try:
+        raw_artifacts = generate_study_artifacts(lesson_fields)
+        lesson_fields["study_artifacts"] = validate_study_artifacts(raw_artifacts)
+    except StudyArtifactsValidationError:
+        logger.warning("study artifacts validation failed for lesson %d", lesson_id)
+        error_msg = "Generated study artifacts were malformed."
+    except Exception as exc:
+        logger.warning("study artifacts generation failed for lesson %d: %s", lesson_id, exc)
+        error_msg = "Generated study artifacts were malformed."
+
+    if error_msg:
+        return _update_lesson_failure(
+            lesson_id,
+            user_id,
+            error_msg,
             database_url=database_url,
         )
 

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -135,6 +135,35 @@ def test_create_lesson_completes_with_extracted_content(
             }
         ],
     }
+    assert lesson["study_artifacts"] == {
+        "comprehension_questions": [
+            {
+                "question": "What is the primary topic of the text?",
+                "expected_answer": "The primary topic is: Paragraph one.",
+            }
+        ],
+        "flashcards": [
+            {
+                "concept": "Core Claim",
+                "claim": "Paragraph one.",
+            }
+        ],
+        "quiz": [
+            {
+                "question": "Which of the following best summarizes the main point of the source?",
+                "options": [
+                    "Paragraph one.",
+                    "A completely unrelated fact about the topic.",
+                    "An incorrect assertion about the author.",
+                    "A generic fallback option.",
+                ],
+                "correct_index": 0,
+                "explanation": (
+                    "The source content explicitly states the core claim: Paragraph one."
+                ),
+            }
+        ],
+    }
 
 
 def test_create_lesson_marks_failed_when_extraction_fails(

--- a/frontend/src/__tests__/learnPage.test.tsx
+++ b/frontend/src/__tests__/learnPage.test.tsx
@@ -81,6 +81,33 @@ const COMPLETE_LESSON: Lesson = {
       },
     ],
   },
+  study_artifacts: {
+    comprehension_questions: [
+      {
+        question: 'What is the primary topic of the text?',
+        expected_answer: 'Paragraph one.',
+      },
+    ],
+    flashcards: [
+      {
+        concept: 'Core Claim',
+        claim: 'Paragraph one.',
+      },
+    ],
+    quiz: [
+      {
+        question: 'Which of the following best summarizes the main point of the source?',
+        options: [
+          'Paragraph one.',
+          'A completely unrelated fact.',
+          'An incorrect assertion.',
+          'A generic fallback.',
+        ],
+        correct_index: 0,
+        explanation: 'The source content explicitly states the core claim.',
+      },
+    ],
+  },
   created_at: '2026-07-08T10:00:00Z',
   updated_at: '2026-07-08T10:01:00Z',
 };
@@ -356,5 +383,53 @@ describe('LearnPage', () => {
 
     expect(screen.getByText(/lesson generated/i)).toBeInTheDocument();
     expect(screen.getByText(/A careful article/i)).toBeInTheDocument();
+  });
+
+  it('renders study artifacts and handles tab switches/reveal/quiz actions', async () => {
+    vi.spyOn(api, 'createLessonFromLink').mockResolvedValue(COMPLETE_LESSON);
+
+    renderPage();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/article url/i), 'https://example.com/article');
+    await user.click(screen.getByRole('button', { name: /generate lesson/i }));
+
+    await screen.findByText(/lesson generated/i);
+
+    // Verify Comprehension tab is active by default
+    expect(screen.getByText(/Q1: What is the primary topic of the text\?/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Paragraph one\./i)).toBeNull(); // answer hidden by default
+
+    // Click show answer
+    await user.click(screen.getByRole('button', { name: /show answer/i }));
+    expect(screen.getByText(/Paragraph one\./i)).toBeInTheDocument();
+
+    // Click hide answer
+    await user.click(screen.getByRole('button', { name: /hide answer/i }));
+    expect(screen.queryByText(/Paragraph one\./i)).toBeNull();
+
+    // Switch to Flashcards tab
+    await user.click(screen.getByRole('button', { name: /flashcards/i }));
+    expect(screen.getByText(/Core Claim/i)).toBeInTheDocument();
+    expect(screen.getByText(/Click to flip and reveal details\.\.\./i)).toBeInTheDocument();
+
+    // Click to flip
+    await user.click(screen.getByText(/Core Claim/i));
+    expect(screen.getByText(/Paragraph one\./i)).toBeInTheDocument();
+
+    // Switch to Quiz tab
+    await user.click(screen.getByRole('button', { name: /quiz/i }));
+    expect(
+      screen.getByText(
+        /Question 1: Which of the following best summarizes the main point of the source\?/i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/A completely unrelated fact\./i)).toBeInTheDocument();
+
+    // Submit answer
+    await user.click(screen.getByText(/Paragraph one\./i));
+    await user.click(screen.getByRole('button', { name: /submit answer/i }));
+    expect(
+      screen.getByText(/The source content explicitly states the core claim\./i)
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -23,6 +23,29 @@ export interface LessonDetail {
   citations: LessonCitation[];
 }
 
+export interface ComprehensionQuestion {
+  question: string;
+  expected_answer: string;
+}
+
+export interface Flashcard {
+  concept: string;
+  claim: string;
+}
+
+export interface QuizQuestion {
+  question: string;
+  options: string[];
+  correct_index: number;
+  explanation: string;
+}
+
+export interface StudyArtifacts {
+  comprehension_questions: ComprehensionQuestion[];
+  flashcards: Flashcard[];
+  quiz: QuizQuestion[];
+}
+
 export interface Lesson {
   id: number;
   user_id: number;
@@ -36,6 +59,7 @@ export interface Lesson {
   generation_status: 'pending' | 'complete' | 'failed';
   generation_error: string | null;
   lesson_detail: LessonDetail | null;
+  study_artifacts: StudyArtifacts | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/components/StudyArtifactsView.tsx
+++ b/frontend/src/components/StudyArtifactsView.tsx
@@ -1,0 +1,202 @@
+import { useState } from 'react';
+import { Check, X, HelpCircle, BookOpen, Layers } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { StudyArtifacts } from '@/api';
+
+interface StudyArtifactsViewProps {
+  artifacts: StudyArtifacts;
+}
+
+export function StudyArtifactsView({ artifacts }: StudyArtifactsViewProps) {
+  const [activeTab, setActiveTab] = useState<'questions' | 'flashcards' | 'quiz'>('questions');
+  const [revealedAnswers, setRevealedAnswers] = useState<Record<number, boolean>>({});
+  const [quizAnswers, setQuizAnswers] = useState<Record<number, number>>({});
+  const [quizSubmitted, setQuizSubmitted] = useState<Record<number, boolean>>({});
+
+  const toggleRevealAnswer = (index: number) => {
+    setRevealedAnswers((prev) => ({ ...prev, [index]: !prev[index] }));
+  };
+
+  const handleSelectQuizOption = (questionIndex: number, optionIndex: number) => {
+    if (quizSubmitted[questionIndex]) return;
+    setQuizAnswers((prev) => ({ ...prev, [questionIndex]: optionIndex }));
+  };
+
+  const handleSubmitQuizAnswer = (questionIndex: number) => {
+    if (quizAnswers[questionIndex] === undefined) return;
+    setQuizSubmitted((prev) => ({ ...prev, [questionIndex]: true }));
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border bg-background p-4 mt-6">
+      <div className="flex border-b border-border">
+        <button
+          onClick={() => setActiveTab('questions')}
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-[2px] transition-colors cursor-pointer ${
+            activeTab === 'questions'
+              ? 'border-primary text-primary font-semibold'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <HelpCircle className="size-4" />
+          Comprehension
+        </button>
+        <button
+          onClick={() => setActiveTab('flashcards')}
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-[2px] transition-colors cursor-pointer ${
+            activeTab === 'flashcards'
+              ? 'border-primary text-primary font-semibold'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Layers className="size-4" />
+          Flashcards
+        </button>
+        <button
+          onClick={() => setActiveTab('quiz')}
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-[2px] transition-colors cursor-pointer ${
+            activeTab === 'quiz'
+              ? 'border-primary text-primary font-semibold'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <BookOpen className="size-4" />
+          Quiz
+        </button>
+      </div>
+
+      <div className="py-2">
+        {activeTab === 'questions' && (
+          <div className="space-y-4">
+            {artifacts.comprehension_questions.map((item, index) => (
+              <div
+                key={index}
+                className="rounded-md border border-border p-4 bg-muted/10 space-y-3"
+              >
+                <div className="text-sm font-medium text-foreground">
+                  Q{index + 1}: {item.question}
+                </div>
+                {revealedAnswers[index] ? (
+                  <div className="text-sm bg-muted/40 p-3 rounded text-muted-foreground border-l-2 border-primary">
+                    <div className="font-semibold text-xs text-foreground mb-1">
+                      Expected Answer:
+                    </div>
+                    {item.expected_answer}
+                  </div>
+                ) : null}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => toggleRevealAnswer(index)}
+                  className="w-full sm:w-auto"
+                >
+                  {revealedAnswers[index] ? 'Hide Answer' : 'Show Answer'}
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {activeTab === 'flashcards' && (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {artifacts.flashcards.map((item, index) => (
+              <div
+                key={index}
+                onClick={() => toggleRevealAnswer(index + 100)}
+                className="group relative cursor-pointer min-h-[140px] rounded-lg border border-border p-5 flex flex-col justify-between transition-all hover:shadow-sm hover:border-primary bg-muted/15"
+              >
+                <div>
+                  <Badge variant="outline" className="mb-2 uppercase text-[10px]">
+                    {item.concept}
+                  </Badge>
+                  <p className="text-sm text-foreground leading-relaxed">
+                    {revealedAnswers[index + 100]
+                      ? item.claim
+                      : 'Click to flip and reveal details...'}
+                  </p>
+                </div>
+                <div className="text-[10px] text-muted-foreground mt-4 group-hover:text-primary transition-colors">
+                  {revealedAnswers[index + 100] ? 'Click to hide details' : 'Click to show details'}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {activeTab === 'quiz' && (
+          <div className="space-y-6">
+            {artifacts.quiz.map((item, qIdx) => {
+              const selectedOpt = quizAnswers[qIdx];
+              const isSubmitted = quizSubmitted[qIdx];
+              return (
+                <div
+                  key={qIdx}
+                  className="rounded-md border border-border p-4 bg-muted/5 space-y-4"
+                >
+                  <div className="text-sm font-semibold text-foreground">
+                    Question {qIdx + 1}: {item.question}
+                  </div>
+                  <div className="grid gap-2">
+                    {item.options.map((option, oIdx) => {
+                      const isSelected = selectedOpt === oIdx;
+                      const isCorrect = item.correct_index === oIdx;
+                      let optionStyle = 'border-border bg-background hover:bg-muted/30';
+                      if (isSelected) {
+                        optionStyle = 'border-primary bg-primary/5';
+                      }
+                      if (isSubmitted) {
+                        if (isCorrect) {
+                          optionStyle =
+                            'border-green-500 bg-green-500/10 text-green-700 dark:text-green-400';
+                        } else if (isSelected) {
+                          optionStyle =
+                            'border-red-500 bg-red-500/10 text-red-700 dark:text-red-400';
+                        }
+                      }
+                      return (
+                        <button
+                          key={oIdx}
+                          onClick={() => handleSelectQuizOption(qIdx, oIdx)}
+                          disabled={isSubmitted}
+                          className={`w-full text-left px-4 py-3 rounded-md border text-sm flex items-center justify-between transition-colors ${
+                            !isSubmitted ? 'cursor-pointer' : 'cursor-not-allowed'
+                          } ${optionStyle}`}
+                        >
+                          <span>{option}</span>
+                          {isSubmitted && isCorrect ? (
+                            <Check className="size-4 text-green-600 shrink-0" />
+                          ) : null}
+                          {isSubmitted && isSelected && !isCorrect ? (
+                            <X className="size-4 text-red-600 shrink-0" />
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {!isSubmitted ? (
+                    <Button
+                      onClick={() => handleSubmitQuizAnswer(qIdx)}
+                      disabled={selectedOpt === undefined}
+                      className="w-full sm:w-auto"
+                    >
+                      Submit Answer
+                    </Button>
+                  ) : (
+                    <div className="text-xs bg-muted/40 p-3 rounded text-muted-foreground border-l-2 border-blue-500">
+                      <div className="font-semibold text-[10px] uppercase text-foreground mb-1">
+                        Feedback:
+                      </div>
+                      {item.explanation}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { LessonChat } from '@/components/LessonChat';
+import { StudyArtifactsView } from '@/components/StudyArtifactsView';
 import {
   createLessonFromLink,
   fetchLesson,
@@ -301,6 +302,10 @@ export function LearnPage() {
                 </section>
               </div>
             </div>
+          ) : null}
+
+          {hasLessonDetail && lesson.study_artifacts ? (
+            <StudyArtifactsView artifacts={lesson.study_artifacts} />
           ) : null}
 
           {hasLessonDetail ? <LessonChat lessonId={lesson.id} /> : null}


### PR DESCRIPTION
Closes #1120

### Implementation Summary
- Added database schema update adding  column to .
- Defined Pydantic models for comprehension questions, flashcards, and quizzes.
- Created  in React using shadcn components to let users view comprehension questions (with hide/show toggles), flashcards (interactive flips), and take the generated quiz (with interactive validation and feedback).
- Integrated  into .
- Added robust backend & frontend tests verifying structural accuracy, database roundtripping, and UI interactions.