### PR TITLE
refactor: extract onboarding endpoints into feature-module package (#826)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -32,7 +32,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from psycopg.errors import UniqueViolation
-from psycopg.types.json import Jsonb
 from pydantic import BaseModel, Field, field_validator
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response as StarletteResponse
@@ -539,13 +538,6 @@ class PreviewSourceRequest(BaseModel):
 
 class SourceCleanupRequest(BaseModel):
     source_slugs: list[str]
-
-
-class OnboardingInterestsRequest(BaseModel):
-    interests: list[str]
-    enabled_source_slugs: list[str] = Field(default_factory=list)
-    disabled_source_slugs: list[str] = Field(default_factory=list)
-    completed: bool = True
 
 
 class IntervalUpdate(BaseModel):
@@ -1233,290 +1225,6 @@ def add_share_message(
     if get_share(share_id, current_user["id"]) is None:
         raise HTTPException(status_code=404, detail="Share not found")
     return add_message(share_id, current_user["id"], payload.message)
-
-
-INTEREST_GROUPS: tuple[dict[str, Any], ...] = (
-    {
-        "id": "ai",
-        "label": "AI",
-        "options": (
-            {"id": "agents", "label": "Agents"},
-            {"id": "model-releases", "label": "Model releases"},
-            {"id": "evals", "label": "Evals"},
-            {"id": "product-news", "label": "Product news"},
-        ),
-    },
-    {
-        "id": "engineering",
-        "label": "Engineering",
-        "options": (
-            {"id": "python", "label": "Python"},
-            {"id": "infra", "label": "Infrastructure"},
-            {"id": "cloud", "label": "Cloud"},
-            {"id": "security", "label": "Security"},
-        ),
-    },
-)
-
-
-def _interest_options() -> set[str]:
-    return {str(option["id"]) for group in INTEREST_GROUPS for option in group["options"]}
-
-
-def _source_recommendations(user_id: int, interests: list[str]) -> list[dict[str, Any]]:
-    from news_dashboard.ingest import sync_sources
-    from news_dashboard.sources import DEFAULT_SOURCES
-
-    selected = set(interests)
-    sync_sources()
-    with connect() as conn:
-        rows = conn.execute(
-            "SELECT source_slug, enabled FROM user_sources WHERE user_id = %s",
-            (user_id,),
-        ).fetchall()
-    subscriptions = {str(row["source_slug"]): bool(row["enabled"]) for row in rows}
-
-    recommendations: list[dict[str, Any]] = []
-    for source in DEFAULT_SOURCES:
-        tags = set(source.interest_tags)
-        matched = sorted(selected & (tags | {source.category}))
-        score = float((len(selected & tags) * 100) + (25 if source.category in selected else 0))
-        score += source.priority / 100
-        recommended = bool(matched)
-        if not selected:
-            score = source.priority / 100
-            recommended = False
-        reason = (
-            f"Matches {', '.join(matched)}" if matched else f"Baseline {source.category} source"
-        )
-        recommendations.append(
-            {
-                "source_slug": source.slug,
-                "source_name": source.name,
-                "kind": source.kind,
-                "url": source.url,
-                "category": source.category,
-                "matched_interests": matched,
-                "reason": reason,
-                "recommended": recommended,
-                "subscribed": subscriptions.get(source.slug, False),
-                "priority": source.priority,
-                "_score": score,
-                "_priority": source.priority,
-            }
-        )
-
-    recommendations.sort(
-        key=lambda item: (
-            float(item["_score"]),
-            bool(item["subscribed"]),
-            int(item["_priority"]),
-            str(item["source_name"]),
-        ),
-        reverse=True,
-    )
-    for item in recommendations:
-        item.pop("_score")
-        item.pop("_priority")
-    return recommendations
-
-
-@api.get("/api/onboarding/status")
-def onboarding_status(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    uid = int(current_user["id"])
-    init_db()
-    with connect() as conn:
-        row = conn.execute(
-            "SELECT completed_at FROM user_interest_profiles WHERE user_id = %s",
-            (uid,),
-        ).fetchone()
-    completed = row is not None and row["completed_at"] is not None
-    return {"completed": completed}
-
-
-@api.get("/api/onboarding/interests")
-def onboarding_interests(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> list[dict[str, Any]]:
-    _ = current_user
-    return [
-        {"id": option["id"], "label": option["label"], "description": option.get("description", "")}
-        for group in INTEREST_GROUPS
-        for option in group["options"]
-    ]
-
-
-class OnboardingRecommendationsRequest(BaseModel):
-    interest_ids: list[str]
-
-
-class OnboardingProfileRequest(BaseModel):
-    interest_ids: list[str]
-    enabled_slugs: list[str] = Field(default_factory=list)
-
-
-def _frontend_recommendations(user_id: int, interests: list[str]) -> list[dict[str, Any]]:
-    """Return source recommendations using the frontend field-name contract (slug, name)."""
-    raw = _source_recommendations(user_id, interests)
-    return [
-        {
-            "slug": item["source_slug"],
-            "name": item["source_name"],
-            "category": item["category"],
-            "kind": item["kind"],
-            "url": item["url"],
-            "matched_interests": item["matched_interests"],
-            "reason": item["reason"],
-            "recommended": item["recommended"],
-            "enabled": 1 if item["subscribed"] else 0,
-            "priority": item["priority"],
-        }
-        for item in raw
-    ]
-
-
-@api.post("/api/onboarding/recommendations")
-def onboarding_recommendations(
-    payload: OnboardingRecommendationsRequest,
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> list[dict[str, Any]]:
-    uid = int(current_user["id"])
-    init_db()
-    return _frontend_recommendations(uid, payload.interest_ids)
-
-
-@api.post("/api/onboarding/profile")
-def save_onboarding_profile(
-    payload: OnboardingProfileRequest,
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.ingest import sync_sources
-
-    valid_interests = _interest_options()
-    interests = list(dict.fromkeys(payload.interest_ids))
-    invalid = [i for i in interests if i not in valid_interests]
-    if invalid:
-        raise HTTPException(status_code=400, detail=f"unknown interests: {', '.join(invalid)}")
-
-    uid = int(current_user["id"])
-    enabled_slugs = list(dict.fromkeys(payload.enabled_slugs))
-    sync_sources()
-    with connect() as conn:
-        if enabled_slugs:
-            rows = conn.execute(
-                "SELECT slug FROM sources WHERE owner_user_id IS NULL AND slug = ANY(%s)",
-                (enabled_slugs,),
-            ).fetchall()
-            allowed = {str(row["slug"]) for row in rows}
-            missing = [slug for slug in enabled_slugs if slug not in allowed]
-            if missing:
-                raise HTTPException(
-                    status_code=404, detail=f"unknown global sources: {', '.join(missing)}"
-                )
-
-        conn.execute(
-            """
-            INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
-            VALUES (%s, %s, NOW(), NOW())
-            ON CONFLICT(user_id) DO UPDATE SET
-              interests = excluded.interests,
-              completed_at = NOW(),
-              updated_at = NOW()
-            """,
-            (uid, Jsonb(interests)),
-        )
-        for slug in enabled_slugs:
-            conn.execute(
-                """
-                INSERT INTO user_sources(user_id, source_slug, enabled)
-                VALUES (%s, %s, TRUE)
-                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = TRUE
-                """,
-                (uid, slug),
-            )
-
-    return {"completed": True}
-
-
-@api.get("/api/onboarding/source-recommendations")
-def onboarding_source_recommendations(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    uid = int(current_user["id"])
-    init_db()
-    with connect() as conn:
-        row = conn.execute(
-            "SELECT interests FROM user_interest_profiles WHERE user_id = %s",
-            (uid,),
-        ).fetchone()
-    interests = list(row["interests"]) if row else []
-    return {"items": _source_recommendations(uid, [str(interest) for interest in interests])}
-
-
-@api.post("/api/onboarding/interests")
-def save_onboarding_interests(
-    payload: OnboardingInterestsRequest,
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, Any]:
-    from news_dashboard.ingest import sync_sources
-
-    valid_interests = _interest_options()
-    interests = list(dict.fromkeys(payload.interests))
-    invalid = [interest for interest in interests if interest not in valid_interests]
-    if invalid:
-        raise HTTPException(status_code=400, detail=f"unknown interests: {', '.join(invalid)}")
-
-    uid = int(current_user["id"])
-    requested = list(dict.fromkeys(payload.enabled_source_slugs + payload.disabled_source_slugs))
-    sync_sources()
-    with connect() as conn:
-        if requested:
-            rows = conn.execute(
-                "SELECT slug FROM sources WHERE owner_user_id IS NULL AND slug = ANY(%s)",
-                (requested,),
-            ).fetchall()
-            allowed = {str(row["slug"]) for row in rows}
-            missing = [slug for slug in requested if slug not in allowed]
-            if missing:
-                detail = f"unknown global sources: {', '.join(missing)}"
-                raise HTTPException(status_code=404, detail=detail)
-
-        conn.execute(
-            """
-            INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
-            VALUES (%s, %s, CASE WHEN %s THEN NOW() ELSE NULL END, NOW())
-            ON CONFLICT(user_id) DO UPDATE SET
-              interests = excluded.interests,
-              completed_at = excluded.completed_at,
-              updated_at = NOW()
-            """,
-            (uid, Jsonb(interests), payload.completed),
-        )
-        for slug in payload.enabled_source_slugs:
-            conn.execute(
-                """
-                INSERT INTO user_sources(user_id, source_slug, enabled)
-                VALUES (%s, %s, TRUE)
-                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = TRUE
-                """,
-                (uid, slug),
-            )
-        for slug in payload.disabled_source_slugs:
-            conn.execute(
-                """
-                INSERT INTO user_sources(user_id, source_slug, enabled)
-                VALUES (%s, %s, FALSE)
-                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = FALSE
-                """,
-                (uid, slug),
-            )
-
-    return {
-        "interests": interests,
-        "items": _source_recommendations(uid, interests),
-    }
 
 
 @api.get("/api/sources")
@@ -3148,6 +2856,7 @@ from news_dashboard.learn_from_link.router import router as learn_from_link_rout
 from news_dashboard.lesson_recaps.router import router as lesson_recaps_router  # noqa: E402
 from news_dashboard.mcp.router import public_mcp_router  # noqa: E402
 from news_dashboard.mcp.router import router as mcp_router  # noqa: E402
+from news_dashboard.onboarding.router import router as onboarding_router  # noqa: E402
 from news_dashboard.personalization.router import router as personalization_router  # noqa: E402
 from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
 from news_dashboard.reading_list.router import router as reading_list_router  # noqa: E402
@@ -3163,6 +2872,7 @@ api.include_router(greader_router)
 api.include_router(learn_from_link_router)
 api.include_router(lesson_recaps_router)
 api.include_router(mcp_router)
+api.include_router(onboarding_router)
 api.include_router(personalization_router)
 api.include_router(quizzes_router)
 api.include_router(reading_list_router)

--- a/backend/news_dashboard/onboarding/__init__.py
+++ b/backend/news_dashboard/onboarding/__init__.py
@@ -1,0 +1,12 @@
+"""New-user onboarding: interest selection and source recommendations.
+
+Feature-module package: HTTP routes live in :mod:`~news_dashboard.onboarding.router`,
+business logic in :mod:`~news_dashboard.onboarding.service`, and request models in
+:mod:`~news_dashboard.onboarding.models`. See ``docs/adr`` for the layout rationale.
+
+The router is imported directly from the ``router`` submodule (``from
+news_dashboard.onboarding.router import router``) rather than re-exported here, so
+the submodule name is never shadowed.
+"""
+
+from __future__ import annotations

--- a/backend/news_dashboard/onboarding/models.py
+++ b/backend/news_dashboard/onboarding/models.py
@@ -1,0 +1,21 @@
+"""Request models for the onboarding feature module."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class OnboardingInterestsRequest(BaseModel):
+    interests: list[str]
+    enabled_source_slugs: list[str] = Field(default_factory=list)
+    disabled_source_slugs: list[str] = Field(default_factory=list)
+    completed: bool = True
+
+
+class OnboardingRecommendationsRequest(BaseModel):
+    interest_ids: list[str]
+
+
+class OnboardingProfileRequest(BaseModel):
+    interest_ids: list[str]
+    enabled_slugs: list[str] = Field(default_factory=list)

--- a/backend/news_dashboard/onboarding/router.py
+++ b/backend/news_dashboard/onboarding/router.py
@@ -1,0 +1,111 @@
+"""HTTP routes for new-user onboarding.
+
+The router carries no blanket auth dependency of its own; it is mounted on
+``main``'s authenticated ``api`` router, which applies ``require_auth``. Each
+handler still depends on ``require_auth`` to receive the current user.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from news_dashboard.auth import require_auth
+from news_dashboard.db import init_db
+from news_dashboard.onboarding import service
+from news_dashboard.onboarding.models import (
+    OnboardingInterestsRequest,
+    OnboardingProfileRequest,
+    OnboardingRecommendationsRequest,
+)
+
+router = APIRouter()
+
+
+@router.get("/api/onboarding/status")
+def onboarding_status(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    init_db()
+    return {"completed": service.get_status(int(current_user["id"]))}
+
+
+@router.get("/api/onboarding/interests")
+def onboarding_interests(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> list[dict[str, Any]]:
+    _ = current_user
+    return [
+        {"id": option["id"], "label": option["label"], "description": option.get("description", "")}
+        for group in service.INTEREST_GROUPS
+        for option in group["options"]
+    ]
+
+
+@router.post("/api/onboarding/recommendations")
+def onboarding_recommendations(
+    payload: OnboardingRecommendationsRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> list[dict[str, Any]]:
+    init_db()
+    return service.frontend_recommendations(int(current_user["id"]), payload.interest_ids)
+
+
+@router.post("/api/onboarding/profile")
+def save_onboarding_profile(
+    payload: OnboardingProfileRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    valid_interests = service.interest_options()
+    interests = list(dict.fromkeys(payload.interest_ids))
+    invalid = [i for i in interests if i not in valid_interests]
+    if invalid:
+        raise HTTPException(status_code=400, detail=f"unknown interests: {', '.join(invalid)}")
+
+    enabled_slugs = list(dict.fromkeys(payload.enabled_slugs))
+    try:
+        service.save_profile(int(current_user["id"]), interests, enabled_slugs)
+    except service.UnknownGlobalSourcesError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return {"completed": True}
+
+
+@router.get("/api/onboarding/source-recommendations")
+def onboarding_source_recommendations(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    init_db()
+    uid = int(current_user["id"])
+    interests = service.get_interests(uid)
+    return {"items": service.source_recommendations(uid, interests)}
+
+
+@router.post("/api/onboarding/interests")
+def save_onboarding_interests(
+    payload: OnboardingInterestsRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    valid_interests = service.interest_options()
+    interests = list(dict.fromkeys(payload.interests))
+    invalid = [interest for interest in interests if interest not in valid_interests]
+    if invalid:
+        raise HTTPException(status_code=400, detail=f"unknown interests: {', '.join(invalid)}")
+
+    uid = int(current_user["id"])
+    try:
+        service.save_interests(
+            uid,
+            interests,
+            payload.enabled_source_slugs,
+            payload.disabled_source_slugs,
+            payload.completed,
+        )
+    except service.UnknownGlobalSourcesError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return {
+        "interests": interests,
+        "items": service.source_recommendations(uid, interests),
+    }

--- a/backend/news_dashboard/onboarding/service.py
+++ b/backend/news_dashboard/onboarding/service.py
@@ -1,0 +1,230 @@
+"""Business logic for new-user onboarding: interests and source recommendations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from psycopg.types.json import Jsonb
+
+from news_dashboard.db import connect
+
+INTEREST_GROUPS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "ai",
+        "label": "AI",
+        "options": (
+            {"id": "agents", "label": "Agents"},
+            {"id": "model-releases", "label": "Model releases"},
+            {"id": "evals", "label": "Evals"},
+            {"id": "product-news", "label": "Product news"},
+        ),
+    },
+    {
+        "id": "engineering",
+        "label": "Engineering",
+        "options": (
+            {"id": "python", "label": "Python"},
+            {"id": "infra", "label": "Infrastructure"},
+            {"id": "cloud", "label": "Cloud"},
+            {"id": "security", "label": "Security"},
+        ),
+    },
+)
+
+
+def interest_options() -> set[str]:
+    return {str(option["id"]) for group in INTEREST_GROUPS for option in group["options"]}
+
+
+def source_recommendations(user_id: int, interests: list[str]) -> list[dict[str, Any]]:
+    from news_dashboard.ingest import sync_sources
+    from news_dashboard.sources import DEFAULT_SOURCES
+
+    selected = set(interests)
+    sync_sources()
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT source_slug, enabled FROM user_sources WHERE user_id = %s",
+            (user_id,),
+        ).fetchall()
+    subscriptions = {str(row["source_slug"]): bool(row["enabled"]) for row in rows}
+
+    recommendations: list[dict[str, Any]] = []
+    for source in DEFAULT_SOURCES:
+        tags = set(source.interest_tags)
+        matched = sorted(selected & (tags | {source.category}))
+        score = float((len(selected & tags) * 100) + (25 if source.category in selected else 0))
+        score += source.priority / 100
+        recommended = bool(matched)
+        if not selected:
+            score = source.priority / 100
+            recommended = False
+        reason = (
+            f"Matches {', '.join(matched)}" if matched else f"Baseline {source.category} source"
+        )
+        recommendations.append(
+            {
+                "source_slug": source.slug,
+                "source_name": source.name,
+                "kind": source.kind,
+                "url": source.url,
+                "category": source.category,
+                "matched_interests": matched,
+                "reason": reason,
+                "recommended": recommended,
+                "subscribed": subscriptions.get(source.slug, False),
+                "priority": source.priority,
+                "_score": score,
+                "_priority": source.priority,
+            }
+        )
+
+    recommendations.sort(
+        key=lambda item: (
+            float(item["_score"]),
+            bool(item["subscribed"]),
+            int(item["_priority"]),
+            str(item["source_name"]),
+        ),
+        reverse=True,
+    )
+    for item in recommendations:
+        item.pop("_score")
+        item.pop("_priority")
+    return recommendations
+
+
+def frontend_recommendations(user_id: int, interests: list[str]) -> list[dict[str, Any]]:
+    """Return source recommendations using the frontend field-name contract (slug, name)."""
+    raw = source_recommendations(user_id, interests)
+    return [
+        {
+            "slug": item["source_slug"],
+            "name": item["source_name"],
+            "category": item["category"],
+            "kind": item["kind"],
+            "url": item["url"],
+            "matched_interests": item["matched_interests"],
+            "reason": item["reason"],
+            "recommended": item["recommended"],
+            "enabled": 1 if item["subscribed"] else 0,
+            "priority": item["priority"],
+        }
+        for item in raw
+    ]
+
+
+def get_status(user_id: int) -> bool:
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT completed_at FROM user_interest_profiles WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()
+    return row is not None and row["completed_at"] is not None
+
+
+def get_interests(user_id: int) -> list[str]:
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT interests FROM user_interest_profiles WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()
+    return [str(interest) for interest in row["interests"]] if row else []
+
+
+def save_profile(user_id: int, interest_ids: list[str], enabled_slugs: list[str]) -> None:
+    from news_dashboard.ingest import sync_sources
+
+    sync_sources()
+    with connect() as conn:
+        if enabled_slugs:
+            rows = conn.execute(
+                "SELECT slug FROM sources WHERE owner_user_id IS NULL AND slug = ANY(%s)",
+                (enabled_slugs,),
+            ).fetchall()
+            allowed = {str(row["slug"]) for row in rows}
+            missing = [slug for slug in enabled_slugs if slug not in allowed]
+            if missing:
+                raise UnknownGlobalSourcesError(missing)
+
+        conn.execute(
+            """
+            INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
+            VALUES (%s, %s, NOW(), NOW())
+            ON CONFLICT(user_id) DO UPDATE SET
+              interests = excluded.interests,
+              completed_at = NOW(),
+              updated_at = NOW()
+            """,
+            (user_id, Jsonb(interest_ids)),
+        )
+        for slug in enabled_slugs:
+            conn.execute(
+                """
+                INSERT INTO user_sources(user_id, source_slug, enabled)
+                VALUES (%s, %s, TRUE)
+                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = TRUE
+                """,
+                (user_id, slug),
+            )
+
+
+def save_interests(
+    user_id: int,
+    interests: list[str],
+    enabled_source_slugs: list[str],
+    disabled_source_slugs: list[str],
+    completed: bool,
+) -> None:
+    from news_dashboard.ingest import sync_sources
+
+    requested = list(dict.fromkeys(enabled_source_slugs + disabled_source_slugs))
+    sync_sources()
+    with connect() as conn:
+        if requested:
+            rows = conn.execute(
+                "SELECT slug FROM sources WHERE owner_user_id IS NULL AND slug = ANY(%s)",
+                (requested,),
+            ).fetchall()
+            allowed = {str(row["slug"]) for row in rows}
+            missing = [slug for slug in requested if slug not in allowed]
+            if missing:
+                raise UnknownGlobalSourcesError(missing)
+
+        conn.execute(
+            """
+            INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
+            VALUES (%s, %s, CASE WHEN %s THEN NOW() ELSE NULL END, NOW())
+            ON CONFLICT(user_id) DO UPDATE SET
+              interests = excluded.interests,
+              completed_at = excluded.completed_at,
+              updated_at = NOW()
+            """,
+            (user_id, Jsonb(interests), completed),
+        )
+        for slug in enabled_source_slugs:
+            conn.execute(
+                """
+                INSERT INTO user_sources(user_id, source_slug, enabled)
+                VALUES (%s, %s, TRUE)
+                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = TRUE
+                """,
+                (user_id, slug),
+            )
+        for slug in disabled_source_slugs:
+            conn.execute(
+                """
+                INSERT INTO user_sources(user_id, source_slug, enabled)
+                VALUES (%s, %s, FALSE)
+                ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = FALSE
+                """,
+                (user_id, slug),
+            )
+
+
+class UnknownGlobalSourcesError(ValueError):
+    """Raised when a request references source slugs that don't exist as global sources."""
+
+    def __init__(self, missing_slugs: list[str]) -> None:
+        self.missing_slugs = missing_slugs
+        super().__init__(f"unknown global sources: {', '.join(missing_slugs)}")

--- a/backend/tests/test_onboarding_package.py
+++ b/backend/tests/test_onboarding_package.py
@@ -1,0 +1,53 @@
+"""Structural tests for the ``onboarding`` feature-module package.
+
+These guard the router/service/models layout (see the feature-module ADR) and
+ensure the refactor stays behaviour-preserving: every ``/api/onboarding*``
+route remains mounted on the app with its original path.
+"""
+
+from __future__ import annotations
+
+from news_dashboard.main import app
+
+
+def test_onboarding_package_modules_import() -> None:
+    """router/service/models are importable from the onboarding package."""
+    from fastapi import APIRouter
+
+    from news_dashboard.onboarding import models, service
+    from news_dashboard.onboarding.router import router
+
+    assert isinstance(router, APIRouter)
+    for name in (
+        "INTEREST_GROUPS",
+        "interest_options",
+        "source_recommendations",
+        "frontend_recommendations",
+        "get_status",
+        "get_interests",
+        "save_profile",
+        "save_interests",
+        "UnknownGlobalSourcesError",
+    ):
+        assert hasattr(service, name), name
+    assert hasattr(models, "OnboardingInterestsRequest")
+    assert hasattr(models, "OnboardingRecommendationsRequest")
+    assert hasattr(models, "OnboardingProfileRequest")
+
+
+def test_onboarding_routes_stay_mounted() -> None:
+    """The refactor must not drop or rename any onboarding route.
+
+    Routers are mounted lazily (as ``_IncludedRouter`` objects) rather than
+    flattened into ``app.routes``, so assert against the resolved OpenAPI paths.
+    """
+    paths = set(app.openapi()["paths"])
+    expected = {
+        "/api/onboarding/status",
+        "/api/onboarding/interests",
+        "/api/onboarding/recommendations",
+        "/api/onboarding/profile",
+        "/api/onboarding/source-recommendations",
+    }
+    missing = expected - paths
+    assert not missing, f"missing routes after refactor: {sorted(missing)}"


### PR DESCRIPTION
## Summary

Follow-up PR for the tracking issue [#826](https://github.com/lihor-hub/news-dashboard/issues/826): migrates the **onboarding** domain (`/api/onboarding/*`) out of `main.py` into a `news_dashboard/onboarding/` feature-module package (`router.py` / `service.py` / `models.py`), following the pattern established by the `quizzes` reference module (#825) and documented in [ADR 0003](docs/adr/0003-feature-module-packages.md).

- Moved `onboarding_status`, `onboarding_interests`, `onboarding_recommendations`, `save_onboarding_profile`, `onboarding_source_recommendations`, and `save_onboarding_interests` into `onboarding/router.py`.
- Moved `INTEREST_GROUPS`, interest/source-recommendation logic, and DB writes into `onboarding/service.py`.
- Moved `OnboardingInterestsRequest`, `OnboardingRecommendationsRequest`, `OnboardingProfileRequest` into `onboarding/models.py`.
- `main.py` now just imports and mounts `onboarding_router` on the authenticated `api` router — no route paths or auth semantics changed.
- Added `test_onboarding_package.py` (mirrors `test_quizzes_package.py`) to guard the package layout and confirm all `/api/onboarding*` routes stay mounted.

This is one domain per PR per the tracking issue's rules; the remaining domains (articles, shares, sources, scheduler, ingest, recommendations, stats, briefings, users/settings, assistant, admin) are left for future follow-ups.

## Test plan

- [x] `ruff check` / `ruff format` — clean
- [x] `mypy news_dashboard` — no issues (115 source files)
- [x] `pytest backend/tests/test_onboarding_package.py backend/tests/test_onboarding_interests.py` — 11 passed
- [x] Full backend suite: `pytest backend` — 2054 passed
- [x] No remaining references to the old private helpers (`_source_recommendations`, `_interest_options`, etc.) outside the new package
- [x] No frontend changes needed (route paths unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)