### PR TITLE
fix: copy bundle budget checker into Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci
 COPY index.html tsconfig.json vite.config.ts ./
+COPY scripts/check-bundle-budget.mjs ./scripts/
 COPY public ./public
 COPY frontend ./frontend
 RUN npm run build


### PR DESCRIPTION
Closes #1166

Copies `scripts/check-bundle-budget.mjs` into the frontend Docker stage before `npm run build`, so the production image build can execute the bundle-size gate introduced in #1135.

Verified with:
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test:frontend` (914 tests)
- `npm run build`
- `docker build --target frontend .`
- `docker build .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)