### PR TITLE
fix: handle expired sessions centrally (#1172)

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -110,6 +110,36 @@ describe('requestJson', () => {
     const headers = calls[0].init?.headers as Record<string, string>;
     expect(headers['X-Custom']).toBe('v');
   });
+
+  it('emits a session-expired event for non-auth API 401 responses', async () => {
+    const listener = vi.fn();
+    window.addEventListener(api.sessionExpiredEvent, listener);
+    stubFetch(() => ({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: () => Promise.resolve({ detail: 'Not authenticated' }),
+    }));
+
+    await expect(api.requestJson('/api/articles')).rejects.toThrow('Not authenticated');
+    expect(listener).toHaveBeenCalledOnce();
+    window.removeEventListener(api.sessionExpiredEvent, listener);
+  });
+
+  it('does not emit session-expired events for auth endpoint 401 responses', async () => {
+    const listener = vi.fn();
+    window.addEventListener(api.sessionExpiredEvent, listener);
+    stubFetch(() => ({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: () => Promise.resolve({ detail: 'Invalid credentials' }),
+    }));
+
+    await expect(api.requestJson('/api/auth/login')).rejects.toThrow('Invalid credentials');
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(api.sessionExpiredEvent, listener);
+  });
 });
 
 describe('article list endpoints', () => {

--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -3,11 +3,12 @@
  * Tests for #130 — auth guard (RequireAuth) and login page.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useEffect } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AuthProvider } from '../contexts/auth';
+import { AuthProvider, useAuth } from '../contexts/auth';
 import { RequireAuth } from '../components/RequireAuth';
 import { LoginPage } from '../pages/LoginPage';
 import * as api from '../api';
@@ -99,7 +100,7 @@ describe('RequireAuth', () => {
   });
 
   it('redirects to /login when /api/auth/me returns 401', async () => {
-    vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401 Unauthorized'));
+    vi.spyOn(api, 'fetchMe').mockRejectedValue(new api.HttpError(401, 'Unauthorized'));
     vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
       provider: 'password',
       keycloak_enabled: false,
@@ -128,7 +129,7 @@ describe('RequireAuth', () => {
   });
 
   it('shows the in-app login page (not an immediate Keycloak redirect) on 401 when Keycloak is enabled', async () => {
-    vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401 Unauthorized'));
+    vi.spyOn(api, 'fetchMe').mockRejectedValue(new api.HttpError(401, 'Unauthorized'));
     vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
       provider: 'keycloak',
       keycloak_enabled: true,
@@ -170,8 +171,27 @@ describe('RequireAuth', () => {
     }
   });
 
-  it('passes the original path via location state when redirecting', async () => {
-    vi.spyOn(api, 'fetchMe').mockRejectedValue(new Error('401 Unauthorized'));
+  it('shows a visible branded checking state while /api/auth/me is pending', () => {
+    vi.spyOn(api, 'fetchMe').mockReturnValue(new Promise(() => undefined));
+
+    renderWithRouter(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <div>Protected content</div>
+            </RequireAuth>
+          }
+        />
+      </Routes>
+    );
+
+    expect(screen.getByText('Checking your session')).toBeTruthy();
+  });
+
+  it('passes the original full app URL via location state when redirecting', async () => {
+    vi.spyOn(api, 'fetchMe').mockRejectedValue(new api.HttpError(401, 'Unauthorized'));
     vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
       provider: 'password',
       keycloak_enabled: false,
@@ -202,13 +222,76 @@ describe('RequireAuth', () => {
           }
         />
       </Routes>,
-      { initialPath: '/today' }
+      { initialPath: '/today?q=ai#results' }
     );
 
     await waitFor(() => {
       expect(capturedState).toBeTruthy();
     });
-    expect((capturedState as { from?: string }).from).toBe('/today');
+    expect((capturedState as { from?: string }).from).toBe('/today?q=ai#results');
+  });
+
+  it('shows a retryable service problem for startup 5xx failures', async () => {
+    vi.spyOn(api, 'fetchMe').mockRejectedValue(new api.HttpError(503, 'Service Unavailable'));
+
+    renderWithRouter(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <div>Protected content</div>
+            </RequireAuth>
+          }
+        />
+        <Route path="/login" element={<div>Login page</div>} />
+      </Routes>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('We could not verify your session')).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
+    expect(screen.queryByText('Login page')).toBeNull();
+  });
+
+  it('routes to login once with session-expired state after an authenticated API 401', async () => {
+    vi.spyOn(api, 'fetchMe').mockResolvedValue({
+      id: 1,
+      username: 'alice',
+      is_admin: false,
+    });
+
+    let capturedState: unknown = undefined;
+
+    renderWithRouter(
+      <Routes>
+        <Route
+          path="/today"
+          element={
+            <RequireAuth>
+              <SessionExpiryTrigger />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/login"
+          element={
+            <RouteStateCapture
+              onState={(s) => {
+                capturedState = s;
+              }}
+            />
+          }
+        />
+      </Routes>,
+      { initialPath: '/today?q=ai#results' }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Login page')).toBeTruthy();
+    });
+    expect(capturedState).toEqual({ from: '/today?q=ai#results', sessionExpired: true });
   });
 });
 
@@ -216,6 +299,17 @@ function RouteStateCapture({ onState }: { onState: (s: unknown) => void }) {
   const loc = useLocation();
   onState(loc.state);
   return <div>Login page</div>;
+}
+
+function SessionExpiryTrigger() {
+  const { setUser } = useAuth();
+
+  useEffect(() => {
+    setUser({ id: 1, username: 'alice', is_admin: false });
+    window.dispatchEvent(new CustomEvent(api.sessionExpiredEvent, { detail: { url: '/api/me' } }));
+  }, [setUser]);
+
+  return <div>Protected content</div>;
 }
 
 // ── LoginPage ─────────────────────────────────────────────────────────────────

--- a/frontend/src/api/core.ts
+++ b/frontend/src/api/core.ts
@@ -28,6 +28,12 @@ export class HttpError extends Error {
   }
 }
 
+export const sessionExpiredEvent = 'news-dashboard:session-expired';
+
+function shouldEmitSessionExpired(url: string): boolean {
+  return url.startsWith('/api/') && !url.startsWith('/api/auth/');
+}
+
 export async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
     headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
@@ -35,7 +41,11 @@ export async function requestJson<T>(url: string, init?: RequestInit): Promise<T
     ...init,
   });
   if (!response.ok) {
-    throw new HttpError(response.status, await readErrorMessage(response));
+    const error = new HttpError(response.status, await readErrorMessage(response));
+    if (response.status === 401 && shouldEmitSessionExpired(url)) {
+      window.dispatchEvent(new CustomEvent(sessionExpiredEvent, { detail: { url } }));
+    }
+    throw error;
   }
   return response.json() as Promise<T>;
 }

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,34 +1,100 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { fetchMe } from '@/api';
+import { fetchMe, HttpError, sessionExpiredEvent } from '@/api';
 import { useAuth } from '@/contexts/auth';
