### PR TITLE
refactor: extract recommendations endpoints into feature-module package (#826)

### DIFF
--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -1795,37 +1795,6 @@ def health_details() -> dict[str, Any]:
     }
 
 
-@api.get("/api/recommendations/health", dependencies=_admin_dep)
-def recommendations_health_endpoint() -> dict[str, Any]:
-    from news_dashboard.recommendation_jobs import recommendation_health
-
-    return recommendation_health()
-
-
-@api.post("/api/recommendations/recalculate", dependencies=_admin_dep)
-def recommendations_recalculate_endpoint() -> dict[str, Any]:
-    from news_dashboard.recommendation_jobs import recalculate_stale_recommendations
-
-    return recalculate_stale_recommendations().as_dict()
-
-
-@api.post("/api/recommendations/recalculate-mine")
-def recommendations_recalculate_mine_endpoint(
-    current_user: Annotated[dict[str, Any], Depends(require_auth)],
-) -> dict[str, int]:
-    """Recompute the calling user's own recommendation scores on demand.
-
-    Lets any authenticated user personalize their feed from the UI without the
-    admin-only stale sweep above. Returns the number of articles scored so the
-    client can tell the user whether personalization has anything to learn from
-    yet (zero means no interaction history exists).
-    """
-    from news_dashboard.recommendations import recompute_user_recommendations
-
-    scored = recompute_user_recommendations(current_user["id"])
-    return {"scored": scored}
-
-
 @api.get("/api/stats/overview", dependencies=_admin_dep)
 def stats_overview_endpoint(
     from_: Annotated[str, Query(alias="from")],
@@ -2862,6 +2831,7 @@ from news_dashboard.quizzes.router import router as quizzes_router  # noqa: E402
 from news_dashboard.reading_list.router import router as reading_list_router  # noqa: E402
 from news_dashboard.reading_progress.router import router as reading_progress_router  # noqa: E402
 from news_dashboard.recaps.router import router as recaps_router  # noqa: E402
+from news_dashboard.recommendations_routes.router import router as recs_router  # noqa: E402
 from news_dashboard.saved_searches.router import router as saved_searches_router  # noqa: E402
 from news_dashboard.system.router import router as system_router  # noqa: E402
 
@@ -2878,6 +2848,7 @@ api.include_router(quizzes_router)
 api.include_router(reading_list_router)
 api.include_router(reading_progress_router)
 api.include_router(recaps_router)
+api.include_router(recs_router)
 api.include_router(saved_searches_router)
 
 app.include_router(public_router)

--- a/backend/news_dashboard/recommendations_routes/__init__.py
+++ b/backend/news_dashboard/recommendations_routes/__init__.py
@@ -1,0 +1,17 @@
+"""Recommendation admin/health endpoints (``/api/recommendations/*``).
+
+Feature-module package: HTTP routes live in
+:mod:`~news_dashboard.recommendations_routes.router`. Business logic already
+lived in the flat sibling modules :mod:`~news_dashboard.recommendation_jobs`
+and :mod:`~news_dashboard.recommendations` before this package existed, so the
+router delegates to them directly rather than duplicating a ``service``
+module. The package is named ``recommendations_routes`` (not
+``recommendations``) to avoid shadowing the existing
+:mod:`~news_dashboard.recommendations` module.
+
+The router is imported directly from the ``router`` submodule (``from
+news_dashboard.recommendations_routes.router import router``) rather than
+re-exported here, so the submodule name is never shadowed.
+"""
+
+from __future__ import annotations

--- a/backend/news_dashboard/recommendations_routes/router.py
+++ b/backend/news_dashboard/recommendations_routes/router.py
@@ -1,0 +1,49 @@
+"""HTTP routes for recommendation health/recalculation.
+
+The router carries no blanket auth dependency of its own; it is mounted on
+``main``'s authenticated ``api`` router, which applies ``require_auth``. The
+admin-only endpoints additionally depend on ``require_admin``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+
+from news_dashboard.auth import require_admin, require_auth
+
+router = APIRouter()
+
+_admin_dep = [Depends(require_admin)]
+
+
+@router.get("/api/recommendations/health", dependencies=_admin_dep)
+def recommendations_health_endpoint() -> dict[str, Any]:
+    from news_dashboard.recommendation_jobs import recommendation_health
+
+    return recommendation_health()
+
+
+@router.post("/api/recommendations/recalculate", dependencies=_admin_dep)
+def recommendations_recalculate_endpoint() -> dict[str, Any]:
+    from news_dashboard.recommendation_jobs import recalculate_stale_recommendations
+
+    return recalculate_stale_recommendations().as_dict()
+
+
+@router.post("/api/recommendations/recalculate-mine")
+def recommendations_recalculate_mine_endpoint(
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, int]:
+    """Recompute the calling user's own recommendation scores on demand.
+
+    Lets any authenticated user personalize their feed from the UI without the
+    admin-only stale sweep above. Returns the number of articles scored so the
+    client can tell the user whether personalization has anything to learn from
+    yet (zero means no interaction history exists).
+    """
+    from news_dashboard.recommendations import recompute_user_recommendations
+
+    scored = recompute_user_recommendations(current_user["id"])
+    return {"scored": scored}

--- a/backend/tests/test_recommendations_routes_package.py
+++ b/backend/tests/test_recommendations_routes_package.py
@@ -1,0 +1,35 @@
+"""Structural tests for the ``recommendations_routes`` feature-module package.
+
+These guard the router layout (see the feature-module ADR) and ensure the
+refactor stays behaviour-preserving: every ``/api/recommendations*`` route
+remains mounted on the app with its original path.
+"""
+
+from __future__ import annotations
+
+from news_dashboard.main import app
+
+
+def test_recommendations_routes_package_modules_import() -> None:
+    """router is importable from the recommendations_routes package."""
+    from fastapi import APIRouter
+
+    from news_dashboard.recommendations_routes.router import router
+
+    assert isinstance(router, APIRouter)
+
+
+def test_recommendations_routes_stay_mounted() -> None:
+    """The refactor must not drop or rename any recommendations route.
+
+    Routers are mounted lazily (as ``_IncludedRouter`` objects) rather than
+    flattened into ``app.routes``, so assert against the resolved OpenAPI paths.
+    """
+    paths = set(app.openapi()["paths"])
+    expected = {
+        "/api/recommendations/health",
+        "/api/recommendations/recalculate",
+        "/api/recommendations/recalculate-mine",
+    }
+    missing = expected - paths
+    assert not missing, f"missing routes after refactor: {sorted(missing)}"


### PR DESCRIPTION
## Summary

Follow-up PR for the tracking issue [#826](https://github.com/lihor-hub/news-dashboard/issues/826): migrates the **recommendations** admin/health domain (`/api/recommendations/*`) out of `main.py` into a `news_dashboard/recommendations_routes/` feature-module package, following the pattern established by the `quizzes` reference module (#825) and documented in [ADR 0003](docs/adr/0003-feature-module-packages.md).

- Moved `recommendations_health_endpoint`, `recommendations_recalculate_endpoint`, and `recommendations_recalculate_mine_endpoint` into `recommendations_routes/router.py`.
- No `service.py`: the business logic these handlers call already lived in the flat sibling modules `recommendation_jobs.py` and `recommendations.py` before this PR, so the router delegates to them directly rather than duplicating a service layer.
- Package is named `recommendations_routes` (not `recommendations`) to avoid shadowing the existing `news_dashboard/recommendations.py` module.
- `main.py` now just imports and mounts the router (`recs_router`) on the authenticated `api` router — no route paths or auth semantics changed.
- Added `test_recommendations_routes_package.py` (mirrors `test_onboarding_package.py`) to guard the package layout and confirm all `/api/recommendations*` routes stay mounted.

This is one domain per PR per the tracking issue's rules; the remaining domains (articles, shares, sources, scheduler, ingest, stats, briefings, users/settings, assistant, admin) are left for future follow-ups.

## Test plan

- [x] `ruff check` / `ruff format` — clean
- [x] `mypy news_dashboard` — no issues (117 source files)
- [x] `pytest backend/tests/test_recommendations_routes_package.py backend/tests/test_recommendation_recalc.py backend/tests/test_today_recommendations.py backend/tests/test_recommendation_contracts.py` — 32 passed
- [x] Full backend suite: `pytest backend` — 2056 passed
- [x] No frontend changes needed (route paths unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)