### PR TITLE
feat: restore archive source subscriptions and preferences (#1168)

### DIFF
--- a/backend/news_dashboard/import_export.py
+++ b/backend/news_dashboard/import_export.py
@@ -7,11 +7,18 @@ user: this is a personal restore, not a cross-instance sync tool.
 
 from __future__ import annotations
 
+import json
 import logging
-from typing import Any
+import re
+from typing import Any, cast
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from psycopg.types.json import Jsonb
 
 from news_dashboard.db import connect
 from news_dashboard.export import SCHEMA_VERSION
+from news_dashboard.sources.models import USER_CREATED_SOURCE_KINDS
+from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +28,10 @@ MAX_IMPORT_ARTICLES = 20_000
 MAX_IMPORT_BRIEFINGS = 5_000
 MAX_IMPORT_AI_MEMORIES = 5_000
 MAX_IMPORT_AI_MEMORY_EVENTS = 20_000
+MAX_IMPORT_SOURCE_SUBSCRIPTIONS = 2_000
 
 _VALID_ARTICLE_STATES = frozenset({"today", "done", "skipped", "archived", "later"})
+_VALID_RECAP_DAYS = frozenset({"mon", "tue", "wed", "thu", "fri", "sat", "sun"})
 
 
 class ArchiveImportError(ValueError):
@@ -45,6 +54,7 @@ def validate_archive(payload: Any) -> None:
         ("briefings", MAX_IMPORT_BRIEFINGS),
         ("ai_memories", MAX_IMPORT_AI_MEMORIES),
         ("ai_memory_events", MAX_IMPORT_AI_MEMORY_EVENTS),
+        ("source_subscriptions", MAX_IMPORT_SOURCE_SUBSCRIPTIONS),
     ):
         value = payload.get(key, [])
         if value is None:
@@ -55,6 +65,11 @@ def validate_archive(payload: Any) -> None:
         if len(value) > limit:
             msg = f"archive has too many {key} entries (max {limit})"
             raise ArchiveImportError(msg)
