### PR TITLE
feat: standardize data page failure states (#1175)

### DIFF
--- a/frontend/src/__tests__/articleListView.test.tsx
+++ b/frontend/src/__tests__/articleListView.test.tsx
@@ -130,6 +130,31 @@ describe('ArticleListView', () => {
     await waitFor(() => expect(screen.getByText('Queue clear')).toBeTruthy());
   });
 
+  it('renders a retryable error state instead of the empty state when the initial load fails', async () => {
+    renderArticleList(() => Promise.reject(new Error('offline')));
+
+    await waitFor(() => expect(screen.getByText('Could not load articles')).toBeTruthy());
+    expect(screen.getByText(/feed request failed/i)).toBeTruthy();
+    expect(screen.queryByText('Queue clear')).toBeNull();
+  });
+
+  it('renders a retryable error state instead of the empty state when the initial load fails', async () => {
+    const queryFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(page([makeArticle()]));
+
+    renderArticleList(queryFn);
+
+    await screen.findByRole('alert');
+    expect(screen.getByText('Could not load articles')).toBeTruthy();
+    expect(screen.queryByText('Queue clear')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await screen.findByText('Readable article');
+  });
+
   it('loads and appends another page when more articles are available', async () => {
     const queryFn = vi
       .fn()

--- a/frontend/src/__tests__/brief.test.tsx
+++ b/frontend/src/__tests__/brief.test.tsx
@@ -131,6 +131,18 @@ describe('BriefPage — empty state', () => {
   });
 });
 
+describe('BriefPage — load failure', () => {
+  it('shows a retryable load error instead of the empty state', async () => {
+    vi.spyOn(api, 'fetchLatestBriefing').mockRejectedValue(new Error('offline'));
+
+    renderBriefPage();
+
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(screen.getByText('Could not load the latest briefing')).toBeTruthy();
+    expect(screen.queryByText('No briefing yet')).toBeNull();
+  });
+});
+
 describe('BriefPage — latest briefing', () => {
   beforeEach(() => {
     vi.spyOn(api, 'fetchLatestBriefing').mockResolvedValue(COMPLETE_BRIEFING);

--- a/frontend/src/__tests__/briefingsHistory.test.tsx
+++ b/frontend/src/__tests__/briefingsHistory.test.tsx
@@ -122,6 +122,18 @@ describe('BriefingsHistoryPage — empty state', () => {
   });
 });
 
+describe('BriefingsHistoryPage — load failure', () => {
+  it('shows a retryable load error instead of the empty history state', async () => {
+    vi.spyOn(api, 'fetchBriefings').mockRejectedValue(new Error('offline'));
+
+    renderHistory();
+
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(screen.getByText('Could not load briefing history')).toBeTruthy();
+    expect(screen.queryByText('No briefings yet')).toBeNull();
+  });
+});
+
 describe('BriefingsHistoryPage — list state', () => {
   beforeEach(() => {
     vi.spyOn(api, 'fetchBriefings').mockResolvedValue({

--- a/frontend/src/__tests__/readingList.test.tsx
+++ b/frontend/src/__tests__/readingList.test.tsx
@@ -86,6 +86,16 @@ describe('ReadingListPage', () => {
     expect(screen.getByText('A very insightful post.')).toBeTruthy();
   });
 
+  it('shows a retryable load error instead of the empty state', async () => {
+    vi.spyOn(readingListApi, 'fetchReadingList').mockRejectedValue(new Error('offline'));
+
+    renderPage();
+
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(screen.getByText('Could not load reading list')).toBeTruthy();
+    expect(screen.queryByText('Your reading list is empty')).toBeNull();
+  });
+
   it('sends search and type filters to the reading list API', async () => {
     const fetchSpy = vi.spyOn(readingListApi, 'fetchReadingList').mockResolvedValue([makeItem()]);
 

--- a/frontend/src/__tests__/shared.test.tsx
+++ b/frontend/src/__tests__/shared.test.tsx
@@ -97,6 +97,23 @@ describe('SharedPage', () => {
     await waitFor(() => expect(screen.getByText('Nothing shared yet')).toBeTruthy());
   });
 
+  it('shows received-share failures separately from an empty inbox', async () => {
+    apiMock.fetchReceivedShares.mockRejectedValue(new Error('offline'));
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+
+    await waitFor(() => expect(screen.getByText('Could not load received shares')).toBeTruthy());
+    expect(screen.queryByText('Nothing shared yet')).toBeNull();
+  });
+
+  it('shows a retryable received-shares error instead of the empty state', async () => {
+    apiMock.fetchReceivedShares.mockRejectedValue(new Error('offline'));
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(screen.getByText('Could not load received shares')).toBeTruthy();
+    expect(screen.queryByText('Nothing shared yet')).toBeNull();
+  });
+
   it('renders a share item with title linking to the detail view', async () => {
     apiMock.fetchReceivedShares.mockResolvedValue({ items: [makeShare()] });
     renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
@@ -127,6 +144,18 @@ describe('SharedPage', () => {
 
     await waitFor(() => expect(screen.getByText('Rust vs Go in 2026')).toBeTruthy());
     expect(screen.getByText('charlie')).toBeTruthy();
+  });
+
+  it('shows sent-share failures separately from an empty sent list', async () => {
+    apiMock.fetchReceivedShares.mockResolvedValue({ items: [] });
+    apiMock.fetchSentShares.mockRejectedValue(new Error('offline'));
+    renderWithRouter(<SharedPage />, { path: '/shared', route: '/shared' });
+    await waitFor(() => expect(screen.getByText('Nothing shared yet')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sent' }));
+
+    await waitFor(() => expect(screen.getByText('Could not load sent shares')).toBeTruthy());
+    expect(screen.queryByText('Nothing sent yet')).toBeNull();
   });
 
   it('revokes a sent share', async () => {

--- a/frontend/src/components/PageState.tsx
+++ b/frontend/src/components/PageState.tsx
@@ -1,0 +1,68 @@
+import { AlertCircle, type LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface RetryableErrorStateProps {
+  title: string;
+  message: string;
+  onRetry: () => void;
+  retryLabel?: string;
+  isRetrying?: boolean;
+  icon?: LucideIcon;
+}
+
+export function RetryableErrorState({
+  title,
+  message,
+  onRetry,
+  retryLabel = 'Retry',
+  isRetrying = false,
+  icon: Icon = AlertCircle,
+}: RetryableErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center px-6 py-16 text-center text-muted-foreground"
+    >
+      <Icon className="mb-3 size-10 text-destructive" strokeWidth={1.25} />
+      <div className="text-sm font-medium text-foreground">{title}</div>
+      <div className="mt-1 max-w-sm text-xs">{message}</div>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="mt-4"
+        onClick={onRetry}
+        disabled={isRetrying}
+      >
+        {isRetrying ? 'Retrying...' : retryLabel}
+      </Button>
+    </div>
+  );
+}
+
+export function ListSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="divide-y divide-border border-t border-border">
+      {Array.from({ length: rows }).map((_, index) => (
+        <div key={index} className="px-4 py-3 md:px-5">
+          <div className="mb-2 h-3 w-28 animate-pulse rounded bg-muted" />
+          <div className="mb-2 h-4 w-2/3 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function InlineError({ message, action }: { message: string; action?: ReactNode }) {
+  return (
+    <div
+      role="alert"
+      className="flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+    >
+      <span>{message}</span>
+      {action}
+    </div>
+  );
+}

--- a/frontend/src/components/article/ArticleListView.tsx
+++ b/frontend/src/components/article/ArticleListView.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo } from 'react';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery, type QueryKey } from '@tanstack/react-query';
 import { Headphones, type LucideIcon } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';
 import { CategoryFilter } from '@/components/CategoryFilter';
 import { EmptyState } from '@/components/EmptyState';
+import { InlineError, RetryableErrorState } from '@/components/PageState';
 import { useFocusedArticle } from '@/contexts/focusedArticle';
 import { useListenQueue } from '@/contexts/listenQueue';
 import { useArticleListNav } from '@/hooks/useArticleListNav';
@@ -22,7 +24,7 @@ interface ArticleListViewProps {
     loadedCount: number;
     hasMore: boolean;
     isLoading: boolean;
-  }) => React.ReactNode;
+  }) => ReactNode;
   queryKey: QueryKey;
   queryFn: (params: { limit: number; offset: number }) => Promise<TriageArticlePage>;
   empty: {
@@ -33,8 +35,8 @@ interface ArticleListViewProps {
   showCategoryFilter?: boolean;
   showLaterUntil?: boolean;
   sortArticles?: (articles: WorkflowArticle[]) => WorkflowArticle[];
-  banner?: React.ReactNode;
-  action?: (state: { articles: WorkflowArticle[] }) => React.ReactNode;
+  banner?: ReactNode;
+  action?: (state: { articles: WorkflowArticle[] }) => ReactNode;
 }
 
 export function ArticleListView({
@@ -50,7 +52,17 @@ export function ArticleListView({
   action,
 }: ArticleListViewProps) {
   const navigate = useNavigate();
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    isFetchNextPageError,
+    refetch,
+  } = useInfiniteQuery({
     queryKey,
     queryFn: ({ pageParam }) => queryFn({ limit: ARTICLE_PAGE_SIZE, offset: pageParam }),
     initialPageParam: 0,
@@ -115,6 +127,13 @@ export function ArticleListView({
       {banner}
       {isLoading ? (
         <ArticleListSkeleton />
+      ) : isError && list.length === 0 ? (
+        <RetryableErrorState
+          title="Could not load articles"
+          message="The feed request failed. Retry to keep this list distinct from an empty queue."
+          onRetry={() => void refetch()}
+          isRetrying={isFetching}
+        />
       ) : list.length === 0 ? (
         <EmptyState icon={empty.icon} title={empty.title} subtitle={empty.subtitle} />
       ) : (
@@ -129,6 +148,11 @@ export function ArticleListView({
           ))}
           {hasMore && (
             <div className="px-4 py-4 md:px-5">
+              {isFetchNextPageError ? (
+                <div className="mb-2">
+                  <InlineError message="Could not load more articles. Try again." />
+                </div>
+              ) : null}
               <button
                 type="button"
                 className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { fetchArticle, fetchArticleBody, fetchSharedArticle, fetchSharedArticleBody } from '@/api';
+import { HttpError } from '@/api/core';
 import { adaptArticle, patchArticleState, patchArticleStar } from '@/api/workflowApi';
 import type { WorkflowState } from '@/lib/workflowTypes';
 import { getReaderList } from '@/lib/readerList';
@@ -24,6 +25,19 @@ import { ArticleMetaHeader } from '@/components/article/ArticleMetaHeader';
 import { ArticleBody } from '@/components/article/ArticleBody';
 import { ArticleSelectionActions } from '@/components/article/ArticleSelectionActions';
 
+function articleErrorCopy(error: unknown) {
+  if (error instanceof HttpError && error.status === 404) {
+    return {
+      title: 'Article not found',
+      message: 'This article may have been removed or the shared link is no longer available.',
+    };
+  }
+  return {
+    title: 'Could not load article',
+    message: 'The article request failed. Check your connection and try again.',
+  };
+}
+
 export function ArticlePage() {
   const { id, shareId } = useParams<{ id?: string; shareId?: string }>();
   const navigate = useNavigate();
@@ -34,7 +48,14 @@ export function ArticlePage() {
     [id, shareId]
   );
 
-  const { data: rawArticle, isLoading } = useQuery({
+  const {
+    data: rawArticle,
+    error: articleError,
+    isError,
+    isLoading,
+    isFetching,
+    refetch,
+  } = useQuery({
     queryKey: articleQueryKey,
     queryFn: () => (shareId ? fetchSharedArticle(shareId) : fetchArticle(id!)),
     enabled: !!articleKey,
@@ -191,7 +212,8 @@ export function ArticlePage() {
     doStar: () => void doStar(),
   });
 
-  if (isLoading || !article) {
+  if (isLoading || isError || !article) {
+    const copy = isError ? articleErrorCopy(articleError) : null;
     return (
       <div className="min-h-screen bg-background flex flex-col">
         <header className="sticky top-0 z-20 border-b border-border bg-background/90 backdrop-blur">
@@ -207,6 +229,21 @@ export function ArticlePage() {
         <div className="flex-1 flex items-center justify-center">
           {isLoading ? (
             <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          ) : copy ? (
+            <div role="alert" className="max-w-sm px-5 text-center">
+              <p className="text-sm font-medium text-foreground">{copy.title}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{copy.message}</p>
+              {!(articleError instanceof HttpError && articleError.status === 404) ? (
+                <button
+                  type="button"
+                  onClick={() => void refetch()}
+                  disabled={isFetching}
+                  className="mt-4 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-surface disabled:opacity-50"
+                >
+                  {isFetching ? 'Retrying...' : 'Retry'}
+                </button>
+              ) : null}
+            </div>
           ) : (
             <p className="text-sm text-muted-foreground">Article not found.</p>
           )}

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Newspaper, RefreshCw, AlertCircle, Inbox, History, Wand2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { RetryableErrorState } from '@/components/PageState';
 import { fetchLatestBriefing, createBriefing } from '@/api';
 import { BriefingView, BriefSkeleton } from '@/components/BriefingView';
 import { BriefingChat } from '@/components/BriefingChat';
@@ -27,7 +28,7 @@ export function BriefPage() {
   const [noCandidates, setNoCandidates] = useState<NoCandidates>({ shown: false });
   const [focusInput, setFocusInput] = useState('');
 
-  const { data, isLoading, refetch } = useQuery({
+  const { data, isLoading, isError, isFetching, refetch } = useQuery({
     queryKey: ['briefings', 'latest'],
     queryFn: fetchLatestBriefing,
   });
@@ -61,6 +62,17 @@ export function BriefPage() {
 
   if (isLoading) {
     return <BriefSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <RetryableErrorState
+        title="Could not load the latest briefing"
+        message="The latest briefing request failed. Retry before generating a new brief."
+        onRetry={() => void refetch()}
+        isRetrying={isFetching}
+      />
+    );
   }
 
   // Error states (after attempted generation)

--- a/frontend/src/pages/BriefingsHistoryPage.tsx
+++ b/frontend/src/pages/BriefingsHistoryPage.tsx
@@ -5,6 +5,7 @@ import { Newspaper, AlertCircle, ChevronRight, Check, Copy, RefreshCw, Rss } fro
 import { toast } from 'sonner';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
+import { RetryableErrorState } from '@/components/PageState';
 import { fetchBriefings, fetchPodcastFeedToken, regeneratePodcastFeedToken } from '@/api';
 import { formatDate, formatWindow } from '@/lib/briefingUtils';
 import type { Briefing } from '@/types';
@@ -61,7 +62,7 @@ function BriefingRow({ briefing }: { briefing: Briefing }) {
 function PodcastFeedCard() {
   const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, isFetching, refetch } = useQuery({
     queryKey: ['briefings', 'podcast-feed-token'],
     queryFn: fetchPodcastFeedToken,
   });
@@ -136,7 +137,7 @@ function HistorySkeleton() {
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export function BriefingsHistoryPage() {
-  const { data, isLoading } = useQuery({
+  const { data, isError, isFetching, isLoading, refetch } = useQuery({
     queryKey: ['briefings', 'list'],
     queryFn: () => fetchBriefings(50, 0),
   });
@@ -154,6 +155,13 @@ export function BriefingsHistoryPage() {
 
       {isLoading ? (
         <HistorySkeleton />
+      ) : isError ? (
+        <RetryableErrorState
+          title="Could not load briefing history"
+          message="The briefing history request failed. Retry before treating the history as empty."
+          onRetry={() => void refetch()}
+          isRetrying={isFetching}
+        />
       ) : briefings.length === 0 ? (
         <div className="flex flex-col items-center justify-center text-center py-20 text-muted-foreground px-4">
           <Newspaper className="size-10 text-subtle mb-3" strokeWidth={1.25} />

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -2,14 +2,22 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Tag as TagIcon, Trash2 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { createTag, deleteTag, fetchTags } from '@/api/tagsApi';
 import { EmptyState } from '@/components/EmptyState';
+import { ListSkeleton, RetryableErrorState } from '@/components/PageState';
 
 export function CollectionsPage() {
   const queryClient = useQueryClient();
   const [newTagName, setNewTagName] = useState('');
 
-  const { data: tags = [], isLoading } = useQuery({
+  const {
+    data: tags = [],
+    isLoading,
+    isError,
+    isFetching,
+    refetch,
+  } = useQuery({
     queryKey: ['tags'],
     queryFn: fetchTags,
   });
@@ -20,11 +28,13 @@ export function CollectionsPage() {
       void queryClient.invalidateQueries({ queryKey: ['tags'] });
       setNewTagName('');
     },
+    onError: () => toast.error('Could not create collection'),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (tagId: number) => deleteTag(tagId),
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['tags'] }),
+    onError: () => toast.error('Could not delete collection'),
   });
 
   function handleCreate() {
@@ -62,7 +72,16 @@ export function CollectionsPage() {
         </button>
       </div>
 
-      {isLoading ? null : tags.length === 0 ? (
+      {isLoading ? (
+        <ListSkeleton rows={4} />
+      ) : isError ? (
+        <RetryableErrorState
+          title="Could not load collections"
+          message="The collections request failed. Retry before assuming there are no collections."
+          onRetry={() => void refetch()}
+          isRetrying={isFetching}
+        />
+      ) : tags.length === 0 ? (
         <EmptyState
           icon={TagIcon}
           title="No collections yet"

--- a/frontend/src/pages/ReadingListPage.tsx
+++ b/frontend/src/pages/ReadingListPage.tsx
@@ -20,6 +20,7 @@ import {
   Users,
 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import {
   DndContext,
   KeyboardSensor,
@@ -51,6 +52,7 @@ import {
   type ReadingListStatus,
 } from '@/api/readingListApi';
 import { EmptyState } from '@/components/EmptyState';
+import { ListSkeleton, RetryableErrorState } from '@/components/PageState';
 
 const IMPORT_SOURCES: { value: ReadingListImportSource; label: string }[] = [
   { value: 'pocket', label: 'Pocket (CSV)' },
@@ -262,7 +264,13 @@ export function ReadingListPage() {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
-  const { data: items = [], isLoading } = useQuery({
+  const {
+    data: items = [],
+    isLoading,
+    isError,
+    isFetching,
+    refetch,
+  } = useQuery({
     queryKey: ['reading-list', filter, searchQuery.trim(), kindFilter],
     queryFn: () =>
       fetchReadingList({
@@ -289,16 +297,19 @@ export function ReadingListPage() {
     mutationFn: ({ id, status }: { id: number; status: ReadingListStatus }) =>
       updateReadingListItem(id, { status }),
     onSuccess: invalidate,
+    onError: () => toast.error('Could not update reading-list item'),
   });
 
   const reorderMutation = useMutation({
     mutationFn: (orderedIds: number[]) => reorderReadingList(orderedIds),
     onSuccess: invalidate,
+    onError: () => toast.error('Could not reorder reading list'),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteReadingListItem(id),
     onSuccess: invalidate,
+    onError: () => toast.error('Could not delete reading-list item'),
   });
 
   const importMutation = useMutation({
@@ -505,7 +516,16 @@ export function ReadingListPage() {
         ) : null}
       </div>
 
-      {isLoading ? null : items.length === 0 ? (
+      {isLoading ? (
+        <ListSkeleton rows={5} />
+      ) : isError ? (
+        <RetryableErrorState
+          title="Could not load reading list"
+          message="The reading-list request failed. Retry before treating this list as empty."
+          onRetry={() => void refetch()}
+          isRetrying={isFetching}
+        />
+      ) : items.length === 0 ? (
         <EmptyState
           icon={BookmarkPlus}
           title={

--- a/frontend/src/pages/SharedPage.tsx
+++ b/frontend/src/pages/SharedPage.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { Send, ExternalLink, Ban } from 'lucide-react';
+import { toast } from 'sonner';
 import { EmptyState } from '@/components/EmptyState';
+import { ListSkeleton, RetryableErrorState } from '@/components/PageState';
 import { fetchReceivedShares, fetchSentShares, markShareRead, revokeShare } from '@/api';
 import { relativeTime } from '@/lib/format';
 import { cn } from '@/lib/utils';
@@ -15,7 +17,7 @@ type Tab = 'received' | 'sent';
 
 function ReceivedTab() {
   const queryClient = useQueryClient();
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, isFetching, refetch } = useQuery({
     queryKey: SHARES_KEY,
     queryFn: fetchReceivedShares,
     staleTime: 15_000,
@@ -40,7 +42,20 @@ function ReceivedTab() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shares.map((s) => (s.read_at ? '' : s.id)).join(',')]);
 
-  if (!isLoading && shares.length === 0) {
+  if (isLoading) return <ListSkeleton rows={3} />;
+
+  if (isError) {
+    return (
+      <RetryableErrorState
+        title="Could not load received shares"
+        message="The received shares request failed. Retry before treating the inbox as empty."
+        onRetry={() => void refetch()}
+        isRetrying={isFetching}
+      />
+    );
+  }
+
+  if (shares.length === 0) {
     return (
       <EmptyState
         icon={Send}
@@ -100,7 +115,7 @@ function ReceivedTab() {
 
 function SentTab() {
   const queryClient = useQueryClient();
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, isFetching, refetch } = useQuery({
     queryKey: SENT_SHARES_KEY,
     queryFn: fetchSentShares,
     staleTime: 15_000,
@@ -113,9 +128,23 @@ function SentTab() {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: SENT_SHARES_KEY });
     },
+    onError: () => toast.error('Could not revoke share'),
   });
 
-  if (!isLoading && shares.length === 0) {
+  if (isLoading) return <ListSkeleton rows={3} />;
+
+  if (isError) {
+    return (
+      <RetryableErrorState
+        title="Could not load sent shares"
+        message="The sent shares request failed. Retry before treating the list as empty."
+        onRetry={() => void refetch()}
+        isRetrying={isFetching}
+      />
+    );
+  }
+
+  if (shares.length === 0) {
     return (
       <EmptyState
         icon={Send}


### PR DESCRIPTION
Closes #1175

## Summary
- Added shared retryable error and list skeleton states for data-driven frontend pages.
- Updated article lists, brief/latest brief, article reader, shared lists, collections, reading list, and briefing history to distinguish loading, empty, not-found, and failed query states.
- Added visible mutation failure feedback for collections, reading-list actions, and share revocation.

## Tests
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:frontend:smoke
- npm run test:frontend
- npm run build

Generated by codex automation.