### PR TITLE
fix: refresh runtime packages before Trivy scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ FROM python:3.14-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 WORKDIR /app
-RUN adduser --disabled-password --gecos '' appuser && mkdir -p /data && chown -R appuser:appuser /data
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && adduser --disabled-password --gecos '' appuser \
+    && mkdir -p /data \
+    && chown -R appuser:appuser /data
 COPY pyproject.toml VERSION CHANGELOG.md ./
 COPY backend ./backend
 COPY --from=frontend /app/frontend/dist ./frontend/dist

--- a/scripts/test_trivy_workflows.py
+++ b/scripts/test_trivy_workflows.py
@@ -9,6 +9,7 @@ WORKFLOWS = [
     ROOT / ".github" / "workflows" / "ci.yml",
     ROOT / ".github" / "workflows" / "trivy-scan.yml",
 ]
+DOCKERFILE = ROOT / "Dockerfile"
 
 
 class TestTrivyWorkflows(unittest.TestCase):
@@ -38,6 +39,18 @@ class TestTrivyWorkflows(unittest.TestCase):
             ):
                 if expected_policy not in workflow:
                     self.fail(f"{path.relative_to(ROOT)} is missing {expected_policy}")
+
+    def test_runtime_image_applies_os_security_updates(self) -> None:
+        dockerfile = DOCKERFILE.read_text()
+        runtime_stage = dockerfile.split("FROM python:3.14-slim AS runtime", maxsplit=1)[1]
+
+        for expected_command in (
+            "apt-get update",
+            "apt-get upgrade -y",
+            "rm -rf /var/lib/apt/lists/*",
+        ):
+            if expected_command not in runtime_stage:
+                self.fail(f"Runtime image is missing `{expected_command}`")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1206

## Summary
- refresh Debian packages in the Python runtime image before installing the app
- remove apt metadata after the upgrade to keep the image tidy
- add a Trivy guard test that requires the runtime stage to keep applying OS security updates

## Verification
- `python -m unittest scripts.test_trivy_workflows`
- `ruff check scripts/test_trivy_workflows.py`
- `ruff format --check scripts/test_trivy_workflows.py`
- `make lint`
- `make typecheck`

## Notes
- `make test` could not complete locally because the copied `.env` points tests at PostgreSQL on `localhost:55432`, and that service refused connections in this worktree.
- Local Docker is unavailable, so the actual image rebuild and Trivy scan are left to CI/GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)