### PR TITLE
feat: add route-aware loading and recovery boundaries (#1176)

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -1,11 +1,18 @@
 import { lazy, Suspense } from 'react';
-import { createBrowserRouter, RouterProvider, Navigate, type RouteObject } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Navigate,
+  Link,
+  type RouteObject,
+} from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { FocusedArticleProvider } from './contexts/focusedArticle';
 import { AuthProvider } from './contexts/auth';
 import { ListenQueueProvider } from './contexts/listenQueue';
 import { RequireAuth } from './components/RequireAuth';
 import { AppShell } from './components/AppShell';
+import { RouteErrorRecovery } from './components/RouteErrorRecovery';
 import { LoginPage } from './pages/LoginPage';
 import { BriefPage } from './pages/BriefPage';
 import { FeedsPage } from './pages/FeedsPage';
@@ -99,8 +106,13 @@ const AiStatsPage = lazy(() =>
 
 function PageLoader() {
   return (
-    <div className="flex min-h-[50vh] flex-1 items-center justify-center p-8">
-      <Loader2 className="text-muted-foreground size-6 animate-spin" />
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex min-h-[50vh] flex-1 items-center justify-center p-8"
+    >
+      <Loader2 className="text-muted-foreground size-6 animate-spin" aria-hidden="true" />
+      <span className="sr-only">Loading page…</span>
     </div>
   );
 }
@@ -139,12 +151,12 @@ export function NotFound() {
           The page you're looking for doesn't exist or has been moved.
         </p>
         <div className="mt-6">
-          <a
-            href="/"
+          <Link
+            to="/"
             className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             Go home
-          </a>
+          </Link>
         </div>
       </div>
     </div>
@@ -156,14 +168,17 @@ export const routes: RouteObject[] = [
   {
     path: '/login',
     element: <LoginPage />,
+    errorElement: <RouteErrorRecovery />,
   },
   {
     path: '/a/:id',
     element: <RequireAuth>{withSuspense(ArticlePage)}</RequireAuth>,
+    errorElement: <RouteErrorRecovery />,
   },
   {
     path: '/shared/:shareId/article',
     element: <RequireAuth>{withSuspense(ArticlePage)}</RequireAuth>,
+    errorElement: <RouteErrorRecovery />,
   },
   {
     path: '/',
@@ -172,6 +187,7 @@ export const routes: RouteObject[] = [
         <AppShell />
       </RequireAuth>
     ),
+    errorElement: <RouteErrorRecovery />,
     children: [
       { index: true, element: <BriefPage /> },
       { path: 'today', element: withSuspense(InboxPage) },

--- a/frontend/src/__tests__/errorBoundary.test.tsx
+++ b/frontend/src/__tests__/errorBoundary.test.tsx
@@ -78,6 +78,17 @@ describe('ErrorBoundary', () => {
     }
   });
 
+  it('renders inline instead of filling the viewport when compact is set', () => {
+    const { container } = render(
+      <ErrorBoundary compact>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(container.querySelector('.min-h-screen')).toBeNull();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
   it('shows chunk-load-specific copy and hides Try again for stale chunk failures', () => {
     render(
       <ErrorBoundary>

--- a/frontend/src/__tests__/errorBoundary.test.tsx
+++ b/frontend/src/__tests__/errorBoundary.test.tsx
@@ -9,6 +9,10 @@ function Bomb(): never {
   throw new Error('test');
 }
 
+function ChunkBomb(): never {
+  throw new Error('error loading dynamically imported module: /assets/page.js');
+}
+
 describe('ErrorBoundary', () => {
   beforeEach(() => {
     vi.spyOn(errorTracking, 'reportError').mockImplementation(() => undefined);
@@ -72,5 +76,70 @@ describe('ErrorBoundary', () => {
         value: originalLocation,
       });
     }
+  });
+
+  it('shows chunk-load-specific copy and hides Try again for stale chunk failures', () => {
+    render(
+      <ErrorBoundary>
+        <ChunkBomb />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('A new version is available')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+  });
+
+  it('recovers without a full reload when Try again is clicked', async () => {
+    function Flaky({ shouldThrow }: { shouldThrow: boolean }) {
+      if (shouldThrow) throw new Error('flaky');
+      return <div>recovered</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary>
+        <Flaky shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary>
+        <Flaky shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(screen.getByText('recovered')).toBeInTheDocument();
+  });
+
+  it('resets automatically when resetKey changes', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKey="/a">
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary resetKey="/b">
+        <div>fresh route</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('fresh route')).toBeInTheDocument();
+  });
+
+  it('renders nothing when silent is set, but still reports the error', () => {
+    const { container } = render(
+      <ErrorBoundary silent>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(errorTracking.reportError).toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/routeErrorRecovery.test.tsx
+++ b/frontend/src/__tests__/routeErrorRecovery.test.tsx
@@ -27,6 +27,7 @@ function renderRouterWithThrower(Thrower: React.ComponentType, initialPath = '/b
 
 describe('RouteErrorRecovery', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.spyOn(errorTracking, 'reportError').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
@@ -48,6 +49,38 @@ describe('RouteErrorRecovery', () => {
     await screen.findByText('Something went wrong');
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Reload' })).not.toBeInTheDocument();
+  });
+
+  it('invokes the router revalidator when Try again is clicked', async () => {
+    renderRouterWithThrower(Bomb);
+    await screen.findByText('Something went wrong');
+
+    // Clicking must not throw and must not fall back to a full page reload.
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('shows not-found copy for a matched 404 route response', async () => {
+    const router = createMemoryRouter(
+      [
+        { path: '/', element: <div>home-page</div> },
+        {
+          path: '/broken',
+          element: <div>never rendered</div>,
+          errorElement: <RouteErrorRecovery />,
+          loader: () => {
+            throw new Response('Not Found', { status: 404 });
+          },
+        },
+      ],
+      { initialEntries: ['/broken'] }
+    );
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByText('Page not found')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reload' })).not.toBeInTheDocument();
+    expect(errorTracking.reportError).not.toHaveBeenCalled();
   });
 
   it('shows chunk-load-specific copy and a Reload action for stale chunk failures', async () => {

--- a/frontend/src/__tests__/routeErrorRecovery.test.tsx
+++ b/frontend/src/__tests__/routeErrorRecovery.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { RouteErrorRecovery } from '../components/RouteErrorRecovery';
+import * as errorTracking from '../lib/errorTracking';
+
+function Bomb(): never {
+  throw new Error('route boom');
+}
+
+function ChunkBomb(): never {
+  throw new Error('Failed to fetch dynamically imported module: /assets/page.js');
+}
+
+function renderRouterWithThrower(Thrower: React.ComponentType, initialPath = '/broken') {
+  const router = createMemoryRouter(
+    [
+      { path: '/', element: <div>home-page</div> },
+      { path: '/broken', element: <Thrower />, errorElement: <RouteErrorRecovery /> },
+    ],
+    { initialEntries: [initialPath] }
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('RouteErrorRecovery', () => {
+  beforeEach(() => {
+    vi.spyOn(errorTracking, 'reportError').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('renders a branded recovery state instead of the default router error UI', async () => {
+    renderRouterWithThrower(Bomb);
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/');
+  });
+
+  it('reports the error for non-response errors', async () => {
+    renderRouterWithThrower(Bomb);
+    await screen.findByText('Something went wrong');
+    expect(errorTracking.reportError).toHaveBeenCalled();
+  });
+
+  it('offers a Try again action that revalidates instead of reloading', async () => {
+    renderRouterWithThrower(Bomb);
+    await screen.findByText('Something went wrong');
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reload' })).not.toBeInTheDocument();
+  });
+
+  it('shows chunk-load-specific copy and a Reload action for stale chunk failures', async () => {
+    renderRouterWithThrower(ChunkBomb);
+    expect(await screen.findByText('A new version is available')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+  });
+
+  it('reloads the page when Reload is clicked on a chunk error', async () => {
+    const reload = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+
+    try {
+      renderRouterWithThrower(ChunkBomb);
+      await screen.findByText('A new version is available');
+      await userEvent.click(screen.getByRole('button', { name: 'Reload' }));
+      expect(reload).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -308,7 +308,7 @@ export function AppShell() {
         <div className="md:flex md:max-w-6xl md:mx-auto md:gap-0">
           <DesktopRail pathname={pathname} />
           <div className="flex-1 min-w-0">
-            <ErrorBoundary>
+            <ErrorBoundary resetKey={pathname} compact>
               <Outlet />
             </ErrorBoundary>
           </div>
@@ -338,19 +338,21 @@ export function AppShell() {
         </div>
       </nav>
 
-      <Suspense fallback={null}>
-        <CommandPalette
-          open={paletteOpen}
-          onOpenChange={setPaletteOpen}
-          onShortcuts={() => {
-            setPaletteOpen(false);
-            setShortcutsOpen(true);
-          }}
-        />
-        <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
-        <WhatsNewDialog state={whatsNew} />
-        <OnboardingWizard open={onboarding.open} onClose={onboarding.skip} />
-      </Suspense>
+      <ErrorBoundary silent resetKey={pathname}>
+        <Suspense fallback={null}>
+          <CommandPalette
+            open={paletteOpen}
+            onOpenChange={setPaletteOpen}
+            onShortcuts={() => {
+              setPaletteOpen(false);
+              setShortcutsOpen(true);
+            }}
+          />
+          <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+          <WhatsNewDialog state={whatsNew} />
+          <OnboardingWizard open={onboarding.open} onClose={onboarding.skip} />
+        </Suspense>
+      </ErrorBoundary>
       <ListenQueuePlayer />
     </div>
   );

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,9 +1,16 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 import { reportError } from '@/lib/errorTracking';
+import { isChunkLoadError } from '@/lib/chunkError';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
+  /** When this value changes (e.g. the route pathname), the boundary resets. */
+  resetKey?: unknown;
+  /** Render the fallback inline instead of filling the viewport, so the app shell stays visible. */
+  compact?: boolean;
+  /** Report the error but render nothing — for nonessential overlays that must not disrupt navigation. */
+  silent?: boolean;
 }
 
 interface ErrorBoundaryState {
@@ -21,15 +28,43 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     reportError(error, { componentStack: errorInfo.componentStack });
   }
 
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  handleRetry = (): void => {
+    this.setState({ error: null });
+  };
+
   render(): ReactNode {
-    if (this.state.error) {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.silent) return null;
+      const chunkError = isChunkLoadError(error);
+      const containerClass = this.props.compact
+        ? 'flex flex-col items-center justify-center gap-4 p-8 text-center'
+        : 'flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center';
+
       return (
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
-          <h1 className="text-lg font-semibold text-foreground">Something went wrong</h1>
+        <div className={containerClass}>
+          <h1 className="text-lg font-semibold text-foreground">
+            {chunkError ? 'A new version is available' : 'Something went wrong'}
+          </h1>
           <p className="max-w-sm text-sm text-muted-foreground">
-            An unexpected error occurred. Reloading the page usually fixes this.
+            {chunkError
+              ? 'This page was updated since it loaded. Reload to get the latest version.'
+              : 'An unexpected error occurred.'}
           </p>
-          <Button onClick={() => window.location.reload()}>Reload</Button>
+          <div className="flex items-center gap-3">
+            {!chunkError && (
+              <Button variant="outline" onClick={this.handleRetry}>
+                Try again
+              </Button>
+            )}
+            <Button onClick={() => window.location.reload()}>Reload</Button>
+          </div>
         </div>
       );
     }

--- a/frontend/src/components/RouteErrorRecovery.tsx
+++ b/frontend/src/components/RouteErrorRecovery.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { isRouteErrorResponse, Link, useRevalidator, useRouteError } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { reportError } from '@/lib/errorTracking';
+import { isChunkLoadError } from '@/lib/chunkError';
+
+// Rendered as a route `errorElement` for errors React Router catches before
+// any inner React error boundary (e.g. AppShell's) gets a chance to — most
+// notably route matching/loader errors and render errors on routes that
+// aren't wrapped by AppShell (login, standalone article view).
+export function RouteErrorRecovery() {
+  const error = useRouteError();
+  const revalidator = useRevalidator();
+
+  useEffect(() => {
+    if (!isRouteErrorResponse(error)) {
+      reportError(error);
+    }
+  }, [error]);
+
+  const chunkError = isChunkLoadError(error);
+  const notFound = isRouteErrorResponse(error) && error.status === 404;
+
+  const title = notFound
+    ? 'Page not found'
+    : chunkError
+      ? 'A new version is available'
+      : 'Something went wrong';
+  const message = notFound
+    ? "The page you're looking for doesn't exist or has been moved."
+    : chunkError
+      ? 'This page was updated since it loaded. Reload to get the latest version.'
+      : 'An unexpected error occurred while loading this page.';
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
+      <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+      <p className="max-w-sm text-sm text-muted-foreground">{message}</p>
+      <div className="flex items-center gap-3">
+        {!notFound && !chunkError && (
+          <Button variant="outline" onClick={() => revalidator.revalidate()}>
+            Try again
+          </Button>
+        )}
+        <Button variant={notFound ? 'default' : 'outline'} asChild>
+          <Link to="/">Go home</Link>
+        </Button>
+        {chunkError && <Button onClick={() => window.location.reload()}>Reload</Button>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/__tests__/chunkError.test.ts
+++ b/frontend/src/lib/__tests__/chunkError.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isChunkLoadError } from '../chunkError';
+
+describe('isChunkLoadError', () => {
+  it('returns false for non-Error values', () => {
+    expect(isChunkLoadError('boom')).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+
+  it('returns false for an unrelated Error', () => {
+    expect(isChunkLoadError(new Error('network timeout'))).toBe(false);
+  });
+
+  it('returns true for a stale dynamic import failure message', () => {
+    expect(isChunkLoadError(new Error('Failed to fetch dynamically imported module: /a.js'))).toBe(
+      true
+    );
+    expect(isChunkLoadError(new Error('error loading dynamically imported module: /b.js'))).toBe(
+      true
+    );
+    expect(isChunkLoadError(new Error('Importing a module script failed'))).toBe(true);
+  });
+});

--- a/frontend/src/lib/chunkError.ts
+++ b/frontend/src/lib/chunkError.ts
@@ -1,0 +1,10 @@
+// Dynamic `import()` failures (stale/missing chunk after a new deploy) throw
+// browser-specific errors that can't be recovered by re-rendering — only a
+// full reload re-fetches the current asset manifest.
+const CHUNK_ERROR_PATTERN =
+  /fetch dynamically imported module|failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed/i;
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return CHUNK_ERROR_PATTERN.test(error.message);
+}


### PR DESCRIPTION
## Summary

Closes #1176.

Route transitions and runtime failures now recover inside the app shell with clear next actions, instead of the generic spinner / raw router error UI / reload-only boundary described in the issue.

- Added `RouteErrorRecovery` (`frontend/src/components/RouteErrorRecovery.tsx`) as a React Router `errorElement`, wired onto `/login`, `/a/:id`, `/shared/:shareId/article`, and the root `/` (app-shell) route. It replaces React Router's default error UI with branded copy, a `useRevalidator`-based "Try again" that doesn't reload the page, a "Go home" link, and (for a matched `Response` 404) not-found-specific copy.
- Added `frontend/src/lib/chunkError.ts` to detect stale dynamic-import ("chunk load") failures by message pattern, shared by both the router-level and React-level boundaries. Chunk failures get "A new version is available" copy and a reload-only action, since a stale asset manifest can't be fixed by re-rendering.
- Enhanced `ErrorBoundary` (`frontend/src/components/ErrorBoundary.tsx`):
  - `resetKey` prop — the boundary clears itself when this value changes; `AppShell` now passes the route `pathname` so navigating away from a broken route resets the boundary.
  - `compact` prop — renders the fallback inline instead of `min-h-screen`, used for the boundary wrapping `AppShell`'s `<Outlet />` so the header/nav shell stays visible.
  - `silent` prop — reports the error but renders nothing; now wraps `AppShell`'s nonessential lazy overlays (command palette, shortcuts, what's-new, onboarding) so a crash there can't take down primary navigation.
  - "Try again" button that clears the error locally without a full reload, in addition to the existing "Reload" action.
- `PageLoader` now has `role="status"`, `aria-live="polite"`, and an `sr-only` label instead of a purely visual spinner.
- `NotFound`'s "Go home" link is now a React Router `Link` instead of a raw `<a href="/">`, so it does an SPA transition instead of a full document navigation.

Route paths, redirects, and the nonessential-overlay `fallback={null}` behavior were left unchanged per the issue's scope.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] New tests: `frontend/src/__tests__/routeErrorRecovery.test.tsx` (branded recovery UI, reporting, retry-vs-reload, chunk-error copy/action)
- [x] Extended tests: `frontend/src/__tests__/errorBoundary.test.tsx` (chunk-error copy, retry-without-reload, `resetKey` reset, `silent` mode)
- [x] Existing suites still pass: `appRouter.test.tsx`, `routing.test.tsx`, `errorBoundary.test.tsx`
- [x] `npm run test:frontend:smoke`
- [x] `npm run build` (bundle budget check passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)