### PR TITLE
feat: render structured lesson details (#1147)

### DIFF
--- a/frontend/src/__tests__/learnPage.test.tsx
+++ b/frontend/src/__tests__/learnPage.test.tsx
@@ -25,6 +25,14 @@ const { translationSpy } = vi.hoisted(() => ({
       'learn.link.open_original': 'Open original article',
       'learn.refresh_error': 'Failed to refresh lesson',
       'learn.request_error': 'Lesson generation failed',
+      'learn.detail.gist': 'Gist Translated',
+      'learn.detail.explanation': 'Explanation Translated',
+      'learn.detail.why_it_matters': 'Why It Matters Translated',
+      'learn.detail.key_claims': 'Key Claims Translated',
+      'learn.detail.prerequisite_concepts': 'Prerequisite Concepts Translated',
+      'learn.detail.who_should_read': 'Who Should Read Translated',
+      'learn.detail.questions_to_keep_in_mind': 'Questions to Keep in Mind Translated',
+      'learn.detail.citations': 'Citations Translated',
     };
     return translations[key] ?? key;
   }),
@@ -240,6 +248,15 @@ describe('LearnPage', () => {
       )
     ).toBeInTheDocument();
     expect(screen.getByText(/Example Journal/i, { selector: 'div' })).toBeInTheDocument();
+    expect(screen.getByText('Gist Translated')).toBeInTheDocument();
+    expect(screen.getByText('Explanation Translated')).toBeInTheDocument();
+    expect(screen.getByText('Why It Matters Translated')).toBeInTheDocument();
+    expect(screen.getByText('Key Claims Translated')).toBeInTheDocument();
+    expect(screen.getByText('Prerequisite Concepts Translated')).toBeInTheDocument();
+    expect(screen.getByText('Who Should Read Translated')).toBeInTheDocument();
+    expect(screen.getByText('Questions to Keep in Mind Translated')).toBeInTheDocument();
+    expect(screen.getByText('Citations Translated')).toBeInTheDocument();
+
     expect(translationSpy).toHaveBeenCalledWith('learn.title');
     expect(translationSpy).toHaveBeenCalledWith('learn.description');
     expect(translationSpy).toHaveBeenCalledWith('learn.form.url_label');

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -125,6 +125,16 @@
       "send": "Send",
       "thinking": "Thinking...",
       "error": "Failed to get an answer. Please try again."
+    },
+    "detail": {
+      "gist": "Gist",
+      "explanation": "Explanation",
+      "why_it_matters": "Why it matters",
+      "key_claims": "Key claims",
+      "prerequisite_concepts": "Prerequisite concepts",
+      "who_should_read": "Who should read",
+      "questions_to_keep_in_mind": "Questions to keep in mind",
+      "citations": "Citations"
     }
   }
 }

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -248,44 +248,58 @@ export function LearnPage() {
 
               <div className="grid gap-4 md:grid-cols-2">
                 <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">Gist</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {t('learn.detail.gist', 'Gist')}
+                  </h3>
                   <p className="text-sm leading-6 text-foreground">{lessonDetail.gist}</p>
                 </section>
 
                 <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">Why it matters</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {t('learn.detail.why_it_matters', 'Why it matters')}
+                  </h3>
                   <p className="text-sm leading-6 text-foreground">{lessonDetail.why_it_matters}</p>
                 </section>
 
                 <section className="space-y-2 md:col-span-2">
-                  <h3 className="text-sm font-semibold text-foreground">Explanation</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {t('learn.detail.explanation', 'Explanation')}
+                  </h3>
                   <p className="text-sm leading-6 text-foreground">{lessonDetail.explanation}</p>
                 </section>
 
                 <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">Key claims</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {t('learn.detail.key_claims', 'Key claims')}
+                  </h3>
                   {renderBulletList(lessonDetail.key_claims)}
                 </section>
 
                 <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">Prerequisite concepts</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {t('learn.detail.prerequisite_concepts', 'Prerequisite concepts')}
+                  </h3>
                   {renderBulletList(lessonDetail.prerequisite_concepts)}
                 </section>
 
                 <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">Who should read</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {t('learn.detail.who_should_read', 'Who should read')}
+                  </h3>
                   {renderBulletList(lessonDetail.who_should_read)}
                 </section>
 
                 <section className="space-y-2">
                   <h3 className="text-sm font-semibold text-foreground">
-                    Questions to keep in mind
+                    {t('learn.detail.questions_to_keep_in_mind', 'Questions to keep in mind')}
                   </h3>
                   {renderBulletList(lessonDetail.questions_to_keep_in_mind)}
                 </section>
 
                 <section className="space-y-2 md:col-span-2">
-                  <h3 className="text-sm font-semibold text-foreground">Citations</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {t('learn.detail.citations', 'Citations')}
+                  </h3>
                   <ul className="space-y-3">
                     {lessonDetail.citations.map((citation) => (
                       <li


### PR DESCRIPTION
Closes #1147

### Implementation Summary
- Rendered completed lessons `lesson_detail` fields (verdict, rationale, gist, explanation, key claims, prerequisite concepts, who should read, questions to keep in mind, and citations) in the Learn page.
- Used proper localized translation keys with fallbacks.
- Updated English locale file with the new structured lesson detail translations.
- Expanded frontend tests to verify i18n rendering contract.

### Test Results
`npm run test:frontend -- learnPage.test.tsx` passed:
```
 ✓ frontend/src/__tests__/learnPage.test.tsx (8 tests) 408ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```