### PR TITLE
feat: add Lesson Library page (#1121)

### DIFF
--- a/backend/news_dashboard/learn_from_link/router.py
+++ b/backend/news_dashboard/learn_from_link/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 
 from news_dashboard.auth import require_auth
 from news_dashboard.learn_from_link import service
@@ -39,6 +39,17 @@ def create_lesson_endpoint(
         return lesson
     except service.LessonUrlError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/api/learn/lessons")
+def list_lessons_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    q: Annotated[str | None, Query(max_length=300)] = None,
+    status: Annotated[str | None, Query(pattern="^(pending|complete|failed)$")] = None,
+    verdict: Annotated[str | None, Query(pattern="^(skip|skim|read|study)$")] = None,
+) -> dict[str, Any]:
+    lessons = service.list_lessons(current_user["id"], q=q, status=status, verdict=verdict)
+    return {"lessons": lessons}
 
 
 @router.get("/api/learn/lessons/{lesson_id}")

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -570,6 +570,40 @@ def generate_lesson_from_url(
     return result
 
 
+def list_lessons(
+    user_id: int,
+    *,
+    q: str | None = None,
+    status: str | None = None,
+    verdict: str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(database_url=database_url)
+    query = "SELECT * FROM lessons WHERE user_id = %s"
+    params: list[Any] = [user_id]
+    if status is not None:
+        query += " AND generation_status = %s"
+        params.append(status)
+    if verdict is not None:
+        query += " AND lesson_detail->'read_worthiness'->>'verdict' = %s"
+        params.append(verdict)
+    if q is not None and q.strip():
+        query += """
+            AND (
+                title ILIKE %s
+                OR original_url ILIKE %s
+                OR source_name ILIKE %s
+                OR lesson_detail::text ILIKE %s
+            )
+        """
+        term = f"%{q.strip()}%"
+        params.extend([term, term, term, term])
+    query += " ORDER BY created_at DESC"
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(query, params).fetchall()
+    return [_serialize_lesson(row) for row in rows]
+
+
 def get_lesson(
     lesson_id: int,
     user_id: int,

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -399,6 +399,106 @@ def test_get_lesson_is_user_scoped(pg_clean: str, monkeypatch: pytest.MonkeyPatc
     assert service.get_lesson(lesson["id"], bob, database_url=pg_clean) is None
 
 
+def test_list_lessons_orders_newest_first_and_scopes_to_user(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+
+    first = service.create_lesson(alice, "https://example.com/first", database_url=pg_clean)
+    second = service.create_lesson(alice, "https://example.com/second", database_url=pg_clean)
+    service.create_lesson(bob, "https://example.com/bobs", database_url=pg_clean)
+
+    lessons = service.list_lessons(alice, database_url=pg_clean)
+
+    assert [lesson["id"] for lesson in lessons] == [second["id"], first["id"]]
+
+
+def test_list_lessons_filters_by_status(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    completed = service.create_lesson(user_id, "https://example.com/ok", database_url=pg_clean)
+    monkeypatch.setattr(service, "extract_body", lambda _url: ("", "error"), raising=False)
+    failed = service.create_lesson(user_id, "https://example.com/bad", database_url=pg_clean)
+
+    complete_only = service.list_lessons(user_id, status="complete", database_url=pg_clean)
+    failed_only = service.list_lessons(user_id, status="failed", database_url=pg_clean)
+
+    assert [lesson["id"] for lesson in complete_only] == [completed["id"]]
+    assert [lesson["id"] for lesson in failed_only] == [failed["id"]]
+
+
+def test_list_lessons_filters_by_verdict(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(user_id, "https://example.com/short", database_url=pg_clean)
+    assert lesson["lesson_detail"]["read_worthiness"]["verdict"] == "skim"
+
+    skim_matches = service.list_lessons(user_id, verdict="skim", database_url=pg_clean)
+    study_matches = service.list_lessons(user_id, verdict="study", database_url=pg_clean)
+
+    assert [item["id"] for item in skim_matches] == [lesson["id"]]
+    assert study_matches == []
+
+
+def test_list_lessons_searches_title_url_source_and_concepts(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(user_id, "https://example.com/story", database_url=pg_clean)
+
+    by_title = service.list_lessons(user_id, q="Title for", database_url=pg_clean)
+    by_url = service.list_lessons(user_id, q="example.com/story", database_url=pg_clean)
+    by_source = service.list_lessons(user_id, q="Example Source", database_url=pg_clean)
+    by_concept = service.list_lessons(
+        user_id, q=lesson["lesson_detail"]["prerequisite_concepts"][0], database_url=pg_clean
+    )
+    no_match = service.list_lessons(user_id, q="no such thing anywhere", database_url=pg_clean)
+
+    assert [item["id"] for item in by_title] == [lesson["id"]]
+    assert [item["id"] for item in by_url] == [lesson["id"]]
+    assert [item["id"] for item in by_source] == [lesson["id"]]
+    assert [item["id"] for item in by_concept] == [lesson["id"]]
+    assert no_match == []
+
+
+def test_list_lessons_endpoint_is_user_scoped(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    lesson = service.create_lesson(alice, "https://example.com/a", database_url=pg_clean)
+    service.create_lesson(bob, "https://example.com/b", database_url=pg_clean)
+
+    with _api_client(alice) as client:
+        response = client.get("/api/learn/lessons")
+
+    assert response.status_code == 200
+    body = response.json()["lessons"]
+    assert [item["id"] for item in body] == [lesson["id"]]
+
+
+def test_list_lessons_endpoint_supports_query_params(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.get(
+            "/api/learn/lessons", params={"status": "complete", "verdict": "skim", "q": "example"}
+        )
+
+    assert response.status_code == 200
+    assert len(response.json()["lessons"]) == 1
+
+
 def test_create_lesson_duplicate_resets_pending_state(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -62,6 +62,12 @@ const OfflineSavedPage = lazy(() =>
   import('./pages/OfflineSavedPage').then((m) => ({ default: m.OfflineSavedPage }))
 );
 const LearnPage = lazy(() => import('./pages/LearnPage').then((m) => ({ default: m.LearnPage })));
+const LessonLibraryPage = lazy(() =>
+  import('./pages/LessonLibraryPage').then((m) => ({ default: m.LessonLibraryPage }))
+);
+const LessonDetailPage = lazy(() =>
+  import('./pages/LessonDetailPage').then((m) => ({ default: m.LessonDetailPage }))
+);
 const WeeklyRecapPage = lazy(() =>
   import('./pages/WeeklyRecapPage').then((m) => ({ default: m.WeeklyRecapPage }))
 );
@@ -226,6 +232,8 @@ export const routes: RouteObject[] = [
       { path: 'reading-dna', element: withSuspense(ReadingDnaPage) },
       { path: 'reading-list', element: withSuspense(ReadingListPage) },
       { path: 'learn', element: withSuspense(LearnPage) },
+      { path: 'learn/library', element: withSuspense(LessonLibraryPage) },
+      { path: 'learn/:id', element: withSuspense(LessonDetailPage) },
       { path: 'offline-saved', element: withSuspense(OfflineSavedPage) },
       { path: 'recap', element: withSuspense(WeeklyRecapPage) },
       { path: 'archive', element: withSuspense(ArchivePage) },

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LessonDetailPage } from '../pages/LessonDetailPage';
+import type { Lesson } from '../api';
+import * as api from '../api';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+    i18n: { changeLanguage: () => Promise.resolve() },
+  }),
+}));
+
+const COMPLETE_LESSON: Lesson = {
+  id: 5,
+  user_id: 1,
+  original_url: 'https://example.com/article',
+  normalized_url: 'https://example.com/article',
+  title: 'A careful article',
+  source_name: 'Example Journal',
+  author: 'Jane Example',
+  published_at: '2026-07-08T10:00:00Z',
+  source_content: 'body content',
+  generation_status: 'complete',
+  generation_error: null,
+  lesson_detail: {
+    gist: 'gist text',
+    explanation: 'explanation text',
+    key_claims: ['claim one'],
+    prerequisite_concepts: ['concept one'],
+    why_it_matters: 'matters text',
+    read_worthiness: { verdict: 'study', rationale: 'rationale text' },
+    who_should_read: ['everyone'],
+    questions_to_keep_in_mind: ['question one'],
+    citations: [{ label: '1', snippet: 'snippet', source: 'source' }],
+  },
+  study_artifacts: null,
+  created_at: '2026-07-08T10:00:00Z',
+  updated_at: '2026-07-08T10:01:00Z',
+};
+
+const PENDING_LESSON: Lesson = {
+  ...COMPLETE_LESSON,
+  id: 6,
+  title: null,
+  lesson_detail: null,
+  generation_status: 'pending',
+};
+
+function renderPage(lessonId: number) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/learn/${lessonId}`]}>
+        <Routes>
+          <Route path="/learn/:id" element={<LessonDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('LessonDetailPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches and renders a lesson by id', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue(COMPLETE_LESSON);
+
+    renderPage(5);
+
+    expect(await screen.findByText('A careful article')).toBeInTheDocument();
+    expect(api.fetchLesson).toHaveBeenCalledWith(5);
+    expect(screen.getByRole('link', { name: /back to library/i })).toHaveAttribute(
+      'href',
+      '/learn/library'
+    );
+  });
+
+  it('shows an error state when the lesson cannot be loaded', async () => {
+    vi.spyOn(api, 'fetchLesson').mockRejectedValue(new Error('lesson fetch failed'));
+
+    renderPage(999);
+
+    expect(await screen.findByText('lesson fetch failed')).toBeInTheDocument();
+  });
+
+  it('polls a pending lesson until it completes', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(api, 'fetchLesson')
+      .mockResolvedValueOnce(PENDING_LESSON)
+      .mockResolvedValueOnce(COMPLETE_LESSON);
+
+    renderPage(6);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getAllByText('learn.status.pending').length).toBeGreaterThan(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(screen.getByText('A careful article')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -26,6 +26,8 @@ const COMPLETE_LESSON: Lesson = {
   source_content: 'body content',
   generation_status: 'complete',
   generation_error: null,
+  depth: 'normal',
+  persona: 'developer',
   lesson_detail: {
     gist: 'gist text',
     explanation: 'explanation text',

--- a/frontend/src/__tests__/lessonLibraryPage.test.tsx
+++ b/frontend/src/__tests__/lessonLibraryPage.test.tsx
@@ -27,6 +27,8 @@ const COMPLETE_LESSON: Lesson = {
   source_content: 'body',
   generation_status: 'complete',
   generation_error: null,
+  depth: 'normal',
+  persona: 'developer',
   lesson_detail: {
     gist: 'The article argues that strong source selection matters more than raw volume.',
     explanation: 'explanation',

--- a/frontend/src/__tests__/lessonLibraryPage.test.tsx
+++ b/frontend/src/__tests__/lessonLibraryPage.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LessonLibraryPage } from '../pages/LessonLibraryPage';
+import type { Lesson } from '../api';
+import * as api from '../api';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+    i18n: { changeLanguage: () => Promise.resolve() },
+  }),
+}));
+
+const COMPLETE_LESSON: Lesson = {
+  id: 1,
+  user_id: 1,
+  original_url: 'https://example.com/article-one',
+  normalized_url: 'https://example.com/article-one',
+  title: 'A careful article',
+  source_name: 'Example Journal',
+  author: 'Jane Example',
+  published_at: '2026-07-08T10:00:00Z',
+  source_content: 'body',
+  generation_status: 'complete',
+  generation_error: null,
+  lesson_detail: {
+    gist: 'The article argues that strong source selection matters more than raw volume.',
+    explanation: 'explanation',
+    key_claims: ['claim one'],
+    prerequisite_concepts: ['concept one'],
+    why_it_matters: 'matters',
+    read_worthiness: { verdict: 'study', rationale: 'rationale' },
+    who_should_read: ['everyone'],
+    questions_to_keep_in_mind: ['question one'],
+    citations: [{ label: '1', snippet: 'snippet', source: 'source' }],
+  },
+  study_artifacts: null,
+  created_at: '2026-07-08T10:00:00Z',
+  updated_at: '2026-07-08T10:01:00Z',
+};
+
+const FAILED_LESSON: Lesson = {
+  ...COMPLETE_LESSON,
+  id: 2,
+  title: null,
+  lesson_detail: null,
+  generation_status: 'failed',
+  generation_error: 'Could not extract readable article content.',
+  original_url: 'https://example.com/article-two',
+};
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/learn/library']}>
+        <LessonLibraryPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('LessonLibraryPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('lists lessons with links to their detail page', async () => {
+    vi.spyOn(api, 'listLessons').mockResolvedValue([COMPLETE_LESSON, FAILED_LESSON]);
+
+    renderPage();
+
+    expect(await screen.findByText('A careful article')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /A careful article/i })).toHaveAttribute(
+      'href',
+      '/learn/1'
+    );
+    expect(screen.getByText('Could not extract readable article content.')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no lessons', async () => {
+    vi.spyOn(api, 'listLessons').mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText(/no lessons yet/i)).toBeInTheDocument();
+  });
+
+  it('re-queries with search text after debounce', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const listSpy = vi.spyOn(api, 'listLessons').mockResolvedValue([COMPLETE_LESSON]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    renderPage();
+    await waitFor(() =>
+      expect(listSpy).toHaveBeenCalledWith({ q: undefined, status: undefined, verdict: undefined })
+    );
+
+    await user.type(screen.getByLabelText(/search lessons/i), 'signal');
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    await waitFor(() =>
+      expect(listSpy).toHaveBeenCalledWith({ q: 'signal', status: undefined, verdict: undefined })
+    );
+  });
+
+  it('filters by status and verdict', async () => {
+    const listSpy = vi.spyOn(api, 'listLessons').mockResolvedValue([COMPLETE_LESSON]);
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(listSpy).toHaveBeenCalled());
+
+    await user.selectOptions(screen.getByLabelText(/filter by status/i), 'complete');
+    await waitFor(() =>
+      expect(listSpy).toHaveBeenCalledWith({ q: undefined, status: 'complete', verdict: undefined })
+    );
+
+    await user.selectOptions(screen.getByLabelText(/filter by read-worthiness/i), 'study');
+    await waitFor(() =>
+      expect(listSpy).toHaveBeenCalledWith({ q: undefined, status: 'complete', verdict: 'study' })
+    );
+  });
+
+  it('shows an error state when loading fails', async () => {
+    vi.spyOn(api, 'listLessons').mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    expect(await screen.findByText(/failed to load your lesson library/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/navigation.test.ts
+++ b/frontend/src/__tests__/navigation.test.ts
@@ -91,3 +91,23 @@ describe('AI Stats navigation', () => {
     expect(getPageTitle('/ai-stats')).toBe('AI Stats');
   });
 });
+
+describe('Lesson Library navigation', () => {
+  it('lists /learn/library in the secondary navigation', () => {
+    const targets = secondaryNavigationItems.map((item) => item.to);
+    expect(targets).toContain('/learn/library');
+  });
+
+  it('wires /learn/library to the expected translation keys', () => {
+    expect(secondaryNavigationItems.find((item) => item.to === '/learn/library')?.labelKey).toBe(
+      'nav.lesson_library'
+    );
+    expect(getPageTitleKey('/learn/library')).toBe('page_title.lesson_library');
+    expect(getPageTitle('/learn/library')).toBe('Lesson Library');
+  });
+
+  it('does not mark /learn active when viewing the library', () => {
+    expect(isNavigationItemActive('/learn', '/learn/library')).toBe(false);
+    expect(isNavigationItemActive('/learn/library', '/learn/library')).toBe(true);
+  });
+});

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -110,6 +110,24 @@ export async function fetchLessonGenerations(id: number): Promise<LessonGenerati
   return requestJson<LessonGeneration[]>(`/api/learn/lessons/${id}/generations`);
 }
 
+export interface ListLessonsParams {
+  q?: string;
+  status?: Lesson['generation_status'];
+  verdict?: LessonReadWorthiness['verdict'];
+}
+
+export async function listLessons(params: ListLessonsParams = {}): Promise<Lesson[]> {
+  const search = new URLSearchParams();
+  if (params.q?.trim()) search.set('q', params.q.trim());
+  if (params.status) search.set('status', params.status);
+  if (params.verdict) search.set('verdict', params.verdict);
+  const query = search.toString();
+  const { lessons } = await requestJson<{ lessons: Lesson[] }>(
+    `/api/learn/lessons${query ? `?${query}` : ''}`
+  );
+  return lessons;
+}
+
 export interface LessonChatMessage {
   role: 'user' | 'assistant';
   content: string;

--- a/frontend/src/components/LessonDetailView.tsx
+++ b/frontend/src/components/LessonDetailView.tsx
@@ -1,0 +1,212 @@
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { LessonChat } from '@/components/LessonChat';
+import { StudyArtifactsView } from '@/components/StudyArtifactsView';
+import type { Lesson, LessonDetail } from '@/api';
+
+function formatPublishedDate(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function statusBadgeVariant(
+  status: Lesson['generation_status']
+): 'default' | 'secondary' | 'destructive' {
+  if (status === 'complete') return 'default';
+  if (status === 'failed') return 'destructive';
+  return 'secondary';
+}
+
+function verdictBadgeVariant(
+  verdict: LessonDetail['read_worthiness']['verdict']
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (verdict === 'study') return 'default';
+  if (verdict === 'read') return 'secondary';
+  if (verdict === 'skim') return 'outline';
+  return 'destructive';
+}
+
+function capitalizeLabel(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function renderBulletList(items: string[]) {
+  return (
+    <ul className="space-y-1.5">
+      {items.map((item) => (
+        <li key={item} className="flex items-start gap-2 text-sm leading-6 text-foreground">
+          <span className="mt-0.5 shrink-0 text-accent">-</span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function LessonDetailView({ lesson }: { lesson: Lesson }) {
+  const { t } = useTranslation();
+  const publishedLabel = formatPublishedDate(lesson.published_at);
+  const isPendingLesson = lesson.generation_status === 'pending';
+  const isFailedLesson = lesson.generation_status === 'failed';
+  const isCompleteLesson = lesson.generation_status === 'complete';
+  const lessonDetail = lesson.lesson_detail ?? null;
+  const hasLessonDetail = isCompleteLesson && lessonDetail !== null;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={statusBadgeVariant(lesson.generation_status)}>
+          {isCompleteLesson
+            ? t('learn.status.complete')
+            : isFailedLesson
+              ? t('learn.status.failed')
+              : t('learn.status.pending')}
+        </Badge>
+        {isPendingLesson ? <Loader2 className="size-4 animate-spin text-muted-foreground" /> : null}
+      </div>
+
+      <div className="space-y-2">
+        {lesson.title ? (
+          <h2 className="text-xl font-semibold text-foreground">{lesson.title}</h2>
+        ) : isPendingLesson ? (
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-64" />
+            <p className="text-sm text-muted-foreground">{t('learn.status.pending')}</p>
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+          {lesson.source_name ? <span>{lesson.source_name}</span> : null}
+          {lesson.author ? <span>{lesson.author}</span> : null}
+          {publishedLabel ? <span>{publishedLabel}</span> : null}
+        </div>
+      </div>
+
+      <div className="text-sm">
+        <a
+          href={lesson.original_url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-accent-foreground hover:underline"
+        >
+          {t('learn.link.open_original')}
+          <ExternalLink className="size-3.5" />
+        </a>
+      </div>
+
+      {lesson.source_content ? (
+        <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm leading-6 text-foreground">
+          {lesson.source_content}
+        </div>
+      ) : isPendingLesson ? (
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-11/12" />
+          <Skeleton className="h-4 w-10/12" />
+        </div>
+      ) : null}
+
+      {hasLessonDetail && lessonDetail ? (
+        <div className="space-y-4 rounded-lg border border-border bg-background p-4">
+          <div className="flex flex-wrap items-start gap-3">
+            <Badge variant={verdictBadgeVariant(lessonDetail.read_worthiness.verdict)}>
+              {capitalizeLabel(lessonDetail.read_worthiness.verdict)}
+            </Badge>
+            <div className="min-w-0 text-sm text-muted-foreground">
+              {lessonDetail.read_worthiness.rationale}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.gist', 'Gist')}
+              </h3>
+              <p className="text-sm leading-6 text-foreground">{lessonDetail.gist}</p>
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.why_it_matters', 'Why it matters')}
+              </h3>
+              <p className="text-sm leading-6 text-foreground">{lessonDetail.why_it_matters}</p>
+            </section>
+
+            <section className="space-y-2 md:col-span-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.explanation', 'Explanation')}
+              </h3>
+              <p className="text-sm leading-6 text-foreground">{lessonDetail.explanation}</p>
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.key_claims', 'Key claims')}
+              </h3>
+              {renderBulletList(lessonDetail.key_claims)}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.prerequisite_concepts', 'Prerequisite concepts')}
+              </h3>
+              {renderBulletList(lessonDetail.prerequisite_concepts)}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.who_should_read', 'Who should read')}
+              </h3>
+              {renderBulletList(lessonDetail.who_should_read)}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.questions_to_keep_in_mind', 'Questions to keep in mind')}
+              </h3>
+              {renderBulletList(lessonDetail.questions_to_keep_in_mind)}
+            </section>
+
+            <section className="space-y-2 md:col-span-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.detail.citations', 'Citations')}
+              </h3>
+              <ul className="space-y-3">
+                {lessonDetail.citations.map((citation) => (
+                  <li
+                    key={`${citation.label}-${citation.source}-${citation.snippet}`}
+                    className="space-y-1"
+                  >
+                    <div className="text-sm font-medium text-foreground">{citation.label}</div>
+                    <p className="text-sm leading-6 text-foreground">{citation.snippet}</p>
+                    <div className="text-xs text-muted-foreground">{citation.source}</div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+        </div>
+      ) : null}
+
+      {hasLessonDetail && lesson.study_artifacts ? (
+        <StudyArtifactsView artifacts={lesson.study_artifacts} />
+      ) : null}
+
+      {hasLessonDetail ? <LessonChat lessonId={lesson.id} /> : null}
+
+      {isFailedLesson && lesson.generation_error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-foreground">
+          {lesson.generation_error}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useLessonPolling.ts
+++ b/frontend/src/hooks/useLessonPolling.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { fetchLesson, type Lesson } from '@/api';
+
+export function useLessonPolling(
+  lesson: Lesson | null,
+  setLesson: (lesson: Lesson) => void,
+  setRequestError: (message: string | null) => void,
+  fallbackErrorMessage: string
+) {
+  useEffect(() => {
+    if (lesson?.generation_status !== 'pending') return;
+
+    const lessonId = lesson.id;
+    let isActive = true;
+    let timeoutId: number | null = null;
+
+    const schedulePoll = () => {
+      timeoutId = window.setTimeout(() => {
+        void (async () => {
+          try {
+            const nextLesson = await fetchLesson(lessonId);
+            if (!isActive) return;
+            setRequestError(null);
+            setLesson(nextLesson);
+            if (nextLesson.id === lessonId && nextLesson.generation_status === 'pending') {
+              schedulePoll();
+            }
+          } catch (error) {
+            if (!isActive) return;
+            setRequestError(error instanceof Error ? error.message : fallbackErrorMessage);
+            schedulePoll();
+          }
+        })();
+      }, 2000);
+    };
+
+    schedulePoll();
+
+    return () => {
+      isActive = false;
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [lesson?.generation_status, lesson?.id, setLesson, setRequestError, fallbackErrorMessage]);
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -10,6 +10,7 @@ import {
   Flame,
   History,
   Inbox,
+  Library,
   Network,
   Newspaper,
   Radio,
@@ -65,6 +66,12 @@ export const secondaryNavigationItems: NavigationItem[] = [
     label: 'Learn',
     labelKey: 'nav.learn',
     icon: GraduationCap,
+  },
+  {
+    to: '/learn/library',
+    label: 'Lesson Library',
+    labelKey: 'nav.lesson_library',
+    icon: Library,
   },
   {
     to: '/offline-saved',
@@ -167,7 +174,7 @@ export function getShortcutTarget(key: string): string | null {
 }
 
 export function isNavigationItemActive(to: string, pathname: string): boolean {
-  if (to === '/' || to === '/today') return pathname === to;
+  if (to === '/' || to === '/today' || to === '/learn') return pathname === to;
   return pathname.startsWith(to);
 }
 
@@ -191,6 +198,11 @@ const pageTitleRules: { test: (pathname: string) => boolean; en: string; key: st
     test: (p) => p.startsWith('/reading-list'),
     en: 'Reading List',
     key: 'page_title.reading_list',
+  },
+  {
+    test: (p) => p.startsWith('/learn/library'),
+    en: 'Lesson Library',
+    key: 'page_title.lesson_library',
   },
   {
     test: (p) => p.startsWith('/learn'),

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -46,7 +46,8 @@
     "analytics": "التحليلات",
     "users": "المستخدمون",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "الموجز",
@@ -71,7 +72,8 @@
     "users": "المستخدمون",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "غير متصل",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analýza",
     "users": "Uživatelé",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Přehled",
@@ -71,7 +72,8 @@
     "users": "Uživatelé",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analyse",
     "users": "Brugere",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Overblik",
@@ -71,7 +72,8 @@
     "users": "Brugere",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analytik",
     "users": "Benutzer",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Übersicht",
@@ -71,7 +72,8 @@
     "users": "Benutzer",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Αναλυτικά",
     "users": "Χρήστες",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Σύνοψη",
@@ -71,7 +72,8 @@
     "users": "Χρήστες",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Εκτός σύνδεσης",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analytics",
     "users": "Users",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Brief",
@@ -71,7 +72,8 @@
     "users": "Users",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analítica",
     "users": "Usuarios",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Resumen",
@@ -71,7 +72,8 @@
     "users": "Usuarios",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Sin conexión",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analytiikka",
     "users": "Käyttäjät",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Yhteenveto",
@@ -71,7 +72,8 @@
     "users": "Käyttäjät",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analytique",
     "users": "Utilisateurs",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Résumé",
@@ -71,7 +72,8 @@
     "users": "Utilisateurs",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Hors ligne",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -46,7 +46,8 @@
     "analytics": "אנליטיקס",
     "users": "משתמשים",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "תקציר",
@@ -71,7 +72,8 @@
     "users": "משתמשים",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "לא מקוון",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -46,7 +46,8 @@
     "analytics": "विश्लेषिकी",
     "users": "उपयोगकर्ता",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "ब्रीफ़",
@@ -71,7 +72,8 @@
     "users": "उपयोगकर्ता",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "ऑफ़लाइन",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analitika",
     "users": "Felhasználók",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Összefoglaló",
@@ -71,7 +72,8 @@
     "users": "Felhasználók",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analitik",
     "users": "Pengguna",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Ringkasan",
@@ -71,7 +72,8 @@
     "users": "Pengguna",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analisi",
     "users": "Utenti",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Riepilogo",
@@ -71,7 +72,8 @@
     "users": "Utenti",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -46,7 +46,8 @@
     "analytics": "分析",
     "users": "ユーザー",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "ブリーフ",
@@ -71,7 +72,8 @@
     "users": "ユーザー",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "オフライン",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -46,7 +46,8 @@
     "analytics": "분석",
     "users": "사용자",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "브리핑",
@@ -71,7 +72,8 @@
     "users": "사용자",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "오프라인",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analyse",
     "users": "Gebruikers",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Overzicht",
@@ -71,7 +72,8 @@
     "users": "Gebruikers",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analyse",
     "users": "Brukere",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Oversikt",
@@ -71,7 +72,8 @@
     "users": "Brukere",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Frakoblet",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analityka",
     "users": "Użytkownicy",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Podsumowanie",
@@ -71,7 +72,8 @@
     "users": "Użytkownicy",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Análises",
     "users": "Usuários",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Resumo",
@@ -71,7 +72,8 @@
     "users": "Usuários",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analitică",
     "users": "Utilizatori",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Rezumat",
@@ -71,7 +72,8 @@
     "users": "Utilizatori",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Аналитика",
     "users": "Пользователи",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Сводка",
@@ -71,7 +72,8 @@
     "users": "Пользователи",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Нет сети",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analys",
     "users": "Användare",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Överblick",
@@ -71,7 +72,8 @@
     "users": "Användare",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Offline",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -46,7 +46,8 @@
     "analytics": "การวิเคราะห์",
     "users": "ผู้ใช้",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "สรุปข่าว",
@@ -71,7 +72,8 @@
     "users": "ผู้ใช้",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "ออฟไลน์",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Analitik",
     "users": "Kullanıcılar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Özet",
@@ -71,7 +72,8 @@
     "users": "Kullanıcılar",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Çevrimdışı",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Аналітика",
     "users": "Користувачі",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Огляд",
@@ -71,7 +72,8 @@
     "users": "Користувачі",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Офлайн",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -46,7 +46,8 @@
     "analytics": "Phân tích",
     "users": "Người dùng",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "Tóm tắt",
@@ -71,7 +72,8 @@
     "users": "Người dùng",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "Ngoại tuyến",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -46,7 +46,8 @@
     "analytics": "分析",
     "users": "用户",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "简报",
@@ -71,7 +72,8 @@
     "users": "用户",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "离线",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -46,7 +46,8 @@
     "analytics": "分析",
     "users": "使用者",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "page_title": {
     "brief": "簡報",
@@ -71,7 +72,8 @@
     "users": "使用者",
     "default": "Radar",
     "offline_saved": "Offline Saved",
-    "learn": "Learn"
+    "learn": "Learn",
+    "lesson_library": "Lesson Library"
   },
   "shell": {
     "offline": "離線",
@@ -156,6 +158,19 @@
       "who_should_read": "Who should read",
       "questions_to_keep_in_mind": "Questions to keep in mind",
       "citations": "Citations"
+    },
+    "library": {
+      "title": "Lesson Library",
+      "description": "Browse, search, and revisit lessons you generated from articles.",
+      "search_label": "Search lessons",
+      "search_placeholder": "Search by title, URL, source, or concept",
+      "status_filter_label": "Filter by status",
+      "verdict_filter_label": "Filter by read-worthiness",
+      "back_to_library": "Back to library",
+      "not_found": "Lesson not found.",
+      "load_error": "Failed to load your lesson library.",
+      "empty": "No lessons yet. Paste a link on the Learn page.",
+      "no_matches": "No lessons match your filters."
     }
   }
 }

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -1,21 +1,18 @@
 import { useEffect, useState } from 'react';
-import { AlertCircle, ExternalLink, GraduationCap, Loader2, RefreshCw } from 'lucide-react';
+import { AlertCircle, GraduationCap, Loader2, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
-import { LessonChat } from '@/components/LessonChat';
-import { StudyArtifactsView } from '@/components/StudyArtifactsView';
+import { LessonDetailView } from '@/components/LessonDetailView';
+import { useLessonPolling } from '@/hooks/useLessonPolling';
 import {
   createLessonFromLink,
-  fetchLesson,
   fetchLessonGenerations,
   regenerateLesson,
   HttpError,
   type Lesson,
   type LessonDepth,
-  type LessonDetail,
   type LessonPersona,
 } from '@/api';
 
@@ -26,51 +23,6 @@ const LESSON_PERSONAS: LessonPersona[] = [
   'new_to_ai',
   'preparing_talk',
 ];
-
-function formatPublishedDate(value: string | null): string | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
-function statusBadgeVariant(
-  status: Lesson['generation_status']
-): 'default' | 'secondary' | 'destructive' {
-  if (status === 'complete') return 'default';
-  if (status === 'failed') return 'destructive';
-  return 'secondary';
-}
-
-function verdictBadgeVariant(
-  verdict: LessonDetail['read_worthiness']['verdict']
-): 'default' | 'secondary' | 'destructive' | 'outline' {
-  if (verdict === 'study') return 'default';
-  if (verdict === 'read') return 'secondary';
-  if (verdict === 'skim') return 'outline';
-  return 'destructive';
-}
-
-function capitalizeLabel(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
-
-function renderBulletList(items: string[]) {
-  return (
-    <ul className="space-y-1.5">
-      {items.map((item) => (
-        <li key={item} className="flex items-start gap-2 text-sm leading-6 text-foreground">
-          <span className="mt-0.5 shrink-0 text-accent">-</span>
-          <span>{item}</span>
-        </li>
-      ))}
-    </ul>
-  );
-}
 
 export function LearnPage() {
   const { t } = useTranslation();
@@ -100,42 +52,7 @@ export function LearnPage() {
     };
   }, [lesson?.id, lesson?.generation_status]);
 
-  useEffect(() => {
-    if (lesson?.generation_status !== 'pending') return;
-
-    const lessonId = lesson.id;
-    let isActive = true;
-    let timeoutId: number | null = null;
-
-    const schedulePoll = () => {
-      timeoutId = window.setTimeout(() => {
-        void (async () => {
-          try {
-            const nextLesson = await fetchLesson(lessonId);
-            if (!isActive) return;
-            setRequestError(null);
-            setLesson(nextLesson);
-            if (nextLesson.id === lessonId && nextLesson.generation_status === 'pending') {
-              schedulePoll();
-            }
-          } catch (error) {
-            if (!isActive) return;
-            setRequestError(error instanceof Error ? error.message : t('learn.refresh_error'));
-            schedulePoll();
-          }
-        })();
-      }, 2000);
-    };
-
-    schedulePoll();
-
-    return () => {
-      isActive = false;
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, [lesson?.generation_status, lesson?.id, t]);
+  useLessonPolling(lesson, setLesson, setRequestError, t('learn.refresh_error'));
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -176,13 +93,8 @@ export function LearnPage() {
     }
   }
 
-  const publishedLabel = formatPublishedDate(lesson?.published_at ?? null);
   const hasLesson = lesson !== null;
   const isPendingLesson = lesson?.generation_status === 'pending';
-  const isFailedLesson = lesson?.generation_status === 'failed';
-  const isCompleteLesson = lesson?.generation_status === 'complete';
-  const lessonDetail = lesson?.lesson_detail ?? null;
-  const hasLessonDetail = isCompleteLesson && lessonDetail !== null;
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
@@ -276,26 +188,14 @@ export function LearnPage() {
         </div>
       ) : (
         <section className="space-y-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant={statusBadgeVariant(lesson.generation_status)}>
-              {isCompleteLesson
-                ? t('learn.status.complete')
-                : isFailedLesson
-                  ? t('learn.status.failed')
-                  : t('learn.status.pending')}
-            </Badge>
-            {isPendingLesson ? (
-              <Loader2 className="size-4 animate-spin text-muted-foreground" />
-            ) : null}
-            {!isPendingLesson ? (
+          {!isPendingLesson ? (
+            <div className="flex flex-wrap items-center gap-2">
               <Badge variant="outline">
                 {t('learn.controls.active_summary', {
                   persona: t(`learn.controls.persona.${lesson.persona}`),
                   depth: t(`learn.controls.depth.${lesson.depth}`).toLowerCase(),
                 })}
               </Badge>
-            ) : null}
-            {!isPendingLesson ? (
               <Button
                 type="button"
                 variant="secondary"
@@ -312,148 +212,15 @@ export function LearnPage() {
                 )}
                 {isRegenerating ? t('learn.controls.regenerating') : t('learn.controls.regenerate')}
               </Button>
-            ) : null}
-            {generationCount !== null && generationCount > 1 ? (
-              <span className="text-xs text-muted-foreground">
-                {t('learn.controls.history_summary', { count: generationCount })}
-              </span>
-            ) : null}
-          </div>
-
-          <div className="space-y-2">
-            {lesson.title ? (
-              <h2 className="text-xl font-semibold text-foreground">{lesson.title}</h2>
-            ) : isPendingLesson ? (
-              <div className="space-y-2">
-                <Skeleton className="h-7 w-64" />
-                <p className="text-sm text-muted-foreground">{t('learn.status.pending')}</p>
-              </div>
-            ) : null}
-
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-              {lesson.source_name ? <span>{lesson.source_name}</span> : null}
-              {lesson.author ? <span>{lesson.author}</span> : null}
-              {publishedLabel ? <span>{publishedLabel}</span> : null}
-            </div>
-          </div>
-
-          <div className="text-sm">
-            <a
-              href={lesson.original_url}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 text-accent-foreground hover:underline"
-            >
-              {t('learn.link.open_original')}
-              <ExternalLink className="size-3.5" />
-            </a>
-          </div>
-
-          {lesson.source_content ? (
-            <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm leading-6 text-foreground">
-              {lesson.source_content}
-            </div>
-          ) : isPendingLesson ? (
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-11/12" />
-              <Skeleton className="h-4 w-10/12" />
+              {generationCount !== null && generationCount > 1 ? (
+                <span className="text-xs text-muted-foreground">
+                  {t('learn.controls.history_summary', { count: generationCount })}
+                </span>
+              ) : null}
             </div>
           ) : null}
 
-          {hasLessonDetail && lessonDetail ? (
-            <div className="space-y-4 rounded-lg border border-border bg-background p-4">
-              <div className="flex flex-wrap items-start gap-3">
-                <Badge variant={verdictBadgeVariant(lessonDetail.read_worthiness.verdict)}>
-                  {capitalizeLabel(lessonDetail.read_worthiness.verdict)}
-                </Badge>
-                <div className="min-w-0 text-sm text-muted-foreground">
-                  {lessonDetail.read_worthiness.rationale}
-                </div>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.gist', 'Gist')}
-                  </h3>
-                  <p className="text-sm leading-6 text-foreground">{lessonDetail.gist}</p>
-                </section>
-
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.why_it_matters', 'Why it matters')}
-                  </h3>
-                  <p className="text-sm leading-6 text-foreground">{lessonDetail.why_it_matters}</p>
-                </section>
-
-                <section className="space-y-2 md:col-span-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.explanation', 'Explanation')}
-                  </h3>
-                  <p className="text-sm leading-6 text-foreground">{lessonDetail.explanation}</p>
-                </section>
-
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.key_claims', 'Key claims')}
-                  </h3>
-                  {renderBulletList(lessonDetail.key_claims)}
-                </section>
-
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.prerequisite_concepts', 'Prerequisite concepts')}
-                  </h3>
-                  {renderBulletList(lessonDetail.prerequisite_concepts)}
-                </section>
-
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.who_should_read', 'Who should read')}
-                  </h3>
-                  {renderBulletList(lessonDetail.who_should_read)}
-                </section>
-
-                <section className="space-y-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.questions_to_keep_in_mind', 'Questions to keep in mind')}
-                  </h3>
-                  {renderBulletList(lessonDetail.questions_to_keep_in_mind)}
-                </section>
-
-                <section className="space-y-2 md:col-span-2">
-                  <h3 className="text-sm font-semibold text-foreground">
-                    {t('learn.detail.citations', 'Citations')}
-                  </h3>
-                  <ul className="space-y-3">
-                    {lessonDetail.citations.map((citation) => (
-                      <li
-                        key={`${citation.label}-${citation.source}-${citation.snippet}`}
-                        className="space-y-1"
-                      >
-                        <div className="text-sm font-medium text-foreground">{citation.label}</div>
-                        <p className="text-sm leading-6 text-foreground">{citation.snippet}</p>
-                        <div className="text-xs text-muted-foreground">{citation.source}</div>
-                      </li>
-                    ))}
-                  </ul>
-                </section>
-              </div>
-            </div>
-          ) : null}
-
-          {hasLessonDetail && lesson.study_artifacts ? (
-            <StudyArtifactsView artifacts={lesson.study_artifacts} />
-          ) : null}
-
-          {hasLessonDetail ? <LessonChat lessonId={lesson.id} /> : null}
-
-          {isFailedLesson && lesson.generation_error ? (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-foreground">
-              {lesson.generation_error}
-            </div>
-          ) : null}
+          <LessonDetailView lesson={lesson} />
         </section>
       )}
     </div>

--- a/frontend/src/pages/LessonDetailPage.tsx
+++ b/frontend/src/pages/LessonDetailPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { LessonDetailView } from '@/components/LessonDetailView';
+import { useLessonPolling } from '@/hooks/useLessonPolling';
+import { fetchLesson, type Lesson } from '@/api';
+
+export function LessonDetailPage() {
+  const { t } = useTranslation();
+  const { id } = useParams<{ id: string }>();
+  const lessonId = Number(id);
+  const [lesson, setLesson] = useState<Lesson | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isActive = true;
+    setIsLoading(true);
+    setLoadError(null);
+    fetchLesson(lessonId)
+      .then((result) => {
+        if (isActive) setLesson(result);
+      })
+      .catch((error: unknown) => {
+        if (!isActive) return;
+        setLoadError(error instanceof Error ? error.message : t('learn.refresh_error'));
+      })
+      .finally(() => {
+        if (isActive) setIsLoading(false);
+      });
+    return () => {
+      isActive = false;
+    };
+    // t is intentionally omitted: react-i18next's t identity can change every
+    // render, and this effect must only refire when the lesson id changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lessonId]);
+
+  useLessonPolling(lesson, setLesson, setLoadError, t('learn.refresh_error'));
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6">
+      <Link
+        to="/learn/library"
+        className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground hover:underline"
+      >
+        <ArrowLeft className="size-3.5" />
+        {t('learn.library.back_to_library', 'Back to library')}
+      </Link>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : lesson ? (
+        <LessonDetailView lesson={lesson} />
+      ) : (
+        <div className="flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+          <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <div className="text-sm text-foreground">
+            {loadError ?? t('learn.library.not_found', 'Lesson not found.')}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/LessonLibraryPage.tsx
+++ b/frontend/src/pages/LessonLibraryPage.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { AlertCircle, ExternalLink, GraduationCap, Loader2, Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { EmptyState } from '@/components/EmptyState';
+import { listLessons, type Lesson, type LessonReadWorthiness } from '@/api';
+
+const STATUS_FILTERS: { value: Lesson['generation_status'] | 'all'; label: string }[] = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'complete', label: 'Complete' },
+  { value: 'pending', label: 'Generating' },
+  { value: 'failed', label: 'Failed' },
+];
+
+const VERDICT_FILTERS: { value: LessonReadWorthiness['verdict'] | 'all'; label: string }[] = [
+  { value: 'all', label: 'All verdicts' },
+  { value: 'study', label: 'Study' },
+  { value: 'read', label: 'Read' },
+  { value: 'skim', label: 'Skim' },
+  { value: 'skip', label: 'Skip' },
+];
+
+function statusBadgeVariant(
+  status: Lesson['generation_status']
+): 'default' | 'secondary' | 'destructive' {
+  if (status === 'complete') return 'default';
+  if (status === 'failed') return 'destructive';
+  return 'secondary';
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function LessonCard({ lesson }: { lesson: Lesson }) {
+  const verdict = lesson.lesson_detail?.read_worthiness.verdict;
+  const isFailed = lesson.generation_status === 'failed';
+  const isPending = lesson.generation_status === 'pending';
+
+  return (
+    <Link
+      to={`/learn/${lesson.id}`}
+      className="block rounded-lg border border-border bg-background p-4 transition-colors hover:bg-surface"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <h3 className="truncate text-sm font-semibold text-foreground">
+            {lesson.title ?? lesson.original_url}
+          </h3>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {lesson.source_name ? <span>{lesson.source_name}</span> : null}
+            <span>{formatDate(lesson.created_at)}</span>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {verdict ? <Badge variant="outline">{verdict}</Badge> : null}
+          <Badge variant={statusBadgeVariant(lesson.generation_status)}>
+            {isPending ? (
+              <span className="inline-flex items-center gap-1">
+                <Loader2 className="size-3 animate-spin" />
+                Generating
+              </span>
+            ) : isFailed ? (
+              'Failed'
+            ) : (
+              'Complete'
+            )}
+          </Badge>
+        </div>
+      </div>
+
+      {isFailed && lesson.generation_error ? (
+        <p className="mt-2 flex items-start gap-1.5 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+          <span>{lesson.generation_error}</span>
+        </p>
+      ) : lesson.lesson_detail ? (
+        <p className="mt-2 line-clamp-2 text-sm text-muted-foreground">
+          {lesson.lesson_detail.gist}
+        </p>
+      ) : null}
+
+      <div className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground">
+        <ExternalLink className="size-3" />
+        <span className="truncate">{lesson.original_url}</span>
+      </div>
+    </Link>
+  );
+}
+
+export function LessonLibraryPage() {
+  const { t } = useTranslation();
+  const [searchInput, setSearchInput] = useState('');
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState<Lesson['generation_status'] | 'all'>('all');
+  const [verdict, setVerdict] = useState<LessonReadWorthiness['verdict'] | 'all'>('all');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setQ(searchInput), 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchInput]);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['lessons', q, status, verdict],
+    queryFn: () =>
+      listLessons({
+        q: q || undefined,
+        status: status === 'all' ? undefined : status,
+        verdict: verdict === 'all' ? undefined : verdict,
+      }),
+  });
+
+  const lessons = data ?? [];
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6">
+      <div className="mb-6 flex items-start gap-3">
+        <div className="mt-0.5 rounded-md border border-border p-2 text-muted-foreground">
+          <GraduationCap className="size-5" />
+        </div>
+        <div>
+          <h1 className="text-lg font-semibold text-foreground">
+            {t('learn.library.title', 'Lesson Library')}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              'learn.library.description',
+              'Browse, search, and revisit lessons you generated from articles.'
+            )}
+          </p>
+        </div>
+      </div>
+
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            aria-label={t('learn.library.search_label', 'Search lessons')}
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+            placeholder={t(
+              'learn.library.search_placeholder',
+              'Search by title, URL, source, or concept'
+            )}
+            className="pl-9"
+          />
+        </div>
+        <select
+          aria-label={t('learn.library.status_filter_label', 'Filter by status')}
+          value={status}
+          onChange={(event) => setStatus(event.target.value as Lesson['generation_status'] | 'all')}
+          className="h-9 rounded-md border border-border bg-surface px-2 text-sm outline-none focus:border-border-strong"
+        >
+          {STATUS_FILTERS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label={t('learn.library.verdict_filter_label', 'Filter by read-worthiness')}
+          value={verdict}
+          onChange={(event) =>
+            setVerdict(event.target.value as LessonReadWorthiness['verdict'] | 'all')
+          }
+          className="h-9 rounded-md border border-border bg-surface px-2 text-sm outline-none focus:border-border-strong"
+        >
+          {VERDICT_FILTERS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : isError ? (
+        <div className="flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+          <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <div className="text-sm text-foreground">
+            {t('learn.library.load_error', 'Failed to load your lesson library.')}
+          </div>
+        </div>
+      ) : lessons.length === 0 ? (
+        <EmptyState
+          icon={GraduationCap}
+          title={
+            q || status !== 'all' || verdict !== 'all'
+              ? t('learn.library.no_matches', 'No lessons match your filters.')
+              : t('learn.library.empty', 'No lessons yet. Paste a link on the Learn page.')
+          }
+        />
+      ) : (
+        <div className="space-y-3">
+          {lessons.map((lesson) => (
+            <LessonCard key={lesson.id} lesson={lesson} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1121.

- Adds `GET /api/learn/lessons` (`service.list_lessons`) to list a user's lessons newest-first, with optional `q` (search across title/URL/source name/lesson detail JSON — covers concepts and citations), `status` (`pending`/`complete`/`failed`), and `verdict` (`skip`/`skim`/`read`/`study`) filters. Scoped to the authenticated user, matching the `reading_list` search convention already in the codebase.
- Adds a **Lesson Library** page (`/learn/library`) with search, status/verdict filters, and empty/failed/loading states. Each item links to a new permalinked lesson detail route.
- Adds `/learn/:id` (`LessonDetailPage`) so a lesson has a durable, shareable URL and polls while generation is pending — previously a lesson was only viewable in local state right after creation.
- Extracted the lesson-rendering JSX from `LearnPage` into a shared `LessonDetailView` component and the poll-until-complete logic into a `useLessonPolling` hook, reused by both `LearnPage` (create flow) and `LessonDetailPage` (durable view), so they render identically without duplicating ~150 lines.
- Added the new nav entry, page-title rule, and translation keys (English source of truth; propagated as English placeholders to all 29 locale files to keep `locales.test.ts`'s key-set-parity check green — matches the existing pattern where new `learn.*` strings ship untranslated until a follow-up localization pass).

## Test plan

- [x] `backend/tests/test_learn_from_link.py` — 32/32 passed (added list/search/filter coverage: ordering + user scoping, status filter, verdict filter, search by title/URL/source/concept, endpoint scoping, endpoint query params)
- [x] `make lint` (ruff, vulture, eslint, prettier, knip) — clean
- [x] `make typecheck` (mypy strict, ty, pyrefly, tsc) — clean
- [x] Full frontend suite (`npx vitest run`) — 90 files / 893 tests passed, including new `lessonLibraryPage.test.tsx` and `lessonDetailPage.test.tsx`
- [x] Pre-commit hooks (ruff/mypy/ty/pyrefly/vulture/eslint/prettier/knip/tsc) — all passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)