### PR TITLE
fix: duplicate key violates articles_url_key constraint during Ask AI

### DIFF
--- a/backend/news_dashboard/articles/service.py
+++ b/backend/news_dashboard/articles/service.py
@@ -52,19 +52,28 @@ def save_shared_url(
         )
         row = conn.execute("SELECT * FROM articles WHERE url = %s", (url,)).fetchone()
         if row is None:
-            row = conn.execute(
-                """
-                INSERT INTO articles(
-                  url, canonical_url, title, source_slug, source_name, category, kind,
-                  published_at, summary, reason, importance_score, tags, discovered_at, updated_at
-                ) VALUES (
-                  %s, %s, %s, %s, %s, 'shared', 'share_target',
-                  %s, %s, 'Saved from the operating system share sheet', 50, '', %s, %s
-                )
-                RETURNING *
-                """,
-                (url, url, article_title, source_slug, source_name, ts, summary, ts, ts),
-            ).fetchone()
+            import psycopg
+
+            try:
+                with conn.transaction():
+                    row = conn.execute(
+                        """
+                        INSERT INTO articles(
+                          url, canonical_url, title, source_slug, source_name, category, kind,
+                          published_at, summary, reason, importance_score, tags,
+                          discovered_at, updated_at
+                        ) VALUES (
+                          %s, %s, %s, %s, %s, 'shared', 'share_target',
+                          %s, %s, 'Saved from the operating system share sheet', 50, '', %s, %s
+                        )
+                        RETURNING *
+                        """,
+                        (url, url, article_title, source_slug, source_name, ts, summary, ts, ts),
+                    ).fetchone()
+            except psycopg.Error:
+                row = conn.execute("SELECT * FROM articles WHERE url = %s", (url,)).fetchone()
+                if row is None:
+                    raise
         article = row_to_dict(row)
         conn.execute(
             """

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -354,19 +354,18 @@ def embed_all_eligible(
             continue
         try:
             vector = _embed(text)
+            from news_dashboard.db import connect as _connect
+
+            with _connect(db_path) as conn:
+                conn.execute(
+                    "UPDATE articles SET embedding_vec=%s::vector WHERE id=%s",
+                    (vector_literal(vector), row["id"]),
+                )
+            count += 1
         except Exception:
             logger.warning(
                 "failed to embed article %s during backfill; skipping", row["id"], exc_info=True
             )
-            continue
-        from news_dashboard.db import connect as _connect
-
-        with _connect(db_path) as conn:
-            conn.execute(
-                "UPDATE articles SET embedding_vec=%s::vector WHERE id=%s",
-                (vector_literal(vector), row["id"]),
-            )
-        count += 1
     return count
 
 

--- a/backend/tests/test_share_target_api.py
+++ b/backend/tests/test_share_target_api.py
@@ -53,3 +53,31 @@ def test_save_shared_url_rejects_unsafe_url(pg_clean: str) -> None:
         )
 
     assert response.status_code == 422
+
+
+def test_save_shared_url_concurrency(pg_clean: str) -> None:
+    _seed_fake_user(pg_clean)
+
+    import concurrent.futures
+
+    from news_dashboard.articles.service import save_shared_url
+
+    url = "https://example.com/concurrent-post"
+
+    # Run save_shared_url concurrently for the same URL to test the race condition
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(
+                save_shared_url,
+                1,
+                url=url,
+                title="Concurrent Post",
+                text="Some text",
+            )
+            for _ in range(2)
+        ]
+        results = [f.result() for f in futures]
+
+    assert len(results) == 2
+    assert results[0]["url"] == url
+    assert results[1]["url"] == url


### PR DESCRIPTION
Closes #1181

Wrap concurrent/duplicate articles insertions in a transaction/try-except block and query again on violation. Also wrap the backfill UPDATE in a try-except to avoid failing the Ask AI endpoint when duplicate URLs are present in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)