### PR TITLE
Harden Learning Agent production readiness (#1131)

### DIFF
--- a/backend/news_dashboard/ai_feedback/models.py
+++ b/backend/news_dashboard/ai_feedback/models.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-SubjectType = Literal["briefing", "recommendation"]
+SubjectType = Literal["briefing", "recommendation", "lesson"]
 Verdict = Literal[-1, 1]
 
 

--- a/backend/news_dashboard/ai_feedback/router.py
+++ b/backend/news_dashboard/ai_feedback/router.py
@@ -23,6 +23,8 @@ def _validate_subject_type(subject_type: str) -> SubjectType:
         return "briefing"
     if subject_type == "recommendation":
         return "recommendation"
+    if subject_type == "lesson":
+        return "lesson"
     raise HTTPException(status_code=400, detail="invalid subject_type")
 
 

--- a/backend/news_dashboard/ai_feedback/service.py
+++ b/backend/news_dashboard/ai_feedback/service.py
@@ -1,18 +1,26 @@
-"""Persist explicit thumbs up/down feedback on briefings and recommendations.
+"""Persist explicit thumbs up/down feedback on briefings, recommendations, and lessons.
 
 Recommendation feedback keys ``subject_id`` on the article id (there is no
 separate recommendation entity — see ``user_article_recommendations``'s
 ``(user_id, article_id)`` primary key). Briefing feedback keys ``subject_id``
 on the briefing id, optionally scoped to one cited ``article_id`` within it.
+Lesson feedback keys ``subject_id`` on the lesson id and doubles as an eval
+seed: each verdict is captured as an ``ai_eval_examples`` row (feature
+``lesson-feedback``) so real user judgments can later be reviewed and
+promoted into the curated eval set.
 """
 
 from __future__ import annotations
 
+import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from news_dashboard.ai_feedback.models import SubjectType
 from news_dashboard.db import connect, init_db, row_to_dict
+
+logger = logging.getLogger(__name__)
 
 
 def _upsert_sql(article_id: int | None) -> str:
@@ -65,6 +73,15 @@ def record_feedback(  # noqa: PLR0913
     if subject_type == "briefing":
         _score_briefing_trace(
             subject_id, verdict, comment, db_path=db_path, database_url=database_url
+        )
+    elif subject_type == "lesson":
+        _seed_lesson_eval_example(
+            subject_id,
+            user_id,
+            verdict,
+            comment,
+            db_path=db_path,
+            database_url=database_url,
         )
     return saved
 
@@ -146,3 +163,52 @@ def _score_briefing_trace(
         data_type="NUMERIC",
         comment=comment,
     )
+
+
+def _seed_lesson_eval_example(
+    lesson_id: int,
+    user_id: int,
+    verdict: int,
+    comment: str | None,
+    *,
+    db_path: Path | str | None,
+    database_url: str | None,
+) -> None:
+    """Capture lesson helpfulness feedback as a candidate eval example.
+
+    Stores the lesson's own structured detail as ``input`` so a human can
+    later review and promote real user feedback into the curated
+    lesson-synthesis eval fixtures (see ``news_dashboard.learn_from_link.evals``).
+    Best-effort: a failure here never blocks recording the feedback itself.
+    """
+    try:
+        with connect(db_path, database_url=database_url) as conn:
+            lesson_row = conn.execute(
+                "SELECT title, original_url, lesson_detail FROM lessons WHERE id = %s",
+                (lesson_id,),
+            ).fetchone()
+            if lesson_row is None:
+                return
+            lesson = row_to_dict(lesson_row)
+            conn.execute(
+                """
+                INSERT INTO ai_eval_examples
+                  (feature, input, expected_properties, feedback_helpful, created_by_user_id)
+                VALUES ('lesson-feedback', %s::jsonb, %s::jsonb, %s, %s)
+                """,
+                (
+                    json.dumps(
+                        {
+                            "lesson_id": lesson_id,
+                            "title": lesson.get("title"),
+                            "original_url": lesson.get("original_url"),
+                            "lesson_detail": lesson.get("lesson_detail"),
+                        }
+                    ),
+                    json.dumps({"feedback_helpful": verdict == 1, "comment": comment}),
+                    verdict == 1,
+                    user_id,
+                ),
+            )
+    except Exception:
+        logger.exception("Failed to seed lesson eval example for lesson %d", lesson_id)

--- a/backend/news_dashboard/cli.py
+++ b/backend/news_dashboard/cli.py
@@ -149,6 +149,20 @@ def eval_ai(feature: str | None = None) -> None:
         raise typer.Exit(code=1)
 
 
+@app.command(name="eval-learning-agent")
+def eval_learning_agent() -> None:
+    """Run the Learn from Link lesson synthesis eval fixture set."""
+    from news_dashboard.learn_from_link.evals import run_lesson_evals
+
+    result = run_lesson_evals()
+    typer.echo(
+        f"eval run {result['run_id']}: "
+        f"{result['passed']}/{result['total']} passed, {result['failed']} failed"
+    )
+    if int(result["failed"]) > 0:
+        raise typer.Exit(code=1)
+
+
 @app.command(name="seed-demo")
 def seed_demo_cmd() -> None:
     """Seed demo data: guest user + sample articles (requires DEMO_MODE=true)."""

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -937,6 +937,54 @@ POSTGRES_MULTIUSER_SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_lesson_recaps_user"
     " ON user_lesson_recaps(user_id, week_start DESC)",
+    "ALTER TABLE ai_feedback DROP CONSTRAINT IF EXISTS ai_feedback_subject_type_check",
+    "ALTER TABLE ai_feedback ADD CONSTRAINT ai_feedback_subject_type_check"
+    " CHECK (subject_type IN ('briefing', 'recommendation', 'lesson'))",
+    """
+    CREATE TABLE IF NOT EXISTS learning_agent_runs (
+      id               BIGSERIAL PRIMARY KEY,
+      lesson_id        BIGINT REFERENCES lessons(id) ON DELETE CASCADE,
+      user_id          INTEGER REFERENCES users(id) ON DELETE CASCADE,
+      status           TEXT NOT NULL DEFAULT 'running'
+        CHECK(status IN ('running','complete','failed')),
+      prompt_version   TEXT NOT NULL DEFAULT 'local',
+      model_version    TEXT NOT NULL DEFAULT 'local',
+      config           JSONB NOT NULL DEFAULT '{}'::jsonb,
+      retry_count      INTEGER NOT NULL DEFAULT 0,
+      total_latency_ms INTEGER,
+      total_tokens     INTEGER,
+      cost_usd         DOUBLE PRECISION,
+      failed_step      TEXT,
+      error            TEXT,
+      created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_learning_agent_runs_lesson"
+    " ON learning_agent_runs(lesson_id, created_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_learning_agent_runs_user"
+    " ON learning_agent_runs(user_id, created_at DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS learning_agent_steps (
+      id                 BIGSERIAL PRIMARY KEY,
+      run_id             BIGINT NOT NULL REFERENCES learning_agent_runs(id) ON DELETE CASCADE,
+      step               TEXT NOT NULL
+        CHECK(step IN ('fetch','extraction','synthesis','citation_verification','persistence')),
+      ordinal            INTEGER NOT NULL,
+      status             TEXT NOT NULL DEFAULT 'running'
+        CHECK(status IN ('running','complete','failed','retry')),
+      model              TEXT,
+      latency_ms         INTEGER,
+      prompt_tokens      INTEGER,
+      completion_tokens  INTEGER,
+      cost_usd           DOUBLE PRECISION,
+      error              TEXT,
+      created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (run_id, ordinal)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_learning_agent_steps_run"
+    " ON learning_agent_steps(run_id, ordinal)",
 ]
 
 # Runs after POSTGRES_SCHEMA/POSTGRES_MULTIUSER_SCHEMA and the embedding_vec

--- a/backend/news_dashboard/learn_from_link/agent_runs.py
+++ b/backend/news_dashboard/learn_from_link/agent_runs.py
@@ -1,0 +1,243 @@
+"""Per-run/per-step trace bookkeeping for the Learn from Link generation pipeline.
+
+Records prompt/model/config version metadata plus per-stage status, latency,
+and (where applicable) token/cost bookkeeping in ``learning_agent_runs`` /
+``learning_agent_steps``, mirroring the run/step convention already used by
+``news_dashboard.briefing_agent`` for the briefing pipeline.
+
+Runtime SQL uses psycopg %s parameter style. No SQLite fallback.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from psycopg.types.json import Jsonb
+
+from news_dashboard.db import connect, init_db, row_to_dict
+
+logger = logging.getLogger(__name__)
+
+STEP_FETCH = "fetch"
+STEP_EXTRACTION = "extraction"
+STEP_SYNTHESIS = "synthesis"
+STEP_CITATION_VERIFICATION = "citation_verification"
+STEP_PERSISTENCE = "persistence"
+
+STEP_ORDER = (
+    STEP_FETCH,
+    STEP_EXTRACTION,
+    STEP_SYNTHESIS,
+    STEP_CITATION_VERIFICATION,
+    STEP_PERSISTENCE,
+)
+
+# Bumped whenever the deterministic synthesis template in
+# ``news_dashboard.learn_from_link.service.generate_structured_lesson_detail``
+# changes in a way that could shift eval baselines. There is no separate LLM
+# "prompt" for core synthesis today (it's template/heuristic-based, not a
+# model call), so this stands in as the versioned unit of behavior.
+SYNTHESIS_PROMPT_VERSION = "lesson-synthesis-v1"
+
+# Coarse USD-per-1K-token estimates, used only for admin/debug cost visibility
+# on steps that do call an LLM (e.g. personal relevance). Not billing-accurate;
+# when Langfuse is configured, ``/api/admin/ai/metrics`` remains the source of
+# truth for actual billed cost.
+_MODEL_PRICE_PER_1K_TOKENS: dict[str, float] = {
+    "gpt-4o-mini": 0.00015,
+}
+_DEFAULT_PRICE_PER_1K_TOKENS = 0.0005
+
+
+def estimate_cost_usd(
+    model: str | None,
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+) -> float | None:
+    """Return a rough USD cost estimate for a step's token usage, or None if unknown."""
+    if prompt_tokens is None and completion_tokens is None:
+        return None
+    total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+    price = _MODEL_PRICE_PER_1K_TOKENS.get(model or "", _DEFAULT_PRICE_PER_1K_TOKENS)
+    return round((total_tokens / 1000) * price, 6)
+
+
+def start_run(
+    database_url: str | None,
+    *,
+    lesson_id: int,
+    user_id: int,
+    prompt_version: str,
+    model_version: str,
+    config: dict[str, Any],
+) -> int:
+    """Create a new 'running' learning_agent_runs row and return its id."""
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO learning_agent_runs(
+              lesson_id, user_id, status, prompt_version, model_version, config
+            )
+            VALUES (%s, %s, 'running', %s, %s, %s::jsonb)
+            RETURNING id
+            """,
+            (lesson_id, user_id, prompt_version, model_version, Jsonb(config)),
+        ).fetchone()
+        if row is None:
+            msg = "INSERT INTO learning_agent_runs returned no row"
+            raise RuntimeError(msg)
+        return int(row_to_dict(row)["id"])
+
+
+def record_step(  # noqa: PLR0913
+    database_url: str | None,
+    run_id: int,
+    step: str,
+    ordinal: int,
+    *,
+    status: str,
+    model: str | None = None,
+    latency_ms: int | None = None,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    error: str | None = None,
+) -> None:
+    """Record one pipeline step's outcome. Failures here are logged, not raised."""
+    cost_usd = estimate_cost_usd(model, prompt_tokens, completion_tokens)
+    try:
+        with connect(database_url=database_url) as conn:
+            conn.execute(
+                """
+                INSERT INTO learning_agent_steps(
+                    run_id, step, ordinal, status, model, latency_ms,
+                    prompt_tokens, completion_tokens, cost_usd, error
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (run_id, ordinal) DO UPDATE SET
+                    status = excluded.status,
+                    model = excluded.model,
+                    latency_ms = excluded.latency_ms,
+                    prompt_tokens = excluded.prompt_tokens,
+                    completion_tokens = excluded.completion_tokens,
+                    cost_usd = excluded.cost_usd,
+                    error = excluded.error
+                """,
+                (
+                    run_id,
+                    step,
+                    ordinal,
+                    status,
+                    model,
+                    latency_ms,
+                    prompt_tokens,
+                    completion_tokens,
+                    cost_usd,
+                    error,
+                ),
+            )
+    except Exception:
+        logger.exception("Failed to record learning agent step %s for run %d", step, run_id)
+
+
+def finish_run(
+    database_url: str | None,
+    run_id: int,
+    *,
+    status: str,
+    retry_count: int = 0,
+    failed_step: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Aggregate step latency/tokens/cost and mark a run complete or failed.
+
+    Failures here are logged, not raised, so a bookkeeping problem never takes
+    down lesson generation itself.
+    """
+    try:
+        with connect(database_url=database_url) as conn:
+            totals_row = conn.execute(
+                """
+                SELECT
+                  SUM(latency_ms) AS total_latency_ms,
+                  SUM(COALESCE(prompt_tokens, 0) + COALESCE(completion_tokens, 0))
+                    AS total_tokens,
+                  SUM(cost_usd) AS cost_usd
+                FROM learning_agent_steps
+                WHERE run_id = %s
+                """,
+                (run_id,),
+            ).fetchone()
+            totals = row_to_dict(totals_row) if totals_row else {}
+            conn.execute(
+                """
+                UPDATE learning_agent_runs
+                SET status = %s, retry_count = %s, failed_step = %s, error = %s,
+                    total_latency_ms = %s, total_tokens = %s, cost_usd = %s,
+                    updated_at = NOW()
+                WHERE id = %s
+                """,
+                (
+                    status,
+                    retry_count,
+                    failed_step,
+                    error,
+                    totals.get("total_latency_ms"),
+                    totals.get("total_tokens"),
+                    totals.get("cost_usd"),
+                    run_id,
+                ),
+            )
+    except Exception:
+        logger.exception("Failed to finalize learning agent run %d", run_id)
+
+
+def admin_run_summary(
+    *,
+    limit: int = 50,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Return recent learning agent runs with their per-step breakdown, for admin/debug."""
+    init_db(database_url=database_url)
+    limit = max(1, min(limit, 200))
+    with connect(database_url=database_url) as conn:
+        runs = conn.execute(
+            """
+            SELECT id, lesson_id, user_id, status, prompt_version, model_version, config,
+                   retry_count, total_latency_ms, total_tokens, cost_usd, failed_step, error,
+                   created_at, updated_at
+            FROM learning_agent_runs
+            ORDER BY created_at DESC
+            LIMIT %s
+            """,
+            (limit,),
+        ).fetchall()
+        run_dicts = [row_to_dict(row) for row in runs]
+        run_ids = [int(d["id"]) for d in run_dicts]
+        steps_by_run: dict[int, list[dict[str, Any]]] = {rid: [] for rid in run_ids}
+        if run_ids:
+            steps = conn.execute(
+                """
+                SELECT run_id, step, ordinal, status, model, latency_ms,
+                       prompt_tokens, completion_tokens, cost_usd, error, created_at
+                FROM learning_agent_steps
+                WHERE run_id = ANY(%s)
+                ORDER BY run_id, ordinal
+                """,
+                (run_ids,),
+            ).fetchall()
+            for step_row in steps:
+                step_dict = row_to_dict(step_row)
+                if step_dict.get("created_at") is not None:
+                    step_dict["created_at"] = step_dict["created_at"].isoformat()
+                steps_by_run.setdefault(int(step_dict["run_id"]), []).append(step_dict)
+
+    items = []
+    for run_dict in run_dicts:
+        run_id = int(run_dict["id"])
+        for key in ("created_at", "updated_at"):
+            if run_dict.get(key) is not None:
+                run_dict[key] = run_dict[key].isoformat()
+        run_dict["steps"] = steps_by_run.get(run_id, [])
+        items.append(run_dict)
+    return {"items": items}

--- a/backend/news_dashboard/learn_from_link/evals.py
+++ b/backend/news_dashboard/learn_from_link/evals.py
@@ -1,0 +1,233 @@
+"""Small eval set for Learn from Link lesson synthesis quality.
+
+Models the persistence/scoring pattern in ``news_dashboard.ai_evals``
+(``ai_eval_examples`` / ``ai_eval_runs`` / ``ai_eval_results``), but scores the
+lesson-specific structured contract (``LessonDetail`` + citation grounding)
+instead of the generic answer/citations shape used for ask-ai/briefing evals.
+
+Covers three cases required by issue #1131: a well-grounded lesson, a lesson
+whose citations don't match the source (must be rejected), and a lesson built
+from an unusually short/insufficient source (must degrade gracefully, not
+crash or silently overclaim).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from news_dashboard.db import connect, init_db
+from news_dashboard.learn_from_link.agent_runs import SYNTHESIS_PROMPT_VERSION
+from news_dashboard.learn_from_link.service import (
+    DEFAULT_LESSON_CHAT_MODEL,
+    LessonCitationValidationError,
+    LessonDetailValidationError,
+    generate_structured_lesson_detail,
+    validate_structured_lesson_detail,
+    verify_lesson_citations,
+)
+
+FEATURE = "lesson-synthesis"
+
+_VERDICT_RANK = {"skip": 0, "skim": 1, "read": 2, "study": 3}
+
+LESSON_EVAL_FIXTURES: list[dict[str, Any]] = [
+    {
+        "name": "good-lesson",
+        "lesson_fields": {
+            "title": "Understanding Rate Limiters",
+            "original_url": "https://example.com/rate-limiters",
+            "source_name": "Example Engineering Blog",
+            "author": "Ada Engineer",
+            "published_at": "2026-01-05",
+            "source_content": (
+                "Rate limiters protect services from overload by capping request "
+                "throughput. The token bucket algorithm refills tokens at a fixed "
+                "rate and rejects requests once the bucket is empty, which allows "
+                "short bursts while still bounding sustained throughput over time. "
+                "Sliding window counters trade memory for smoother enforcement than "
+                "fixed windows, avoiding the burst-at-boundary problem that simple "
+                "fixed windows suffer from. Leaky bucket queues excess requests and "
+                "drains them at a constant rate instead of rejecting them outright. "
+                "Choosing an algorithm depends on burst tolerance, fairness "
+                "requirements, and implementation complexity across a distributed "
+                "fleet of servers that must agree on shared counters."
+            ),
+        },
+        "depth": "normal",
+        "persona": "developer",
+        "expected": {"min_key_claims": 3, "min_verdict": "read", "expect_valid": True},
+    },
+    {
+        "name": "insufficient-source",
+        "lesson_fields": {
+            "title": "Short Note",
+            "original_url": "https://example.com/short-note",
+            "source_name": "Example Blog",
+            "author": None,
+            "published_at": None,
+            "source_content": "A brief announcement with little substance.",
+        },
+        "depth": "normal",
+        "persona": "developer",
+        "expected": {"verdict": "skim", "expect_valid": True},
+    },
+    {
+        "name": "bad-citation",
+        "lesson_fields": {
+            "title": "Grounded Article",
+            "original_url": "https://example.com/grounded",
+            "source_name": "Example Journal",
+            "author": "Ada Writer",
+            "published_at": "2026-02-01",
+            "source_content": "This article explains how caches evict entries using LRU.",
+        },
+        "depth": "normal",
+        "persona": "developer",
+        "expected": {"expect_valid": False},
+        # A deliberately-fabricated synthesis payload simulating a hallucinated
+        # citation that never appears in the source, to exercise the citation
+        # verification failure path end to end.
+        "fake_raw_detail": {
+            "gist": "Caches use LRU eviction.",
+            "explanation": "This article explains how caches evict entries using LRU.",
+            "key_claims": ["Caches use LRU eviction."],
+            "prerequisite_concepts": ["Cache basics"],
+            "why_it_matters": "It matters for developers weighing implementation details.",
+            "read_worthiness": {"verdict": "read", "rationale": "Useful background."},
+            "who_should_read": ["Developers"],
+            "questions_to_keep_in_mind": ["What evicts first?"],
+            "citations": [
+                {
+                    "label": "1",
+                    "snippet": "This invented quote never appears in the source.",
+                    "source": "Grounded Article",
+                }
+            ],
+        },
+    },
+]
+
+
+def score_lesson_fixture(fixture: dict[str, Any]) -> tuple[bool, float, str | None]:
+    """Run one fixture through the real synthesis + validation pipeline and score it."""
+    lesson_fields = fixture["lesson_fields"]
+    expected = fixture["expected"]
+    try:
+        raw_detail = fixture.get("fake_raw_detail") or generate_structured_lesson_detail(
+            lesson_fields, depth=fixture["depth"], persona=fixture["persona"]
+        )
+        detail = validate_structured_lesson_detail(raw_detail)
+        verify_lesson_citations(detail, lesson_fields)
+    except (LessonDetailValidationError, LessonCitationValidationError) as exc:
+        if expected.get("expect_valid", True) is False:
+            return True, 1.0, None
+        return False, 0.0, f"unexpected validation failure: {exc}"
+
+    if expected.get("expect_valid") is False:
+        return False, 0.0, "expected validation to fail but it passed"
+
+    failures: list[str] = []
+    min_key_claims = expected.get("min_key_claims")
+    if min_key_claims is not None and len(detail.key_claims) < min_key_claims:
+        failures.append("too few key claims")
+    verdict = expected.get("verdict")
+    if verdict is not None and detail.read_worthiness.verdict != verdict:
+        failures.append(f"expected verdict {verdict!r}, got {detail.read_worthiness.verdict!r}")
+    min_verdict = expected.get("min_verdict")
+    if (
+        min_verdict is not None
+        and _VERDICT_RANK[detail.read_worthiness.verdict] < _VERDICT_RANK[min_verdict]
+    ):
+        failures.append(f"verdict {detail.read_worthiness.verdict!r} below minimum {min_verdict!r}")
+    passed = not failures
+    return passed, 1.0 if passed else 0.0, "; ".join(failures) or None
+
+
+def seed_lesson_eval_examples(*, database_url: str | None = None) -> list[int]:
+    """Insert the fixture set into ai_eval_examples if not already present, return ids."""
+    init_db(database_url=database_url)
+    ids: list[int] = []
+    with connect(database_url=database_url) as conn:
+        for fixture in LESSON_EVAL_FIXTURES:
+            existing = conn.execute(
+                "SELECT id FROM ai_eval_examples WHERE feature = %s AND input->>'name' = %s",
+                (FEATURE, fixture["name"]),
+            ).fetchone()
+            if existing is not None:
+                ids.append(int(existing["id"]))
+                continue
+            row = conn.execute(
+                """
+                INSERT INTO ai_eval_examples
+                  (feature, prompt_version, model_version, input, expected_properties)
+                VALUES (%s, %s, %s, %s::jsonb, %s::jsonb)
+                RETURNING id
+                """,
+                (
+                    FEATURE,
+                    SYNTHESIS_PROMPT_VERSION,
+                    DEFAULT_LESSON_CHAT_MODEL,
+                    json.dumps(fixture),
+                    json.dumps(fixture["expected"]),
+                ),
+            ).fetchone()
+            if row is not None:
+                ids.append(int(row["id"]))
+    return ids
+
+
+def run_lesson_evals(*, database_url: str | None = None) -> dict[str, Any]:
+    """Seed (if needed) and score the lesson eval fixture set, persisting a run."""
+    init_db(database_url=database_url)
+    seed_lesson_eval_examples(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        run = conn.execute(
+            """
+            INSERT INTO ai_eval_runs(feature, prompt_version, model_version)
+            VALUES (%s, %s, %s)
+            RETURNING id
+            """,
+            (FEATURE, SYNTHESIS_PROMPT_VERSION, DEFAULT_LESSON_CHAT_MODEL),
+        ).fetchone()
+        if run is None:
+            msg = "INSERT INTO ai_eval_runs returned no row"
+            raise RuntimeError(msg)
+        run_id = int(run["id"])
+        examples = conn.execute(
+            "SELECT id, input FROM ai_eval_examples WHERE feature = %s ORDER BY id",
+            (FEATURE,),
+        ).fetchall()
+        passed_count = 0
+        for example in examples:
+            fixture = dict(example["input"])
+            passed, score, failure_reason = score_lesson_fixture(fixture)
+            if passed:
+                passed_count += 1
+            conn.execute(
+                """
+                INSERT INTO ai_eval_results
+                  (run_id, example_id, output, score, passed, failure_reason)
+                VALUES (%s, %s, %s::jsonb, %s, %s, %s)
+                """,
+                (
+                    run_id,
+                    int(example["id"]),
+                    json.dumps({"name": fixture.get("name")}),
+                    score,
+                    passed,
+                    failure_reason,
+                ),
+            )
+        total = len(examples)
+        failed = total - passed_count
+        status = "passed" if failed == 0 else "failed"
+        conn.execute(
+            """
+            UPDATE ai_eval_runs
+            SET status = %s, total = %s, passed = %s, failed = %s, finished_at = NOW()
+            WHERE id = %s
+            """,
+            (status, total, passed_count, failed, run_id),
+        )
+    return {"run_id": run_id, "total": total, "passed": passed_count, "failed": failed}

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -13,6 +14,7 @@ from pydantic import ValidationError
 
 from news_dashboard.body_fetch import extract_body
 from news_dashboard.db import connect, init_db, row_to_dict
+from news_dashboard.learn_from_link import agent_runs
 from news_dashboard.learn_from_link.models import (
     LessonDepth,
     LessonDetail,
@@ -668,16 +670,25 @@ def generate_structured_lesson_detail(
     }
 
 
-def validate_structured_lesson_detail(
-    raw_detail: Any,
-    *,
-    lesson_fields: dict[str, Any],
-) -> dict[str, Any]:
+def validate_structured_lesson_detail(raw_detail: Any) -> LessonDetail:
+    """Validate a raw synthesis payload against the LessonDetail schema.
+
+    This is the structured-output boundary check: it runs immediately after
+    generation and before any downstream code (including citation
+    verification) touches the payload.
+    """
     try:
-        detail = LessonDetail.model_validate(raw_detail)
+        return LessonDetail.model_validate(raw_detail)
     except ValidationError as exc:
         raise LessonDetailValidationError from exc
 
+
+def verify_lesson_citations(detail: LessonDetail, lesson_fields: dict[str, Any]) -> dict[str, Any]:
+    """Verify every citation is grounded in the source content, as its own pipeline step.
+
+    Raises LessonCitationValidationError if any citation snippet or source
+    label cannot be found in the lesson's fetched metadata/content.
+    """
     source_context = _normalized_text(
         "\n".join(
             str(value)
@@ -747,16 +758,18 @@ def _build_lesson_detail(
     depth: LessonDepth,
     persona: LessonPersona,
     lesson_id: int,
-) -> tuple[dict[str, Any] | None, str | None]:
+) -> tuple[LessonDetail | None, str | None]:
+    """Generate + schema-validate a lesson detail (the "synthesis" step).
+
+    Citation grounding is verified separately by :func:`verify_lesson_citations`
+    so it can be tracked as its own pipeline step.
+    """
     try:
         raw_detail = generate_structured_lesson_detail(lesson_fields, depth=depth, persona=persona)
-        detail = validate_structured_lesson_detail(raw_detail, lesson_fields=lesson_fields)
+        detail = validate_structured_lesson_detail(raw_detail)
     except LessonDetailValidationError:
         logger.warning("lesson detail validation failed for lesson %d", lesson_id)
         return None, "Generated lesson detail was malformed."
-    except LessonCitationValidationError:
-        logger.warning("lesson citation validation failed for lesson %d", lesson_id)
-        return None, "Generated lesson citations did not match source content."
     except Exception as exc:
         logger.warning("lesson detail generation failed for lesson %d: %s", lesson_id, exc)
         return None, "Generated lesson detail was malformed."
@@ -800,6 +813,129 @@ def _add_personal_relevance(
         }
 
 
+def _timed(func: Any, *args: Any, **kwargs: Any) -> tuple[Any, int]:
+    """Call ``func`` and return ``(result, elapsed_ms)``."""
+    start = time.monotonic()
+    result = func(*args, **kwargs)
+    return result, int((time.monotonic() - start) * 1000)
+
+
+def _run_fetch_step(database_url: str | None, run_id: int, lesson_url: str) -> dict[str, Any]:
+    """Fetch article metadata. Non-fatal: failures are logged and the pipeline continues."""
+    try:
+        metadata, latency_ms = _timed(fetch_url_metadata, lesson_url)
+    except Exception as exc:
+        logger.warning("lesson metadata fetch failed for %r: %s", lesson_url, exc)
+        agent_runs.record_step(
+            database_url, run_id, agent_runs.STEP_FETCH, 1, status="failed", error=str(exc)[:2000]
+        )
+        return {}
+    agent_runs.record_step(
+        database_url, run_id, agent_runs.STEP_FETCH, 1, status="complete", latency_ms=latency_ms
+    )
+    return dict(metadata)
+
+
+def _run_extraction_step(
+    database_url: str | None, run_id: int, lesson_url: str
+) -> tuple[str | None, str | None]:
+    """Extract article body text. Returns ``(body_text, error_message)``."""
+    try:
+        (body, status), latency_ms = _timed(extract_body, lesson_url)
+    except Exception as exc:
+        logger.warning("lesson body extraction failed for %r: %s", lesson_url, exc)
+        agent_runs.record_step(
+            database_url,
+            run_id,
+            agent_runs.STEP_EXTRACTION,
+            2,
+            status="failed",
+            error=str(exc)[:2000],
+        )
+        return None, "Could not extract readable article content."
+
+    body_text = body.strip()
+    if status != "ok" or not body_text:
+        agent_runs.record_step(
+            database_url,
+            run_id,
+            agent_runs.STEP_EXTRACTION,
+            2,
+            status="failed",
+            latency_ms=latency_ms,
+            error=f"extract_body returned status={status!r}",
+        )
+        return None, "Could not extract readable article content."
+
+    agent_runs.record_step(
+        database_url,
+        run_id,
+        agent_runs.STEP_EXTRACTION,
+        2,
+        status="complete",
+        latency_ms=latency_ms,
+    )
+    return body_text, None
+
+
+def _run_synthesis_step(
+    database_url: str | None,
+    run_id: int,
+    lesson_fields: dict[str, Any],
+    depth: LessonDepth,
+    persona: LessonPersona,
+    lesson_id: int,
+) -> tuple[LessonDetail | None, dict[str, Any] | None, str | None]:
+    """Generate the lesson detail + study artifacts. Returns ``(detail, artifacts, error)``."""
+    start = time.monotonic()
+    detail_model, detail_error = _build_lesson_detail(lesson_fields, depth, persona, lesson_id)
+    artifacts: dict[str, Any] | None = None
+    error = detail_error
+    if error is None:
+        artifacts, artifacts_error = _build_study_artifacts(lesson_fields, lesson_id)
+        error = artifacts_error
+    agent_runs.record_step(
+        database_url,
+        run_id,
+        agent_runs.STEP_SYNTHESIS,
+        3,
+        status="failed" if error else "complete",
+        latency_ms=int((time.monotonic() - start) * 1000),
+        error=error,
+    )
+    if error or detail_model is None:
+        return None, None, error or "Generated lesson detail was malformed."
+    return detail_model, artifacts, None
+
+
+def _run_citation_verification_step(
+    database_url: str | None,
+    run_id: int,
+    detail_model: LessonDetail,
+    lesson_fields: dict[str, Any],
+    lesson_id: int,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Verify citations are grounded in source content. Returns ``(detail, error)``."""
+    start = time.monotonic()
+    error: str | None = None
+    detail: dict[str, Any] | None = None
+    try:
+        detail = verify_lesson_citations(detail_model, lesson_fields)
+    except LessonCitationValidationError:
+        logger.warning("lesson citation validation failed for lesson %d", lesson_id)
+        error = "Generated lesson citations did not match source content."
+    agent_runs.record_step(
+        database_url,
+        run_id,
+        agent_runs.STEP_CITATION_VERIFICATION,
+        4,
+        status="failed" if error else "complete",
+        latency_ms=int((time.monotonic() - start) * 1000),
+        error=error,
+    )
+    return detail, error
+
+
 def generate_lesson_from_url(
     lesson_id: int,
     user_id: int,
@@ -812,8 +948,17 @@ def generate_lesson_from_url(
 
     depth = lesson["depth"]
     persona = lesson["persona"]
+    chat_model = os.getenv("OPENAI_LESSON_CHAT_MODEL", DEFAULT_LESSON_CHAT_MODEL)
+    run_id = agent_runs.start_run(
+        database_url,
+        lesson_id=lesson_id,
+        user_id=user_id,
+        prompt_version=agent_runs.SYNTHESIS_PROMPT_VERSION,
+        model_version=chat_model,
+        config={"depth": depth, "persona": persona},
+    )
 
-    def _fail(error_message: str) -> dict[str, Any]:
+    def _fail(error_message: str, *, failed_step: str) -> dict[str, Any]:
         result = _update_lesson_failure(
             lesson_id,
             user_id,
@@ -829,24 +974,24 @@ def generate_lesson_from_url(
             generation_error=error_message,
             database_url=database_url,
         )
+        agent_runs.finish_run(
+            database_url,
+            run_id,
+            status="failed",
+            failed_step=failed_step,
+            error=error_message,
+        )
         return result
 
     lesson_url = str(lesson["original_url"])
-    metadata: dict[str, Any] = {}
-    try:
-        metadata = fetch_url_metadata(lesson_url)
-    except Exception as exc:
-        logger.warning("lesson metadata fetch failed for %r: %s", lesson_url, exc)
+    metadata = _run_fetch_step(database_url, run_id, lesson_url)
 
-    try:
-        body, status = extract_body(lesson_url)
-    except Exception as exc:
-        logger.warning("lesson body extraction failed for %r: %s", lesson_url, exc)
-        return _fail("Could not extract readable article content.")
-
-    body_text = body.strip()
-    if status != "ok" or not body_text:
-        return _fail("Could not extract readable article content.")
+    body_text, extraction_error = _run_extraction_step(database_url, run_id, lesson_url)
+    if extraction_error or body_text is None:
+        return _fail(
+            extraction_error or "Could not extract readable article content.",
+            failed_step=agent_runs.STEP_EXTRACTION,
+        )
 
     lesson_fields: dict[str, Any] = {
         "original_url": lesson_url,
@@ -857,15 +1002,25 @@ def generate_lesson_from_url(
         "source_content": body_text,
     }
 
-    detail, detail_error = _build_lesson_detail(lesson_fields, depth, persona, lesson_id)
-    if detail_error:
-        return _fail(detail_error)
-    lesson_fields["lesson_detail"] = detail
-
-    artifacts, artifacts_error = _build_study_artifacts(lesson_fields, lesson_id)
-    if artifacts_error:
-        return _fail(artifacts_error)
+    detail_model, artifacts, synthesis_error = _run_synthesis_step(
+        database_url, run_id, lesson_fields, depth, persona, lesson_id
+    )
+    if synthesis_error or detail_model is None:
+        return _fail(
+            synthesis_error or "Generated lesson detail was malformed.",
+            failed_step=agent_runs.STEP_SYNTHESIS,
+        )
     lesson_fields["study_artifacts"] = artifacts
+
+    detail, citation_error = _run_citation_verification_step(
+        database_url, run_id, detail_model, lesson_fields, lesson_id
+    )
+    if citation_error or detail is None:
+        return _fail(
+            citation_error or "Generated lesson citations did not match source content.",
+            failed_step=agent_runs.STEP_CITATION_VERIFICATION,
+        )
+    lesson_fields["lesson_detail"] = detail
 
     _add_personal_relevance(
         user_id,
@@ -874,21 +1029,50 @@ def generate_lesson_from_url(
         database_url=database_url,
     )
 
-    result = _update_lesson_success(
-        lesson_id,
-        user_id,
-        lesson_fields=lesson_fields,
-        database_url=database_url,
+    persistence_start = time.monotonic()
+    try:
+        result = _update_lesson_success(
+            lesson_id,
+            user_id,
+            lesson_fields=lesson_fields,
+            database_url=database_url,
+        )
+        _record_lesson_generation(
+            lesson_id,
+            depth=depth,
+            persona=persona,
+            generation_status="complete",
+            lesson_detail=lesson_fields["lesson_detail"],
+            generation_error=None,
+            database_url=database_url,
+        )
+    except Exception as exc:
+        agent_runs.record_step(
+            database_url,
+            run_id,
+            agent_runs.STEP_PERSISTENCE,
+            5,
+            status="failed",
+            latency_ms=int((time.monotonic() - persistence_start) * 1000),
+            error=str(exc)[:2000],
+        )
+        agent_runs.finish_run(
+            database_url,
+            run_id,
+            status="failed",
+            failed_step=agent_runs.STEP_PERSISTENCE,
+            error=str(exc)[:2000],
+        )
+        raise
+    agent_runs.record_step(
+        database_url,
+        run_id,
+        agent_runs.STEP_PERSISTENCE,
+        5,
+        status="complete",
+        latency_ms=int((time.monotonic() - persistence_start) * 1000),
     )
-    _record_lesson_generation(
-        lesson_id,
-        depth=depth,
-        persona=persona,
-        generation_status="complete",
-        lesson_detail=lesson_fields["lesson_detail"],
-        generation_error=None,
-        database_url=database_url,
-    )
+    agent_runs.finish_run(database_url, run_id, status="complete")
     return result
 
 

--- a/backend/news_dashboard/main.py
+++ b/backend/news_dashboard/main.py
@@ -2727,6 +2727,17 @@ def admin_ai_quality(days: Annotated[int, Query(ge=1, le=365)] = 30) -> dict[str
     return admin_quality_summary(days=days)
 
 
+@admin.get("/learning-agent/runs")
+def admin_learning_agent_runs(limit: Annotated[int, Query(ge=1, le=200)] = 50) -> dict[str, Any]:
+    """Recent Learn from Link generation runs with per-step status/latency/cost/retry.
+
+    For debug workflows: shows what happened in a run without reading logs.
+    """
+    from news_dashboard.learn_from_link.agent_runs import admin_run_summary
+
+    return admin_run_summary(limit=limit)
+
+
 @admin.get("/users")
 def admin_list_users() -> dict[str, Any]:
     return {"items": list_users()}

--- a/backend/tests/test_ai_evals.py
+++ b/backend/tests/test_ai_evals.py
@@ -48,6 +48,17 @@ def test_run_local_evals_records_pass_and_failure(pg_clean: str) -> None:
     assert summary["recent_failures"][0]["failure_reason"] == "unknown briefing citations"
 
 
+def test_eval_learning_agent_cli_runs_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, pg_clean: str
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+
+    result = CliRunner().invoke(app, ["eval-learning-agent"])
+
+    assert result.exit_code == 0
+    assert "passed, 0 failed" in result.output
+
+
 def test_eval_ai_cli_exits_nonzero_on_failed_eval(
     monkeypatch: pytest.MonkeyPatch, pg_clean: str
 ) -> None:

--- a/backend/tests/test_ai_quality_api.py
+++ b/backend/tests/test_ai_quality_api.py
@@ -37,3 +37,33 @@ def test_admin_ai_quality_returns_local_summary(monkeypatch: Any) -> None:
 
     assert response.status_code == 200
     assert response.json()["range_days"] == 14
+
+
+def test_admin_learning_agent_runs_requires_admin() -> None:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 2,
+        "username": "reader",
+        "is_admin": False,
+    }
+    app.dependency_overrides[require_admin] = lambda: (_ for _ in ()).throw(
+        HTTPException(status_code=403, detail="admin role required")
+    )
+
+    response = TestClient(app, raise_server_exceptions=False).get("/api/admin/learning-agent/runs")
+
+    assert response.status_code == 403
+    app.dependency_overrides.pop(require_auth, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+def test_admin_learning_agent_runs_returns_summary(monkeypatch: Any) -> None:
+    def fake_summary(*, limit: int) -> dict[str, Any]:
+        assert limit == 25
+        return {"items": [{"id": 1, "status": "complete", "steps": []}]}
+
+    monkeypatch.setattr("news_dashboard.learn_from_link.agent_runs.admin_run_summary", fake_summary)
+
+    response = TestClient(app).get("/api/admin/learning-agent/runs?limit=25")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["status"] == "complete"

--- a/backend/tests/test_learn_from_link_agent_runs.py
+++ b/backend/tests/test_learn_from_link_agent_runs.py
@@ -1,0 +1,198 @@
+"""Tests for Learn from Link run/step trace bookkeeping (issue #1131)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from news_dashboard.db import connect
+from news_dashboard.learn_from_link import agent_runs, service
+from news_dashboard.learn_from_link.agent_runs import (
+    STEP_CITATION_VERIFICATION,
+    STEP_EXTRACTION,
+    STEP_FETCH,
+    STEP_PERSISTENCE,
+    STEP_SYNTHESIS,
+    SYNTHESIS_PROMPT_VERSION,
+)
+
+
+def _run_row(database_url: str, lesson_id: int) -> dict[str, Any]:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "SELECT * FROM learning_agent_runs WHERE lesson_id = %s ORDER BY id DESC LIMIT 1",
+            (lesson_id,),
+        ).fetchone()
+    assert row is not None
+    return dict(row)
+
+
+def _step_rows(database_url: str, run_id: int) -> list[dict[str, Any]]:
+    with connect(database_url=database_url) as conn:
+        rows = conn.execute(
+            "SELECT * FROM learning_agent_steps WHERE run_id = %s ORDER BY ordinal",
+            (run_id,),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+@pytest.fixture(autouse=True)
+def _lesson_extraction_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        service,
+        "fetch_url_metadata",
+        lambda url: {
+            "title": f"Title for {url}",
+            "site_name": "Example Source",
+            "author": "Example Author",
+            "published_at": "2026-07-09",
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        service,
+        "extract_body",
+        lambda url: (f"Body for {url}", "ok"),
+        raising=False,
+    )
+
+
+def test_successful_generation_records_version_metadata_and_all_steps(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    lesson = service.create_lesson(
+        user_id, "https://example.com/a", depth="deep", persona="new_to_ai", database_url=pg_clean
+    )
+
+    run = _run_row(pg_clean, int(lesson["id"]))
+    assert run["status"] == "complete"
+    assert run["prompt_version"] == SYNTHESIS_PROMPT_VERSION
+    assert run["model_version"]
+    assert run["config"] == {"depth": "deep", "persona": "new_to_ai"}
+    assert run["failed_step"] is None
+    assert run["error"] is None
+    assert run["total_latency_ms"] is not None
+
+    steps = _step_rows(pg_clean, int(run["id"]))
+    assert [s["step"] for s in steps] == [
+        STEP_FETCH,
+        STEP_EXTRACTION,
+        STEP_SYNTHESIS,
+        STEP_CITATION_VERIFICATION,
+        STEP_PERSISTENCE,
+    ]
+    assert all(s["status"] == "complete" for s in steps)
+    assert all(s["latency_ms"] is not None for s in steps)
+
+
+def test_extraction_failure_marks_run_failed_at_extraction_step(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    monkeypatch.setattr(service, "extract_body", lambda _url: ("", "error"), raising=False)
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    run = _run_row(pg_clean, int(lesson["id"]))
+    assert run["status"] == "failed"
+    assert run["failed_step"] == STEP_EXTRACTION
+
+    steps = _step_rows(pg_clean, int(run["id"]))
+    extraction_step = next(s for s in steps if s["step"] == STEP_EXTRACTION)
+    assert extraction_step["status"] == "failed"
+    assert not any(s["step"] == STEP_SYNTHESIS for s in steps)
+
+
+def test_citation_failure_marks_run_failed_at_citation_verification_step(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    monkeypatch.setattr(
+        service,
+        "generate_structured_lesson_detail",
+        lambda _fields, **_kwargs: {
+            "gist": "A gist grounded in the article.",
+            "explanation": "A short explanation grounded in the article.",
+            "key_claims": ["A grounded claim."],
+            "prerequisite_concepts": ["Background context"],
+            "why_it_matters": "It matters because the source is useful.",
+            "read_worthiness": {"verdict": "read", "rationale": "The source is useful."},
+            "who_should_read": ["Curious readers"],
+            "questions_to_keep_in_mind": ["Which claims are supported?"],
+            "citations": [
+                {
+                    "label": "1",
+                    "snippet": "This invented quote is absent from the article.",
+                    "source": "Metadata title",
+                }
+            ],
+        },
+        raising=False,
+    )
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    run = _run_row(pg_clean, int(lesson["id"]))
+    assert run["status"] == "failed"
+    assert run["failed_step"] == STEP_CITATION_VERIFICATION
+
+    steps = _step_rows(pg_clean, int(run["id"]))
+    synthesis_step = next(s for s in steps if s["step"] == STEP_SYNTHESIS)
+    citation_step = next(s for s in steps if s["step"] == STEP_CITATION_VERIFICATION)
+    assert synthesis_step["status"] == "complete"
+    assert citation_step["status"] == "failed"
+    assert not any(s["step"] == STEP_PERSISTENCE for s in steps)
+
+
+def test_synthesis_failure_marks_run_failed_at_synthesis_step(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    monkeypatch.setattr(
+        service,
+        "generate_structured_lesson_detail",
+        lambda _fields, **_kwargs: {"gist": "Only one field is not enough."},
+        raising=False,
+    )
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "failed"
+    run = _run_row(pg_clean, int(lesson["id"]))
+    assert run["status"] == "failed"
+    assert run["failed_step"] == STEP_SYNTHESIS
+
+
+def test_admin_run_summary_returns_recent_runs_with_steps(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    summary = agent_runs.admin_run_summary(database_url=pg_clean)
+
+    assert len(summary["items"]) == 1
+    item = summary["items"][0]
+    assert item["status"] == "complete"
+    assert len(item["steps"]) == 5
+    assert item["steps"][0]["step"] == STEP_FETCH

--- a/backend/tests/test_learn_from_link_evals.py
+++ b/backend/tests/test_learn_from_link_evals.py
@@ -1,0 +1,87 @@
+"""Tests for the Learn from Link lesson synthesis eval set (issue #1131)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from news_dashboard.db import connect
+from news_dashboard.learn_from_link.evals import (
+    FEATURE,
+    LESSON_EVAL_FIXTURES,
+    run_lesson_evals,
+    score_lesson_fixture,
+    seed_lesson_eval_examples,
+)
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return next(f for f in LESSON_EVAL_FIXTURES if f["name"] == name)
+
+
+def test_good_lesson_fixture_passes() -> None:
+    passed, score, reason = score_lesson_fixture(_fixture("good-lesson"))
+    assert passed is True
+    assert score == 1.0
+    assert reason is None
+
+
+def test_insufficient_source_fixture_passes_with_skim_verdict() -> None:
+    passed, score, reason = score_lesson_fixture(_fixture("insufficient-source"))
+    assert passed is True
+    assert score == 1.0
+    assert reason is None
+
+
+def test_bad_citation_fixture_passes_because_validation_correctly_rejects_it() -> None:
+    passed, score, reason = score_lesson_fixture(_fixture("bad-citation"))
+    assert passed is True
+    assert score == 1.0
+    assert reason is None
+
+
+def test_score_lesson_fixture_fails_when_validation_unexpectedly_rejects_a_good_case() -> None:
+    fixture = dict(_fixture("good-lesson"))
+    fixture["expected"] = {**fixture["expected"], "min_key_claims": 99}
+    passed, score, reason = score_lesson_fixture(fixture)
+    assert passed is False
+    assert score == 0.0
+    assert reason is not None
+    assert "too few key claims" in reason
+
+
+def test_score_lesson_fixture_fails_when_a_bad_case_unexpectedly_validates() -> None:
+    fixture = dict(_fixture("bad-citation"))
+    fixture["expected"] = {"expect_valid": True, "min_key_claims": 1}
+    passed, _score, reason = score_lesson_fixture(fixture)
+    assert passed is False
+    assert reason is not None
+
+
+def test_seed_lesson_eval_examples_is_idempotent(pg_clean: str) -> None:
+    first_ids = seed_lesson_eval_examples(database_url=pg_clean)
+    second_ids = seed_lesson_eval_examples(database_url=pg_clean)
+
+    assert first_ids == second_ids
+    with connect(database_url=pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM ai_eval_examples WHERE feature = %s", (FEATURE,)
+        ).fetchone()["count"]
+    assert count == len(LESSON_EVAL_FIXTURES)
+
+
+def test_run_lesson_evals_persists_a_passing_run(pg_clean: str) -> None:
+    result = run_lesson_evals(database_url=pg_clean)
+
+    assert result["total"] == len(LESSON_EVAL_FIXTURES)
+    assert result["failed"] == 0
+    assert result["passed"] == len(LESSON_EVAL_FIXTURES)
+
+    with connect(database_url=pg_clean) as conn:
+        run_row = conn.execute(
+            "SELECT status FROM ai_eval_runs WHERE id = %s", (result["run_id"],)
+        ).fetchone()
+        result_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM ai_eval_results WHERE run_id = %s", (result["run_id"],)
+        ).fetchone()["count"]
+    assert run_row["status"] == "passed"
+    assert result_count == len(LESSON_EVAL_FIXTURES)

--- a/backend/tests/test_learn_from_link_feedback.py
+++ b/backend/tests/test_learn_from_link_feedback.py
@@ -1,0 +1,123 @@
+"""Tests for lesson helpfulness feedback via the generic ai_feedback module (#1131)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.ai_feedback import service
+from news_dashboard.auth import require_auth
+from news_dashboard.db import connect, init_db
+from news_dashboard.main import app
+
+
+def _make_user(database_url: str, username: str = "alice") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, %s) RETURNING id",
+            (username, "test-hash"),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _seed_lesson(database_url: str, *, user_id: int, title: str = "A Lesson") -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO lessons(user_id, original_url, normalized_url, title,
+                                 generation_status, lesson_detail)
+            VALUES (%s, %s, %s, %s, 'complete', %s::jsonb)
+            RETURNING id
+            """,
+            (
+                user_id,
+                "https://example.com/a",
+                "https://example.com/a",
+                title,
+                '{"gist": "A grounded gist."}',
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
+def _client_for(user_id: int) -> TestClient:
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": user_id,
+        "username": "alice",
+        "email": None,
+        "is_admin": False,
+    }
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_record_lesson_feedback_seeds_eval_example(pg_clean: str) -> None:
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson_id = _seed_lesson(pg_clean, user_id=user_id)
+
+    saved = service.record_feedback(
+        user_id, "lesson", lesson_id, 1, comment="Very useful", database_url=pg_clean
+    )
+
+    assert saved["verdict"] == 1
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT * FROM ai_eval_examples WHERE feature = 'lesson-feedback'"
+            " AND input->>'lesson_id' = %s",
+            (str(lesson_id),),
+        ).fetchone()
+    assert row is not None
+    assert row["feedback_helpful"] is True
+    assert row["created_by_user_id"] == user_id
+    assert row["expected_properties"]["comment"] == "Very useful"
+
+
+def test_record_negative_lesson_feedback_seeds_unhelpful_eval_example(pg_clean: str) -> None:
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson_id = _seed_lesson(pg_clean, user_id=user_id)
+
+    service.record_feedback(user_id, "lesson", lesson_id, -1, database_url=pg_clean)
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT feedback_helpful FROM ai_eval_examples WHERE feature = 'lesson-feedback'"
+            " AND input->>'lesson_id' = %s",
+            (str(lesson_id),),
+        ).fetchone()
+    assert row["feedback_helpful"] is False
+
+
+def test_record_lesson_feedback_for_missing_lesson_does_not_raise(pg_clean: str) -> None:
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+
+    saved = service.record_feedback(user_id, "lesson", 999999, 1, database_url=pg_clean)
+
+    assert saved["verdict"] == 1
+    with connect(database_url=pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM ai_eval_examples WHERE feature = 'lesson-feedback'"
+        ).fetchone()["count"]
+    assert count == 0
+
+
+def test_post_lesson_feedback_endpoint(monkeypatch: pytest.MonkeyPatch, pg_clean: str) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson_id = _seed_lesson(pg_clean, user_id=user_id)
+
+    try:
+        with _client_for(user_id) as client:
+            response = client.post(
+                "/api/ai-feedback",
+                json={"subject_type": "lesson", "subject_id": lesson_id, "verdict": 1},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json()["verdict"] == 1


### PR DESCRIPTION
## Summary

Implements #1131 (https://github.com/lihor-hub/news-dashboard/issues/1131): hardens the Learn from Link lesson pipeline so it behaves like a production agentic system rather than a demo.

- **Version metadata**: new `learning_agent_runs` table records `prompt_version`/`model_version`/`config` (depth, persona) for every generation run.
- **Per-step trace/run metadata**: new `learning_agent_steps` table records status (`complete`/`failed`), latency, tokens/cost (where applicable), and error for each of the 5 pipeline steps — `fetch`, `extraction`, `synthesis`, `citation_verification`, `persistence` — mirroring the existing `briefing_agent.py` run/step convention rather than inventing a new mechanism.
- **Structured output validation at the boundary**: split `validate_structured_lesson_detail` (Pydantic schema check) from a new `verify_lesson_citations` (grounding check) so both are independently validated immediately after generation and tracked as separate pipeline steps, with a clear failure path (`LessonDetailValidationError` / `LessonCitationValidationError`) into `_fail(...)`.
- **Eval set**: `learn_from_link/evals.py` adds 3 fixtures — a well-grounded lesson, a bad-citation case, and an insufficient-source case — scored against the *real* synthesis + validation pipeline code and persisted through the existing `ai_eval_examples`/`ai_eval_runs`/`ai_eval_results` tables (same pattern as `ai_evals.py`). New `eval-learning-agent` CLI command mirrors `eval-ai`.
- **User feedback → eval seed**: `ai_feedback` gains `subject_type="lesson"` (extending the existing generic thumbs up/down feature rather than building a new one), so a lesson's helpfulness can be recorded via the existing `/api/ai-feedback` endpoint. Each lesson verdict also seeds an `ai_eval_examples` row (`feature="lesson-feedback"`) capturing the lesson's structured detail, so real user judgments are queryable and can later be promoted into the curated eval set.
- **Admin/debug visibility**: new `GET /api/admin/learning-agent/runs` returns recent runs with per-step latency/status/cost/error, for debugging without reading logs.

### Judgment calls (noted per the issue's "make reasonable choices" instruction)

- Core lesson synthesis (`generate_structured_lesson_detail`) is deterministic/template-based today, not an LLM call — there's no separate "prompt" to version, so `SYNTHESIS_PROMPT_VERSION` versions the template/heuristic logic itself, bumped whenever that logic changes in a way that could shift eval baselines. `model_version` on runs reflects the configured `OPENAI_LESSON_CHAT_MODEL` (used by the personal-relevance/slide-deck/chat side-features).
- Cost is a coarse per-model USD-per-1K-token estimate for admin visibility only (not billing-accurate); when Langfuse is configured, the existing `/api/admin/ai/metrics` remains the source of truth for actual billed cost. Core synthesis steps show null cost/tokens since they're not LLM calls today — an honest reflection of the current pipeline, not a gap in the instrumentation.
- No SQLite fallback, no database-type sniffing — all new SQL is Postgres/psycopg-style per this repo's `AGENTS.md`, added as idempotent `CREATE TABLE IF NOT EXISTS`/`ALTER TABLE` statements in `db.py` following the existing schema convention (no Alembic in this repo).

## Test plan

- [x] `make lint` — ruff check + format clean
- [x] `make typecheck` — mypy (strict), ty, pyrefly all clean
- [x] Full backend suite: `pytest --cov` — **2075 passed**, 0 failed (657.99s), including new files `test_learn_from_link_agent_runs.py`, `test_learn_from_link_evals.py`, `test_learn_from_link_feedback.py` at 100% coverage, plus extensions to `test_ai_evals.py` and `test_ai_quality_api.py`
- [x] New tests cover: version metadata persistence, per-step failure-state persistence (extraction/synthesis/citation_verification failures each recorded with the correct `failed_step`), eval scoring paths (good/bad-citation/insufficient-source), feedback capture + eval seeding, and the new admin endpoint (including the `require_admin` gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)