### PR TITLE
feat: add depth and persona controls for lesson generation (#1119)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -653,6 +653,26 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS lesson_detail JSONB",
     "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS study_artifacts JSONB",
     "CREATE INDEX IF NOT EXISTS idx_lessons_user_created ON lessons(user_id, created_at DESC)",
+    "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS depth TEXT NOT NULL DEFAULT 'normal'"
+    " CHECK(depth IN ('tiny','normal','deep','expert'))",
+    "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS persona TEXT NOT NULL DEFAULT 'developer'"
+    " CHECK(persona IN ('developer','product_builder','new_to_ai','preparing_talk'))",
+    """
+    CREATE TABLE IF NOT EXISTS lesson_generations (
+      id BIGSERIAL PRIMARY KEY,
+      lesson_id BIGINT NOT NULL REFERENCES lessons(id) ON DELETE CASCADE,
+      depth TEXT NOT NULL CHECK(depth IN ('tiny','normal','deep','expert')),
+      persona TEXT NOT NULL
+        CHECK(persona IN ('developer','product_builder','new_to_ai','preparing_talk')),
+      lesson_detail JSONB,
+      generation_status TEXT NOT NULL
+        CHECK(generation_status IN ('complete','failed')),
+      generation_error TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_lesson_generations_lesson_created"
+    " ON lesson_generations(lesson_id, created_at DESC)",
     """
     CREATE TABLE IF NOT EXISTS agent_action_runs (
       id          BIGSERIAL PRIMARY KEY,

--- a/backend/news_dashboard/learn_from_link/models.py
+++ b/backend/news_dashboard/learn_from_link/models.py
@@ -14,9 +14,23 @@ QuestionText = Annotated[
 
 MAX_LESSON_CHAT_HISTORY_ITEMS = 50
 
+LessonDepth = Literal["tiny", "normal", "deep", "expert"]
+LessonPersona = Literal["developer", "product_builder", "new_to_ai", "preparing_talk"]
+
 
 class LessonCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     url: str
+    depth: LessonDepth = "normal"
+    persona: LessonPersona = "developer"
+
+
+class LessonRegenerateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    depth: LessonDepth = "normal"
+    persona: LessonPersona = "developer"
 
 
 class LessonChatMessage(BaseModel):

--- a/backend/news_dashboard/learn_from_link/router.py
+++ b/backend/news_dashboard/learn_from_link/router.py
@@ -8,7 +8,11 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from news_dashboard.auth import require_auth
 from news_dashboard.learn_from_link import service
-from news_dashboard.learn_from_link.models import LessonCreateRequest, LessonQuestionRequest
+from news_dashboard.learn_from_link.models import (
+    LessonCreateRequest,
+    LessonQuestionRequest,
+    LessonRegenerateRequest,
+)
 
 router = APIRouter()
 
@@ -23,6 +27,8 @@ def create_lesson_endpoint(
         lesson = service.create_lesson(
             current_user["id"],
             payload.url,
+            depth=payload.depth,
+            persona=payload.persona,
             extract=False,
         )
         background_tasks.add_task(
@@ -44,6 +50,41 @@ def get_lesson_endpoint(
     if lesson is None:
         raise HTTPException(status_code=404, detail="lesson not found")
     return lesson
+
+
+@router.post("/api/learn/lessons/{lesson_id}/regenerate")
+def regenerate_lesson_endpoint(
+    lesson_id: int,
+    payload: LessonRegenerateRequest,
+    background_tasks: BackgroundTasks,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        lesson = service.regenerate_lesson(
+            lesson_id,
+            current_user["id"],
+            depth=payload.depth,
+            persona=payload.persona,
+        )
+    except service.LessonNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="lesson not found") from exc
+    background_tasks.add_task(
+        service.generate_lesson_from_url,
+        lesson_id,
+        current_user["id"],
+    )
+    return lesson
+
+
+@router.get("/api/learn/lessons/{lesson_id}/generations")
+def list_lesson_generations_endpoint(
+    lesson_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> list[dict[str, Any]]:
+    try:
+        return service.list_lesson_generations(lesson_id, current_user["id"])
+    except service.LessonNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="lesson not found") from exc
 
 
 @router.post("/api/learn/lessons/{lesson_id}/questions")

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -448,6 +448,43 @@ def generate_study_artifacts(lesson_fields: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _build_lesson_detail(
+    lesson_fields: dict[str, Any],
+    depth: LessonDepth,
+    persona: LessonPersona,
+    lesson_id: int,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        raw_detail = generate_structured_lesson_detail(lesson_fields, depth=depth, persona=persona)
+        detail = validate_structured_lesson_detail(raw_detail, lesson_fields=lesson_fields)
+    except LessonDetailValidationError:
+        logger.warning("lesson detail validation failed for lesson %d", lesson_id)
+        return None, "Generated lesson detail was malformed."
+    except LessonCitationValidationError:
+        logger.warning("lesson citation validation failed for lesson %d", lesson_id)
+        return None, "Generated lesson citations did not match source content."
+    except Exception as exc:
+        logger.warning("lesson detail generation failed for lesson %d: %s", lesson_id, exc)
+        return None, "Generated lesson detail was malformed."
+    return detail, None
+
+
+def _build_study_artifacts(
+    lesson_fields: dict[str, Any],
+    lesson_id: int,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        raw_artifacts = generate_study_artifacts(lesson_fields)
+        artifacts = validate_study_artifacts(raw_artifacts)
+    except StudyArtifactsValidationError:
+        logger.warning("study artifacts validation failed for lesson %d", lesson_id)
+        return None, "Generated study artifacts were malformed."
+    except Exception as exc:
+        logger.warning("study artifacts generation failed for lesson %d: %s", lesson_id, exc)
+        return None, "Generated study artifacts were malformed."
+    return artifacts, None
+
+
 def generate_lesson_from_url(
     lesson_id: int,
     user_id: int,
@@ -504,31 +541,16 @@ def generate_lesson_from_url(
         "published_at": metadata.get("published_at"),
         "source_content": body_text,
     }
-    try:
-        raw_detail = generate_structured_lesson_detail(lesson_fields, depth=depth, persona=persona)
-        lesson_fields["lesson_detail"] = validate_structured_lesson_detail(
-            raw_detail,
-            lesson_fields=lesson_fields,
-        )
-    except LessonDetailValidationError:
-        logger.warning("lesson detail validation failed for lesson %d", lesson_id)
-        return _fail("Generated lesson detail was malformed.")
-    except LessonCitationValidationError:
-        logger.warning("lesson citation validation failed for lesson %d", lesson_id)
-        return _fail("Generated lesson citations did not match source content.")
-    except Exception as exc:
-        logger.warning("lesson detail generation failed for lesson %d: %s", lesson_id, exc)
-        return _fail("Generated lesson detail was malformed.")
 
-    try:
-        raw_artifacts = generate_study_artifacts(lesson_fields)
-        lesson_fields["study_artifacts"] = validate_study_artifacts(raw_artifacts)
-    except StudyArtifactsValidationError:
-        logger.warning("study artifacts validation failed for lesson %d", lesson_id)
-        return _fail("Generated study artifacts were malformed.")
-    except Exception as exc:
-        logger.warning("study artifacts generation failed for lesson %d: %s", lesson_id, exc)
-        return _fail("Generated study artifacts were malformed.")
+    detail, detail_error = _build_lesson_detail(lesson_fields, depth, persona, lesson_id)
+    if detail_error:
+        return _fail(detail_error)
+    lesson_fields["lesson_detail"] = detail
+
+    artifacts, artifacts_error = _build_study_artifacts(lesson_fields, lesson_id)
+    if artifacts_error:
+        return _fail(artifacts_error)
+    lesson_fields["study_artifacts"] = artifacts
 
     result = _update_lesson_success(
         lesson_id,

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -13,7 +13,12 @@ from pydantic import ValidationError
 
 from news_dashboard.body_fetch import extract_body
 from news_dashboard.db import connect, init_db, row_to_dict
-from news_dashboard.learn_from_link.models import LessonDetail, StudyArtifacts
+from news_dashboard.learn_from_link.models import (
+    LessonDepth,
+    LessonDetail,
+    LessonPersona,
+    StudyArtifacts,
+)
 from news_dashboard.reading_list.metadata import fetch_url_metadata
 from news_dashboard.reading_list.service import normalize_url
 from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
@@ -26,6 +31,25 @@ class StudyArtifactsValidationError(ValueError):
 logger = logging.getLogger(__name__)
 
 DEFAULT_LESSON_CHAT_MODEL = "gpt-4o-mini"
+
+_DEPTH_EXPLANATION_LIMITS: dict[str, int] = {
+    "tiny": 150,
+    "normal": 600,
+    "deep": 1500,
+    "expert": 4000,
+}
+_DEPTH_KEY_CLAIM_COUNTS: dict[str, int] = {
+    "tiny": 1,
+    "normal": 3,
+    "deep": 5,
+    "expert": 8,
+}
+_PERSONA_FRAMING: dict[str, str] = {
+    "developer": "for developers weighing implementation details",
+    "product_builder": "for product builders assessing user impact",
+    "new_to_ai": "for readers new to AI who want a clear on-ramp",
+    "preparing_talk": "for someone preparing a talk on this topic",
+}
 
 _LESSON_CHAT_SYSTEM_PROMPT = """\
 You are the Lesson Follow-up Assistant. Answer follow-up questions about the \
@@ -85,6 +109,8 @@ def create_lesson(
     user_id: int,
     url: str,
     *,
+    depth: LessonDepth = "normal",
+    persona: LessonPersona = "developer",
     database_url: str | None = None,
     extract: bool = True,
 ) -> dict[str, Any]:
@@ -104,9 +130,11 @@ def create_lesson(
               original_url,
               normalized_url,
               generation_status,
-              generation_error
+              generation_error,
+              depth,
+              persona
             )
-            VALUES (%s, %s, %s, 'pending', NULL)
+            VALUES (%s, %s, %s, 'pending', NULL, %s, %s)
             ON CONFLICT (user_id, normalized_url) DO UPDATE
             SET generation_status = 'pending',
                 generation_error = NULL,
@@ -116,10 +144,12 @@ def create_lesson(
                 published_at = NULL,
                 source_content = NULL,
                 lesson_detail = NULL,
+                depth = %s,
+                persona = %s,
                 updated_at = NOW()
             RETURNING *
             """,
-            (user_id, cleaned, normalized),
+            (user_id, cleaned, normalized, depth, persona, depth, persona),
         ).fetchone()
     lesson = _serialize_lesson(row)
     if not extract:
@@ -129,6 +159,39 @@ def create_lesson(
         user_id,
         database_url=database_url,
     )
+
+
+def regenerate_lesson(
+    lesson_id: int,
+    user_id: int,
+    *,
+    depth: LessonDepth,
+    persona: LessonPersona,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Mark a lesson pending regeneration under new depth/persona controls.
+
+    Prior generations remain in ``lesson_generations`` history; only the
+    current-generation controls on the ``lessons`` row are replaced.
+    """
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE lessons
+            SET depth = %s,
+                persona = %s,
+                generation_status = 'pending',
+                generation_error = NULL,
+                updated_at = NOW()
+            WHERE id = %s AND user_id = %s
+            RETURNING *
+            """,
+            (depth, persona, lesson_id, user_id),
+        ).fetchone()
+    if row is None:
+        raise LessonNotFoundError
+    return _serialize_lesson(row)
 
 
 def _update_lesson_success(
@@ -203,6 +266,37 @@ def _update_lesson_failure(
     return _serialize_lesson(row)
 
 
+def _record_lesson_generation(
+    lesson_id: int,
+    *,
+    depth: str,
+    persona: str,
+    generation_status: str,
+    lesson_detail: dict[str, Any] | None,
+    generation_error: str | None,
+    database_url: str | None = None,
+) -> None:
+    """Append an immutable history row for a completed or failed generation."""
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO lesson_generations (
+              lesson_id, depth, persona, lesson_detail, generation_status, generation_error
+            )
+            VALUES (%s, %s, %s, %s::jsonb, %s, %s)
+            """,
+            (
+                lesson_id,
+                depth,
+                persona,
+                Jsonb(lesson_detail) if lesson_detail is not None else None,
+                generation_status,
+                generation_error,
+            ),
+        )
+
+
 def _sentences(text: str) -> list[str]:
     compact = re.sub(r"\s+", " ", text).strip()
     if not compact:
@@ -223,13 +317,19 @@ def _normalized_text(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip().lower()
 
 
-def generate_structured_lesson_detail(lesson_fields: dict[str, Any]) -> dict[str, Any]:
+def generate_structured_lesson_detail(
+    lesson_fields: dict[str, Any],
+    *,
+    depth: LessonDepth = "normal",
+    persona: LessonPersona = "developer",
+) -> dict[str, Any]:
     source_content = str(lesson_fields["source_content"])
     title = str(lesson_fields["title"] or lesson_fields["original_url"])
     source_name = lesson_fields.get("source_name")
     sentence_list = _sentences(source_content)
     gist = sentence_list[0] if sentence_list else _clip(source_content, 180)
-    key_claims = sentence_list[:3] or [gist]
+    claim_count = _DEPTH_KEY_CLAIM_COUNTS[depth]
+    key_claims = sentence_list[:claim_count] or [gist]
     source_label = str(source_name or "the source")
     if len(source_content) >= 2000:
         verdict = "study"
@@ -241,17 +341,26 @@ def generate_structured_lesson_detail(lesson_fields: dict[str, Any]) -> dict[str
         verdict = "skim"
         rationale = "Start with a skim: the source is short enough to inspect quickly."
 
+    explanation_limit = _DEPTH_EXPLANATION_LIMITS[depth]
+    framing = _PERSONA_FRAMING[persona]
+
     return {
         "gist": gist,
-        "explanation": source_content if len(source_content) <= 600 else _clip(source_content, 600),
+        "explanation": source_content
+        if len(source_content) <= explanation_limit
+        else _clip(source_content, explanation_limit),
         "key_claims": key_claims,
         "prerequisite_concepts": [f"Context from {source_label}"],
-        "why_it_matters": f"It helps you decide whether {title} deserves deeper reading.",
+        "why_it_matters": (
+            f"It helps you decide whether {title} deserves deeper reading, {framing}."
+        ),
         "read_worthiness": {
             "verdict": verdict,
             "rationale": rationale,
         },
-        "who_should_read": ["Readers deciding whether to spend more time with this source."],
+        "who_should_read": [
+            f"Readers deciding whether to spend more time with this source, {framing}."
+        ],
         "questions_to_keep_in_mind": [
             "What evidence does the source provide for its central claim?"
         ],
@@ -349,6 +458,27 @@ def generate_lesson_from_url(
     if lesson is None:
         raise LessonNotFoundError
 
+    depth = lesson["depth"]
+    persona = lesson["persona"]
+
+    def _fail(error_message: str) -> dict[str, Any]:
+        result = _update_lesson_failure(
+            lesson_id,
+            user_id,
+            error_message,
+            database_url=database_url,
+        )
+        _record_lesson_generation(
+            lesson_id,
+            depth=depth,
+            persona=persona,
+            generation_status="failed",
+            lesson_detail=None,
+            generation_error=error_message,
+            database_url=database_url,
+        )
+        return result
+
     lesson_url = str(lesson["original_url"])
     metadata: dict[str, Any] = {}
     try:
@@ -356,24 +486,15 @@ def generate_lesson_from_url(
     except Exception as exc:
         logger.warning("lesson metadata fetch failed for %r: %s", lesson_url, exc)
 
-    error_msg = None
-    body_text = ""
     try:
         body, status = extract_body(lesson_url)
-        body_text = body.strip()
-        if status != "ok" or not body_text:
-            error_msg = "Could not extract readable article content."
     except Exception as exc:
         logger.warning("lesson body extraction failed for %r: %s", lesson_url, exc)
-        error_msg = "Could not extract readable article content."
+        return _fail("Could not extract readable article content.")
 
-    if error_msg:
-        return _update_lesson_failure(
-            lesson_id,
-            user_id,
-            error_msg,
-            database_url=database_url,
-        )
+    body_text = body.strip()
+    if status != "ok" or not body_text:
+        return _fail("Could not extract readable article content.")
 
     lesson_fields: dict[str, Any] = {
         "original_url": lesson_url,
@@ -384,53 +505,47 @@ def generate_lesson_from_url(
         "source_content": body_text,
     }
     try:
-        raw_detail = generate_structured_lesson_detail(lesson_fields)
+        raw_detail = generate_structured_lesson_detail(lesson_fields, depth=depth, persona=persona)
         lesson_fields["lesson_detail"] = validate_structured_lesson_detail(
             raw_detail,
             lesson_fields=lesson_fields,
         )
     except LessonDetailValidationError:
         logger.warning("lesson detail validation failed for lesson %d", lesson_id)
-        error_msg = "Generated lesson detail was malformed."
+        return _fail("Generated lesson detail was malformed.")
     except LessonCitationValidationError:
         logger.warning("lesson citation validation failed for lesson %d", lesson_id)
-        error_msg = "Generated lesson citations did not match source content."
+        return _fail("Generated lesson citations did not match source content.")
     except Exception as exc:
         logger.warning("lesson detail generation failed for lesson %d: %s", lesson_id, exc)
-        error_msg = "Generated lesson detail was malformed."
-
-    if error_msg:
-        return _update_lesson_failure(
-            lesson_id,
-            user_id,
-            error_msg,
-            database_url=database_url,
-        )
+        return _fail("Generated lesson detail was malformed.")
 
     try:
         raw_artifacts = generate_study_artifacts(lesson_fields)
         lesson_fields["study_artifacts"] = validate_study_artifacts(raw_artifacts)
     except StudyArtifactsValidationError:
         logger.warning("study artifacts validation failed for lesson %d", lesson_id)
-        error_msg = "Generated study artifacts were malformed."
+        return _fail("Generated study artifacts were malformed.")
     except Exception as exc:
         logger.warning("study artifacts generation failed for lesson %d: %s", lesson_id, exc)
-        error_msg = "Generated study artifacts were malformed."
+        return _fail("Generated study artifacts were malformed.")
 
-    if error_msg:
-        return _update_lesson_failure(
-            lesson_id,
-            user_id,
-            error_msg,
-            database_url=database_url,
-        )
-
-    return _update_lesson_success(
+    result = _update_lesson_success(
         lesson_id,
         user_id,
         lesson_fields=lesson_fields,
         database_url=database_url,
     )
+    _record_lesson_generation(
+        lesson_id,
+        depth=depth,
+        persona=persona,
+        generation_status="complete",
+        lesson_detail=lesson_fields["lesson_detail"],
+        generation_error=None,
+        database_url=database_url,
+    )
+    return result
 
 
 def get_lesson(
@@ -448,6 +563,39 @@ def get_lesson(
     if row is None:
         return None
     return _serialize_lesson(row)
+
+
+def list_lesson_generations(
+    lesson_id: int,
+    user_id: int,
+    *,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return prior generation history for a lesson, newest first.
+
+    Raises LessonNotFoundError if the lesson does not exist for this user.
+    """
+    if get_lesson(lesson_id, user_id, database_url=database_url) is None:
+        raise LessonNotFoundError
+
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT * FROM lesson_generations
+            WHERE lesson_id = %s
+            ORDER BY created_at DESC
+            """,
+            (lesson_id,),
+        ).fetchall()
+
+    generations = []
+    for row in rows:
+        generation = row_to_dict(row)
+        if generation.get("created_at") is not None:
+            generation["created_at"] = generation["created_at"].isoformat()
+        generations.append(generation)
+    return generations
 
 
 def _lesson_chat_ai_config() -> tuple[str, str | None]:

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from news_dashboard.auth import require_admin, require_auth
 from news_dashboard.db import connect, init_db
 from news_dashboard.learn_from_link import service
+from news_dashboard.learn_from_link.models import LessonDepth
 from news_dashboard.main import app
 from news_dashboard.url_safety import UnsafeUrlError
 
@@ -113,17 +114,25 @@ def test_create_lesson_completes_with_extracted_content(
     assert lesson["author"] == "Ada Writer"
     assert lesson["published_at"] == "2026-07-09"
     assert lesson["source_content"] == "Paragraph one.\n\nParagraph two."
+    assert lesson["depth"] == "normal"
+    assert lesson["persona"] == "developer"
     assert lesson["lesson_detail"] == {
         "gist": "Paragraph one.",
         "explanation": "Paragraph one.\n\nParagraph two.",
         "key_claims": ["Paragraph one.", "Paragraph two."],
         "prerequisite_concepts": ["Context from Example Journal"],
-        "why_it_matters": "It helps you decide whether A careful article deserves deeper reading.",
+        "why_it_matters": (
+            "It helps you decide whether A careful article deserves deeper reading, "
+            "for developers weighing implementation details."
+        ),
         "read_worthiness": {
             "verdict": "skim",
             "rationale": "Start with a skim: the source is short enough to inspect quickly.",
         },
-        "who_should_read": ["Readers deciding whether to spend more time with this source."],
+        "who_should_read": [
+            "Readers deciding whether to spend more time with this source, "
+            "for developers weighing implementation details."
+        ],
         "questions_to_keep_in_mind": [
             "What evidence does the source provide for its central claim?"
         ],
@@ -203,7 +212,7 @@ def test_create_lesson_marks_failed_when_structured_detail_is_malformed(
     monkeypatch.setattr(
         service,
         "generate_structured_lesson_detail",
-        lambda _fields: {"gist": "Only one field is not enough."},
+        lambda _fields, **_kwargs: {"gist": "Only one field is not enough."},
         raising=False,
     )
 
@@ -242,7 +251,7 @@ def test_create_lesson_rejects_citations_not_found_in_source_context(
     monkeypatch.setattr(
         service,
         "generate_structured_lesson_detail",
-        lambda _fields: {
+        lambda _fields, **_kwargs: {
             "gist": "A gist grounded in the article.",
             "explanation": "A short explanation grounded in the article.",
             "key_claims": ["A grounded claim."],
@@ -278,7 +287,7 @@ def test_create_lesson_rejects_citation_sources_not_found_in_source_context(
     monkeypatch.setattr(
         service,
         "generate_structured_lesson_detail",
-        lambda _fields: {
+        lambda _fields, **_kwargs: {
             "gist": "Body for https://example.com/a",
             "explanation": "Body for https://example.com/a",
             "key_claims": ["Body for https://example.com/a"],
@@ -314,7 +323,7 @@ def test_create_lesson_rejects_structured_detail_with_extra_blank_or_long_fields
     monkeypatch.setattr(
         service,
         "generate_structured_lesson_detail",
-        lambda _fields: {
+        lambda _fields, **_kwargs: {
             "gist": "x" * 281,
             "unexpected_extra_field": "not part of the contract",
             "explanation": "Body for https://example.com/a",
@@ -814,3 +823,279 @@ def test_ask_lesson_question_endpoint_returns_503_when_ai_not_configured(
         )
 
     assert response.status_code == 503
+
+
+def test_create_lesson_persists_depth_and_persona(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    lesson = service.create_lesson(
+        user_id,
+        "https://example.com/a",
+        depth="deep",
+        persona="new_to_ai",
+        database_url=pg_clean,
+    )
+
+    assert lesson["depth"] == "deep"
+    assert lesson["persona"] == "new_to_ai"
+
+    persisted = service.get_lesson(int(lesson["id"]), user_id, database_url=pg_clean)
+    assert persisted is not None
+    assert persisted["depth"] == "deep"
+    assert persisted["persona"] == "new_to_ai"
+
+
+@pytest.mark.parametrize(
+    ("depth", "expected_claim_count", "max_explanation_length"),
+    [
+        ("tiny", 1, 150),
+        ("normal", 3, 600),
+        ("deep", 5, 1500),
+        ("expert", 8, 4000),
+    ],
+)
+def test_generate_structured_lesson_detail_shapes_output_by_depth(
+    depth: LessonDepth, expected_claim_count: int, max_explanation_length: int
+) -> None:
+    sentences = " ".join(f"Sentence number {i}." for i in range(1, 10))
+    lesson_fields = {
+        "original_url": "https://example.com/a",
+        "title": "A deep dive",
+        "source_name": "Example Source",
+        "source_content": sentences,
+    }
+
+    detail = service.generate_structured_lesson_detail(
+        lesson_fields,
+        depth=depth,
+        persona="developer",
+    )
+
+    assert len(detail["key_claims"]) == expected_claim_count
+    assert len(detail["explanation"]) <= max_explanation_length
+
+
+def test_generate_structured_lesson_detail_frames_content_by_persona() -> None:
+    lesson_fields = {
+        "original_url": "https://example.com/a",
+        "title": "A talk-worthy piece",
+        "source_name": "Example Source",
+        "source_content": "A single sentence to summarize.",
+    }
+
+    detail = service.generate_structured_lesson_detail(
+        lesson_fields, depth="normal", persona="preparing_talk"
+    )
+
+    assert "preparing a talk" in detail["why_it_matters"]
+    assert "preparing a talk" in detail["who_should_read"][0]
+
+
+def test_regenerate_lesson_updates_controls_and_marks_pending(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+    assert lesson["generation_status"] == "complete"
+
+    updated = service.regenerate_lesson(
+        int(lesson["id"]),
+        user_id,
+        depth="expert",
+        persona="product_builder",
+        database_url=pg_clean,
+    )
+
+    assert updated["generation_status"] == "pending"
+    assert updated["generation_error"] is None
+    assert updated["depth"] == "expert"
+    assert updated["persona"] == "product_builder"
+
+
+def test_regenerate_lesson_raises_not_found_for_missing_lesson(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+
+    with pytest.raises(service.LessonNotFoundError):
+        service.regenerate_lesson(
+            999_999,
+            user_id,
+            depth="normal",
+            persona="developer",
+            database_url=pg_clean,
+        )
+
+
+def test_regenerate_lesson_raises_not_found_for_other_users_lesson(pg_clean: str) -> None:
+    owner_id = _make_user(pg_clean, username="owner")
+    other_id = _make_user(pg_clean, username="other")
+    lesson = service.create_lesson(owner_id, "https://example.com/a", database_url=pg_clean)
+
+    with pytest.raises(service.LessonNotFoundError):
+        service.regenerate_lesson(
+            int(lesson["id"]),
+            other_id,
+            depth="normal",
+            persona="developer",
+            database_url=pg_clean,
+        )
+
+
+def test_generate_lesson_from_url_records_generation_history(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(
+        user_id, "https://example.com/a", depth="tiny", persona="developer", database_url=pg_clean
+    )
+
+    service.regenerate_lesson(
+        int(lesson["id"]),
+        user_id,
+        depth="deep",
+        persona="preparing_talk",
+        database_url=pg_clean,
+    )
+    service.generate_lesson_from_url(int(lesson["id"]), user_id, database_url=pg_clean)
+
+    generations = service.list_lesson_generations(int(lesson["id"]), user_id, database_url=pg_clean)
+    assert len(generations) == 2
+    assert generations[0]["depth"] == "deep"
+    assert generations[0]["persona"] == "preparing_talk"
+    assert generations[0]["generation_status"] == "complete"
+    assert generations[1]["depth"] == "tiny"
+    assert generations[1]["persona"] == "developer"
+
+
+def test_generate_lesson_from_url_records_failed_generation_history(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    monkeypatch.setattr(service, "extract_body", lambda _url: ("", "error"), raising=False)
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    generations = service.list_lesson_generations(int(lesson["id"]), user_id, database_url=pg_clean)
+    assert len(generations) == 1
+    assert generations[0]["generation_status"] == "failed"
+    assert generations[0]["lesson_detail"] is None
+    assert generations[0]["generation_error"] == "Could not extract readable article content."
+
+
+def test_list_lesson_generations_raises_not_found_for_other_users_lesson(pg_clean: str) -> None:
+    owner_id = _make_user(pg_clean, username="owner")
+    other_id = _make_user(pg_clean, username="other")
+    lesson = service.create_lesson(owner_id, "https://example.com/a", database_url=pg_clean)
+
+    with pytest.raises(service.LessonNotFoundError):
+        service.list_lesson_generations(int(lesson["id"]), other_id, database_url=pg_clean)
+
+
+def test_create_lesson_endpoint_accepts_depth_and_persona(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.post(
+            "/api/learn/lessons",
+            json={"url": "https://example.com/a", "depth": "expert", "persona": "product_builder"},
+        )
+
+    assert response.status_code == 201
+    lesson = response.json()
+    assert lesson["depth"] == "expert"
+    assert lesson["persona"] == "product_builder"
+
+
+def test_regenerate_lesson_endpoint_reruns_generation_with_new_controls(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        create_response = client.post("/api/learn/lessons", json={"url": "https://example.com/a"})
+        lesson_id = create_response.json()["id"]
+
+        regenerate_response = client.post(
+            f"/api/learn/lessons/{lesson_id}/regenerate",
+            json={"depth": "deep", "persona": "new_to_ai"},
+        )
+
+    assert regenerate_response.status_code == 200
+    body = regenerate_response.json()
+    assert body["depth"] == "deep"
+    assert body["persona"] == "new_to_ai"
+
+    persisted = service.get_lesson(int(lesson_id), user_id, database_url=pg_clean)
+    assert persisted is not None
+    assert persisted["generation_status"] == "complete"
+    assert persisted["depth"] == "deep"
+    assert persisted["persona"] == "new_to_ai"
+
+    generations = service.list_lesson_generations(int(lesson_id), user_id, database_url=pg_clean)
+    assert len(generations) == 2
+
+
+def test_regenerate_lesson_endpoint_404s_for_missing_lesson(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.post(
+            "/api/learn/lessons/999999/regenerate",
+            json={"depth": "normal", "persona": "developer"},
+        )
+
+    assert response.status_code == 404
+
+
+def test_list_lesson_generations_endpoint_returns_history(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        create_response = client.post("/api/learn/lessons", json={"url": "https://example.com/a"})
+        lesson_id = create_response.json()["id"]
+
+        response = client.get(f"/api/learn/lessons/{lesson_id}/generations")
+
+    assert response.status_code == 200
+    generations = response.json()
+    assert len(generations) == 1
+    assert generations[0]["depth"] == "normal"
+    assert generations[0]["persona"] == "developer"
+    assert generations[0]["generation_status"] == "complete"
+
+
+def test_list_lesson_generations_endpoint_404s_for_other_user(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    owner_id = _make_user(pg_clean, username="owner")
+    other_id = _make_user(pg_clean, username="other")
+
+    with _api_client(owner_id) as client:
+        create_response = client.post("/api/learn/lessons", json={"url": "https://example.com/a"})
+        lesson_id = create_response.json()["id"]
+
+    with _api_client(other_id, username="other") as client:
+        response = client.get(f"/api/learn/lessons/{lesson_id}/generations")
+
+    assert response.status_code == 404

--- a/frontend/src/__tests__/learnPage.test.tsx
+++ b/frontend/src/__tests__/learnPage.test.tsx
@@ -10,7 +10,7 @@ import type { Lesson } from '../api';
 import * as api from '../api';
 
 const { translationSpy } = vi.hoisted(() => ({
-  translationSpy: vi.fn((key: string) => {
+  translationSpy: vi.fn((key: string, options?: Record<string, string | number>) => {
     const translations: Record<string, string> = {
       'learn.title': 'Learn',
       'learn.description': 'Turn one article into a compact lesson you can review inside Radar.',
@@ -33,8 +33,28 @@ const { translationSpy } = vi.hoisted(() => ({
       'learn.detail.who_should_read': 'Who Should Read Translated',
       'learn.detail.questions_to_keep_in_mind': 'Questions to Keep in Mind Translated',
       'learn.detail.citations': 'Citations Translated',
+      'learn.controls.depth_label': 'Explanation depth',
+      'learn.controls.persona_label': 'Learning persona',
+      'learn.controls.depth.tiny': 'Tiny',
+      'learn.controls.depth.normal': 'Normal',
+      'learn.controls.depth.deep': 'Deep',
+      'learn.controls.depth.expert': 'Expert',
+      'learn.controls.persona.developer': 'Developer',
+      'learn.controls.persona.product_builder': 'Product builder',
+      'learn.controls.persona.new_to_ai': 'New to AI',
+      'learn.controls.persona.preparing_talk': 'Preparing a talk',
+      'learn.controls.regenerate': 'Regenerate lesson',
+      'learn.controls.regenerating': 'Regenerating...',
+      'learn.controls.regenerate_error': 'Failed to regenerate lesson',
+      'learn.controls.active_summary': 'Generated for {{persona}} at {{depth}} depth',
+      'learn.controls.history_summary': '{{count}} prior generations saved',
     };
-    return translations[key] ?? key;
+    const template = translations[key] ?? key;
+    if (!options) return template;
+    return Object.entries(options).reduce(
+      (result, [name, value]) => result.replaceAll(`{{${name}}}`, String(value)),
+      template
+    );
   }),
 }));
 
@@ -61,6 +81,8 @@ const COMPLETE_LESSON: Lesson = {
   source_content: 'A compact but useful article body preview.',
   generation_status: 'complete',
   generation_error: null,
+  depth: 'normal',
+  persona: 'developer',
   lesson_detail: {
     gist: 'The article argues that strong source selection matters more than raw volume.',
     explanation:
@@ -181,7 +203,30 @@ describe('learn API client', () => {
 
     expect(result).toEqual(COMPLETE_LESSON);
     expect(global.fetch).toHaveBeenCalledWith('/api/learn/lessons', {
-      body: JSON.stringify({ url: 'https://example.com/article' }),
+      body: JSON.stringify({
+        url: 'https://example.com/article',
+        depth: 'normal',
+        persona: 'developer',
+      }),
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+  });
+
+  it('posts depth and persona controls when regenerating a lesson', async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify(COMPLETE_LESSON), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await api.regenerateLesson(7, 'deep', 'new_to_ai');
+
+    expect(result).toEqual(COMPLETE_LESSON);
+    expect(global.fetch).toHaveBeenCalledWith('/api/learn/lessons/7/regenerate', {
+      body: JSON.stringify({ depth: 'deep', persona: 'new_to_ai' }),
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
@@ -210,6 +255,7 @@ describe('LearnPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     translationSpy.mockClear();
+    vi.spyOn(api, 'fetchLessonGenerations').mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -448,5 +494,75 @@ describe('LearnPage', () => {
     expect(
       screen.getByText(/The source content explicitly states the core claim\./i)
     ).toBeInTheDocument();
+  });
+
+  it('sends the selected depth and persona when generating a lesson', async () => {
+    const createSpy = vi
+      .spyOn(api, 'createLessonFromLink')
+      .mockResolvedValue({ ...COMPLETE_LESSON, depth: 'deep', persona: 'new_to_ai' });
+
+    renderPage();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/article url/i), 'https://example.com/article');
+    await user.selectOptions(screen.getByLabelText(/explanation depth/i), 'deep');
+    await user.selectOptions(screen.getByLabelText(/learning persona/i), 'new_to_ai');
+    await user.click(screen.getByRole('button', { name: /generate lesson/i }));
+
+    await screen.findByText(/lesson generated/i);
+    expect(createSpy).toHaveBeenCalledWith('https://example.com/article', 'deep', 'new_to_ai');
+    expect(screen.getByText(/generated for new to ai at deep depth/i)).toBeInTheDocument();
+  });
+
+  it('regenerates a lesson with the currently selected controls', async () => {
+    vi.spyOn(api, 'createLessonFromLink').mockResolvedValue(COMPLETE_LESSON);
+    const regenerateSpy = vi.spyOn(api, 'regenerateLesson').mockResolvedValue({
+      ...COMPLETE_LESSON,
+      depth: 'tiny',
+      persona: 'preparing_talk',
+    });
+
+    renderPage();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/article url/i), 'https://example.com/article');
+    await user.click(screen.getByRole('button', { name: /generate lesson/i }));
+    await screen.findByText(/lesson generated/i);
+
+    await user.selectOptions(screen.getByLabelText(/explanation depth/i), 'tiny');
+    await user.selectOptions(screen.getByLabelText(/learning persona/i), 'preparing_talk');
+    await user.click(screen.getByRole('button', { name: /regenerate lesson/i }));
+
+    await screen.findByText(/generated for preparing a talk at tiny depth/i);
+    expect(regenerateSpy).toHaveBeenCalledWith(COMPLETE_LESSON.id, 'tiny', 'preparing_talk');
+  });
+
+  it('shows an error when regeneration fails', async () => {
+    vi.spyOn(api, 'createLessonFromLink').mockResolvedValue(COMPLETE_LESSON);
+    vi.spyOn(api, 'regenerateLesson').mockRejectedValue(new HttpError(500, 'server exploded'));
+
+    renderPage();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/article url/i), 'https://example.com/article');
+    await user.click(screen.getByRole('button', { name: /generate lesson/i }));
+    await screen.findByText(/lesson generated/i);
+
+    await user.click(screen.getByRole('button', { name: /regenerate lesson/i }));
+
+    await screen.findByText(/server exploded/i);
+  });
+
+  it('shows a history summary once a lesson has more than one saved generation', async () => {
+    vi.spyOn(api, 'createLessonFromLink').mockResolvedValue(COMPLETE_LESSON);
+    vi.spyOn(api, 'fetchLessonGenerations').mockResolvedValue([
+      { ...COMPLETE_LESSON, id: 1, lesson_id: 7, generation_status: 'complete' },
+      { ...COMPLETE_LESSON, id: 2, lesson_id: 7, generation_status: 'complete' },
+    ]);
+
+    renderPage();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/article url/i), 'https://example.com/article');
+    await user.click(screen.getByRole('button', { name: /generate lesson/i }));
+    await screen.findByText(/lesson generated/i);
+
+    await screen.findByText(/2 prior generations saved/i);
   });
 });

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -1,5 +1,8 @@
 import { requestJson } from './core';
 
+export type LessonDepth = 'tiny' | 'normal' | 'deep' | 'expert';
+export type LessonPersona = 'developer' | 'product_builder' | 'new_to_ai' | 'preparing_talk';
+
 export interface LessonReadWorthiness {
   verdict: 'skip' | 'skim' | 'read' | 'study';
   rationale: string;
@@ -60,19 +63,51 @@ export interface Lesson {
   generation_error: string | null;
   lesson_detail: LessonDetail | null;
   study_artifacts: StudyArtifacts | null;
+  depth: LessonDepth;
+  persona: LessonPersona;
   created_at: string;
   updated_at: string;
 }
 
-export async function createLessonFromLink(url: string): Promise<Lesson> {
+export interface LessonGeneration {
+  id: number;
+  lesson_id: number;
+  depth: LessonDepth;
+  persona: LessonPersona;
+  lesson_detail: LessonDetail | null;
+  generation_status: 'complete' | 'failed';
+  generation_error: string | null;
+  created_at: string;
+}
+
+export async function createLessonFromLink(
+  url: string,
+  depth: LessonDepth = 'normal',
+  persona: LessonPersona = 'developer'
+): Promise<Lesson> {
   return requestJson<Lesson>('/api/learn/lessons', {
     method: 'POST',
-    body: JSON.stringify({ url }),
+    body: JSON.stringify({ url, depth, persona }),
   });
 }
 
 export async function fetchLesson(id: number): Promise<Lesson> {
   return requestJson<Lesson>(`/api/learn/lessons/${id}`);
+}
+
+export async function regenerateLesson(
+  id: number,
+  depth: LessonDepth,
+  persona: LessonPersona
+): Promise<Lesson> {
+  return requestJson<Lesson>(`/api/learn/lessons/${id}/regenerate`, {
+    method: 'POST',
+    body: JSON.stringify({ depth, persona }),
+  });
+}
+
+export async function fetchLessonGenerations(id: number): Promise<LessonGeneration[]> {
+  return requestJson<LessonGeneration[]>(`/api/learn/lessons/${id}/generations`);
 }
 
 export interface LessonChatMessage {

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -100,6 +100,27 @@
       "submit": "Generate lesson",
       "submitting": "Generating lesson..."
     },
+    "controls": {
+      "depth_label": "Explanation depth",
+      "persona_label": "Learning persona",
+      "depth": {
+        "tiny": "Tiny",
+        "normal": "Normal",
+        "deep": "Deep",
+        "expert": "Expert"
+      },
+      "persona": {
+        "developer": "Developer",
+        "product_builder": "Product builder",
+        "new_to_ai": "New to AI",
+        "preparing_talk": "Preparing a talk"
+      },
+      "regenerate": "Regenerate lesson",
+      "regenerating": "Regenerating...",
+      "regenerate_error": "Failed to regenerate lesson",
+      "active_summary": "Generated for {{persona}} at {{depth}} depth",
+      "history_summary": "{{count}} prior generations saved"
+    },
     "empty": "Paste a link to generate a lesson summary from a readable article.",
     "status": {
       "pending": "Generating lesson...",

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AlertCircle, ExternalLink, GraduationCap, Loader2 } from 'lucide-react';
+import { AlertCircle, ExternalLink, GraduationCap, Loader2, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -10,10 +10,22 @@ import { StudyArtifactsView } from '@/components/StudyArtifactsView';
 import {
   createLessonFromLink,
   fetchLesson,
+  fetchLessonGenerations,
+  regenerateLesson,
   HttpError,
   type Lesson,
+  type LessonDepth,
   type LessonDetail,
+  type LessonPersona,
 } from '@/api';
+
+const LESSON_DEPTHS: LessonDepth[] = ['tiny', 'normal', 'deep', 'expert'];
+const LESSON_PERSONAS: LessonPersona[] = [
+  'developer',
+  'product_builder',
+  'new_to_ai',
+  'preparing_talk',
+];
 
 function formatPublishedDate(value: string | null): string | null {
   if (!value) return null;
@@ -66,6 +78,27 @@ export function LearnPage() {
   const [lesson, setLesson] = useState<Lesson | null>(null);
   const [requestError, setRequestError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [depth, setDepth] = useState<LessonDepth>('normal');
+  const [persona, setPersona] = useState<LessonPersona>('developer');
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [generationCount, setGenerationCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (lesson?.generation_status !== 'complete') return;
+
+    let isActive = true;
+    void fetchLessonGenerations(lesson.id)
+      .then((generations) => {
+        if (isActive) setGenerationCount(generations.length);
+      })
+      .catch(() => {
+        if (isActive) setGenerationCount(null);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [lesson?.id, lesson?.generation_status]);
 
   useEffect(() => {
     if (lesson?.generation_status !== 'pending') return;
@@ -111,7 +144,7 @@ export function LearnPage() {
     setIsSubmitting(true);
     setRequestError(null);
     try {
-      setLesson(await createLessonFromLink(trimmed));
+      setLesson(await createLessonFromLink(trimmed, depth, persona));
     } catch (error) {
       setLesson(null);
       if (error instanceof HttpError) {
@@ -121,6 +154,25 @@ export function LearnPage() {
       }
     } finally {
       setIsSubmitting(false);
+    }
+  }
+
+  async function handleRegenerate() {
+    if (!lesson) return;
+    setIsRegenerating(true);
+    setRequestError(null);
+    try {
+      setLesson(await regenerateLesson(lesson.id, depth, persona));
+    } catch (error) {
+      if (error instanceof HttpError) {
+        setRequestError(error.message);
+      } else {
+        setRequestError(
+          error instanceof Error ? error.message : t('learn.controls.regenerate_error')
+        );
+      }
+    } finally {
+      setIsRegenerating(false);
     }
   }
 
@@ -146,27 +198,69 @@ export function LearnPage() {
 
       <form
         noValidate
-        className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end"
+        className="mb-6 flex flex-col gap-3"
         onSubmit={(event) => {
           void handleSubmit(event);
         }}
       >
-        <div className="flex-1">
-          <label htmlFor="learn-url" className="mb-2 block text-sm font-medium text-foreground">
-            {t('learn.form.url_label')}
-          </label>
-          <Input
-            id="learn-url"
-            type="url"
-            value={url}
-            onChange={(event) => setUrl(event.target.value)}
-            placeholder={t('learn.form.url_placeholder')}
-          />
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="flex-1">
+            <label htmlFor="learn-url" className="mb-2 block text-sm font-medium text-foreground">
+              {t('learn.form.url_label')}
+            </label>
+            <Input
+              id="learn-url"
+              type="url"
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              placeholder={t('learn.form.url_placeholder')}
+            />
+          </div>
+          <Button type="submit" disabled={isSubmitting || !url.trim()}>
+            {isSubmitting ? <Loader2 className="animate-spin" /> : null}
+            {isSubmitting ? t('learn.form.submitting') : t('learn.form.submit')}
+          </Button>
         </div>
-        <Button type="submit" disabled={isSubmitting || !url.trim()}>
-          {isSubmitting ? <Loader2 className="animate-spin" /> : null}
-          {isSubmitting ? t('learn.form.submitting') : t('learn.form.submit')}
-        </Button>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div>
+            <label htmlFor="learn-depth" className="mb-2 block text-sm font-medium text-foreground">
+              {t('learn.controls.depth_label')}
+            </label>
+            <select
+              id="learn-depth"
+              value={depth}
+              onChange={(event) => setDepth(event.target.value as LessonDepth)}
+              className="rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              {LESSON_DEPTHS.map((value) => (
+                <option key={value} value={value}>
+                  {t(`learn.controls.depth.${value}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label
+              htmlFor="learn-persona"
+              className="mb-2 block text-sm font-medium text-foreground"
+            >
+              {t('learn.controls.persona_label')}
+            </label>
+            <select
+              id="learn-persona"
+              value={persona}
+              onChange={(event) => setPersona(event.target.value as LessonPersona)}
+              className="rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              {LESSON_PERSONAS.map((value) => (
+                <option key={value} value={value}>
+                  {t(`learn.controls.persona.${value}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
       </form>
 
       {requestError ? (
@@ -192,6 +286,37 @@ export function LearnPage() {
             </Badge>
             {isPendingLesson ? (
               <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            ) : null}
+            {!isPendingLesson ? (
+              <Badge variant="outline">
+                {t('learn.controls.active_summary', {
+                  persona: t(`learn.controls.persona.${lesson.persona}`),
+                  depth: t(`learn.controls.depth.${lesson.depth}`).toLowerCase(),
+                })}
+              </Badge>
+            ) : null}
+            {!isPendingLesson ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={isRegenerating}
+                onClick={() => {
+                  void handleRegenerate();
+                }}
+              >
+                {isRegenerating ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <RefreshCw className="size-3.5" />
+                )}
+                {isRegenerating ? t('learn.controls.regenerating') : t('learn.controls.regenerate')}
+              </Button>
+            ) : null}
+            {generationCount !== null && generationCount > 1 ? (
+              <span className="text-xs text-muted-foreground">
+                {t('learn.controls.history_summary', { count: generationCount })}
+              </span>
             ) : null}
           </div>
 


### PR DESCRIPTION
## Summary
Closes #1119.

- Users can pick an explanation **depth** (Tiny / Normal / Deep / Expert) and a **learning persona** (Developer / Product builder / New to AI / Preparing a talk) before generating or regenerating a lesson, via new controls on the Learn page.
- `lessons.depth` / `lessons.persona` store the active generation controls; `generate_structured_lesson_detail` now shapes the heuristic output (explanation length, key-claim count, audience framing) based on these controls.
- A new `lesson_generations` history table records every completed/failed generation (depth, persona, resulting detail, status) so regenerating never destroys prior lesson history.
- New `POST /api/learn/lessons/{id}/regenerate` endpoint reruns generation with newly selected controls, keeping the source article unchanged. New `GET /api/learn/lessons/{id}/generations` exposes the saved history.
- The Learn page shows the currently active depth/persona as a small badge, a "Regenerate lesson" button, and (once more than one generation exists) an unobtrusive "N prior generations saved" hint — without cluttering the reading experience.
- i18n keys added under `learn.controls.*` across all 29 locale files (English copy, matching this feature area's existing convention of not yet localizing "Learn" strings).

## Design notes
- Regeneration re-triggers the full fetch+generate pipeline via the same background-task/polling flow already used for lesson creation (reusing the existing URL is safe since it fetches the same article).
- The lesson-detail generator here is a deterministic heuristic (not an LLM call), consistent with the current `generate_structured_lesson_detail` implementation — depth/persona are threaded through it directly.

## Test plan
- `mypy backend`, `PYTHONPATH=.:backend ty check backend`, `pyrefly check backend` — all pass.
- `ruff check backend`, `ruff format --check backend`, `vulture backend backend/vulture_whitelist.py --min-confidence 80` — all pass.
- `pytest backend/tests` — **1977 passed**.
- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run dead-code` — all pass.
- `vitest run` — **886 passed** (frontend).
- New backend tests cover: depth/persona persistence, generation input shaping by depth (claim count / explanation length), persona framing, regenerate service/endpoint behavior, 404s for cross-user access, and generation-history recording/listing (including failed generations).
- New frontend tests cover: sending depth/persona on create, regenerating with newly selected controls, regenerate error handling, and the history-summary hint rendering once multiple generations exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)