### PR TITLE
feat: generate podcast audio from a lesson (#1126)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -661,6 +661,9 @@ POSTGRES_MULTIUSER_SCHEMA = [
     " CHECK(depth IN ('tiny','normal','deep','expert'))",
     "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS persona TEXT NOT NULL DEFAULT 'developer'"
     " CHECK(persona IN ('developer','product_builder','new_to_ai','preparing_talk'))",
+    "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS podcast_status TEXT"
+    " CHECK(podcast_status IN ('complete','failed'))",
+    "ALTER TABLE lessons ADD COLUMN IF NOT EXISTS podcast_error TEXT",
     """
     CREATE TABLE IF NOT EXISTS lesson_generations (
       id BIGSERIAL PRIMARY KEY,

--- a/backend/news_dashboard/learn_from_link/router.py
+++ b/backend/news_dashboard/learn_from_link/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
 
 from news_dashboard.auth import require_auth
 from news_dashboard.learn_from_link import service
@@ -63,6 +64,45 @@ def get_lesson_endpoint(
     if lesson is None:
         raise HTTPException(status_code=404, detail="lesson not found")
     return lesson
+
+
+@router.post("/api/learn/lessons/{lesson_id}/podcast")
+def generate_lesson_podcast_endpoint(
+    lesson_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    force: Annotated[bool, Query()] = False,
+) -> dict[str, Any]:
+    try:
+        return service.generate_lesson_podcast(lesson_id, current_user["id"], force=force)
+    except service.LessonNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="lesson not found") from exc
+    except service.LessonNotReadyError as exc:
+        raise HTTPException(
+            status_code=409, detail="lesson must finish generating before creating audio"
+        ) from exc
+    except service.LessonPodcastNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except service.LessonPodcastGenerationError as exc:
+        raise HTTPException(status_code=500, detail="Could not generate podcast audio.") from exc
+
+
+@router.get("/api/learn/lessons/{lesson_id}/podcast")
+def get_lesson_podcast_endpoint(
+    lesson_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> FileResponse:
+    from news_dashboard.tts import _lesson_podcast_audio_path
+
+    lesson = service.get_lesson(lesson_id, current_user["id"])
+    if lesson is None:
+        raise HTTPException(status_code=404, detail="lesson not found")
+
+    path = _lesson_podcast_audio_path(lesson_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="podcast audio not generated")
+    return FileResponse(path, media_type="audio/mpeg", filename=f"lesson-{lesson_id}-podcast.mp3")
 
 
 @router.post("/api/learn/lessons/{lesson_id}/regenerate")

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -82,6 +82,18 @@ class LessonChatNotConfiguredError(RuntimeError):
     """Raised when no AI credentials are configured for lesson follow-up chat."""
 
 
+class LessonNotReadyError(ValueError):
+    """Raised when podcast audio is requested before the lesson finished generating."""
+
+
+class LessonPodcastNotConfiguredError(RuntimeError):
+    """Raised when no TTS credentials are configured for lesson podcast audio."""
+
+
+class LessonPodcastGenerationError(RuntimeError):
+    """Raised when lesson podcast audio synthesis fails for a reason other than missing config."""
+
+
 class LessonDetailValidationError(ValueError):
     """Raised when generated lesson detail fails schema validation."""
 
@@ -269,6 +281,102 @@ def _update_lesson_failure(
             (error_message, lesson_id, user_id),
         ).fetchone()
     return _serialize_lesson(row)
+
+
+def _update_lesson_podcast_success(
+    lesson_id: int,
+    user_id: int,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE lessons
+            SET podcast_status = 'complete',
+                podcast_error = NULL,
+                updated_at = NOW()
+            WHERE id = %s AND user_id = %s
+            RETURNING *
+            """,
+            (lesson_id, user_id),
+        ).fetchone()
+    if row is None:
+        raise LessonNotFoundError
+    return _serialize_lesson(row)
+
+
+def _update_lesson_podcast_failure(
+    lesson_id: int,
+    user_id: int,
+    error_message: str,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE lessons
+            SET podcast_status = 'failed',
+                podcast_error = %s,
+                updated_at = NOW()
+            WHERE id = %s AND user_id = %s
+            RETURNING *
+            """,
+            (error_message, lesson_id, user_id),
+        ).fetchone()
+    if row is None:
+        raise LessonNotFoundError
+    return _serialize_lesson(row)
+
+
+def generate_lesson_podcast(
+    lesson_id: int,
+    user_id: int,
+    *,
+    force: bool = False,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Generate (or return cached) spoken narration audio for a completed lesson.
+
+    Narration is built from the lesson's structured ``lesson_detail`` fields so
+    it stays consistent with what's shown on the lesson page, rather than
+    re-summarizing the raw source article independently.
+    """
+    lesson = get_lesson(lesson_id, user_id, database_url=database_url)
+    if lesson is None:
+        raise LessonNotFoundError
+    if lesson.get("generation_status") != "complete" or lesson.get("lesson_detail") is None:
+        raise LessonNotReadyError
+
+    from news_dashboard.tts import TTSNotConfiguredError, generate_lesson_podcast_audio
+
+    title = str(lesson.get("title") or lesson["original_url"])
+    try:
+        generate_lesson_podcast_audio(
+            lesson_id,
+            title,
+            lesson["lesson_detail"],
+            force=force,
+        )
+    except TTSNotConfiguredError as exc:
+        _update_lesson_podcast_failure(lesson_id, user_id, str(exc), database_url=database_url)
+        raise LessonPodcastNotConfiguredError(str(exc)) from exc
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.warning("lesson podcast audio generation failed for lesson %d: %s", lesson_id, exc)
+        _update_lesson_podcast_failure(
+            lesson_id,
+            user_id,
+            "Could not generate podcast audio.",
+            database_url=database_url,
+        )
+        raise LessonPodcastGenerationError from exc
+
+    return _update_lesson_podcast_success(lesson_id, user_id, database_url=database_url)
 
 
 def _record_lesson_generation(

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -186,6 +186,74 @@ def generate_podcast_audio(
     return path
 
 
+def _lesson_podcast_audio_path(lesson_id: int, data_dir: Path | None = None) -> Path:
+    base = data_dir if data_dir is not None else _data_dir()
+    # int() coerces lesson_id to a plain digit string, so it cannot carry
+    # path-traversal or separator characters into the constructed path.
+    return base / "audio" / f"lesson-podcast-{int(lesson_id)}.mp3"
+
+
+def _build_lesson_podcast_text(title: str, lesson_detail: dict[str, Any]) -> str:
+    gist = str(lesson_detail.get("gist") or "")
+    explanation = str(lesson_detail.get("explanation") or "")
+    why_it_matters = str(lesson_detail.get("why_it_matters") or "")
+    key_claims = [str(claim) for claim in lesson_detail.get("key_claims") or []]
+
+    parts = [title, gist, explanation]
+    if key_claims:
+        parts.append("Key takeaways: " + " ".join(key_claims))
+    if why_it_matters:
+        parts.append(f"Why it matters: {why_it_matters}")
+    return "\n\n".join(part for part in parts if part.strip())
+
+
+def generate_lesson_podcast_audio(
+    lesson_id: int,
+    title: str,
+    lesson_detail: dict[str, Any],
+    *,
+    force: bool = False,
+    data_dir: Path | None = None,
+) -> Path:
+    """Return path to cached lesson podcast MP3, generating it via OpenAI TTS if needed.
+
+    Narration is built from the lesson's structured ``lesson_detail`` fields
+    (gist, explanation, key claims, why it matters) so the audio stays
+    consistent with what's shown on the lesson page, rather than
+    re-summarizing the raw source article independently.
+
+    Raises TTSNotConfiguredError when OPENAI_API_KEY is absent.
+    """
+    api_key, base_url = _tts_ai_config()
+
+    path = _lesson_podcast_audio_path(lesson_id, data_dir)
+    if force and path.exists():
+        path.unlink()
+    if path.exists():
+        logger.debug("Lesson podcast cache hit for lesson %d", lesson_id)
+        return path
+
+    text = _build_lesson_podcast_text(title, lesson_detail)
+    if not text.strip():
+        msg = "lesson has no readable detail to narrate"
+        raise ValueError(msg)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    from news_dashboard.ai_client import get_openai_client, tts_timeout_seconds
+
+    client = get_openai_client(
+        api_key=api_key, base_url=base_url, timeout_seconds=tts_timeout_seconds()
+    )
+    logger.info("Generating lesson podcast audio for lesson %d (%d chars)", lesson_id, len(text))
+    with client.audio.speech.with_streaming_response.create(
+        model=_PODCAST_MODEL, voice=_ALEX_VOICE, input=text[:_MAX_CHARS]
+    ) as response:
+        response.stream_to_file(path)
+    logger.info("Lesson podcast audio cached at %s", path)
+    return path
+
+
 _PODCAST_SYSTEM_PROMPT = (
     "You are a podcast script writer. Given a news briefing containing a title, summary, "
     "and several sections, rewrite the content into a natural, conversational dialogue script "

--- a/backend/tests/test_lesson_podcast.py
+++ b/backend/tests/test_lesson_podcast.py
@@ -1,0 +1,276 @@
+"""Tests for generating podcast audio from a completed lesson."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_admin, require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.learn_from_link import service
+from news_dashboard.main import app
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+@contextmanager
+def _api_client(user_id: int, username: str = "alice") -> Generator[TestClient]:
+    fake_user = {"id": user_id, "username": username, "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    app.dependency_overrides[require_admin] = lambda: fake_user
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+@pytest.fixture(autouse=True)
+def _lesson_extraction_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        service,
+        "fetch_url_metadata",
+        lambda url: {
+            "title": f"Title for {url}",
+            "site_name": "Example Source",
+            "author": "Example Author",
+            "published_at": "2026-07-09",
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        service,
+        "extract_body",
+        lambda url: (f"Body for {url}. It has enough detail to be a lesson.", "ok"),
+        raising=False,
+    )
+
+
+def _completed_lesson(pg_clean: str, user_id: int) -> dict[str, Any]:
+    return service.create_lesson(user_id, "https://example.com/story", database_url=pg_clean)
+
+
+def _mock_audio_client() -> MagicMock:
+    mock_response = MagicMock()
+
+    def fake_stream(path: Path) -> None:
+        path.write_bytes(b"fake-mp3-data")
+
+    mock_response.stream_to_file.side_effect = fake_stream
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.audio.speech.with_streaming_response.create.return_value = mock_response
+    return mock_client
+
+
+# ── service.generate_lesson_podcast ───────────────────────────────────────────
+
+
+def test_generate_lesson_podcast_raises_not_found(pg_clean: str) -> None:
+    with pytest.raises(service.LessonNotFoundError):
+        service.generate_lesson_podcast(999, 1, database_url=pg_clean)
+
+
+def test_generate_lesson_podcast_raises_not_ready_when_lesson_pending(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(
+        user_id, "https://example.com/story", database_url=pg_clean, extract=False
+    )
+
+    with pytest.raises(service.LessonNotReadyError):
+        service.generate_lesson_podcast(int(lesson["id"]), user_id, database_url=pg_clean)
+
+
+def test_generate_lesson_podcast_raises_not_configured_and_persists_failure(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    user_id = _make_user(pg_clean)
+    lesson = _completed_lesson(pg_clean, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(service.LessonPodcastNotConfiguredError):
+        service.generate_lesson_podcast(int(lesson["id"]), user_id, database_url=pg_clean)
+
+    persisted = service.get_lesson(int(lesson["id"]), user_id, database_url=pg_clean)
+    assert persisted is not None
+    assert persisted["podcast_status"] == "failed"
+    assert persisted["podcast_error"]
+
+
+def test_generate_lesson_podcast_succeeds_and_persists_complete(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    user_id = _make_user(pg_clean)
+    lesson = _completed_lesson(pg_clean, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with patch("openai.OpenAI", return_value=mock_client):
+        result = service.generate_lesson_podcast(int(lesson["id"]), user_id, database_url=pg_clean)
+
+    assert result["podcast_status"] == "complete"
+    assert result["podcast_error"] is None
+    mock_client.audio.speech.with_streaming_response.create.assert_called_once()
+    call_kwargs = mock_client.audio.speech.with_streaming_response.create.call_args
+    # Narration is built from the structured lesson detail fields.
+    assert result["lesson_detail"]["gist"] in call_kwargs.kwargs["input"]
+    assert result["lesson_detail"]["why_it_matters"] in call_kwargs.kwargs["input"]
+
+
+def test_generate_lesson_podcast_is_user_scoped(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    lesson = _completed_lesson(pg_clean, alice)
+
+    with pytest.raises(service.LessonNotFoundError):
+        service.generate_lesson_podcast(int(lesson["id"]), bob, database_url=pg_clean)
+
+
+# ── router endpoints ──────────────────────────────────────────────────────────
+
+
+def test_generate_lesson_podcast_endpoint_returns_complete_lesson(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = _completed_lesson(pg_clean, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with (
+        patch("openai.OpenAI", return_value=mock_client),
+        _api_client(user_id) as client,
+    ):
+        response = client.post(f"/api/learn/lessons/{lesson['id']}/podcast")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["podcast_status"] == "complete"
+
+
+def test_generate_lesson_podcast_endpoint_404s_for_missing_lesson(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.post("/api/learn/lessons/999999/podcast")
+
+    assert response.status_code == 404
+
+
+def test_generate_lesson_podcast_endpoint_409s_when_lesson_not_ready(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(
+        user_id, "https://example.com/story", database_url=pg_clean, extract=False
+    )
+
+    with _api_client(user_id) as client:
+        response = client.post(f"/api/learn/lessons/{lesson['id']}/podcast")
+
+    assert response.status_code == 409
+
+
+def test_generate_lesson_podcast_endpoint_503s_when_not_configured(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = _completed_lesson(pg_clean, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with _api_client(user_id) as client:
+        response = client.post(f"/api/learn/lessons/{lesson['id']}/podcast")
+
+    assert response.status_code == 503
+
+
+def test_get_lesson_podcast_endpoint_404s_before_generation(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = _completed_lesson(pg_clean, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    with _api_client(user_id) as client:
+        response = client.get(f"/api/learn/lessons/{lesson['id']}/podcast")
+
+    assert response.status_code == 404
+
+
+def test_get_lesson_podcast_endpoint_serves_generated_audio(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = _completed_lesson(pg_clean, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with patch("openai.OpenAI", return_value=mock_client):
+        service.generate_lesson_podcast(int(lesson["id"]), user_id, database_url=pg_clean)
+
+    with _api_client(user_id) as client:
+        response = client.get(f"/api/learn/lessons/{lesson['id']}/podcast")
+
+    assert response.status_code == 200
+    assert response.content == b"fake-mp3-data"
+
+
+def test_get_lesson_podcast_endpoint_404s_for_other_user(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    lesson = _completed_lesson(pg_clean, alice)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with patch("openai.OpenAI", return_value=mock_client):
+        service.generate_lesson_podcast(int(lesson["id"]), alice, database_url=pg_clean)
+
+    with _api_client(bob, username="bob") as client:
+        response = client.get(f"/api/learn/lessons/{lesson['id']}/podcast")
+
+    assert response.status_code == 404

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -13,13 +13,23 @@ import pytest
 
 from news_dashboard.tts import (
     TTSNotConfiguredError,
+    _build_lesson_podcast_text,
     _build_text,
+    _lesson_podcast_audio_path,
     _script_ai_config,
     _tts_ai_config,
     generate_audio,
+    generate_lesson_podcast_audio,
     generate_podcast_audio,
     generate_podcast_script,
 )
+
+_LESSON_DETAIL: dict[str, Any] = {
+    "gist": "The gist of the lesson.",
+    "explanation": "A longer explanation of the source article.",
+    "key_claims": ["Claim one.", "Claim two."],
+    "why_it_matters": "It matters because of reasons.",
+}
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -401,3 +411,127 @@ def test_generate_podcast_script_fallback_uses_alex_onyx() -> None:
     assert len(script) == 1
     assert script[0]["speaker"] == "Alex"
     assert script[0]["voice"] == "onyx"
+
+
+# ── _build_lesson_podcast_text ────────────────────────────────────────────────
+
+
+def test_build_lesson_podcast_text_uses_structured_fields_not_raw_source() -> None:
+    text = _build_lesson_podcast_text("Lesson Title", _LESSON_DETAIL)
+    assert "Lesson Title" in text
+    assert "The gist of the lesson." in text
+    assert "A longer explanation of the source article." in text
+    assert "Claim one." in text
+    assert "Claim two." in text
+    assert "It matters because of reasons." in text
+
+
+def test_build_lesson_podcast_text_skips_missing_key_claims() -> None:
+    detail = {**_LESSON_DETAIL, "key_claims": []}
+    text = _build_lesson_podcast_text("Lesson Title", detail)
+    assert "Key takeaways" not in text
+
+
+# ── generate_lesson_podcast_audio — no API key ────────────────────────────────
+
+
+def test_generate_lesson_podcast_audio_raises_when_no_api_key(tmp_path: Path) -> None:
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("OPENAI_API_KEY", None)
+        with pytest.raises(TTSNotConfiguredError):
+            generate_lesson_podcast_audio(1, "Lesson Title", _LESSON_DETAIL, data_dir=tmp_path)
+
+
+# ── generate_lesson_podcast_audio — cache miss (calls API) ───────────────────
+
+
+def test_generate_lesson_podcast_audio_calls_openai_and_writes_file(tmp_path: Path) -> None:
+    mock_response = MagicMock()
+
+    def fake_stream(path: Path) -> None:
+        path.write_bytes(b"fake-mp3-data")
+
+    mock_response.stream_to_file.side_effect = fake_stream
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.audio.speech.with_streaming_response.create.return_value = mock_response
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        path = generate_lesson_podcast_audio(7, "Lesson Title", _LESSON_DETAIL, data_dir=tmp_path)
+
+    assert path.exists()
+    assert path.read_bytes() == b"fake-mp3-data"
+    assert path == _lesson_podcast_audio_path(7, tmp_path)
+    call_kwargs = mock_client.audio.speech.with_streaming_response.create.call_args
+    assert call_kwargs.kwargs["model"] == "gpt-4o-mini-tts"
+    assert call_kwargs.kwargs["voice"] == "onyx"
+    assert "The gist of the lesson." in call_kwargs.kwargs["input"]
+
+
+# ── generate_lesson_podcast_audio — cache hit (skips API) ─────────────────────
+
+
+def test_generate_lesson_podcast_audio_returns_cached_file_without_api_call(
+    tmp_path: Path,
+) -> None:
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    cached = audio_dir / "lesson-podcast-7.mp3"
+    cached.write_bytes(b"cached-mp3")
+
+    mock_client = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        path = generate_lesson_podcast_audio(7, "Lesson Title", _LESSON_DETAIL, data_dir=tmp_path)
+
+    assert path == cached
+    assert path.read_bytes() == b"cached-mp3"
+    mock_client.audio.speech.with_streaming_response.create.assert_not_called()
+
+
+def test_generate_lesson_podcast_audio_force_regenerates_cached_file(tmp_path: Path) -> None:
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    cached = audio_dir / "lesson-podcast-7.mp3"
+    cached.write_bytes(b"stale-mp3")
+
+    mock_response = MagicMock()
+
+    def fake_stream(path: Path) -> None:
+        path.write_bytes(b"fresh-mp3-data")
+
+    mock_response.stream_to_file.side_effect = fake_stream
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.audio.speech.with_streaming_response.create.return_value = mock_response
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        path = generate_lesson_podcast_audio(
+            7, "Lesson Title", _LESSON_DETAIL, force=True, data_dir=tmp_path
+        )
+
+    assert path.read_bytes() == b"fresh-mp3-data"
+    mock_client.audio.speech.with_streaming_response.create.assert_called_once()
+
+
+def test_generate_lesson_podcast_audio_raises_on_empty_detail(tmp_path: Path) -> None:
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        pytest.raises(ValueError, match="no readable detail"),
+    ):
+        generate_lesson_podcast_audio(7, "", {}, data_dir=tmp_path)

--- a/frontend/src/__tests__/learnPage.test.tsx
+++ b/frontend/src/__tests__/learnPage.test.tsx
@@ -83,6 +83,8 @@ const COMPLETE_LESSON: Lesson = {
   generation_error: null,
   depth: 'normal',
   persona: 'developer',
+  podcast_status: null,
+  podcast_error: null,
   lesson_detail: {
     gist: 'The article argues that strong source selection matters more than raw volume.',
     explanation:

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LessonDetailPage } from '../pages/LessonDetailPage';
@@ -28,6 +29,8 @@ const COMPLETE_LESSON: Lesson = {
   generation_error: null,
   depth: 'normal',
   persona: 'developer',
+  podcast_status: null,
+  podcast_error: null,
   lesson_detail: {
     gist: 'gist text',
     explanation: 'explanation text',
@@ -115,5 +118,76 @@ describe('LessonDetailPage', () => {
     });
 
     expect(screen.getByText('A careful article')).toBeInTheDocument();
+  });
+
+  it('shows a create-podcast button, then the player once generation succeeds', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue(COMPLETE_LESSON);
+    vi.spyOn(api, 'generateLessonPodcast').mockResolvedValue({
+      ...COMPLETE_LESSON,
+      podcast_status: 'complete',
+    });
+
+    renderPage(5);
+    await screen.findByText('A careful article');
+
+    const createButton = screen.getByRole('button', { name: 'Create podcast' });
+    expect(createButton).toBeInTheDocument();
+
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(api.generateLessonPodcast).toHaveBeenCalledWith(5, false);
+    });
+    expect(await screen.findByRole('button', { name: 'Regenerate' })).toBeInTheDocument();
+    const player = document.querySelector('audio');
+    expect(player).toHaveAttribute('src', '/api/learn/lessons/5/podcast');
+  });
+
+  it('shows a friendly error and keeps the create button when podcast generation fails', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue(COMPLETE_LESSON);
+    vi.spyOn(api, 'generateLessonPodcast').mockRejectedValue(
+      new api.HttpError(503, 'AI not configured')
+    );
+
+    renderPage(5);
+    await screen.findByText('A careful article');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create podcast' }));
+
+    expect(await screen.findByText('AI not configured')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create podcast' })).toBeInTheDocument();
+  });
+
+  it('shows the failed-podcast banner from persisted lesson state', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue({
+      ...COMPLETE_LESSON,
+      podcast_status: 'failed',
+      podcast_error: 'Could not generate podcast audio.',
+    });
+
+    renderPage(5);
+
+    expect(await screen.findByText('Could not generate podcast audio.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Regenerate' })).toBeInTheDocument();
+  });
+
+  it('forces regeneration when clicking regenerate on an existing podcast', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue({
+      ...COMPLETE_LESSON,
+      podcast_status: 'complete',
+    });
+    vi.spyOn(api, 'generateLessonPodcast').mockResolvedValue({
+      ...COMPLETE_LESSON,
+      podcast_status: 'complete',
+    });
+
+    renderPage(5);
+    await screen.findByText('A careful article');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+
+    await waitFor(() => {
+      expect(api.generateLessonPodcast).toHaveBeenCalledWith(5, true);
+    });
   });
 });

--- a/frontend/src/__tests__/lessonLibraryPage.test.tsx
+++ b/frontend/src/__tests__/lessonLibraryPage.test.tsx
@@ -29,6 +29,8 @@ const COMPLETE_LESSON: Lesson = {
   generation_error: null,
   depth: 'normal',
   persona: 'developer',
+  podcast_status: null,
+  podcast_error: null,
   lesson_detail: {
     gist: 'The article argues that strong source selection matters more than raw volume.',
     explanation: 'explanation',

--- a/frontend/src/__tests__/lessonSuggestions.test.tsx
+++ b/frontend/src/__tests__/lessonSuggestions.test.tsx
@@ -49,6 +49,8 @@ const GENERATED_LESSON: Lesson = {
   generation_error: null,
   depth: 'normal',
   persona: 'developer',
+  podcast_status: null,
+  podcast_error: null,
   lesson_detail: null,
   study_artifacts: null,
   created_at: '2026-07-08T10:00:00Z',

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -65,6 +65,8 @@ export interface Lesson {
   study_artifacts: StudyArtifacts | null;
   depth: LessonDepth;
   persona: LessonPersona;
+  podcast_status: 'complete' | 'failed' | null;
+  podcast_error: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -108,6 +110,12 @@ export async function regenerateLesson(
 
 export async function fetchLessonGenerations(id: number): Promise<LessonGeneration[]> {
   return requestJson<LessonGeneration[]>(`/api/learn/lessons/${id}/generations`);
+}
+
+export async function generateLessonPodcast(id: number, force = false): Promise<Lesson> {
+  return requestJson<Lesson>(`/api/learn/lessons/${id}/podcast${force ? '?force=true' : ''}`, {
+    method: 'POST',
+  });
 }
 
 export interface ListLessonsParams {

--- a/frontend/src/components/LessonDetailView.tsx
+++ b/frontend/src/components/LessonDetailView.tsx
@@ -1,10 +1,13 @@
-import { ExternalLink, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { AlertCircle, ExternalLink, Headphones, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { LessonChat } from '@/components/LessonChat';
 import { StudyArtifactsView } from '@/components/StudyArtifactsView';
-import type { Lesson, LessonDetail } from '@/api';
+import { generateLessonPodcast, type Lesson, type LessonDetail } from '@/api';
+import { classifyGenerationError, type FriendlyError } from '@/lib/errorPresentation';
 
 function formatPublishedDate(value: string | null): string | null {
   if (!value) return null;
@@ -51,14 +54,35 @@ function renderBulletList(items: string[]) {
   );
 }
 
-export function LessonDetailView({ lesson }: { lesson: Lesson }) {
+export function LessonDetailView({
+  lesson,
+  onLessonUpdate,
+}: {
+  lesson: Lesson;
+  onLessonUpdate?: (lesson: Lesson) => void;
+}) {
   const { t } = useTranslation();
+  const [isGeneratingPodcast, setIsGeneratingPodcast] = useState(false);
+  const [podcastError, setPodcastError] = useState<FriendlyError | null>(null);
   const publishedLabel = formatPublishedDate(lesson.published_at);
   const isPendingLesson = lesson.generation_status === 'pending';
   const isFailedLesson = lesson.generation_status === 'failed';
   const isCompleteLesson = lesson.generation_status === 'complete';
   const lessonDetail = lesson.lesson_detail ?? null;
   const hasLessonDetail = isCompleteLesson && lessonDetail !== null;
+
+  async function handleGeneratePodcast(force: boolean) {
+    setIsGeneratingPodcast(true);
+    setPodcastError(null);
+    try {
+      const updated = await generateLessonPodcast(lesson.id, force);
+      onLessonUpdate?.(updated);
+    } catch (error: unknown) {
+      setPodcastError(classifyGenerationError(error));
+    } finally {
+      setIsGeneratingPodcast(false);
+    }
+  }
 
   return (
     <section className="space-y-4">
@@ -198,6 +222,56 @@ export function LessonDetailView({ lesson }: { lesson: Lesson }) {
 
       {hasLessonDetail && lesson.study_artifacts ? (
         <StudyArtifactsView artifacts={lesson.study_artifacts} />
+      ) : null}
+
+      {hasLessonDetail ? (
+        <div className="space-y-3 rounded-lg border border-border bg-card/60 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Headphones className="size-4 text-muted-foreground" />
+              <h3 className="text-sm font-semibold text-foreground">
+                {t('learn.podcast.title', 'Podcast audio')}
+              </h3>
+            </div>
+            <Button
+              size="sm"
+              variant={lesson.podcast_status ? 'outline' : 'default'}
+              onClick={() => {
+                void handleGeneratePodcast(lesson.podcast_status !== null);
+              }}
+              disabled={isGeneratingPodcast}
+            >
+              {isGeneratingPodcast
+                ? t('learn.podcast.generating', 'Generating…')
+                : lesson.podcast_status
+                  ? t('learn.podcast.regenerate', 'Regenerate')
+                  : t('learn.podcast.create', 'Create podcast')}
+            </Button>
+          </div>
+
+          {lesson.podcast_status === 'complete' ? (
+            <audio
+              src={`/api/learn/lessons/${lesson.id}/podcast`}
+              controls
+              className="h-9 w-full"
+            />
+          ) : null}
+
+          {podcastError ? (
+            <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-xs text-destructive">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              <div>
+                <div className="font-semibold">{podcastError.title}</div>
+                <div className="mt-0.5">{podcastError.message}</div>
+              </div>
+            </div>
+          ) : lesson.podcast_status === 'failed' && lesson.podcast_error ? (
+            <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-xs text-destructive">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              <div>{lesson.podcast_error}</div>
+            </div>
+          ) : null}
+        </div>
       ) : null}
 
       {hasLessonDetail ? <LessonChat lessonId={lesson.id} /> : null}

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "صوت البودكاست",
+      "create": "إنشاء بودكاست",
+      "generating": "جارٍ الإنشاء...",
+      "regenerate": "إعادة الإنشاء"
     }
   }
 }

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Zvuk podcastu",
+      "create": "Vytvořit podcast",
+      "generating": "Generuje se...",
+      "regenerate": "Znovu vygenerovat"
     }
   }
 }

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcastlyd",
+      "create": "Opret podcast",
+      "generating": "Genererer...",
+      "regenerate": "Regenerer"
     }
   }
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcast-Audio",
+      "create": "Podcast erstellen",
+      "generating": "Wird erstellt...",
+      "regenerate": "Erneut generieren"
     }
   }
 }

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Ήχος podcast",
+      "create": "Δημιουργία podcast",
+      "generating": "Δημιουργία...",
+      "regenerate": "Αναδημιουργία"
     }
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcast audio",
+      "create": "Create podcast",
+      "generating": "Generating...",
+      "regenerate": "Regenerate"
     }
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Audio del podcast",
+      "create": "Crear podcast",
+      "generating": "Generando...",
+      "regenerate": "Regenerar"
     }
   }
 }

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcast-ääni",
+      "create": "Luo podcast",
+      "generating": "Luodaan...",
+      "regenerate": "Luo uudelleen"
     }
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Audio du podcast",
+      "create": "Créer le podcast",
+      "generating": "Génération...",
+      "regenerate": "Régénérer"
     }
   }
 }

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "שמע פודקאסט",
+      "create": "צור פודקאסט",
+      "generating": "יוצר...",
+      "regenerate": "צור מחדש"
     }
   }
 }

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "पॉडकास्ट ऑडियो",
+      "create": "पॉडकास्ट बनाएं",
+      "generating": "बनाया जा रहा है...",
+      "regenerate": "फिर से बनाएं"
     }
   }
 }

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcast hang",
+      "create": "Podcast létrehozása",
+      "generating": "Létrehozás...",
+      "regenerate": "Újragenerálás"
     }
   }
 }

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Audio podcast",
+      "create": "Buat podcast",
+      "generating": "Membuat...",
+      "regenerate": "Buat ulang"
     }
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Audio del podcast",
+      "create": "Crea podcast",
+      "generating": "Generazione...",
+      "regenerate": "Rigenera"
     }
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "ポッドキャスト音声",
+      "create": "ポッドキャストを作成",
+      "generating": "生成中...",
+      "regenerate": "再生成"
     }
   }
 }

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "팟캐스트 오디오",
+      "create": "팟캐스트 만들기",
+      "generating": "생성 중...",
+      "regenerate": "다시 생성"
     }
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcast-audio",
+      "create": "Podcast maken",
+      "generating": "Genereren...",
+      "regenerate": "Opnieuw genereren"
     }
   }
 }

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podkast-lyd",
+      "create": "Opprett podkast",
+      "generating": "Genererer...",
+      "regenerate": "Regenerer"
     }
   }
 }

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Dźwięk podcastu",
+      "create": "Utwórz podcast",
+      "generating": "Generowanie...",
+      "regenerate": "Wygeneruj ponownie"
     }
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Áudio do podcast",
+      "create": "Criar podcast",
+      "generating": "Gerando...",
+      "regenerate": "Regenerar"
     }
   }
 }

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Audio podcast",
+      "create": "Creează podcast",
+      "generating": "Se generează...",
+      "regenerate": "Regenerează"
     }
   }
 }

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Аудио подкаста",
+      "create": "Создать подкаст",
+      "generating": "Создание...",
+      "regenerate": "Создать заново"
     }
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcastljud",
+      "create": "Skapa podcast",
+      "generating": "Genererar...",
+      "regenerate": "Återskapa"
     }
   }
 }

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "เสียงพอดแคสต์",
+      "create": "สร้างพอดแคสต์",
+      "generating": "กำลังสร้าง...",
+      "regenerate": "สร้างใหม่"
     }
   }
 }

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcast sesi",
+      "create": "Podcast oluştur",
+      "generating": "Oluşturuluyor...",
+      "regenerate": "Yeniden oluştur"
     }
   }
 }

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Аудіо подкасту",
+      "create": "Створити подкаст",
+      "generating": "Створення...",
+      "regenerate": "Створити знову"
     }
   }
 }

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Âm thanh podcast",
+      "create": "Tạo podcast",
+      "generating": "Đang tạo...",
+      "regenerate": "Tạo lại"
     }
   }
 }

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "播客音频",
+      "create": "创建播客",
+      "generating": "生成中...",
+      "regenerate": "重新生成"
     }
   }
 }

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -177,6 +177,12 @@
       "dismiss": "Dismiss",
       "save": "Save",
       "generate": "Generate lesson"
+    },
+    "podcast": {
+      "title": "Podcast 音訊",
+      "create": "建立 Podcast",
+      "generating": "產生中...",
+      "regenerate": "重新產生"
     }
   }
 }

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -223,7 +223,7 @@ export function LearnPage() {
             </div>
           ) : null}
 
-          <LessonDetailView lesson={lesson} />
+          <LessonDetailView lesson={lesson} onLessonUpdate={setLesson} />
         </section>
       )}
     </div>

--- a/frontend/src/pages/LessonDetailPage.tsx
+++ b/frontend/src/pages/LessonDetailPage.tsx
@@ -54,7 +54,7 @@ export function LessonDetailPage() {
           <Loader2 className="size-6 animate-spin text-muted-foreground" />
         </div>
       ) : lesson ? (
-        <LessonDetailView lesson={lesson} />
+        <LessonDetailView lesson={lesson} onLessonUpdate={setLesson} />
       ) : (
         <div className="flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
           <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />


### PR DESCRIPTION
## Summary

Closes #1126.

- Adds a "Create podcast" action to the lesson detail page (`LessonDetailView`, used by both `/learn` and `/learn/library/:id`) that narrates a **completed** lesson via OpenAI TTS, built from the lesson's structured `lesson_detail` fields (gist, explanation, key claims, why it matters) rather than re-summarizing the raw source article.
- New `lessons.podcast_status` (`complete`/`failed`) and `lessons.podcast_error` columns persist generation state so the UI shows create / playable / failed / regenerate states across reloads, not just for the duration of one request.
- New endpoints: `POST /api/learn/lessons/{id}/podcast` (optionally `?force=true` to regenerate) and `GET /api/learn/lessons/{id}/podcast` (serves the cached mp3), following the same auth/ownership rules as the rest of the Learn from Link feature.
- Missing `OPENAI_API_KEY` returns a 503 with a friendly message (consistent with the existing lesson-chat "not configured" convention), persisted so a page reload still shows the friendly error instead of nothing.
- Audio is cached at `$DATA_DIR/audio/lesson-podcast-<id>.mp3`, same storage convention as article/briefing audio.

## Test plan

- [x] `backend/tests/test_tts.py` — new unit tests for `_build_lesson_podcast_text`, `generate_lesson_podcast_audio` (no API key, cache hit/miss, force regenerate, empty-detail error) — mocked OpenAI client, 28/28 passing.
- [x] `backend/tests/test_lesson_podcast.py` (new file) — service + router tests: not found, not-ready (409), not-configured (503, persists failure), success (persists complete, narration built from structured fields), user-scoping, GET audio 404/200 — 12/12 passing.
- [x] `backend/tests/test_learn_from_link.py` + `test_learn_from_link_suggestions.py` — no regressions, 62/62 passing.
- [x] Full backend suite: 2015/2015 passing.
- [x] `frontend/src/__tests__/lessonDetailPage.test.tsx` — new tests for create → playable, error (503 → friendly copy), failed-state banner from persisted lesson, and forced regeneration — 7/7 passing.
- [x] Updated existing `Lesson` fixtures (`learnPage`, `lessonLibraryPage`, `lessonSuggestions` tests) for the new `podcast_status`/`podcast_error` fields — all still passing.
- [x] Full frontend suite: 907/907 passing (includes the locale key-parity test, after adding translated `learn.podcast.*` strings to all 29 locales).
- [x] `ruff`, `mypy`, `ty`, `pyrefly`, `eslint`, `tsc`, `prettier` all pass via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)