### PR TITLE
feat: suggest high-value articles to turn into lessons (#1129)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -678,6 +678,14 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_lesson_generations_lesson_created"
     " ON lesson_generations(lesson_id, created_at DESC)",
     """
+    CREATE TABLE IF NOT EXISTS user_lesson_suggestion_dismissals (
+      user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      article_id  BIGINT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+      dismissed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (user_id, article_id)
+    )
+    """,
+    """
     CREATE TABLE IF NOT EXISTS agent_action_runs (
       id          BIGSERIAL PRIMARY KEY,
       user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/news_dashboard/learn_from_link/models.py
+++ b/backend/news_dashboard/learn_from_link/models.py
@@ -120,3 +120,9 @@ class RelevanceFeedbackRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     helpful: bool
+
+
+class LessonSuggestionDismissRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    article_id: int

--- a/backend/news_dashboard/learn_from_link/router.py
+++ b/backend/news_dashboard/learn_from_link/router.py
@@ -12,6 +12,7 @@ from news_dashboard.learn_from_link.models import (
     LessonCreateRequest,
     LessonQuestionRequest,
     LessonRegenerateRequest,
+    LessonSuggestionDismissRequest,
     RelevanceFeedbackRequest,
 )
 
@@ -135,3 +136,18 @@ def submit_relevance_feedback_endpoint(
         )
     except service.LessonNotFoundError as exc:
         raise HTTPException(status_code=404, detail="lesson not found") from exc
+
+
+@router.get("/api/learn/suggestions")
+def list_lesson_suggestions_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return {"items": service.list_lesson_suggestions(current_user["id"])}
+
+
+@router.post("/api/learn/suggestions/dismiss")
+def dismiss_lesson_suggestion_endpoint(
+    payload: LessonSuggestionDismissRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return service.dismiss_lesson_suggestion(current_user["id"], payload.article_id)

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -895,6 +895,169 @@ def validate_personal_relevance(raw_relevance: Any) -> dict[str, Any]:
     return relevance.model_dump(mode="json")
 
 
+_SUGGESTION_LIMIT_DEFAULT = 10
+_SUGGESTION_CANDIDATE_POOL = 200
+_NOVELTY_RECENT_DAYS = 7
+_NOVELTY_MEDIUM_DAYS = 30
+
+
+def _novelty_score(age_days: float | None) -> float:
+    if age_days is None:
+        return 0.3
+    if age_days <= _NOVELTY_RECENT_DAYS:
+        return 1.0
+    if age_days <= _NOVELTY_MEDIUM_DAYS:
+        return 0.6
+    return 0.3
+
+
+def _score_suggestion_candidate(
+    article: dict[str, Any],
+    *,
+    interests: list[str],
+    dna_categories: list[str],
+    dna_sources: list[str],
+) -> dict[str, Any]:
+    url = str(article["canonical_url"])
+    category = str(article.get("category") or "")
+    source_name = str(article.get("source_name") or "")
+    title = str(article.get("title") or "")
+    starred = bool(article.get("starred"))
+    try:
+        importance = int(article.get("importance_score") or 50)
+    except (TypeError, ValueError):
+        importance = 50
+    age_days_raw = article.get("age_days")
+    age_days = float(age_days_raw) if age_days_raw is not None else None
+
+    reasons: list[str] = []
+    relevance_score = 0.0
+    if category and category in dna_categories:
+        relevance_score += 0.5
+        reasons.append(f"Matches your recent interest in {category}")
+    if source_name and source_name in dna_sources:
+        relevance_score += 0.3
+        reasons.append(f"From {source_name}, a source you read often")
+    if interests and any(interest.lower() in title.lower() for interest in interests):
+        relevance_score += 0.2
+        reasons.append("Matches topics you told us you're interested in")
+    relevance_score = min(relevance_score, 1.0)
+
+    interest_signal = 1.0 if starred else 0.6
+    if starred:
+        reasons.append("You starred this article")
+
+    novelty_score = _novelty_score(age_days)
+    if novelty_score >= 1.0:
+        reasons.append("Recently added to your reading list")
+
+    value_score = importance / 100
+    if importance >= 80:
+        reasons.append("High editorial importance score")
+
+    total = (
+        0.35 * relevance_score + 0.25 * interest_signal + 0.15 * novelty_score + 0.25 * value_score
+    )
+    if not reasons:
+        reasons.append("A good candidate based on your reading history")
+
+    return {
+        "article_id": int(article["id"]),
+        "title": title or url,
+        "url": url,
+        "source_name": source_name or None,
+        "category": category or None,
+        "score": round(total, 3),
+        "reasons": reasons,
+    }
+
+
+def list_lesson_suggestions(
+    user_id: int,
+    *,
+    database_url: str | None = None,
+    limit: int = _SUGGESTION_LIMIT_DEFAULT,
+) -> list[dict[str, Any]]:
+    """Suggest saved/read articles worth turning into a lesson.
+
+    Candidates are the user's starred or completed articles that don't already
+    have a lesson and haven't been dismissed, scored using relevance to the
+    user's reading DNA/interests, novelty, and editorial importance.
+    """
+    from news_dashboard.article_visibility import visible_article_sql
+
+    interests, dna_categories, dna_sources, _ = _get_relevance_data(user_id, database_url)
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT a.id, a.title, a.canonical_url, a.source_name, a.category,
+                   a.importance_score, s.starred,
+                   EXTRACT(EPOCH FROM (NOW() - a.discovered_at::timestamptz)) / 86400.0
+                     AS age_days
+            FROM articles a
+            JOIN user_article_state s ON s.article_id = a.id
+            JOIN sources a_src ON a_src.slug = a.source_slug
+            LEFT JOIN user_sources a_us
+              ON a_us.source_slug = a.source_slug AND a_us.user_id = %s
+            WHERE s.user_id = %s AND (s.state = 'done' OR s.starred = TRUE)
+              AND ({visible_article_sql("a")})
+            ORDER BY a.discovered_at DESC
+            LIMIT %s
+            """,
+            (user_id, user_id, user_id, _SUGGESTION_CANDIDATE_POOL),
+        ).fetchall()
+        existing_lesson_rows = conn.execute(
+            "SELECT normalized_url FROM lessons WHERE user_id = %s", (user_id,)
+        ).fetchall()
+        dismissed_rows = conn.execute(
+            "SELECT article_id FROM user_lesson_suggestion_dismissals WHERE user_id = %s",
+            (user_id,),
+        ).fetchall()
+
+    existing_lesson_urls = {str(r["normalized_url"]) for r in existing_lesson_rows}
+    dismissed_ids = {int(r["article_id"]) for r in dismissed_rows}
+
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        article = row_to_dict(row)
+        article_id = int(article["id"])
+        if article_id in dismissed_ids:
+            continue
+        if _normalize_lesson_url(str(article["canonical_url"])) in existing_lesson_urls:
+            continue
+        candidates.append(
+            _score_suggestion_candidate(
+                article,
+                interests=interests,
+                dna_categories=dna_categories,
+                dna_sources=dna_sources,
+            )
+        )
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    return candidates[:limit]
+
+
+def dismiss_lesson_suggestion(
+    user_id: int,
+    article_id: int,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO user_lesson_suggestion_dismissals(user_id, article_id)
+            VALUES (%s, %s)
+            ON CONFLICT (user_id, article_id) DO NOTHING
+            """,
+            (user_id, article_id),
+        )
+    return {"dismissed": True, "article_id": article_id}
+
+
 def submit_relevance_feedback(
     lesson_id: int,
     user_id: int,

--- a/backend/tests/test_learn_from_link_suggestions.py
+++ b/backend/tests/test_learn_from_link_suggestions.py
@@ -1,0 +1,248 @@
+"""Tests for suggesting high-value articles to turn into Learn from Link lessons."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_admin, require_auth
+from news_dashboard.db import connect
+from news_dashboard.learn_from_link import service
+from news_dashboard.main import app
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _add_source(conn: Any, slug: str, name: str, category: str = "tech") -> None:
+    conn.execute(
+        """
+        INSERT INTO sources(slug, name, url, category, kind, priority, enabled)
+        VALUES (%s, %s, %s, %s, 'rss_feed', 10, TRUE)
+        """,
+        (slug, name, f"https://example.com/{slug}.xml", category),
+    )
+
+
+def _add_article(  # noqa: PLR0913
+    conn: Any,
+    *,
+    user_id: int,
+    slug: str,
+    index: int,
+    title: str | None = None,
+    category: str = "tech",
+    state: str = "done",
+    starred: bool = False,
+    days_old: int = 1,
+    importance_score: int = 50,
+) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO articles(
+          url, canonical_url, title, source_slug, source_name, category, kind,
+          discovered_at, importance_score
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, 'rss_feed', NOW() - (%s * INTERVAL '1 day'), %s)
+        RETURNING id
+        """,
+        (
+            f"https://example.com/{slug}/{index}",
+            f"https://example.com/{slug}/{index}",
+            title or f"{slug} article {index}",
+            slug,
+            slug,
+            category,
+            days_old,
+            importance_score,
+        ),
+    ).fetchone()
+    article_id = int(row["id"])
+    conn.execute(
+        """
+        INSERT INTO user_article_state(user_id, article_id, state, starred, done_at)
+        VALUES (%s, %s, %s, %s, CASE WHEN %s = 'done' THEN NOW() ELSE NULL END)
+        """,
+        (user_id, article_id, state, starred, state),
+    )
+    return article_id
+
+
+@contextmanager
+def _api_client(user_id: int, username: str = "alice") -> Generator[TestClient]:
+    fake_user = {"id": user_id, "username": username, "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    app.dependency_overrides[require_admin] = lambda: fake_user
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_suggests_starred_and_done_articles(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        _add_article(conn, user_id=user_id, slug="blog", index=1, state="done")
+        _add_article(conn, user_id=user_id, slug="blog", index=2, state="today", starred=True)
+        _add_article(conn, user_id=user_id, slug="blog", index=3, state="skipped")
+
+    suggestions = service.list_lesson_suggestions(user_id, database_url=pg_clean)
+
+    urls = {item["url"] for item in suggestions}
+    assert "https://example.com/blog/1" in urls
+    assert "https://example.com/blog/2" in urls
+    assert "https://example.com/blog/3" not in urls
+
+
+def test_starred_articles_score_higher_than_unstarred(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        _add_article(conn, user_id=user_id, slug="blog", index=1, state="done", starred=False)
+        _add_article(conn, user_id=user_id, slug="blog", index=2, state="done", starred=True)
+
+    suggestions = service.list_lesson_suggestions(user_id, database_url=pg_clean)
+    by_url = {item["url"]: item for item in suggestions}
+
+    starred = by_url["https://example.com/blog/2"]
+    unstarred = by_url["https://example.com/blog/1"]
+    assert starred["score"] > unstarred["score"]
+    assert "You starred this article" in starred["reasons"]
+
+
+def test_excludes_articles_that_already_have_a_lesson(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        _add_article(conn, user_id=user_id, slug="blog", index=1, state="done")
+
+    service.create_lesson(
+        user_id, "https://example.com/blog/1", database_url=pg_clean, extract=False
+    )
+
+    suggestions = service.list_lesson_suggestions(user_id, database_url=pg_clean)
+
+    assert suggestions == []
+
+
+def test_excludes_dismissed_suggestions(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        article_id = _add_article(conn, user_id=user_id, slug="blog", index=1, state="done")
+
+    service.dismiss_lesson_suggestion(user_id, article_id, database_url=pg_clean)
+
+    suggestions = service.list_lesson_suggestions(user_id, database_url=pg_clean)
+
+    assert suggestions == []
+
+
+def test_dismiss_is_idempotent(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        article_id = _add_article(conn, user_id=user_id, slug="blog", index=1, state="done")
+
+    result_one = service.dismiss_lesson_suggestion(user_id, article_id, database_url=pg_clean)
+    result_two = service.dismiss_lesson_suggestion(user_id, article_id, database_url=pg_clean)
+
+    assert result_one == {"dismissed": True, "article_id": article_id}
+    assert result_two == {"dismissed": True, "article_id": article_id}
+
+
+def test_suggestions_are_scoped_to_user(pg_clean: str) -> None:
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        _add_article(conn, user_id=alice, slug="blog", index=1, state="done")
+        _add_article(conn, user_id=bob, slug="blog", index=2, state="done")
+
+    alice_suggestions = service.list_lesson_suggestions(alice, database_url=pg_clean)
+    bob_suggestions = service.list_lesson_suggestions(bob, database_url=pg_clean)
+
+    assert [item["url"] for item in alice_suggestions] == ["https://example.com/blog/1"]
+    assert [item["url"] for item in bob_suggestions] == ["https://example.com/blog/2"]
+
+
+def test_high_importance_articles_are_flagged(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        _add_article(conn, user_id=user_id, slug="blog", index=1, state="done", importance_score=95)
+
+    suggestions = service.list_lesson_suggestions(user_id, database_url=pg_clean)
+
+    assert "High editorial importance score" in suggestions[0]["reasons"]
+
+
+def test_get_suggestions_endpoint_is_user_scoped(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        _add_article(conn, user_id=alice, slug="blog", index=1, state="done")
+        _add_article(conn, user_id=bob, slug="blog", index=2, state="done")
+
+    with _api_client(alice) as client:
+        response = client.get("/api/learn/suggestions")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["url"] for item in items] == ["https://example.com/blog/1"]
+
+
+def test_dismiss_suggestion_endpoint(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        article_id = _add_article(conn, user_id=user_id, slug="blog", index=1, state="done")
+
+    with _api_client(user_id) as client:
+        dismiss_response = client.post(
+            "/api/learn/suggestions/dismiss", json={"article_id": article_id}
+        )
+        list_response = client.get("/api/learn/suggestions")
+
+    assert dismiss_response.status_code == 200
+    assert dismiss_response.json() == {"dismissed": True, "article_id": article_id}
+    assert list_response.json()["items"] == []
+
+
+def test_dismiss_suggestion_endpoint_does_not_affect_other_users(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    with connect(database_url=pg_clean) as conn:
+        _add_source(conn, "blog", "Blog")
+        _add_article(conn, user_id=alice, slug="blog", index=1, state="done")
+        article_id = _add_article(conn, user_id=bob, slug="blog", index=2, state="done")
+
+    with _api_client(bob, "bob") as client:
+        client.post("/api/learn/suggestions/dismiss", json={"article_id": article_id})
+
+    with _api_client(alice) as client:
+        response = client.get("/api/learn/suggestions")
+
+    assert [item["url"] for item in response.json()["items"]] == ["https://example.com/blog/1"]

--- a/frontend/src/__tests__/lessonSuggestions.test.tsx
+++ b/frontend/src/__tests__/lessonSuggestions.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LessonSuggestions } from '../components/LessonSuggestions';
+import type { Lesson, LessonSuggestion } from '../api';
+import * as api from '../api';
+import * as workflowApi from '../api/workflowApi';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+    i18n: { changeLanguage: () => Promise.resolve() },
+  }),
+}));
+
+const SUGGESTION_ONE: LessonSuggestion = {
+  article_id: 1,
+  title: 'A deep dive into caching',
+  url: 'https://example.com/caching',
+  source_name: 'Example Journal',
+  category: 'tech',
+  score: 0.9,
+  reasons: ['You starred this article'],
+};
+
+const SUGGESTION_TWO: LessonSuggestion = {
+  article_id: 2,
+  title: 'Notes on distributed systems',
+  url: 'https://example.com/distsys',
+  source_name: 'Another Source',
+  category: 'tech',
+  score: 0.7,
+  reasons: ['High editorial importance score'],
+};
+
+const GENERATED_LESSON: Lesson = {
+  id: 10,
+  user_id: 1,
+  original_url: SUGGESTION_ONE.url,
+  normalized_url: SUGGESTION_ONE.url,
+  title: SUGGESTION_ONE.title,
+  source_name: SUGGESTION_ONE.source_name,
+  author: null,
+  published_at: null,
+  source_content: null,
+  generation_status: 'pending',
+  generation_error: null,
+  depth: 'normal',
+  persona: 'developer',
+  lesson_detail: null,
+  study_artifacts: null,
+  created_at: '2026-07-08T10:00:00Z',
+  updated_at: '2026-07-08T10:00:00Z',
+};
+
+function renderSuggestions(onGenerated: (lesson: Lesson) => void = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LessonSuggestions onGenerated={onGenerated} />
+    </QueryClientProvider>
+  );
+}
+
+describe('LessonSuggestions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing while loading and nothing when there are no suggestions', async () => {
+    vi.spyOn(api, 'listLessonSuggestions').mockResolvedValue([]);
+
+    const { container } = renderSuggestions();
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it('lists suggestions with their reasons', async () => {
+    vi.spyOn(api, 'listLessonSuggestions').mockResolvedValue([SUGGESTION_ONE, SUGGESTION_TWO]);
+
+    renderSuggestions();
+
+    expect(await screen.findByText('A deep dive into caching')).toBeInTheDocument();
+    expect(screen.getByText('Notes on distributed systems')).toBeInTheDocument();
+    expect(screen.getByText('You starred this article')).toBeInTheDocument();
+    expect(screen.getByText('High editorial importance score')).toBeInTheDocument();
+  });
+
+  it('removes a suggestion from the list when dismissed', async () => {
+    vi.spyOn(api, 'listLessonSuggestions').mockResolvedValue([SUGGESTION_ONE]);
+    const dismissSpy = vi
+      .spyOn(api, 'dismissLessonSuggestion')
+      .mockResolvedValue({ dismissed: true, article_id: SUGGESTION_ONE.article_id });
+
+    renderSuggestions();
+    await screen.findByText('A deep dive into caching');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    await waitFor(() => expect(dismissSpy).toHaveBeenCalledWith(SUGGESTION_ONE.article_id));
+    await waitFor(() =>
+      expect(screen.queryByText('A deep dive into caching')).not.toBeInTheDocument()
+    );
+  });
+
+  it('stars the article and removes it from the list when saved', async () => {
+    vi.spyOn(api, 'listLessonSuggestions').mockResolvedValue([SUGGESTION_ONE]);
+    const starSpy = vi.spyOn(workflowApi, 'patchArticleStar').mockResolvedValue(undefined);
+
+    renderSuggestions();
+    await screen.findByText('A deep dive into caching');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(starSpy).toHaveBeenCalledWith(String(SUGGESTION_ONE.article_id), true)
+    );
+    await waitFor(() =>
+      expect(screen.queryByText('A deep dive into caching')).not.toBeInTheDocument()
+    );
+  });
+
+  it('generates a lesson from a suggestion and notifies the caller', async () => {
+    vi.spyOn(api, 'listLessonSuggestions').mockResolvedValue([SUGGESTION_ONE]);
+    const createSpy = vi.spyOn(api, 'createLessonFromLink').mockResolvedValue(GENERATED_LESSON);
+    const onGenerated = vi.fn();
+
+    renderSuggestions(onGenerated);
+    await screen.findByText('A deep dive into caching');
+
+    await userEvent.click(screen.getByRole('button', { name: /Generate lesson/i }));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledWith(SUGGESTION_ONE.url));
+    await waitFor(() => expect(onGenerated).toHaveBeenCalledWith(GENERATED_LESSON));
+    await waitFor(() =>
+      expect(screen.queryByText('A deep dive into caching')).not.toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -143,3 +143,27 @@ export async function askLessonQuestion(
     body: JSON.stringify({ question, history }),
   });
 }
+
+export interface LessonSuggestion {
+  article_id: number;
+  title: string;
+  url: string;
+  source_name: string | null;
+  category: string | null;
+  score: number;
+  reasons: string[];
+}
+
+export async function listLessonSuggestions(): Promise<LessonSuggestion[]> {
+  const { items } = await requestJson<{ items: LessonSuggestion[] }>('/api/learn/suggestions');
+  return items;
+}
+
+export async function dismissLessonSuggestion(
+  articleId: number
+): Promise<{ dismissed: boolean; article_id: number }> {
+  return requestJson('/api/learn/suggestions/dismiss', {
+    method: 'POST',
+    body: JSON.stringify({ article_id: articleId }),
+  });
+}

--- a/frontend/src/components/LessonSuggestions.tsx
+++ b/frontend/src/components/LessonSuggestions.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2, Sparkles, Star, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  createLessonFromLink,
+  dismissLessonSuggestion,
+  listLessonSuggestions,
+  type Lesson,
+  type LessonSuggestion,
+} from '@/api';
+import { patchArticleStar } from '@/api/workflowApi';
+
+const SUGGESTIONS_QUERY_KEY = ['learn-suggestions'];
+
+export function LessonSuggestions({ onGenerated }: { onGenerated: (lesson: Lesson) => void }) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [pendingAction, setPendingAction] = useState<{
+    articleId: number;
+    action: 'generate' | 'save' | 'dismiss';
+  } | null>(null);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: SUGGESTIONS_QUERY_KEY,
+    queryFn: listLessonSuggestions,
+  });
+
+  const dismissMutation = useMutation({
+    mutationFn: (articleId: number) => dismissLessonSuggestion(articleId),
+    onSuccess: (_result, articleId) => {
+      queryClient.setQueryData<LessonSuggestion[]>(SUGGESTIONS_QUERY_KEY, (current) =>
+        (current ?? []).filter((item) => item.article_id !== articleId)
+      );
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (articleId: number) => patchArticleStar(String(articleId), true),
+    onSuccess: (_result, articleId) => {
+      queryClient.setQueryData<LessonSuggestion[]>(SUGGESTIONS_QUERY_KEY, (current) =>
+        (current ?? []).filter((item) => item.article_id !== articleId)
+      );
+    },
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: (suggestion: LessonSuggestion) => createLessonFromLink(suggestion.url),
+    onSuccess: (lesson, suggestion) => {
+      onGenerated(lesson);
+      queryClient.setQueryData<LessonSuggestion[]>(SUGGESTIONS_QUERY_KEY, (current) =>
+        (current ?? []).filter((item) => item.article_id !== suggestion.article_id)
+      );
+    },
+  });
+
+  const suggestions = data ?? [];
+
+  if (isLoading || isError || suggestions.length === 0) return null;
+
+  return (
+    <section className="mb-6 rounded-lg border border-border bg-surface p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Sparkles className="size-4 text-muted-foreground" />
+        <h2 className="text-sm font-semibold text-foreground">
+          {t('learn.suggestions.title', 'Worth turning into a lesson')}
+        </h2>
+      </div>
+      <ul className="space-y-3">
+        {suggestions.map((suggestion) => {
+          const isBusy = pendingAction?.articleId === suggestion.article_id;
+          return (
+            <li
+              key={suggestion.article_id}
+              className="flex flex-col gap-2 rounded-md border border-border p-3 sm:flex-row sm:items-start sm:justify-between"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-foreground">{suggestion.title}</p>
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                  {suggestion.source_name ? <span>{suggestion.source_name}</span> : null}
+                  {suggestion.reasons.map((reason) => (
+                    <Badge key={reason} variant="outline" className="font-normal">
+                      {reason}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={t('learn.suggestions.dismiss', 'Dismiss')}
+                  disabled={isBusy}
+                  onClick={() => {
+                    setPendingAction({ articleId: suggestion.article_id, action: 'dismiss' });
+                    dismissMutation.mutate(suggestion.article_id, {
+                      onSettled: () => setPendingAction(null),
+                    });
+                  }}
+                >
+                  {isBusy && pendingAction?.action === 'dismiss' ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <X className="size-3.5" />
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={t('learn.suggestions.save', 'Save')}
+                  disabled={isBusy}
+                  onClick={() => {
+                    setPendingAction({ articleId: suggestion.article_id, action: 'save' });
+                    saveMutation.mutate(suggestion.article_id, {
+                      onSettled: () => setPendingAction(null),
+                    });
+                  }}
+                >
+                  {isBusy && pendingAction?.action === 'save' ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <Star className="size-3.5" />
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={isBusy}
+                  onClick={() => {
+                    setPendingAction({ articleId: suggestion.article_id, action: 'generate' });
+                    generateMutation.mutate(suggestion, {
+                      onSettled: () => setPendingAction(null),
+                    });
+                  }}
+                >
+                  {isBusy && pendingAction?.action === 'generate' ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : null}
+                  {t('learn.suggestions.generate', 'Generate lesson')}
+                </Button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -171,6 +171,12 @@
       "load_error": "Failed to load your lesson library.",
       "empty": "No lessons yet. Paste a link on the Learn page.",
       "no_matches": "No lessons match your filters."
+    },
+    "suggestions": {
+      "title": "Worth turning into a lesson",
+      "dismiss": "Dismiss",
+      "save": "Save",
+      "generate": "Generate lesson"
     }
   }
 }

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { LessonDetailView } from '@/components/LessonDetailView';
+import { LessonSuggestions } from '@/components/LessonSuggestions';
 import { useLessonPolling } from '@/hooks/useLessonPolling';
 import {
   createLessonFromLink,
@@ -107,6 +108,8 @@ export function LearnPage() {
           <p className="text-sm text-muted-foreground">{t('learn.description')}</p>
         </div>
       </div>
+
+      <LessonSuggestions onGenerated={setLesson} />
 
       <form
         noValidate


### PR DESCRIPTION
## Summary

Closes #1129.

- Score the user's starred or completed articles for lesson-worthiness using relevance to their reading DNA/interests, novelty (recency), and editorial importance, reusing the existing `_get_relevance_data` signals from Learn from Link's personal-relevance feature.
- New `GET /api/learn/suggestions` and `POST /api/learn/suggestions/dismiss` endpoints (`backend/news_dashboard/learn_from_link/{service,router,models}.py`), backed by a new `user_lesson_suggestion_dismissals` table.
- Candidates already lessoned (matched by normalized URL) or explicitly dismissed are excluded. No automatic/expensive lesson generation happens — suggestions only surface existing scored candidates.
- New `LessonSuggestions` component on the Learn page shows each suggestion with its explanation ("why"), and lets the user dismiss it, save (star) it, or generate a lesson from it directly.

## Test plan

- [x] `backend/tests/test_learn_from_link_suggestions.py` — candidate scoring, exclusion of already-lessoned/dismissed articles, dismiss idempotency, user scoping at both service and endpoint level (62/62 passing alongside existing `test_learn_from_link.py`)
- [x] `frontend/src/__tests__/lessonSuggestions.test.tsx` — rendering, dismiss/save/generate actions (5/5 passing)
- [x] `ruff check`, `mypy`, `eslint`, `tsc --noEmit` all clean
- [x] Full frontend vitest suite: 903/903 passing (includes the locale key-parity test, since translation keys were added to all 29 locales)
- [x] pre-commit hooks (ruff, mypy, ty, pyrefly, vulture, eslint, prettier, knip, tsc) all passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)