### PR TITLE
fix: reset lesson artifacts on regeneration (#1167)

### DIFF
--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -68,6 +68,17 @@ clearly rather than guessing.
 {source_context}
 """
 
+_LESSON_ARTIFACT_RESET_ASSIGNMENTS = """\
+podcast_status = NULL,
+                podcast_error = NULL,
+                slide_deck = NULL,
+                slide_deck_status = NULL,
+                slide_deck_error = NULL,
+                study_artifacts = NULL,
+                personal_relevance = NULL,
+                relevance_feedback = NULL,
+"""
+
 
 class LessonUrlError(ValueError):
     """Raised when a lesson URL cannot be fetched safely."""
@@ -152,7 +163,7 @@ def create_lesson(
     init_db(database_url=database_url)
     with connect(database_url=database_url) as conn:
         row = conn.execute(
-            """
+            f"""
             INSERT INTO lessons (
               user_id,
               original_url,
@@ -172,6 +183,7 @@ def create_lesson(
                 published_at = NULL,
                 source_content = NULL,
                 lesson_detail = NULL,
+                {_LESSON_ARTIFACT_RESET_ASSIGNMENTS}
                 depth = %s,
                 persona = %s,
                 updated_at = NOW()
@@ -205,12 +217,13 @@ def regenerate_lesson(
     init_db(database_url=database_url)
     with connect(database_url=database_url) as conn:
         row = conn.execute(
-            """
+            f"""
             UPDATE lessons
             SET depth = %s,
                 persona = %s,
                 generation_status = 'pending',
                 generation_error = NULL,
+                {_LESSON_ARTIFACT_RESET_ASSIGNMENTS}
                 updated_at = NOW()
             WHERE id = %s AND user_id = %s
             RETURNING *

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -510,10 +510,32 @@ def test_create_lesson_duplicate_resets_pending_state(
         conn.execute(
             """
             UPDATE lessons
-            SET generation_status = 'failed', generation_error = %s, source_content = %s
+            SET generation_status = 'failed',
+                generation_error = %s,
+                source_content = %s,
+                podcast_status = 'complete',
+                podcast_error = %s,
+                slide_deck = %s::jsonb,
+                slide_deck_status = 'complete',
+                slide_deck_error = %s,
+                study_artifacts = %s::jsonb,
+                personal_relevance = %s::jsonb,
+                relevance_feedback = true
             WHERE id = %s
             """,
-            ("boom", "old content", first["id"]),
+            (
+                "boom",
+                "old content",
+                "old podcast error",
+                '{"slides":[{"title":"Old slide","bullets":["Old bullet"]}]}',
+                "old slide error",
+                '{"flashcards":[{"concept":"Old","claim":"Old claim"}]}',
+                (
+                    '{"summary":"Old relevance","reasons":["Old reason"],'
+                    '"suggested_actions":["Old action"]}'
+                ),
+                first["id"],
+            ),
         )
 
     second = service.create_lesson(
@@ -527,6 +549,12 @@ def test_create_lesson_duplicate_resets_pending_state(
     assert second["generation_status"] == "complete"
     assert second["generation_error"] is None
     assert second["source_content"] == "Body for https://example.com/story"
+    assert second["podcast_status"] is None
+    assert second["podcast_error"] is None
+    assert second["slide_deck"] is None
+    assert second["slide_deck_status"] is None
+    assert second["slide_deck_error"] is None
+    assert second["relevance_feedback"] is None
 
 
 def test_create_lesson_failed_retry_clears_stale_extracted_fields(
@@ -1001,6 +1029,32 @@ def test_regenerate_lesson_updates_controls_and_marks_pending(
     user_id = _make_user(pg_clean)
     lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
     assert lesson["generation_status"] == "complete"
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            UPDATE lessons
+            SET podcast_status = 'complete',
+                podcast_error = %s,
+                slide_deck = %s::jsonb,
+                slide_deck_status = 'complete',
+                slide_deck_error = %s,
+                study_artifacts = %s::jsonb,
+                personal_relevance = %s::jsonb,
+                relevance_feedback = false
+            WHERE id = %s
+            """,
+            (
+                "old podcast error",
+                '{"slides":[{"title":"Old slide","bullets":["Old bullet"]}]}',
+                "old slide error",
+                '{"flashcards":[{"concept":"Old","claim":"Old claim"}]}',
+                (
+                    '{"summary":"Old relevance","reasons":["Old reason"],'
+                    '"suggested_actions":["Old action"]}'
+                ),
+                lesson["id"],
+            ),
+        )
 
     updated = service.regenerate_lesson(
         int(lesson["id"]),
@@ -1014,6 +1068,14 @@ def test_regenerate_lesson_updates_controls_and_marks_pending(
     assert updated["generation_error"] is None
     assert updated["depth"] == "expert"
     assert updated["persona"] == "product_builder"
+    assert updated["podcast_status"] is None
+    assert updated["podcast_error"] is None
+    assert updated["slide_deck"] is None
+    assert updated["slide_deck_status"] is None
+    assert updated["slide_deck_error"] is None
+    assert updated["study_artifacts"] is None
+    assert updated["personal_relevance"] is None
+    assert updated["relevance_feedback"] is None
 
 
 def test_regenerate_lesson_raises_not_found_for_missing_lesson(pg_clean: str) -> None:

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -274,4 +274,24 @@ describe('LessonDetailPage', () => {
       expect(api.generateLessonSlideDeck).toHaveBeenCalledWith(5, true);
     });
   });
+
+  it('shows create actions after regenerated artifacts are cleared', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue({
+      ...COMPLETE_LESSON,
+      podcast_status: null,
+      slide_deck: null,
+      slide_deck_status: null,
+      study_artifacts: null,
+    });
+
+    renderPage(5);
+    await screen.findByText('A careful article');
+
+    expect(screen.getByRole('button', { name: 'Create podcast' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create slide deck' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Regenerate' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Flashcards' })).not.toBeInTheDocument();
+    expect(document.querySelector('audio')).not.toBeInTheDocument();
+    expect(screen.queryByText('Slide 1')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #1167

## Summary
- clear podcast, slide deck, study artifact, personal relevance, and relevance feedback fields whenever a lesson enters pending generation
- apply the same invalidation to same-URL lesson recreation and explicit regeneration
- add backend and frontend regression coverage for cleared artifacts showing create actions instead of stale generated content

## Tests
- PATH="$PWD/.venv/bin:$PATH" make lint
- PATH="$PWD/.venv/bin:$PATH" make typecheck
- PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_learn_from_link.py
- npm run test:frontend
- npm run build

Note: `dotenv run -- make test` ran the full backend suite and failed in unrelated article/ingest tests because tmp_path-based tests were routed into the shared dotenv database, causing duplicate article rows and one schema deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)