### PR TITLE
feat: add weekly learning recap and optional podcast (#1130)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -921,6 +921,22 @@ POSTGRES_MULTIUSER_SCHEMA = [
     " WHERE article_id IS NOT NULL",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_feedback_unique_subject"
     " ON ai_feedback(user_id, subject_type, subject_id) WHERE article_id IS NULL",
+    "ALTER TABLE users ADD COLUMN IF NOT EXISTS lesson_recap_enabled BOOLEAN NOT NULL DEFAULT TRUE",
+    """
+    CREATE TABLE IF NOT EXISTS user_lesson_recaps (
+      id            SERIAL PRIMARY KEY,
+      user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      week_start    DATE NOT NULL,
+      created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      data          JSONB NOT NULL DEFAULT '{}'::jsonb,
+      narrative     TEXT,
+      podcast_status TEXT CHECK(podcast_status IN ('complete','failed')),
+      podcast_error TEXT,
+      UNIQUE (user_id, week_start)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_lesson_recaps_user"
+    " ON user_lesson_recaps(user_id, week_start DESC)",
 ]
 
 # Runs after POSTGRES_SCHEMA/POSTGRES_MULTIUSER_SCHEMA and the embedding_vec

--- a/backend/news_dashboard/lesson_recaps/__init__.py
+++ b/backend/news_dashboard/lesson_recaps/__init__.py
@@ -1,0 +1,1 @@
+"""Weekly learning recap: a digest of lessons created/completed in a week."""

--- a/backend/news_dashboard/lesson_recaps/narrative.py
+++ b/backend/news_dashboard/lesson_recaps/narrative.py
@@ -1,0 +1,75 @@
+"""AI-written weekly learning recap narrative."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _fallback_narrative(recap: dict[str, Any]) -> str:
+    completed = int(recap.get("lessons_completed") or 0)
+    concepts: list[dict[str, Any]] = recap.get("key_concepts") or []
+    top_concept = concepts[0].get("concept") if concepts else None
+
+    if completed <= 0:
+        return "You didn't finish any lessons this week — your next recap is a fresh start."
+    if top_concept:
+        return (
+            f"You completed {completed} lessons this week, with a recurring focus on {top_concept}."
+        )
+    return f"You completed {completed} lessons this week."
+
+
+def generate_lesson_recap_narrative(recap: dict[str, Any]) -> str:
+    """Generate a short AI narrative for a weekly learning recap.
+
+    Takes the recap dict from
+    ``lesson_recaps.service.assemble_weekly_lesson_recap()`` and asks the chat
+    model for a "here's what you learned this week" review grounded strictly
+    in the given metrics. Falls back to a deterministic template sentence if
+    the LLM is not configured or the call fails, matching the
+    graceful-degradation contract of ``recaps.narrative.generate_recap_narrative``.
+    """
+    fallback = _fallback_narrative(recap)
+
+    try:
+        from news_dashboard.ai_client import free_llm_config, get_chat_client
+
+        api_key, base_url = free_llm_config()
+        if not api_key:
+            return fallback
+
+        client = get_chat_client(api_key=api_key, base_url=base_url)
+        model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
+
+        metrics = {k: v for k, v in recap.items() if k != "generated_at"}
+
+        prompt = (
+            "Write a weekly learning review in the voice of 'here's what you "
+            "learned this week', addressed directly to the reader (second "
+            "person). Write exactly 2 short paragraphs, roughly 60-120 words "
+            "total. Ground everything strictly in the metrics below — do not "
+            "invent lessons, concepts, or numbers that are not present in the "
+            "data. Mention repeated themes and unfinished lessons when present.\n\n"
+            f"Recap metrics (JSON):\n{json.dumps(metrics, default=str)}\n\n"
+            "Reply with only the narrative text, as plain paragraphs separated "
+            "by a blank line."
+        )
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=300,
+            temperature=0.7,
+        )
+        narrative = (response.choices[0].message.content or "").strip()
+        if narrative:
+            return narrative
+    except Exception:
+        logger.warning("Lesson recap narrative LLM generation failed; using default message")
+
+    return fallback