+
+    preferences = payload.get("preferences")
+    if preferences is not None and not isinstance(preferences, dict):
+        msg = "'preferences' must be an object"
+        raise ArchiveImportError(msg)
 
 
 def _upsert_article_state(  # noqa: PLR0913
@@ -388,6 +403,214 @@ def _restore_ai_memory_events(conn: Any, user_id: int, events: list[Any]) -> dic
     return counts
 
 
+def _restore_global_source_subscription(
+    conn: Any, user_id: int, slug: str, *, enabled: bool
+) -> str | None:
+    """Restore subscribed/unsubscribed state for a global source. Returns 'added'/'updated'/None."""
+    exists = conn.execute(
+        "SELECT 1 FROM sources WHERE slug = %s AND owner_user_id IS NULL", (slug,)
+    ).fetchone()
+    if exists is None:
+        return None
+
+    existing = conn.execute(
+        "SELECT 1 FROM user_sources WHERE user_id = %s AND source_slug = %s",
+        (user_id, slug),
+    ).fetchone()
+    conn.execute(
+        """
+        INSERT INTO user_sources(user_id, source_slug, enabled)
+        VALUES (%s, %s, %s)
+        ON CONFLICT(user_id, source_slug) DO UPDATE SET enabled = excluded.enabled
+        """,
+        (user_id, slug, enabled),
+    )
+    return "updated" if existing is not None else "added"
+
+
+def _validate_private_source_fields(item: dict[str, Any]) -> tuple[str, str, str, str, str] | None:
+    slug = item.get("slug")
+    name = item.get("name")
+    url = item.get("url")
+    category = item.get("category")
+    kind = item.get("kind")
+    required = (slug, name, url, category, kind)
+    if not all(isinstance(v, str) and v.strip() for v in required):
+        return None
+    slug, name, url, category, kind = cast("tuple[str, str, str, str, str]", required)
+    if kind not in USER_CREATED_SOURCE_KINDS:
+        return None
+    try:
+        validate_server_fetch_url(url)
+    except UnsafeUrlError:
+        return None
+    return slug, name, url, category, kind
+
+
+def _restore_private_source(conn: Any, user_id: int, item: dict[str, Any]) -> str | None:
+    """Restore a user-owned private source. Returns 'added'/'updated'/None (skipped)."""
+    fields = _validate_private_source_fields(item)
+    if fields is None:
+        return None
+    slug, name, url, category, kind = fields
+    enabled = bool(item.get("subscribed", True))
+
+    existing = conn.execute("SELECT owner_user_id FROM sources WHERE slug = %s", (slug,)).fetchone()
+    if existing is None:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+            VALUES (%s, %s, %s, %s, %s, 0, %s, %s)
+            """,
+            (slug, name, url, category, kind, enabled, user_id),
+        )
+        return "added"
+    if existing["owner_user_id"] != user_id:
+        # Never overwrite a global source or another user's private source.
+        return None
+    conn.execute(
+        """
+        UPDATE sources SET name = %s, url = %s, category = %s, kind = %s, enabled = %s
+        WHERE slug = %s
+        """,
+        (name, url, category, kind, enabled, slug),
+    )
+    return "updated"
+
+
+def _restore_source_subscriptions(
+    conn: Any, user_id: int, subscriptions: list[Any]
+) -> dict[str, int]:
+    counts = {"added": 0, "updated": 0, "skipped": 0}
+    for item in subscriptions:
+        if not isinstance(item, dict):
+            counts["skipped"] += 1
+            continue
+        try:
+            with conn.transaction():
+                if item.get("private"):
+                    outcome = _restore_private_source(conn, user_id, item)
+                else:
+                    slug = item.get("slug")
+                    if not isinstance(slug, str) or not slug.strip():
+                        outcome = None
+                    else:
+                        outcome = _restore_global_source_subscription(
+                            conn, user_id, slug, enabled=bool(item.get("subscribed", True))
+                        )
+                counts[outcome or "skipped"] += 1
+        except Exception:
+            logger.exception("Failed to restore archived source subscription")
+            counts["skipped"] += 1
+    return counts
+
+
+def _restore_recommendation_preferences(conn: Any, user_id: int, data: Any) -> bool:
+    if not isinstance(data, dict):
+        return False
+    raw_weights = data.get("category_weights")
+    if not isinstance(raw_weights, dict):
+        raw_weights = {}
+    weights = {
+        str(category).strip().lower(): min(3.0, max(0.0, float(weight)))
+        for category, weight in raw_weights.items()
+        if str(category).strip() and isinstance(weight, (int, float))
+    }
+    novelty = data.get("novelty_weight")
+    novelty = min(3.0, max(0.0, float(novelty))) if isinstance(novelty, (int, float)) else 1.0
+
+    conn.execute(
+        """
+        INSERT INTO user_settings(user_id, category_weights, novelty_weight)
+        VALUES (%s, %s::jsonb, %s)
+        ON CONFLICT(user_id) DO UPDATE SET
+          category_weights = excluded.category_weights,
+          novelty_weight = excluded.novelty_weight,
+          updated_at = NOW()
+        """,
+        (user_id, json.dumps(weights), novelty),
+    )
+    conn.execute(
+        "UPDATE user_article_recommendations SET stale = TRUE WHERE user_id = %s",
+        (user_id,),
+    )
+    return True
+
+
+def _restore_onboarding(conn: Any, user_id: int, data: Any) -> bool:
+    if not isinstance(data, dict):
+        return False
+    raw_interests = data.get("interests")
+    interests = [str(i) for i in raw_interests] if isinstance(raw_interests, list) else []
+    completed_at = data.get("completed_at")
+    completed = isinstance(completed_at, str) and bool(completed_at.strip())
+
+    conn.execute(
+        """
+        INSERT INTO user_interest_profiles(user_id, interests, completed_at, updated_at)
+        VALUES (%s, %s, CASE WHEN %s THEN NOW() ELSE NULL END, NOW())
+        ON CONFLICT(user_id) DO UPDATE SET
+          interests = excluded.interests,
+          completed_at = excluded.completed_at,
+          updated_at = NOW()
+        """,
+        (user_id, Jsonb(interests), completed),
+    )
+    return True
+
+
+def _restore_notification_settings(conn: Any, user_id: int, data: Any) -> bool:
+    if not isinstance(data, dict):
+        return False
+
+    updates: dict[str, Any] = {}
+    briefing_time = data.get("briefing_time")
+    if isinstance(briefing_time, str) and re.fullmatch(r"([01]\d|2[0-3]):[0-5]\d", briefing_time):
+        updates["briefing_time"] = briefing_time
+    briefing_timezone = data.get("briefing_timezone")
+    if isinstance(briefing_timezone, str) and briefing_timezone.strip():
+        try:
+            ZoneInfo(briefing_timezone)
+        except (ZoneInfoNotFoundError, KeyError):
+            pass
+        else:
+            updates["briefing_timezone"] = briefing_timezone
+    if isinstance(data.get("push_enabled"), bool):
+        updates["briefing_push_enabled"] = data["push_enabled"]
+    if isinstance(data.get("recap_enabled"), bool):
+        updates["recap_enabled"] = data["recap_enabled"]
+    recap_day = data.get("recap_day")
+    if isinstance(recap_day, str) and recap_day in _VALID_RECAP_DAYS:
+        updates["recap_day"] = recap_day
+    if isinstance(data.get("analytics_enabled"), bool):
+        updates["analytics_enabled"] = data["analytics_enabled"]
+
+    if not updates:
+        return False
+
+    set_clauses = ", ".join(f"{key} = %s" for key in updates)
+    conn.execute(
+        f"UPDATE users SET {set_clauses} WHERE id = %s",
+        [*updates.values(), user_id],
+    )
+    return True
+
+
+def _restore_preferences(conn: Any, user_id: int, preferences: Any) -> dict[str, int]:
+    counts = {"added": 0, "updated": 0, "skipped": 0}
+    if not isinstance(preferences, dict):
+        return counts
+
+    sections = (
+        _restore_recommendation_preferences(conn, user_id, preferences.get("recommendations")),
+        _restore_onboarding(conn, user_id, preferences.get("onboarding")),
+        _restore_notification_settings(conn, user_id, preferences.get("notifications")),
+    )
+    for restored in sections:
+        counts["updated" if restored else "skipped"] += 1
+    return counts
+
+
 def restore_user_archive(
     user_id: int,
     payload: dict[str, Any],
@@ -398,7 +621,8 @@ def restore_user_archive(
     Idempotent: re-importing the same archive updates/keeps existing restored
     state rather than duplicating rows, for object types with a stable
     identity (article canonical_url, briefing created_at+title, AI memory
-    content+source). Only ever writes data scoped to `user_id`.
+    content+source, source subscription slug, preferences per user). Only
+    ever writes data scoped to `user_id`.
     """
     validate_archive(payload)
 
@@ -409,10 +633,16 @@ def restore_user_archive(
         ai_memory_events = _restore_ai_memory_events(
             conn, user_id, payload.get("ai_memory_events") or []
         )
+        source_subscriptions = _restore_source_subscriptions(
+            conn, user_id, payload.get("source_subscriptions") or []
+        )
+        preferences = _restore_preferences(conn, user_id, payload.get("preferences"))
 
     return {
         "articles": articles,
         "briefings": briefings,
         "ai_memories": ai_memories,
         "ai_memory_events": ai_memory_events,
+        "source_subscriptions": source_subscriptions,
+        "preferences": preferences,
     }

--- a/backend/tests/test_import_export.py
+++ b/backend/tests/test_import_export.py
@@ -465,6 +465,232 @@ def test_import_endpoint_restores_archive(pg_clean: str, monkeypatch: pytest.Mon
         app.dependency_overrides.pop(require_auth, None)
 
 
+# ── source subscription restore ─────────────────────────────────────────────
+
+
+def test_restores_global_source_subscription(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_source_global")
+
+    archive = _base_archive(
+        source_subscriptions=[{"slug": "python-insider", "private": False, "subscribed": False}]
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+    assert result["source_subscriptions"] == {"added": 1, "updated": 0, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT enabled FROM user_sources WHERE user_id = %s AND source_slug = %s",
+            (uid, "python-insider"),
+        ).fetchone()
+    assert row is not None
+    assert row["enabled"] is False
+
+
+def test_skips_global_source_subscription_for_unknown_slug(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_source_unknown")
+
+    archive = _base_archive(
+        source_subscriptions=[{"slug": "does-not-exist", "private": False, "subscribed": True}]
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+    assert result["source_subscriptions"] == {"added": 0, "updated": 0, "skipped": 1}
+
+
+def test_restores_private_source(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_source_private")
+
+    archive = _base_archive(
+        source_subscriptions=[
+            {
+                "slug": "u42-my-blog",
+                "name": "My Blog",
+                "url": "https://example.com/feed.xml",
+                "category": "tech",
+                "kind": "rss_feed",
+                "private": True,
+                "subscribed": True,
+            }
+        ]
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+    assert result["source_subscriptions"] == {"added": 1, "updated": 0, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT owner_user_id, enabled FROM sources WHERE slug = %s", ("u42-my-blog",)
+        ).fetchone()
+    assert row is not None
+    assert row["owner_user_id"] == uid
+    assert row["enabled"] is True
+
+
+def test_reimporting_private_source_updates_not_duplicates(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_source_private_idem")
+
+    archive = _base_archive(
+        source_subscriptions=[
+            {
+                "slug": "u1-my-blog",
+                "name": "My Blog",
+                "url": "https://example.com/feed.xml",
+                "category": "tech",
+                "kind": "rss_feed",
+                "private": True,
+                "subscribed": True,
+            }
+        ]
+    )
+    restore_user_archive(uid, archive, database_url=pg_clean)
+
+    archive["source_subscriptions"][0]["subscribed"] = False
+    second = restore_user_archive(uid, archive, database_url=pg_clean)
+
+    assert second["source_subscriptions"] == {"added": 0, "updated": 1, "skipped": 0}
+    with connect(database_url=pg_clean) as conn:
+        rows = conn.execute(
+            "SELECT enabled FROM sources WHERE slug = %s", ("u1-my-blog",)
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["enabled"] is False
+
+
+def test_private_source_never_takes_over_another_users_source(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid_alice = _make_user(pg_clean, "import_source_owner_alice")
+    uid_bob = _make_user(pg_clean, "import_source_owner_bob")
+
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, priority, enabled, owner_user_id)
+            VALUES ('u1-taken', 'Alice Blog', 'https://alice.example.com/feed.xml',
+                    'tech', 'rss_feed', 0, TRUE, %s)
+            """,
+            (uid_alice,),
+        )
+
+    archive = _base_archive(
+        source_subscriptions=[
+            {
+                "slug": "u1-taken",
+                "name": "Bob Hijack",
+                "url": "https://bob.example.com/feed.xml",
+                "category": "tech",
+                "kind": "rss_feed",
+                "private": True,
+                "subscribed": True,
+            }
+        ]
+    )
+    result = restore_user_archive(uid_bob, archive, database_url=pg_clean)
+    assert result["source_subscriptions"] == {"added": 0, "updated": 0, "skipped": 1}
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute(
+            "SELECT owner_user_id, name FROM sources WHERE slug = %s", ("u1-taken",)
+        ).fetchone()
+    assert row is not None
+    assert row["owner_user_id"] == uid_alice
+    assert row["name"] == "Alice Blog"
+
+
+# ── preferences restore ──────────────────────────────────────────────────────
+
+
+def test_restores_preferences(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_preferences")
+
+    archive = _base_archive(
+        preferences={
+            "recommendations": {"category_weights": {"python": 2.0}, "novelty_weight": 1.5},
+            "onboarding": {
+                "interests": ["python", "infra"],
+                "completed_at": "2026-01-01T00:00:00+00:00",
+            },
+            "notifications": {
+                "briefing_time": "07:30",
+                "briefing_timezone": "America/New_York",
+                "push_enabled": True,
+                "recap_enabled": False,
+                "recap_day": "fri",
+                "analytics_enabled": False,
+            },
+        }
+    )
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+    assert result["preferences"] == {"added": 0, "updated": 3, "skipped": 0}
+
+    with connect(database_url=pg_clean) as conn:
+        settings_row = conn.execute(
+            "SELECT category_weights, novelty_weight FROM user_settings WHERE user_id = %s",
+            (uid,),
+        ).fetchone()
+        profile_row = conn.execute(
+            "SELECT interests, completed_at FROM user_interest_profiles WHERE user_id = %s",
+            (uid,),
+        ).fetchone()
+        user_row = conn.execute(
+            """
+            SELECT briefing_time, briefing_timezone, briefing_push_enabled,
+                   recap_enabled, recap_day, analytics_enabled
+            FROM users WHERE id = %s
+            """,
+            (uid,),
+        ).fetchone()
+
+    assert settings_row is not None
+    assert settings_row["category_weights"] == {"python": 2.0}
+    assert settings_row["novelty_weight"] == 1.5
+    assert profile_row is not None
+    assert list(profile_row["interests"]) == ["python", "infra"]
+    assert profile_row["completed_at"] is not None
+    assert user_row is not None
+    assert user_row["briefing_time"] == "07:30"
+    assert user_row["briefing_timezone"] == "America/New_York"
+    assert user_row["briefing_push_enabled"] is True
+    assert user_row["recap_enabled"] is False
+    assert user_row["recap_day"] == "fri"
+    assert user_row["analytics_enabled"] is False
+
+
+def test_restore_preferences_skips_missing_sections(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean, "import_preferences_empty")
+
+    archive = _base_archive(preferences={})
+
+    result = restore_user_archive(uid, archive, database_url=pg_clean)
+    assert result["preferences"] == {"added": 0, "updated": 0, "skipped": 3}
+
+
+def test_import_never_restores_preferences_for_another_user(pg_clean: str) -> None:
+    sync_sources(pg_clean)
+    uid_alice = _make_user(pg_clean, "import_pref_scope_alice")
+    uid_bob = _make_user(pg_clean, "import_pref_scope_bob")
+
+    archive = _base_archive(
+        preferences={
+            "recommendations": {"category_weights": {"python": 3.0}, "novelty_weight": 2.0},
+        }
+    )
+    restore_user_archive(uid_alice, archive, database_url=pg_clean)
+
+    with connect(database_url=pg_clean) as conn:
+        bob_row = conn.execute(
+            "SELECT 1 FROM user_settings WHERE user_id = %s", (uid_bob,)
+        ).fetchone()
+    assert bob_row is None
+
+
 def test_import_endpoint_rejects_invalid_json(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/docs/user-guide/saved-history.md
+++ b/docs/user-guide/saved-history.md
@@ -99,11 +99,20 @@ session tokens, push subscription keys, API tokens) are never included.
 
 To restore an archive, click "Restore archive" next to the download button
 and pick a previously downloaded JSON file. Re-importing the same file is
-safe: existing articles, briefings, and AI memories are matched and updated
-in place rather than duplicated. Only the same major archive schema version
-produced by this instance can be restored (an older or newer
-`schema_version` is rejected), and restoring only ever writes data for your
-own account.
+safe: existing articles, briefings, AI memories, source subscriptions, and
+preferences are matched and updated in place rather than duplicated. Only
+the same major archive schema version produced by this instance can be
+restored (an older or newer `schema_version` is rejected), and restoring
+only ever writes data for your own account.
+
+Restore covers your global source enabled/disabled state, private sources
+you own (recreated if missing, never taking over someone else's source or a
+global one), recommendation weights, onboarding interests/completion state,
+and notification settings (briefing time/timezone, push-enabled, recap day,
+analytics opt-in). It intentionally skips anything that isn't safe to
+restore automatically, such as push subscription keys, reading-list digest
+preferences not present in the archive, and any private source whose slug
+already belongs to a different account.
 
 ## Auto-cleanup
 

--- a/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
+++ b/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
@@ -342,6 +342,8 @@ describe('SettingsPage', () => {
       briefings: { added: 1, updated: 0, skipped: 0 },
       ai_memories: { added: 0, updated: 1, skipped: 0 },
       ai_memory_events: { added: 3, skipped: 0 },
+      source_subscriptions: { added: 1, updated: 0, skipped: 0 },
+      preferences: { added: 0, updated: 3, skipped: 0 },
     });
     renderPage(<SettingsPage />);
 
@@ -351,6 +353,8 @@ describe('SettingsPage', () => {
     fireEvent.change(screen.getByLabelText('Restore archive'), { target: { files: [file] } });
 
     await waitFor(() => expect(screen.getByText(/Articles: 2 added/)).toBeTruthy());
+    expect(screen.getByText(/Source subscriptions: 1 added/)).toBeTruthy();
+    expect(screen.getByText(/Preferences: 0 added, 3 updated/)).toBeTruthy();
     expect(apiMock.importUserArchive).toHaveBeenCalledWith(file);
   });
 

--- a/frontend/src/components/settings/DataExportSection.tsx
+++ b/frontend/src/components/settings/DataExportSection.tsx
@@ -69,7 +69,8 @@ export function DataExportSection() {
         <div className="border-t border-border pt-3">
           <p className="text-xs text-muted-foreground mb-2">
             Restore a previously downloaded archive into this account. Existing articles, briefings,
-            and AI memories are matched and updated rather than duplicated.
+            AI memories, source subscriptions, and preferences are matched and updated rather than
+            duplicated.
           </p>
           <button
             onClick={() => document.getElementById('archive-import-input')?.click()}
@@ -116,6 +117,8 @@ export function DataExportSection() {
               <li>Articles: {formatCounts(importResult.articles)}</li>
               <li>Briefings: {formatCounts(importResult.briefings)}</li>
               <li>AI memories: {formatCounts(importResult.ai_memories)}</li>
+              <li>Source subscriptions: {formatCounts(importResult.source_subscriptions)}</li>
+              <li>Preferences: {formatCounts(importResult.preferences)}</li>
             </ul>
           )}
           {importState === 'error' && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -865,4 +865,6 @@ export interface ArchiveImportResult {
   briefings: ArchiveImportCounts;
   ai_memories: ArchiveImportCounts;
   ai_memory_events: { added: number; skipped: number };
+  source_subscriptions: ArchiveImportCounts;
+  preferences: ArchiveImportCounts;
 }


### PR DESCRIPTION
## Summary

Closes #1168.

Personal archive export already includes `source_subscriptions` and
`preferences` (recommendation weights, onboarding interests/completion,
notification settings), but restore previously only imported articles,
briefings, and AI memories — leaving export/restore asymmetric.

- `restore_user_archive()` now restores global source enabled/disabled
  state and user-owned private sources. Private sources are recreated if
  missing; restore never overwrites a global source or another user's
  private source (ownership is always checked before writing).
- Recommendation preferences (`category_weights`, `novelty_weight`),
  onboarding interests/completion metadata, and notification settings
  (`briefing_time`, `briefing_timezone`, push-enabled, recap day,
  analytics opt-in) are restored for the importing user only.
- The import API result and Settings UI now report
  `source_subscriptions` and `preferences` counts alongside the existing
  sections.
- Re-importing the same archive is idempotent (matches by slug for
  sources; preferences are a per-user singleton upsert).
- Restore continues to write only to `current_user["id"]`, per the
  security boundary from #999 — never to IDs embedded in the archive.
- Docs updated to describe what's restored and what's intentionally
  skipped (secrets, push subscription keys, reading-list digest
  settings not present in the archive schema).

## Test plan

- [x] `uv run pytest backend/tests/test_import_export.py -q` — 24 passed
  (new tests cover global/private source subscription restore,
  ownership-boundary protection, preferences restore/skip, and
  per-user scoping)
- [x] `make test` (full backend + frontend suite) — 2522 backend tests
  and 915 frontend tests passed
- [x] `make lint` and `make typecheck` — clean (ruff, mypy, ty, pyrefly,
  eslint, tsc)
- [x] pre-commit hooks pass on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)