+import { AppLogo } from './AppLogo';
 
 interface Props {
   children: ReactNode;
 }
 
 export function RequireAuth({ children }: Props) {
-  const { setUser } = useAuth();
+  const { status, sessionExpired, setUser, setStatus, resetAuth } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [checked, setChecked] = useState(false);
+  const [startupError, setStartupError] = useState(false);
+  const intendedRoute = `${location.pathname}${location.search}${location.hash}`;
 
   useEffect(() => {
+    setStatus('checking');
+    setStartupError(false);
     fetchMe()
       .then((user) => {
         setUser(user);
-        setChecked(true);
       })
-      .catch(() => {
-        // Always route to the in-app login page. Even when Keycloak is enabled,
-        // the login page offers email OTP as the primary option with Keycloak as
-        // a secondary choice, so we no longer redirect straight to Keycloak.
-        void navigate('/login', { state: { from: location.pathname }, replace: true });
+      .catch((error: unknown) => {
+        if (isUnauthorized(error)) {
+          setStatus('anonymous');
+          // Always route to the in-app login page. Even when Keycloak is enabled,
+          // the login page offers email OTP as the primary option with Keycloak as
+          // a secondary choice, so we no longer redirect straight to Keycloak.
+          void navigate('/login', { state: { from: intendedRoute }, replace: true });
+          return;
+        }
+        setStatus('recoverable-error');
+        setStartupError(true);
       });
     // Run once on mount only
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (!checked) return null;
+  useEffect(() => {
+    function handleSessionExpired() {
+      if (location.pathname === '/login') return;
+      resetAuth('session-expired');
+      void navigate('/login', {
+        state: { from: intendedRoute, sessionExpired: true },
+        replace: true,
+      });
+    }
+
+    window.addEventListener(sessionExpiredEvent, handleSessionExpired);
+    return () => window.removeEventListener(sessionExpiredEvent, handleSessionExpired);
+  }, [intendedRoute, location.pathname, navigate, resetAuth]);
+
+  if (status === 'checking') return <AuthStatusPanel title="Checking your session" />;
+  if (startupError || status === 'recoverable-error') {
+    return (
+      <AuthStatusPanel
+        title="We could not verify your session"
+        detail="Check your connection and retry. Your sign-in was not changed."
+        onRetry={() => window.location.reload()}
+      />
+    );
+  }
+  if (sessionExpired) return <AuthStatusPanel title="Your session expired" />;
   return <>{children}</>;
+}
+
+function isUnauthorized(error: unknown): boolean {
+  return error instanceof HttpError && error.status === 401;
+}
+
+function AuthStatusPanel({
+  title,
+  detail,
+  onRetry,
+}: {
+  title: string;
+  detail?: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 text-center shadow-sm">
+        <AppLogo className="mx-auto size-10 rounded-xl" />
+        <h1 className="mt-4 text-lg font-semibold text-foreground">{title}</h1>
+        {detail ? <p className="mt-2 text-sm text-muted-foreground">{detail}</p> : null}
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-4 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
+          >
+            Retry
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -1,16 +1,51 @@
-import { createContext, useContext, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { queryClient } from '@/lib/queryClient';
 import type { User } from '@/types';
+
+export type AuthStatus = 'checking' | 'authenticated' | 'anonymous' | 'recoverable-error';
 
 interface AuthState {
   user: User | null;
+  status: AuthStatus;
+  sessionExpired: boolean;
   setUser: (u: User | null) => void;
+  setStatus: (status: AuthStatus) => void;
+  resetAuth: (reason?: 'session-expired' | 'sign-out') => void;
 }
 
 const AuthContext = createContext<AuthState | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
-  return <AuthContext.Provider value={{ user, setUser }}>{children}</AuthContext.Provider>;
+  const [status, setStatus] = useState<AuthStatus>('checking');
+  const [sessionExpired, setSessionExpired] = useState(false);
+
+  const handleSetUser = useCallback((nextUser: User | null) => {
+    setUser(nextUser);
+    setStatus(nextUser ? 'authenticated' : 'anonymous');
+    if (nextUser) setSessionExpired(false);
+  }, []);
+
+  const resetAuth = useCallback((reason?: 'session-expired' | 'sign-out') => {
+    setUser(null);
+    setStatus('anonymous');
+    setSessionExpired(reason === 'session-expired');
+    queryClient.clear();
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      status,
+      sessionExpired,
+      setUser: handleSetUser,
+      setStatus,
+      resetAuth,
+    }),
+    [handleSetUser, resetAuth, sessionExpired, status, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,7 +13,8 @@ export function LoginPage() {
   const { setUser } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = (location.state as { from?: string } | null)?.from ?? '/';
+  const locationState = location.state as { from?: string; sessionExpired?: boolean } | null;
+  const from = locationState?.from ?? '/';
 
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
   const [mode, setMode] = useState<LoginMode>('password');
@@ -23,7 +24,9 @@ export function LoginPage() {
   const [password, setPassword] = useState('');
   const [otpEmail, setOtpEmail] = useState('');
   const [otpCode, setOtpCode] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    locationState?.sessionExpired ? 'Your session expired. Sign in again to continue.' : null
+  );
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #1172

## Summary
- add explicit auth lifecycle state and reset handling for expired sessions
- show a branded startup checking state and retryable recoverable auth failure state
- preserve pathname, search, and hash when redirecting to login
- emit a central session-expired event for non-auth API 401s and route once to login with session-expired copy

## Tests
- npm run test:frontend -- frontend/src/__tests__/auth.test.tsx frontend/src/__tests__/api.test.ts
- npm run test:frontend:smoke
- npm run build
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)