--- a/backend/news_dashboard/lesson_recaps/router.py
+++ b/backend/news_dashboard/lesson_recaps/router.py
@@ -1,0 +1,80 @@
+"""HTTP routes for weekly learning recaps.
+
+Mounted on ``main``'s authenticated ``api`` router, which applies
+``require_auth``; handlers still depend on it to receive the current user.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+
+from news_dashboard.auth import require_auth
+from news_dashboard.lesson_recaps import service
+
+router = APIRouter()
+
+
+@router.get("/api/lesson-recaps")
+def list_lesson_recaps_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    limit: Annotated[int, Query(ge=1, le=52)] = 12,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    return {"items": service.list_lesson_recaps(current_user["id"], limit=limit, offset=offset)}
+
+
+@router.get("/api/lesson-recaps/latest")
+def get_latest_lesson_recap_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    recap = service.get_latest_lesson_recap(current_user["id"])
+    if not recap:
+        raise HTTPException(status_code=404, detail="no lesson recap available")
+    return recap
+
+
+@router.post("/api/lesson-recaps/generate")
+def generate_lesson_recap_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    return service.generate_and_save_weekly_lesson_recap(current_user["id"])
+
+
+@router.post("/api/lesson-recaps/{recap_id}/podcast")
+def generate_lesson_recap_podcast_endpoint(
+    recap_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+    force: Annotated[bool, Query()] = False,
+) -> dict[str, Any]:
+    try:
+        return service.generate_lesson_recap_podcast(recap_id, current_user["id"], force=force)
+    except service.LessonRecapNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="lesson recap not found") from exc
+    except service.LessonRecapPodcastNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except service.LessonRecapPodcastGenerationError as exc:
+        raise HTTPException(status_code=500, detail="Could not generate podcast audio.") from exc
+
+
+@router.get("/api/lesson-recaps/{recap_id}/podcast")
+def get_lesson_recap_podcast_endpoint(
+    recap_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> FileResponse:
+    from news_dashboard.tts import _lesson_recap_audio_path
+
+    recap = service.get_lesson_recap(recap_id, current_user["id"])
+    if recap is None:
+        raise HTTPException(status_code=404, detail="lesson recap not found")
+
+    path = _lesson_recap_audio_path(recap_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="podcast audio not generated")
+    return FileResponse(
+        path, media_type="audio/mpeg", filename=f"lesson-recap-{recap_id}-podcast.mp3"
+    )

--- a/backend/news_dashboard/lesson_recaps/service.py
+++ b/backend/news_dashboard/lesson_recaps/service.py
@@ -1,0 +1,318 @@
+"""Weekly learning recap assembly and persistence.
+
+A learning recap summarizes one user's trailing 7-day lesson activity: which
+lessons were created or completed, the concepts and themes that came up
+across them, unfinished lessons still in progress, and notable source
+articles worth revisiting. Persisted so history can be listed via
+``GET /api/lesson-recaps``, mirroring ``news_dashboard.recaps`` for reading
+recaps.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+
+logger = logging.getLogger(__name__)
+
+RECAP_WINDOW_DAYS = 7
+_TOP_CONCEPTS = 8
+_MAX_NOTABLE_ARTICLES = 5
+_MAX_UNFINISHED = 5
+_NOTABLE_VERDICTS = {"read", "study"}
+
+
+class LessonRecapNotFoundError(LookupError):
+    """Raised when a lesson recap does not exist or is not owned by the user."""
+
+
+def assemble_weekly_lesson_recap(
+    user_id: int,
+    now: datetime | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate the trailing 7 days of lesson activity for ``user_id``."""
+    init_db(db_path, database_url=database_url)
+    now = now or datetime.now(timezone.utc)
+    start = now - timedelta(days=RECAP_WINDOW_DAYS)
+
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, title, original_url, source_name, generation_status,
+                   lesson_detail, created_at, updated_at
+            FROM lessons
+            WHERE user_id = %s
+              AND (created_at >= %s
+                   OR (generation_status = 'complete' AND updated_at >= %s))
+            ORDER BY created_at DESC
+            """,
+            (user_id, start, start),
+        ).fetchall()
+    lessons = [dict(r) for r in rows]
+
+    completed = [lesson for lesson in lessons if lesson["generation_status"] == "complete"]
+    unfinished = [lesson for lesson in lessons if lesson["generation_status"] != "complete"]
+
+    return {
+        "week_start": start.date().isoformat(),
+        "week_end": now.date().isoformat(),
+        "generated_at": now.isoformat(),
+        "lessons_touched": len(lessons),
+        "lessons_completed": len(completed),
+        "key_concepts": _top_concepts(completed),
+        "repeated_themes": _repeated_themes(completed),
+        "unfinished_lessons": _unfinished_lessons(unfinished),
+        "notable_articles": _notable_articles(completed),
+    }
+
+
+def _top_concepts(completed: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    counter: Counter[str] = Counter()
+    for lesson in completed:
+        detail = lesson.get("lesson_detail") or {}
+        for raw_concept in detail.get("prerequisite_concepts") or []:
+            concept = str(raw_concept).strip()
+            if concept:
+                counter[concept] += 1
+    return [
+        {"concept": concept, "count": count}
+        for concept, count in counter.most_common(_TOP_CONCEPTS)
+    ]
+
+
+def _repeated_themes(completed: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [entry for entry in _top_concepts(completed) if entry["count"] > 1]
+
+
+def _unfinished_lessons(unfinished: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": lesson["id"],
+            "title": lesson.get("title") or lesson["original_url"],
+            "original_url": lesson["original_url"],
+            "generation_status": lesson["generation_status"],
+        }
+        for lesson in unfinished[:_MAX_UNFINISHED]
+    ]
+
+
+def _notable_articles(completed: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    notable = [
+        lesson
+        for lesson in completed
+        if ((lesson.get("lesson_detail") or {}).get("read_worthiness") or {}).get("verdict")
+        in _NOTABLE_VERDICTS
+    ]
+    return [
+        {
+            "id": lesson["id"],
+            "title": lesson.get("title") or lesson["original_url"],
+            "source_name": lesson.get("source_name"),
+            "verdict": (lesson.get("lesson_detail") or {})
+            .get("read_worthiness", {})
+            .get("verdict"),
+        }
+        for lesson in notable[:_MAX_NOTABLE_ARTICLES]
+    ]
+
+
+def save_weekly_lesson_recap(
+    user_id: int,
+    recap: dict[str, Any],
+    narrative: str | None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Persist a computed recap, upserting on (user_id, week_start)."""
+    init_db(db_path, database_url=database_url)
+    week_start = date.fromisoformat(recap["week_start"])
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO user_lesson_recaps (user_id, week_start, data, narrative)
+            VALUES (%s, %s, %s::jsonb, %s)
+            ON CONFLICT (user_id, week_start)
+            DO UPDATE SET data = EXCLUDED.data, narrative = EXCLUDED.narrative,
+                          podcast_status = NULL, podcast_error = NULL
+            RETURNING id, user_id, week_start, created_at, data, narrative,
+                      podcast_status, podcast_error
+            """,
+            (user_id, week_start, json.dumps(recap), narrative),
+        ).fetchone()
+    result = dict(row)
+    result["data"] = recap
+    return result
+
+
+def list_lesson_recaps(
+    user_id: int,
+    limit: int = 12,
+    offset: int = 0,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, user_id, week_start, created_at, data, narrative,
+                   podcast_status, podcast_error
+            FROM user_lesson_recaps
+            WHERE user_id = %s
+            ORDER BY week_start DESC
+            LIMIT %s OFFSET %s
+            """,
+            (user_id, limit, offset),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_latest_lesson_recap(
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    recaps = list_lesson_recaps(user_id, limit=1, db_path=db_path, database_url=database_url)
+    return recaps[0] if recaps else None
+
+
+def get_lesson_recap(
+    recap_id: int,
+    user_id: int,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any] | None:
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            SELECT id, user_id, week_start, created_at, data, narrative,
+                   podcast_status, podcast_error
+            FROM user_lesson_recaps
+            WHERE id = %s AND user_id = %s
+            """,
+            (recap_id, user_id),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def generate_and_save_weekly_lesson_recap(
+    user_id: int,
+    now: datetime | None = None,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Assemble, narrate, and persist the current week's recap on demand."""
+    from news_dashboard.lesson_recaps.narrative import generate_lesson_recap_narrative
+
+    recap = assemble_weekly_lesson_recap(
+        user_id, now=now, db_path=db_path, database_url=database_url
+    )
+    narrative = generate_lesson_recap_narrative(recap)
+    return save_weekly_lesson_recap(
+        user_id, recap, narrative, db_path=db_path, database_url=database_url
+    )
+
+
+def _update_lesson_recap_podcast_success(
+    recap_id: int,
+    user_id: int,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE user_lesson_recaps
+            SET podcast_status = 'complete', podcast_error = NULL
+            WHERE id = %s AND user_id = %s
+            RETURNING id, user_id, week_start, created_at, data, narrative,
+                      podcast_status, podcast_error
+            """,
+            (recap_id, user_id),
+        ).fetchone()
+    if row is None:
+        raise LessonRecapNotFoundError
+    return dict(row)
+
+
+def _update_lesson_recap_podcast_failure(
+    recap_id: int,
+    user_id: int,
+    error_message: str,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            UPDATE user_lesson_recaps
+            SET podcast_status = 'failed', podcast_error = %s
+            WHERE id = %s AND user_id = %s
+            RETURNING id, user_id, week_start, created_at, data, narrative,
+                      podcast_status, podcast_error
+            """,
+            (error_message, recap_id, user_id),
+        ).fetchone()
+    if row is None:
+        raise LessonRecapNotFoundError
+    return dict(row)
+
+
+class LessonRecapPodcastNotConfiguredError(RuntimeError):
+    """Raised when podcast audio synthesis has no configured API key."""
+
+
+class LessonRecapPodcastGenerationError(RuntimeError):
+    """Raised when podcast audio synthesis fails unexpectedly."""
+
+
+def generate_lesson_recap_podcast(
+    recap_id: int,
+    user_id: int,
+    *,
+    force: bool = False,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Generate (or return cached) spoken narration audio for a lesson recap."""
+    recap = get_lesson_recap(recap_id, user_id, database_url=database_url)
+    if recap is None:
+        raise LessonRecapNotFoundError
+
+    from news_dashboard.tts import TTSNotConfiguredError, generate_lesson_recap_podcast_audio
+
+    try:
+        generate_lesson_recap_podcast_audio(
+            recap_id,
+            recap["narrative"] or "",
+            recap["data"],
+            force=force,
+        )
+    except TTSNotConfiguredError as exc:
+        _update_lesson_recap_podcast_failure(recap_id, user_id, str(exc), database_url=database_url)
+        raise LessonRecapPodcastNotConfiguredError(str(exc)) from exc
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "lesson recap podcast audio generation failed for recap %d: %s", recap_id, exc
+        )
+        _update_lesson_recap_podcast_failure(
+            recap_id,
+            user_id,
+            "Could not generate podcast audio.",
+            database_url=database_url,
+        )
+        raise LessonRecapPodcastGenerationError from exc
+
+    return _update_lesson_recap_podcast_success(recap_id, user_id, database_url=database_url)

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -3145,6 +3145,7 @@ from news_dashboard.ai_stats.router import router as ai_stats_router  # noqa: E4
 from news_dashboard.greader import public_greader_router  # noqa: E402
 from news_dashboard.greader import router as greader_router  # noqa: E402
 from news_dashboard.learn_from_link.router import router as learn_from_link_router  # noqa: E402
+from news_dashboard.lesson_recaps.router import router as lesson_recaps_router  # noqa: E402
 from news_dashboard.mcp.router import public_mcp_router  # noqa: E402
 from news_dashboard.mcp.router import router as mcp_router  # noqa: E402
 from news_dashboard.personalization.router import router as personalization_router  # noqa: E402
@@ -3160,6 +3161,7 @@ api.include_router(ai_stats_router)
 api.include_router(ai_memory_router)
 api.include_router(greader_router)
 api.include_router(learn_from_link_router)
+api.include_router(lesson_recaps_router)
 api.include_router(mcp_router)
 api.include_router(personalization_router)
 api.include_router(quizzes_router)

--- a/backend/news_dashboard/scheduler.py
+++ b/backend/news_dashboard/scheduler.py
@@ -308,6 +308,80 @@ def _run_weekly_recaps() -> tuple[str, str | None] | None:
     return status, msg
 
 
+def _generate_lesson_recap_for_user(user_id: int) -> bool:
+    """Assemble and persist a weekly learning recap for one user."""
+    from news_dashboard.lesson_recaps.narrative import generate_lesson_recap_narrative
+    from news_dashboard.lesson_recaps.service import (
+        assemble_weekly_lesson_recap,
+        save_weekly_lesson_recap,
+    )
+
+    logger.info("Weekly lesson recap: generating for user_id=%s", user_id)
+    try:
+        recap = assemble_weekly_lesson_recap(user_id)
+        narrative = generate_lesson_recap_narrative(recap)
+        saved = save_weekly_lesson_recap(user_id, recap, narrative)
+        logger.info("Weekly lesson recap: complete for user_id=%s id=%s", user_id, saved.get("id"))
+        return True
+    except Exception:
+        logger.exception("Weekly lesson recap: unexpected error for user_id=%s", user_id)
+        return False
+
+
+def _run_weekly_lesson_recaps() -> tuple[str, str | None] | None:
+    """Generate weekly lesson recaps for users whose local scheduled day/time matches now.
+
+    Reuses each user's ``recap_day``/``briefing_time``/``briefing_timezone``
+    cadence settings, gated by the separate ``lesson_recap_enabled`` flag, so
+    learning recaps land alongside reading recaps without adding a second set
+    of scheduling controls. Returns None when no users are scheduled this
+    minute so the run is not recorded.
+    """
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    from news_dashboard.db import connect, row_to_dict
+
+    now = datetime.now(timezone.utc)
+
+    try:
+        with connect() as conn:
+            rows = conn.execute(
+                "SELECT id, recap_day, briefing_time, briefing_timezone"
+                " FROM users WHERE lesson_recap_enabled = TRUE",
+            ).fetchall()
+        user_rows = [row_to_dict(r) for r in rows]
+    except Exception as exc:
+        logger.exception("Weekly lesson recap: failed to query users")
+        return "failure", str(exc)[:500]
+
+    scheduled_users: list[int] = []
+    for row in user_rows:
+        tz_name: str = row.get("briefing_timezone") or "UTC"
+        recap_time: str = row.get("briefing_time") or "09:00"
+        recap_day: str = row.get("recap_day") or "mon"
+        try:
+            tz = ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, KeyError):
+            tz = ZoneInfo("UTC")
+        local_now = now.astimezone(tz)
+        day_matches = local_now.strftime("%a").lower() == recap_day
+        time_matches = local_now.strftime("%H:%M") == recap_time
+        if day_matches and time_matches:
+            scheduled_users.append(int(row["id"]))
+
+    if not scheduled_users:
+        return None  # nothing scheduled this minute — skip recording
+
+    results = [_generate_lesson_recap_for_user(uid) for uid in scheduled_users]
+    succeeded = sum(1 for ok in results if ok)
+    failed = len(results) - succeeded
+    total = len(scheduled_users)
+    noun = "user" if total == 1 else "users"
+    msg = f"{total} {noun} targeted, {succeeded} succeeded, {failed} failed"
+    status = "failure" if failed == total else "success"
+    return status, msg
+
+
 def _run_digest() -> tuple[str, str | None]:
     from news_dashboard.digest import send_digest
 
@@ -467,6 +541,10 @@ def _job_weekly_recaps() -> None:
     _run_and_record("weekly_recaps", _run_weekly_recaps)
 
 
+def _job_weekly_lesson_recaps() -> None:
+    _run_and_record("weekly_lesson_recaps", _run_weekly_lesson_recaps)
+
+
 def _job_reading_list_fetch() -> None:
     _run_and_record("reading_list_fetch", _run_reading_list_fetch)
 
@@ -549,6 +627,14 @@ def _register_recurring_jobs(scheduler: Any) -> None:
         trigger="interval",
         minutes=1,
         id="weekly_recaps",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _job_weekly_lesson_recaps,
+        trigger="interval",
+        minutes=1,
+        id="weekly_lesson_recaps",
         replace_existing=True,
     )
 

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -351,3 +351,70 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
         )
 
     return valid_script
+
+
+def _lesson_recap_audio_path(recap_id: int, data_dir: Path | None = None) -> Path:
+    base = data_dir if data_dir is not None else _data_dir()
+    # int() coerces recap_id to a plain digit string, so it cannot carry
+    # path-traversal or separator characters into the constructed path.
+    return base / "audio" / f"lesson-recap-podcast-{int(recap_id)}.mp3"
+
+
+def _build_lesson_recap_podcast_text(narrative: str, recap_data: dict[str, Any]) -> str:
+    concepts = [str(c.get("concept")) for c in recap_data.get("key_concepts") or []]
+    notable = [str(a.get("title")) for a in recap_data.get("notable_articles") or []]
+
+    parts = [narrative]
+    if concepts:
+        parts.append("Key concepts this week: " + ", ".join(concepts))
+    if notable:
+        parts.append("Notable articles: " + ", ".join(notable))
+    return "\n\n".join(part for part in parts if part.strip())
+
+
+def generate_lesson_recap_podcast_audio(
+    recap_id: int,
+    narrative: str,
+    recap_data: dict[str, Any],
+    *,
+    force: bool = False,
+    data_dir: Path | None = None,
+) -> Path:
+    """Return path to cached lesson recap podcast MP3, generating it if needed.
+
+    Narration is built from the recap's narrative plus key concepts and
+    notable articles, so the audio stays consistent with what's shown on the
+    recap page.
+
+    Raises TTSNotConfiguredError when OPENAI_API_KEY is absent.
+    """
+    api_key, base_url = _tts_ai_config()
+
+    path = _lesson_recap_audio_path(recap_id, data_dir)
+    if force and path.exists():
+        path.unlink()
+    if path.exists():
+        logger.debug("Lesson recap podcast cache hit for recap %d", recap_id)
+        return path
+
+    text = _build_lesson_recap_podcast_text(narrative, recap_data)
+    if not text.strip():
+        msg = "recap has no readable content to narrate"
+        raise ValueError(msg)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    from news_dashboard.ai_client import get_openai_client, tts_timeout_seconds
+
+    client = get_openai_client(
+        api_key=api_key, base_url=base_url, timeout_seconds=tts_timeout_seconds()
+    )
+    logger.info(
+        "Generating lesson recap podcast audio for recap %d (%d chars)", recap_id, len(text)
+    )
+    with client.audio.speech.with_streaming_response.create(
+        model=_PODCAST_MODEL, voice=_ALEX_VOICE, input=text[:_MAX_CHARS]
+    ) as response:
+        response.stream_to_file(path)
+    logger.info("Lesson recap podcast audio cached at %s", path)
+    return path

--- a/backend/tests/test_lesson_recap_narrative.py
+++ b/backend/tests/test_lesson_recap_narrative.py
@@ -1,0 +1,82 @@
+"""Tests for the AI weekly learning recap narrative generator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_dashboard.lesson_recaps.narrative import generate_lesson_recap_narrative
+
+
+def _make_recap(**overrides: object) -> dict[str, object]:
+    recap: dict[str, object] = {
+        "week_start": "2026-06-22",
+        "week_end": "2026-06-29",
+        "generated_at": "2026-06-29T09:00:00+00:00",
+        "lessons_touched": 4,
+        "lessons_completed": 3,
+        "key_concepts": [{"concept": "gradient descent", "count": 2}],
+        "repeated_themes": [{"concept": "gradient descent", "count": 2}],
+        "unfinished_lessons": [],
+        "notable_articles": [{"id": 1, "title": "Backprop Explained", "source_name": "Example"}],
+    }
+    recap.update(overrides)
+    return recap
+
+
+def test_generate_lesson_recap_narrative_falls_back_when_no_api_key() -> None:
+    with patch("news_dashboard.ai_client.free_llm_config", return_value=("", None)):
+        result = generate_lesson_recap_narrative(_make_recap())
+
+    assert "3" in result
+
+
+def test_generate_lesson_recap_narrative_falls_back_with_zero_lessons() -> None:
+    with patch("news_dashboard.ai_client.free_llm_config", return_value=("", None)):
+        result = generate_lesson_recap_narrative(_make_recap(lessons_completed=0, key_concepts=[]))
+
+    assert result
+    assert "didn't finish" in result
+
+
+def test_generate_lesson_recap_narrative_returns_llm_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+
+    narrative_text = (
+        "You completed 3 lessons this week, circling back to gradient descent.\n\n"
+        "Consider finishing your remaining lesson to close out the trail."
+    )
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content=narrative_text))]
+    )
+
+    with (
+        patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+    ):
+        result = generate_lesson_recap_narrative(_make_recap())
+
+    assert result == narrative_text
+    mock_client.chat.completions.create.assert_called_once()
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert "gradient descent" in call_kwargs["messages"][0]["content"]
+
+
+def test_generate_lesson_recap_narrative_falls_back_on_llm_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError("LLM unavailable")
+
+    with (
+        patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+    ):
+        result = generate_lesson_recap_narrative(_make_recap())
+
+    assert "3" in result
+    mock_client.chat.completions.create.assert_called_once()

--- a/backend/tests/test_lesson_recaps.py
+++ b/backend/tests/test_lesson_recaps.py
@@ -1,0 +1,525 @@
+"""Tests for weekly learning recap assembly, persistence, and podcast audio."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.lesson_recaps import service
+from news_dashboard.main import app
+
+pytestmark = pytest.mark.postgres
+
+
+def _setup_db(monkeypatch: Any, pg_url: str) -> str:
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    init_db(database_url=pg_url)
+    return pg_url
+
+
+def _make_user(db_path: str, username: str = "alice") -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _insert_lesson(
+    db_path: str,
+    user_id: int,
+    *,
+    url: str,
+    title: str,
+    generation_status: str = "complete",
+    lesson_detail: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
+) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO lessons(
+              user_id, original_url, normalized_url, title, source_name,
+              generation_status, lesson_detail, created_at, updated_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s)
+            RETURNING id
+            """,
+            (
+                user_id,
+                url,
+                url,
+                title,
+                "Example Source",
+                generation_status,
+                json.dumps(lesson_detail) if lesson_detail is not None else None,
+                created_at or datetime.now(timezone.utc),
+                created_at or datetime.now(timezone.utc),
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _detail(concepts: list[str] | None = None, verdict: str = "read") -> dict[str, Any]:
+    return {
+        "gist": "A short summary.",
+        "explanation": "A longer explanation.",
+        "key_claims": ["Claim one"],
+        "prerequisite_concepts": concepts or [],
+        "why_it_matters": "It matters because...",
+        "read_worthiness": {"verdict": verdict, "rationale": "Solid source."},
+        "who_should_read": [],
+        "questions_to_keep_in_mind": [],
+        "citations": [],
+    }
+
+
+# ── assemble_weekly_lesson_recap ──────────────────────────────────────────────
+
+
+def test_assemble_weekly_lesson_recap_empty_week_returns_zeroed_recap(
+    monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    now = datetime.now(timezone.utc)
+
+    recap = service.assemble_weekly_lesson_recap(user_id, now=now, database_url=db_path)
+
+    assert recap["lessons_touched"] == 0
+    assert recap["lessons_completed"] == 0
+    assert recap["key_concepts"] == []
+    assert recap["repeated_themes"] == []
+    assert recap["unfinished_lessons"] == []
+    assert recap["notable_articles"] == []
+
+
+def test_assemble_weekly_lesson_recap_counts_within_window(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    now = datetime.now(timezone.utc)
+    stale = now - timedelta(days=30)
+
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/a",
+        title="Lesson A",
+        lesson_detail=_detail(["gradient descent", "backprop"]),
+        created_at=now,
+    )
+    # Outside the 7-day window: must not be counted.
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/old",
+        title="Old Lesson",
+        lesson_detail=_detail(["gradient descent"]),
+        created_at=stale,
+    )
+
+    recap = service.assemble_weekly_lesson_recap(user_id, now=now, database_url=db_path)
+
+    assert recap["lessons_touched"] == 1
+    assert recap["lessons_completed"] == 1
+
+
+def test_assemble_weekly_lesson_recap_key_concepts_and_themes(
+    monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    now = datetime.now(timezone.utc)
+
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/a",
+        title="Lesson A",
+        lesson_detail=_detail(["gradient descent", "backprop"]),
+        created_at=now,
+    )
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/b",
+        title="Lesson B",
+        lesson_detail=_detail(["gradient descent"]),
+        created_at=now,
+    )
+
+    recap = service.assemble_weekly_lesson_recap(user_id, now=now, database_url=db_path)
+
+    concepts = {entry["concept"]: entry["count"] for entry in recap["key_concepts"]}
+    assert concepts["gradient descent"] == 2
+    assert concepts["backprop"] == 1
+    themes = {entry["concept"] for entry in recap["repeated_themes"]}
+    assert themes == {"gradient descent"}
+
+
+def test_assemble_weekly_lesson_recap_unfinished_and_notable(
+    monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    now = datetime.now(timezone.utc)
+
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/pending",
+        title="Still Pending",
+        generation_status="pending",
+        lesson_detail=None,
+        created_at=now,
+    )
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/skip",
+        title="Skip This",
+        lesson_detail=_detail(verdict="skip"),
+        created_at=now,
+    )
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/study",
+        title="Study This",
+        lesson_detail=_detail(verdict="study"),
+        created_at=now,
+    )
+
+    recap = service.assemble_weekly_lesson_recap(user_id, now=now, database_url=db_path)
+
+    assert len(recap["unfinished_lessons"]) == 1
+    assert recap["unfinished_lessons"][0]["title"] == "Still Pending"
+    assert len(recap["notable_articles"]) == 1
+    assert recap["notable_articles"][0]["title"] == "Study This"
+
+
+# ── save / list / get ─────────────────────────────────────────────────────────
+
+
+def test_save_and_list_lesson_recaps_upserts_by_week(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = {
+        "week_start": "2026-06-22",
+        "week_end": "2026-06-29",
+        "generated_at": "2026-06-29T00:00:00+00:00",
+        "lessons_touched": 2,
+        "lessons_completed": 2,
+        "key_concepts": [],
+        "repeated_themes": [],
+        "unfinished_lessons": [],
+        "notable_articles": [],
+    }
+
+    saved = service.save_weekly_lesson_recap(
+        user_id, recap, "Great learning week!", database_url=db_path
+    )
+    assert saved["narrative"] == "Great learning week!"
+    assert saved["data"]["lessons_completed"] == 2
+
+    updated = dict(recap, lessons_completed=5)
+    service.save_weekly_lesson_recap(user_id, updated, "Even better!", database_url=db_path)
+
+    recaps = service.list_lesson_recaps(user_id, database_url=db_path)
+    assert len(recaps) == 1
+    assert recaps[0]["data"]["lessons_completed"] == 5
+    assert recaps[0]["narrative"] == "Even better!"
+
+
+def test_get_latest_lesson_recap_returns_none_when_empty(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+
+    assert service.get_latest_lesson_recap(user_id, database_url=db_path) is None
+
+
+# ── router endpoints ──────────────────────────────────────────────────────────
+
+
+def test_lesson_recaps_endpoint_returns_saved_history(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = {
+        "week_start": "2026-06-22",
+        "week_end": "2026-06-29",
+        "generated_at": "2026-06-29T00:00:00+00:00",
+        "lessons_touched": 3,
+        "lessons_completed": 3,
+        "key_concepts": [],
+        "repeated_themes": [],
+        "unfinished_lessons": [],
+        "notable_articles": [],
+    }
+    service.save_weekly_lesson_recap(user_id, recap, "Nice learning week", database_url=db_path)
+
+    try:
+        with _client_for(user_id) as client:
+            list_response = client.get("/api/lesson-recaps")
+            latest_response = client.get("/api/lesson-recaps/latest")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert list_response.status_code == 200
+    items = list_response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["data"]["lessons_completed"] == 3
+
+    assert latest_response.status_code == 200
+    assert latest_response.json()["narrative"] == "Nice learning week"
+
+
+def test_lesson_recaps_latest_endpoint_404_when_none(monkeypatch: Any, pg_clean: str) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.get("/api/lesson-recaps/latest")
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 404
+
+
+def test_generate_lesson_recap_endpoint_assembles_and_persists(
+    monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    _insert_lesson(
+        db_path,
+        user_id,
+        url="https://example.com/a",
+        title="Lesson A",
+        lesson_detail=_detail(["gradient descent"]),
+    )
+
+    with patch("news_dashboard.ai_client.free_llm_config", return_value=("", None)):
+        try:
+            with _client_for(user_id) as client:
+                response = client.post("/api/lesson-recaps/generate")
+        finally:
+            app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["lessons_completed"] == 1
+    assert body["narrative"]
+
+
+# ── podcast audio ──────────────────────────────────────────────────────────────
+
+
+@contextmanager
+def _api_client(user_id: int) -> Generator[TestClient]:
+    fake_user = {"id": user_id, "username": "alice", "email": None, "is_admin": False}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+
+def _mock_audio_client() -> MagicMock:
+    mock_response = MagicMock()
+
+    def fake_stream(path: Path) -> None:
+        path.write_bytes(b"fake-mp3-data")
+
+    mock_response.stream_to_file.side_effect = fake_stream
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.audio.speech.with_streaming_response.create.return_value = mock_response
+    return mock_client
+
+
+def _saved_recap(db_path: str, user_id: int) -> dict[str, Any]:
+    recap = {
+        "week_start": "2026-06-22",
+        "week_end": "2026-06-29",
+        "generated_at": "2026-06-29T00:00:00+00:00",
+        "lessons_touched": 1,
+        "lessons_completed": 1,
+        "key_concepts": [{"concept": "gradient descent", "count": 1}],
+        "repeated_themes": [],
+        "unfinished_lessons": [],
+        "notable_articles": [{"id": 1, "title": "Backprop Explained", "source_name": "Example"}],
+    }
+    return service.save_weekly_lesson_recap(
+        user_id, recap, "You completed 1 lesson this week.", database_url=db_path
+    )
+
+
+def test_generate_lesson_recap_podcast_raises_not_found(pg_clean: str) -> None:
+    with pytest.raises(service.LessonRecapNotFoundError):
+        service.generate_lesson_recap_podcast(999, 1, database_url=pg_clean)
+
+
+def test_generate_lesson_recap_podcast_raises_not_configured_and_persists_failure(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str, tmp_path: Path
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = _saved_recap(db_path, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(service.LessonRecapPodcastNotConfiguredError):
+        service.generate_lesson_recap_podcast(int(recap["id"]), user_id, database_url=db_path)
+
+    persisted = service.get_lesson_recap(int(recap["id"]), user_id, database_url=db_path)
+    assert persisted is not None
+    assert persisted["podcast_status"] == "failed"
+    assert persisted["podcast_error"]
+
+
+def test_generate_lesson_recap_podcast_succeeds_and_persists_complete(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str, tmp_path: Path
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = _saved_recap(db_path, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with patch("openai.OpenAI", return_value=mock_client):
+        result = service.generate_lesson_recap_podcast(
+            int(recap["id"]), user_id, database_url=db_path
+        )
+
+    assert result["podcast_status"] == "complete"
+    assert result["podcast_error"] is None
+    mock_client.audio.speech.with_streaming_response.create.assert_called_once()
+
+
+def test_generate_lesson_recap_podcast_endpoint_returns_complete(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str, tmp_path: Path
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = _saved_recap(db_path, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with (
+        patch("openai.OpenAI", return_value=mock_client),
+        _api_client(user_id) as client,
+    ):
+        response = client.post(f"/api/lesson-recaps/{recap['id']}/podcast")
+
+    assert response.status_code == 200
+    assert response.json()["podcast_status"] == "complete"
+
+
+def test_generate_lesson_recap_podcast_endpoint_404s_for_missing_recap(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+
+    with _api_client(user_id) as client:
+        response = client.post("/api/lesson-recaps/999999/podcast")
+
+    assert response.status_code == 404
+
+
+def test_generate_lesson_recap_podcast_endpoint_503s_when_not_configured(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str, tmp_path: Path
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = _saved_recap(db_path, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with _api_client(user_id) as client:
+        response = client.post(f"/api/lesson-recaps/{recap['id']}/podcast")
+
+    assert response.status_code == 503
+
+
+def test_get_lesson_recap_podcast_endpoint_404s_before_generation(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str, tmp_path: Path
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = _saved_recap(db_path, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    with _api_client(user_id) as client:
+        response = client.get(f"/api/lesson-recaps/{recap['id']}/podcast")
+
+    assert response.status_code == 404
+
+
+def test_get_lesson_recap_podcast_endpoint_serves_generated_audio(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str, tmp_path: Path
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path)
+    recap = _saved_recap(db_path, user_id)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with patch("openai.OpenAI", return_value=mock_client):
+        service.generate_lesson_recap_podcast(int(recap["id"]), user_id, database_url=db_path)
+
+    with _api_client(user_id) as client:
+        response = client.get(f"/api/lesson-recaps/{recap['id']}/podcast")
+
+    assert response.status_code == 200
+    assert response.content == b"fake-mp3-data"
+
+
+def test_get_lesson_recap_podcast_endpoint_404s_for_other_user(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str, tmp_path: Path
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    alice = _make_user(db_path, "alice")
+    bob = _make_user(db_path, "bob")
+    recap = _saved_recap(db_path, alice)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    mock_client = _mock_audio_client()
+    with patch("openai.OpenAI", return_value=mock_client):
+        service.generate_lesson_recap_podcast(int(recap["id"]), alice, database_url=db_path)
+
+    with _api_client(bob) as client:
+        response = client.get(f"/api/lesson-recaps/{recap['id']}/podcast")
+
+    assert response.status_code == 404

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -14,7 +14,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from news_dashboard.briefings import BriefingAINotConfiguredError, BriefingGenerationError
-from news_dashboard.scheduler import _run_briefing, _run_per_user_briefings, _run_weekly_recaps
+from news_dashboard.scheduler import (
+    _run_briefing,
+    _run_per_user_briefings,
+    _run_weekly_lesson_recaps,
+    _run_weekly_recaps,
+)
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -280,6 +285,71 @@ def test_run_weekly_recaps_returns_none_when_no_users_scheduled() -> None:
     ):
         mock_dt.now.return_value = now
         result = _run_weekly_recaps()
+
+    assert result is None
+
+
+# ── _run_weekly_lesson_recaps ─────────────────────────────────────────────────
+
+
+def test_run_weekly_lesson_recaps_generates_when_enabled() -> None:
+    fake_conn = _FakeRowsConn(
+        [
+            {
+                "id": 42,
+                "recap_day": "mon",
+                "briefing_time": "09:00",
+                "briefing_timezone": "UTC",
+            }
+        ]
+    )
+    now = datetime(2026, 6, 29, 9, 0, 0, tzinfo=timezone.utc)
+    recap = {"lessons_completed": 2, "key_concepts": []}
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch("news_dashboard.db.connect", return_value=fake_conn),
+        patch(
+            "news_dashboard.lesson_recaps.service.assemble_weekly_lesson_recap",
+            return_value=recap,
+        ) as assemble,
+        patch(
+            "news_dashboard.lesson_recaps.service.save_weekly_lesson_recap",
+            return_value={"id": 1, **recap},
+        ) as save,
+        patch(
+            "news_dashboard.lesson_recaps.narrative.generate_lesson_recap_narrative",
+            return_value="You learned things...",
+        ) as narrative,
+    ):
+        mock_dt.now.return_value = now
+        _run_weekly_lesson_recaps()
+
+    assert "lesson_recap_enabled" in fake_conn.sql
+    assemble.assert_called_once_with(42)
+    narrative.assert_called_once_with(recap)
+    save.assert_called_once_with(42, recap, "You learned things...")
+
+
+def test_run_weekly_lesson_recaps_returns_none_when_no_users_scheduled() -> None:
+    fake_conn = _FakeRowsConn(
+        [
+            {
+                "id": 42,
+                "recap_day": "tue",
+                "briefing_time": "09:00",
+                "briefing_timezone": "UTC",
+            }
+        ]
+    )
+    now = datetime(2026, 6, 29, 9, 0, 0, tzinfo=timezone.utc)  # a Monday
+
+    with (
+        patch("news_dashboard.scheduler.datetime") as mock_dt,
+        patch("news_dashboard.db.connect", return_value=fake_conn),
+    ):
+        mock_dt.now.return_value = now
+        result = _run_weekly_lesson_recaps()
 
     assert result is None
 

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -71,6 +71,9 @@ const LessonDetailPage = lazy(() =>
 const WeeklyRecapPage = lazy(() =>
   import('./pages/WeeklyRecapPage').then((m) => ({ default: m.WeeklyRecapPage }))
 );
+const LessonRecapPage = lazy(() =>
+  import('./pages/LessonRecapPage').then((m) => ({ default: m.LessonRecapPage }))
+);
 const SettingsPage = lazy(() =>
   import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage }))
 );
@@ -233,6 +236,7 @@ export const routes: RouteObject[] = [
       { path: 'reading-list', element: withSuspense(ReadingListPage) },
       { path: 'learn', element: withSuspense(LearnPage) },
       { path: 'learn/library', element: withSuspense(LessonLibraryPage) },
+      { path: 'learn/recap', element: withSuspense(LessonRecapPage) },
       { path: 'learn/:id', element: withSuspense(LessonDetailPage) },
       { path: 'offline-saved', element: withSuspense(OfflineSavedPage) },
       { path: 'recap', element: withSuspense(WeeklyRecapPage) },

--- a/frontend/src/__tests__/lessonRecapPage.test.tsx
+++ b/frontend/src/__tests__/lessonRecapPage.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import * as api from '../api';
+import { LessonRecapPage } from '../pages/LessonRecapPage';
+import type { LessonRecap } from '../types';
+
+vi.mock('../api', () => ({
+  fetchLessonRecaps: vi.fn(),
+  generateLessonRecap: vi.fn(),
+  generateLessonRecapPodcast: vi.fn(),
+}));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+const RECAP: LessonRecap = {
+  id: 1,
+  user_id: 1,
+  week_start: '2026-06-29',
+  created_at: '2026-07-06T00:00:00+00:00',
+  narrative: 'You completed 2 lessons this week, mostly about gradient descent.',
+  podcast_status: null,
+  podcast_error: null,
+  data: {
+    week_start: '2026-06-29',
+    week_end: '2026-07-06',
+    generated_at: '2026-07-06T00:00:00+00:00',
+    lessons_touched: 3,
+    lessons_completed: 2,
+    key_concepts: [{ concept: 'gradient descent', count: 2 }],
+    repeated_themes: [{ concept: 'gradient descent', count: 2 }],
+    unfinished_lessons: [
+      {
+        id: 9,
+        title: 'Still Pending',
+        original_url: 'https://example.com/pending',
+        generation_status: 'pending',
+      },
+    ],
+    notable_articles: [
+      { id: 5, title: 'Backprop Explained', source_name: 'Example Source', verdict: 'study' },
+    ],
+  },
+};
+
+const EMPTY_RECAP: LessonRecap = {
+  ...RECAP,
+  id: 2,
+  narrative: null,
+  data: {
+    ...RECAP.data,
+    lessons_touched: 0,
+    lessons_completed: 0,
+    key_concepts: [],
+    repeated_themes: [],
+    unfinished_lessons: [],
+    notable_articles: [],
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('LessonRecapPage', () => {
+  it('renders key concepts, unfinished lessons, and notable articles', async () => {
+    vi.mocked(api.fetchLessonRecaps).mockResolvedValue([RECAP]);
+    render(<LessonRecapPage />, { wrapper: Wrapper });
+
+    await screen.findByText('Key concepts');
+    expect(screen.getAllByText('gradient descent').length).toBeGreaterThan(0);
+    expect(screen.getByText('Still Pending')).toBeInTheDocument();
+    expect(screen.getByText('Backprop Explained')).toBeInTheDocument();
+    expect(
+      screen.getByText('You completed 2 lessons this week, mostly about gradient descent.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there is no recap yet', async () => {
+    vi.mocked(api.fetchLessonRecaps).mockResolvedValue([]);
+    render(<LessonRecapPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'No recap yet — finish a lesson this week, then check back or generate one now.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('does not render a podcast player when podcast audio has not been generated', async () => {
+    vi.mocked(api.fetchLessonRecaps).mockResolvedValue([EMPTY_RECAP]);
+    render(<LessonRecapPage />, { wrapper: Wrapper });
+
+    await screen.findByText('Podcast audio');
+    expect(screen.getByText('Create podcast')).toBeInTheDocument();
+    expect(screen.queryByRole('audio')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unfinished lessons')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notable articles')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -1,3 +1,4 @@
+import type { LessonRecap } from '../types';
 import { requestJson } from './core';
 
 export type LessonDepth = 'tiny' | 'normal' | 'deep' | 'expert';
@@ -192,4 +193,23 @@ export async function dismissLessonSuggestion(
     method: 'POST',
     body: JSON.stringify({ article_id: articleId }),
   });
+}
+
+export async function fetchLessonRecaps(): Promise<LessonRecap[]> {
+  const { items } = await requestJson<{ items: LessonRecap[] }>('/api/lesson-recaps');
+  return items;
+}
+
+export async function generateLessonRecap(): Promise<LessonRecap> {
+  return requestJson<LessonRecap>('/api/lesson-recaps/generate', { method: 'POST' });
+}
+
+export async function generateLessonRecapPodcast(
+  recapId: number,
+  force = false
+): Promise<LessonRecap> {
+  return requestJson<LessonRecap>(
+    `/api/lesson-recaps/${recapId}/podcast${force ? '?force=true' : ''}`,
+    { method: 'POST' }
+  );
 }

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -13,6 +13,7 @@ import {
   Library,
   Network,
   Newspaper,
+  Podcast,
   Radio,
   Search,
   Send,
@@ -72,6 +73,12 @@ export const secondaryNavigationItems: NavigationItem[] = [
     label: 'Lesson Library',
     labelKey: 'nav.lesson_library',
     icon: Library,
+  },
+  {
+    to: '/learn/recap',
+    label: 'Learning Recap',
+    labelKey: 'nav.learning_recap',
+    icon: Podcast,
   },
   {
     to: '/offline-saved',
@@ -203,6 +210,11 @@ const pageTitleRules: { test: (pathname: string) => boolean; en: string; key: st
     test: (p) => p.startsWith('/learn/library'),
     en: 'Lesson Library',
     key: 'page_title.lesson_library',
+  },
+  {
+    test: (p) => p.startsWith('/learn/recap'),
+    en: 'Learning Recap',
+    key: 'page_title.learning_recap',
   },
   {
     test: (p) => p.startsWith('/learn'),

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -47,7 +47,8 @@
     "users": "المستخدمون",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "الموجز",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "غير متصل",

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -47,7 +47,8 @@
     "users": "Uživatelé",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Přehled",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -47,7 +47,8 @@
     "users": "Brugere",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Overblik",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -47,7 +47,8 @@
     "users": "Benutzer",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Übersicht",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -47,7 +47,8 @@
     "users": "Χρήστες",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Σύνοψη",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Εκτός σύνδεσης",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -47,7 +47,8 @@
     "users": "Users",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Brief",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -47,7 +47,8 @@
     "users": "Usuarios",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Resumen",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Sin conexión",

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -47,7 +47,8 @@
     "users": "Käyttäjät",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Yhteenveto",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -47,7 +47,8 @@
     "users": "Utilisateurs",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Résumé",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Hors ligne",

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -47,7 +47,8 @@
     "users": "משתמשים",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "תקציר",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "לא מקוון",

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -47,7 +47,8 @@
     "users": "उपयोगकर्ता",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "ब्रीफ़",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "ऑफ़लाइन",

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -47,7 +47,8 @@
     "users": "Felhasználók",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Összefoglaló",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -47,7 +47,8 @@
     "users": "Pengguna",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Ringkasan",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -47,7 +47,8 @@
     "users": "Utenti",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Riepilogo",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -47,7 +47,8 @@
     "users": "ユーザー",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "ブリーフ",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "オフライン",

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -47,7 +47,8 @@
     "users": "사용자",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "브리핑",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "오프라인",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -47,7 +47,8 @@
     "users": "Gebruikers",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Overzicht",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -47,7 +47,8 @@
     "users": "Brukere",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Oversikt",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Frakoblet",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -47,7 +47,8 @@
     "users": "Użytkownicy",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Podsumowanie",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -47,7 +47,8 @@
     "users": "Usuários",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Resumo",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -47,7 +47,8 @@
     "users": "Utilizatori",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Rezumat",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -47,7 +47,8 @@
     "users": "Пользователи",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Сводка",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Нет сети",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -47,7 +47,8 @@
     "users": "Användare",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Överblick",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Offline",

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -47,7 +47,8 @@
     "users": "ผู้ใช้",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "สรุปข่าว",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "ออฟไลน์",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -47,7 +47,8 @@
     "users": "Kullanıcılar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Özet",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Çevrimdışı",

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -47,7 +47,8 @@
     "users": "Користувачі",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Огляд",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Офлайн",

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -47,7 +47,8 @@
     "users": "Người dùng",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "Tóm tắt",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "Ngoại tuyến",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -47,7 +47,8 @@
     "users": "用户",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "简报",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "离线",

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -47,7 +47,8 @@
     "users": "使用者",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "page_title": {
     "brief": "簡報",
@@ -73,7 +74,8 @@
     "default": "Radar",
     "offline_saved": "Offline Saved",
     "learn": "Learn",
-    "lesson_library": "Lesson Library"
+    "lesson_library": "Lesson Library",
+    "learning_recap": "Learning Recap"
   },
   "shell": {
     "offline": "離線",

--- a/frontend/src/pages/LessonRecapPage.tsx
+++ b/frontend/src/pages/LessonRecapPage.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertCircle, GraduationCap, Headphones, Loader2 } from 'lucide-react';
+import { fetchLessonRecaps, generateLessonRecap, generateLessonRecapPodcast } from '../api';
+import { Button } from '@/components/ui/button';
+import { classifyGenerationError, type FriendlyError } from '@/lib/errorPresentation';
+import type { LessonRecap, LessonRecapConcept } from '../types';
+
+interface PageState {
+  recaps: LessonRecap[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function LessonRecapPage() {
+  const [state, setState] = useState<PageState>({ recaps: [], loading: true, error: null });
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isGeneratingPodcast, setIsGeneratingPodcast] = useState(false);
+  const [podcastError, setPodcastError] = useState<FriendlyError | null>(null);
+
+  function load() {
+    setState((s) => ({ ...s, loading: true }));
+    fetchLessonRecaps()
+      .then((recaps) => {
+        setState({ recaps, loading: false, error: null });
+      })
+      .catch((err) => {
+        setState((s) => ({
+          ...s,
+          loading: false,
+          error: err instanceof Error ? err.message : 'Failed to load learning recaps',
+        }));
+      });
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function handleGenerate() {
+    setIsGenerating(true);
+    try {
+      await generateLessonRecap();
+      load();
+    } catch (err) {
+      setState((s) => ({
+        ...s,
+        error: err instanceof Error ? err.message : 'Failed to generate learning recap',
+      }));
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  async function handleGeneratePodcast(recapId: number, force: boolean) {
+    setIsGeneratingPodcast(true);
+    setPodcastError(null);
+    try {
+      const updated = await generateLessonRecapPodcast(recapId, force);
+      setState((s) => ({
+        ...s,
+        recaps: s.recaps.map((r) => (r.id === updated.id ? updated : r)),
+      }));
+    } catch (err) {
+      setPodcastError(classifyGenerationError(err));
+    } finally {
+      setIsGeneratingPodcast(false);
+    }
+  }
+
+  const { recaps, loading, error } = state;
+  const [latest, ...history] = recaps;
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center p-8">
+        <Loader2 className="text-muted-foreground size-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl space-y-5 p-4 md:p-5">
+      <section className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-[22px] font-semibold tracking-tight">Weekly Learning Recap</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            A summary of the lessons you worked through this week
+          </p>
+        </div>
+        <Button size="sm" onClick={() => void handleGenerate()} disabled={isGenerating}>
+          {isGenerating ? 'Generating…' : 'Generate now'}
+        </Button>
+      </section>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {!latest ? (
+        <Panel title="This week">
+          <EmptyLine />
+        </Panel>
+      ) : (
+        <>
+          <section className="grid grid-cols-2 gap-2 md:grid-cols-4">
+            <Metric label="Lessons touched" value={String(latest.data.lessons_touched)} />
+            <Metric label="Lessons completed" value={String(latest.data.lessons_completed)} />
+            <Metric label="Unfinished" value={String(latest.data.unfinished_lessons.length)} />
+            <Metric
+              label="Week"
+              value={`${formatDate(latest.data.week_start)} – ${formatDate(latest.data.week_end)}`}
+            />
+          </section>
+
+          {latest.narrative && (
+            <Panel title="What you learned">
+              <div className="flex items-start gap-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
+                  <GraduationCap className="size-5" />
+                </div>
+                <div className="space-y-2 text-sm">
+                  {latest.narrative
+                    .split(/\n\s*\n/)
+                    .map((paragraph) => paragraph.trim())
+                    .filter(Boolean)
+                    .map((paragraph, index) => (
+                      <p key={index}>{paragraph}</p>
+                    ))}
+                </div>
+              </div>
+            </Panel>
+          )}
+
+          <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <Panel title="Key concepts">
+              <ConceptBars items={latest.data.key_concepts} />
+            </Panel>
+            <Panel title="Repeated themes">
+              <ConceptBars items={latest.data.repeated_themes} />
+            </Panel>
+          </section>
+
+          {latest.data.unfinished_lessons.length > 0 && (
+            <Panel title="Unfinished lessons">
+              <ul className="divide-y divide-border">
+                {latest.data.unfinished_lessons.map((lesson) => (
+                  <li key={lesson.id} className="py-2 text-sm">
+                    <Link to={`/learn/${lesson.id}`} className="hover:underline">
+                      {lesson.title}
+                    </Link>
+                    <span className="ml-2 text-xs text-muted-foreground capitalize">
+                      {lesson.generation_status}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </Panel>
+          )}
+
+          {latest.data.notable_articles.length > 0 && (
+            <Panel title="Notable articles">
+              <ul className="divide-y divide-border">
+                {latest.data.notable_articles.map((article) => (
+                  <li key={article.id} className="flex items-center justify-between py-2 text-sm">
+                    <Link to={`/learn/${article.id}`} className="hover:underline">
+                      {article.title}
+                    </Link>
+                    <span className="text-xs text-muted-foreground">{article.source_name}</span>
+                  </li>
+                ))}
+              </ul>
+            </Panel>
+          )}
+
+          <Panel title="Podcast audio">
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <Headphones className="size-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">Listen to this week's recap</span>
+                </div>
+                <Button
+                  size="sm"
+                  variant={latest.podcast_status ? 'outline' : 'default'}
+                  onClick={() =>
+                    void handleGeneratePodcast(latest.id, latest.podcast_status !== null)
+                  }
+                  disabled={isGeneratingPodcast}
+                >
+                  {isGeneratingPodcast
+                    ? 'Generating…'
+                    : latest.podcast_status
+                      ? 'Regenerate'
+                      : 'Create podcast'}
+                </Button>
+              </div>
+
+              {latest.podcast_status === 'complete' ? (
+                <audio
+                  src={`/api/lesson-recaps/${latest.id}/podcast`}
+                  controls
+                  className="h-9 w-full"
+                />
+              ) : null}
+
+              {podcastError ? (
+                <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-xs text-destructive">
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                  <div>
+                    <div className="font-semibold">{podcastError.title}</div>
+                    <div className="mt-0.5">{podcastError.message}</div>
+                  </div>
+                </div>
+              ) : latest.podcast_status === 'failed' && latest.podcast_error ? (
+                <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-xs text-destructive">
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                  <div>{latest.podcast_error}</div>
+                </div>
+              ) : null}
+            </div>
+          </Panel>
+        </>
+      )}
+
+      {history.length > 0 && (
+        <Panel title="Past recaps">
+          <ul className="divide-y divide-border">
+            {history.map((recap) => (
+              <li key={recap.id} className="flex items-center justify-between py-2 text-sm">
+                <span className="text-muted-foreground">
+                  {formatDate(recap.data.week_start)} – {formatDate(recap.data.week_end)}
+                </span>
+                <span className="tabular-nums">{recap.data.lessons_completed} lessons</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      )}
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-surface px-3 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="mt-1 text-xl font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-md border border-border bg-surface p-3">
+      <h3 className="text-sm font-medium">{title}</h3>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function ConceptBars({ items }: { items: LessonRecapConcept[] }) {
+  if (items.length === 0) return <EmptyLine />;
+  const max = Math.max(...items.map((item) => item.count), 1);
+  return (
+    <div className="space-y-3">
+      {items.map((item) => (
+        <div key={item.concept} className="space-y-1">
+          <div className="flex items-center justify-between gap-3 text-xs">
+            <span className="truncate font-medium capitalize">{item.concept}</span>
+            <span className="text-muted-foreground tabular-nums">{item.count}</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded bg-muted">
+            <div className="h-full bg-chart-1" style={{ width: `${(item.count / max) * 100}%` }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyLine() {
+  return (
+    <div className="py-8 text-center text-sm text-muted-foreground">
+      No recap yet — finish a lesson this week, then check back or generate one now.
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -482,6 +482,48 @@ export interface WeeklyRecap {
   narrative: string | null;
 }
 
+export interface LessonRecapConcept {
+  concept: string;
+  count: number;
+}
+
+export interface LessonRecapUnfinishedLesson {
+  id: number;
+  title: string;
+  original_url: string;
+  generation_status: 'pending' | 'failed';
+}
+
+export interface LessonRecapNotableArticle {
+  id: number;
+  title: string;
+  source_name: string | null;
+  verdict: 'skip' | 'skim' | 'read' | 'study' | null;
+}
+
+export interface LessonRecapData {
+  week_start: string;
+  week_end: string;
+  generated_at: string;
+  lessons_touched: number;
+  lessons_completed: number;
+  key_concepts: LessonRecapConcept[];
+  repeated_themes: LessonRecapConcept[];
+  unfinished_lessons: LessonRecapUnfinishedLesson[];
+  notable_articles: LessonRecapNotableArticle[];
+}
+
+export interface LessonRecap {
+  id: number;
+  user_id: number;
+  week_start: string;
+  created_at: string;
+  data: LessonRecapData;
+  narrative: string | null;
+  podcast_status: 'complete' | 'failed' | null;
+  podcast_error: string | null;
+}
+
 export interface Achievement {
   key: string;
   title: string;


### PR DESCRIPTION
## Summary

Closes #1130.

- Adds a new `lesson_recaps` backend package mirroring the existing `recaps` (reading recap) module: `assemble_weekly_lesson_recap` aggregates lessons created or completed in the trailing 7 days into key concepts, repeated themes, unfinished lessons, and notable source articles.
- `POST /api/lesson-recaps/generate` lets a user generate the current week's recap on demand; `GET /api/lesson-recaps` / `GET /api/lesson-recaps/latest` list saved history, matching the reading-recap endpoints' shape.
- A new `weekly_lesson_recaps` APScheduler job runs every minute and generates recaps automatically for users whose local scheduled day/time matches (reusing each user's existing `recap_day`/`briefing_time`/`briefing_timezone` cadence, gated by a new, separate `lesson_recap_enabled` column so learning recaps can be toggled independently of reading recaps).
- Optional podcast audio: `POST/GET /api/lesson-recaps/{id}/podcast` generates and serves spoken narration built from the recap's AI narrative, key concepts, and notable articles, following the same TTS pattern as lesson podcasts (#1126) — gated behind `OPENAI_API_KEY`, degrading to a clear 503 when not configured, without failing the underlying recap.
- New `Learning Recap` page at `/learn/recap` (added to nav under Learn), showing metrics, an AI narrative, key concepts / repeated themes bar charts, unfinished lessons and notable articles (both linking back to the lesson detail page), a "Generate now" button, and podcast playback/creation — with an empty state when there's no recap yet.
- Empty weeks return a zeroed recap object rather than erroring, and the frontend renders a clear empty state.

## Test plan

- [x] Backend: `pytest tests/test_lesson_recaps.py tests/test_lesson_recap_narrative.py tests/test_scheduler.py` — 40 new/updated tests covering assembly (window filtering, concept/theme aggregation, unfinished/notable extraction, empty weeks), persistence (upsert-by-week), narrative generation (LLM + fallback), scheduler cadence matching, and podcast audio (not-configured, generation, endpoint auth/scoping) — all passing.
- [x] Backend: broader related suite (`test_learn_from_link*`, `test_recaps.py`, `test_recap_narrative.py`, `test_tts.py`, `test_push_notifications.py`, `test_lesson_podcast.py`, `test_lesson_slide_deck.py`, `test_migrate_multi_user.py`) — 297 passed, no regressions.
- [x] Backend: full suite collection (`pytest --collect-only`) — 2052 tests collected with no import errors.
- [x] Backend: `ruff check`, `mypy` — clean.
- [x] Frontend: `vitest run` full suite — 886 passed; the only 5 failures are pre-existing and unrelated (`websiteBranding.test.ts` / `brandRebrand.test.tsx` reference a `frontend/website` Docusaurus directory that doesn't exist in this worktree).
- [x] Frontend: `tsc --noEmit`, `eslint`, `prettier --check` — clean.
- [x] Locale consistency test (`locales.test.ts`) — added the new `nav.learning_recap` / `page_title.learning_recap` keys to all 29 locale files (untranslated placeholders in non-English locales, matching the existing pattern for new keys) so the key-parity check keeps passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)