### PR TITLE
fix: render branded recovery states for Keycloak and OAuth failures (#1174)

### DIFF
--- a/backend/news_dashboard/auth_routes/router.py
+++ b/backend/news_dashboard/auth_routes/router.py
@@ -35,9 +35,26 @@ from news_dashboard.login_throttle import clear_failures, is_throttled, record_f
 
 SESSION_COOKIE = "nd_session"
 OAUTH_STATE_COOKIE = "nd_oauth_state"
+OAUTH_NEXT_COOKIE = "nd_oauth_next"
 
 public_router = APIRouter()
 router = APIRouter()
+
+
+def _safe_next_path(next_path: str | None) -> str | None:
+    """Only accept an app-relative path so Keycloak can't be used as an open redirect."""
+    if not next_path or not next_path.startswith("/") or next_path.startswith("//"):
+        return None
+    if "://" in next_path:
+        return None
+    return next_path
+
+
+def _login_error_redirect(error_code: str) -> RedirectResponse:
+    redirect = RedirectResponse(url=f"/login?auth_error={error_code}")
+    redirect.delete_cookie(key=OAUTH_STATE_COOKIE, path="/auth/callback")
+    redirect.delete_cookie(key=OAUTH_NEXT_COOKIE, path="/auth/callback")
+    return redirect
 
 
 @public_router.get("/api/auth/config")
@@ -51,7 +68,7 @@ def auth_metadata() -> dict[str, Any]:
 
 
 @public_router.get("/auth/login")
-def keycloak_login() -> RedirectResponse:
+def keycloak_login(request: Request) -> RedirectResponse:
     if not keycloak_config().enabled:
         return RedirectResponse(url="/login")
     state = secrets.token_urlsafe(32)
@@ -65,11 +82,22 @@ def keycloak_login() -> RedirectResponse:
         max_age=600,
         path="/auth/callback",
     )
+    next_path = _safe_next_path(request.query_params.get("next"))
+    if next_path:
+        redirect.set_cookie(
+            key=OAUTH_NEXT_COOKIE,
+            value=next_path,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=600,
+            path="/auth/callback",
+        )
     return redirect
 
 
 @public_router.get("/auth/register")
-def keycloak_register() -> RedirectResponse:
+def keycloak_register(request: Request) -> RedirectResponse:
     if not keycloak_config().enabled:
         return RedirectResponse(url="/login")
     state = secrets.token_urlsafe(32)
@@ -83,22 +111,42 @@ def keycloak_register() -> RedirectResponse:
         max_age=600,
         path="/auth/callback",
     )
+    next_path = _safe_next_path(request.query_params.get("next"))
+    if next_path:
+        redirect.set_cookie(
+            key=OAUTH_NEXT_COOKIE,
+            value=next_path,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=600,
+            path="/auth/callback",
+        )
     return redirect
 
 
 @public_router.get("/auth/callback")
 async def keycloak_callback(request: Request) -> RedirectResponse:
+    provider_error = request.query_params.get("error")
+    if provider_error:
+        return _login_error_redirect("oauth_denied")
+
     expected_state = request.cookies.get(OAUTH_STATE_COOKIE)
     state = request.query_params.get("state")
     code = request.query_params.get("code")
     if not expected_state or not state or not secrets.compare_digest(expected_state, state):
-        raise HTTPException(status_code=400, detail="Invalid Keycloak OAuth state")
+        return _login_error_redirect("oauth_state")
     if not code:
-        raise HTTPException(status_code=400, detail="Missing Keycloak OAuth code")
+        return _login_error_redirect("oauth_code")
 
-    user = await exchange_keycloak_code(code)
+    try:
+        user = await exchange_keycloak_code(code)
+    except HTTPException:
+        return _login_error_redirect("oauth_exchange_failed")
+
     token = create_session_token(user["id"], bool(user["is_admin"]))
-    redirect = RedirectResponse(url="/")
+    next_path = _safe_next_path(request.cookies.get(OAUTH_NEXT_COOKIE)) or "/"
+    redirect = RedirectResponse(url=next_path)
     redirect.set_cookie(
         key=SESSION_COOKIE,
         value=token,
@@ -109,6 +157,7 @@ async def keycloak_callback(request: Request) -> RedirectResponse:
         path="/",
     )
     redirect.delete_cookie(key=OAUTH_STATE_COOKIE, path="/auth/callback")
+    redirect.delete_cookie(key=OAUTH_NEXT_COOKIE, path="/auth/callback")
     return redirect
 
 

--- a/backend/tests/test_main_oauth.py
+++ b/backend/tests/test_main_oauth.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from news_dashboard import main as main_module
@@ -59,23 +60,43 @@ def test_keycloak_login_redirects_to_provider_and_sets_state_cookie() -> None:
 
 def test_keycloak_callback_rejects_missing_state() -> None:
     resp = _client().get("/auth/callback?code=abc")
-    assert resp.status_code == 400
-    assert "state" in resp.json()["detail"].lower()
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/login?auth_error=oauth_state"
 
 
 def test_keycloak_callback_rejects_mismatched_state() -> None:
     client = _client()
     client.cookies.set("nd_oauth_state", "expected")
     resp = client.get("/auth/callback?state=different&code=abc")
-    assert resp.status_code == 400
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/login?auth_error=oauth_state"
 
 
 def test_keycloak_callback_rejects_missing_code() -> None:
     client = _client()
     client.cookies.set("nd_oauth_state", "match")
     resp = client.get("/auth/callback?state=match")
-    assert resp.status_code == 400
-    assert "code" in resp.json()["detail"].lower()
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/login?auth_error=oauth_code"
+
+
+def test_keycloak_callback_redirects_on_provider_denial() -> None:
+    resp = _client().get("/auth/callback?error=access_denied&state=match")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/login?auth_error=oauth_denied"
+
+
+def test_keycloak_callback_redirects_on_token_exchange_failure() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "match")
+    exchange_error = HTTPException(status_code=401, detail="Keycloak token exchange failed")
+    with patch(
+        "news_dashboard.auth_routes.router.exchange_keycloak_code",
+        new=AsyncMock(side_effect=exchange_error),
+    ):
+        resp = client.get("/auth/callback?state=match&code=bad")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/login?auth_error=oauth_exchange_failed"
 
 
 def test_keycloak_callback_success_sets_session_and_redirects() -> None:
@@ -92,6 +113,68 @@ def test_keycloak_callback_success_sets_session_and_redirects() -> None:
     assert resp.status_code == 307
     assert resp.headers["location"] == "/"
     assert resp.cookies.get("nd_session") == "sess-token"
+
+
+def test_keycloak_callback_success_returns_to_next_path() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "match")
+    client.cookies.set("nd_oauth_next", "/articles/42")
+    with (
+        patch(
+            "news_dashboard.auth_routes.router.exchange_keycloak_code",
+            new=AsyncMock(return_value={"id": 7, "is_admin": False}),
+        ),
+        patch("news_dashboard.auth_routes.router.create_session_token", return_value="sess-token"),
+    ):
+        resp = client.get("/auth/callback?state=match&code=good")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/articles/42"
+
+
+def test_keycloak_callback_ignores_unsafe_next_path() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "match")
+    client.cookies.set("nd_oauth_next", "https://evil.example/steal")
+    with (
+        patch(
+            "news_dashboard.auth_routes.router.exchange_keycloak_code",
+            new=AsyncMock(return_value={"id": 7, "is_admin": False}),
+        ),
+        patch("news_dashboard.auth_routes.router.create_session_token", return_value="sess-token"),
+    ):
+        resp = client.get("/auth/callback?state=match&code=good")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/"
+
+
+def test_keycloak_login_sets_next_cookie_for_safe_relative_path() -> None:
+    with (
+        patch(
+            "news_dashboard.auth_routes.router.keycloak_config",
+            return_value=SimpleNamespace(enabled=True),
+        ),
+        patch(
+            "news_dashboard.auth_routes.router.keycloak_authorization_url",
+            return_value="https://idp.example/auth?state=x",
+        ),
+    ):
+        resp = _client().get("/auth/login?next=/articles/42")
+    assert "/articles/42" in (resp.cookies.get("nd_oauth_next") or "")
+
+
+def test_keycloak_login_ignores_unsafe_next_path() -> None:
+    with (
+        patch(
+            "news_dashboard.auth_routes.router.keycloak_config",
+            return_value=SimpleNamespace(enabled=True),
+        ),
+        patch(
+            "news_dashboard.auth_routes.router.keycloak_authorization_url",
+            return_value="https://idp.example/auth?state=x",
+        ),
+    ):
+        resp = _client().get("/auth/login?next=https://evil.example")
+    assert "nd_oauth_next" not in resp.cookies
 
 
 # ── /auth/logout ──────────────────────────────────────────────────────────────

--- a/deploy/keycloak-theme/README.md
+++ b/deploy/keycloak-theme/README.md
@@ -1,0 +1,66 @@
+# Keycloak theme: auth-state coverage
+
+The `news-dashboard` theme inherits `keycloak.v2` and overrides only
+`login/resources/css/login.css` (no custom FreeMarker templates). CSS-only
+inheritance is enough to brand every page keycloak.v2 already renders,
+because the selectors below (`#kc-page-title`, `.pf-v5-c-alert`,
+`#kc-social-providers`, form controls, buttons) are shared across all of
+them.
+
+## State matrix
+
+| State | Keycloak page/template | Coverage |
+| --- | --- | --- |
+| Normal login | `login.ftl` | Styled (form controls, primary button, brand header) |
+| Invalid credentials | `login.ftl` + `#input-error` | Styled (`.pf-v5-c-alert`, `#input-error`) |
+| Locked account | `login.ftl` (temporarily disabled message) | Styled via the same alert/helper-text selectors |
+| Required action / update password | `login-update-password.ftl` | Styled (shared form control + button selectors) |
+| TOTP/OTP MFA challenge | `login-otp.ftl` | Styled (shared form control + button selectors) |
+| Verify email | `login-verify-email.ftl` | Styled (shared alert/info selectors) |
+| Registration | `register.ftl` | Styled (shared form control + button selectors) |
+| Reset credentials | `login-reset-password.ftl` | Styled (shared form control + button selectors) |
+| Expired session / action timeout | `login-page-expired.ftl` | Styled (shared alert/link selectors) |
+| Generic provider error | `error.ftl` | Styled (shared alert selectors); browser-side OAuth callback failures never reach this page — see below |
+
+Brand mark and tagline are configured once as CSS custom properties
+(`--nd-brand-mark`, `--nd-brand-tagline` in `:root`) instead of being
+duplicated across selectors.
+
+## OAuth callback failures (application side, not Keycloak-rendered)
+
+`GET /auth/callback` in `backend/news_dashboard/auth_routes/router.py` never
+returns a raw `HTTPException` to the browser. Invalid/missing OAuth state,
+a missing authorization code, a provider-side denial (`?error=...`), and
+token-exchange failures all redirect to `/login?auth_error=<code>`, where
+`LoginPage` renders branded, non-sensitive recovery copy with a "try
+Keycloak again" / "use email code" / "return home" path. A successful
+callback restores the originally requested app route via a short-lived,
+app-relative-only `next` cookie set by `/auth/login` and `/auth/register`.
+
+## Manual verification checklist
+
+1. `docker compose -f deploy/keycloak-theme/... up` (or the project's local
+   Keycloak stack) with the `news-dashboard` theme selected on the realm.
+2. Visit `/auth/login`, confirm the branded header, form controls, and
+   primary button render instead of default PatternFly styling.
+3. Trigger each state below and confirm branded rendering:
+   - Wrong password → invalid-credentials alert.
+   - Repeated wrong passwords until the realm's brute-force lockout fires →
+     locked-account alert.
+   - A user with a required action (e.g. `UPDATE_PASSWORD`) → required
+     action form.
+   - A user with OTP enabled → TOTP challenge form.
+   - `/auth/register` → registration form; submit with an unverified email
+     → verify-email page.
+   - "Forgot password" → reset-credentials form.
+   - Let the login `code` param expire, then submit → page-expired state.
+4. Cancel the Keycloak login screen (deny consent, or navigate back) and
+   confirm the app redirects to `/login?auth_error=oauth_denied` with
+   branded copy instead of a raw error.
+5. Tamper with or drop the `nd_oauth_state` cookie before completing
+   `/auth/callback` and confirm `/login?auth_error=oauth_state`.
+6. Stop the Keycloak container after `/auth/login` but before completing
+   the callback, then finish the flow, and confirm
+   `/login?auth_error=oauth_exchange_failed`.
+7. Start the flow from a deep link (e.g. `/articles/42`) and confirm a
+   successful login returns to `/articles/42` rather than `/`.

--- a/deploy/keycloak-theme/news-dashboard/login/resources/css/login.css
+++ b/deploy/keycloak-theme/news-dashboard/login/resources/css/login.css
@@ -1,5 +1,10 @@
-/* Keycloak login theme for the Radar Dashboard application. */
+/* Keycloak login theme for the Radar Dashboard application.
+ * Brand mark and tagline are configured once below via CSS custom
+ * properties; update --nd-brand-mark / --nd-brand-tagline here rather
+ * than editing the #kc-page-title::before/::after selectors. */
 :root {
+  --nd-brand-mark: 'RD';
+  --nd-brand-tagline: 'Private radar dashboard for news.lihor.ro';
   --nd-radius: 0.5rem;
   --nd-background: oklch(0.985 0.003 80);
   --nd-foreground: oklch(0.2 0.012 70);
@@ -84,7 +89,7 @@ body.login-pf {
 }
 
 #kc-page-title::before {
-  content: 'RD';
+  content: var(--nd-brand-mark);
   display: grid;
   place-items: center;
   width: 2.5rem;
@@ -99,7 +104,7 @@ body.login-pf {
 }
 
 #kc-page-title::after {
-  content: 'Private radar dashboard for news.lihor.ro';
+  content: var(--nd-brand-tagline);
   display: block;
   margin-top: 0.25rem;
   color: var(--nd-muted-foreground);

--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -49,6 +49,17 @@ vi.mock('react-i18next', () => ({
         'auth.signing_in': 'Signing in…',
         'auth.sign_in_with_keycloak': 'Sign in with Keycloak',
         'auth.create_account': 'Create Account',
+        'auth.error_oauth_state':
+          'Your sign-in link expired or was already used. Try signing in again.',
+        'auth.error_oauth_code': "Sign-in didn't complete. Try signing in again.",
+        'auth.error_oauth_denied':
+          'Sign-in was cancelled or denied. Try again, or use an email code instead.',
+        'auth.error_oauth_exchange_failed':
+          "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+        'auth.error_oauth_generic':
+          'Something went wrong signing you in. Try again, or use an email code instead.',
+        'auth.retry_keycloak': 'Try Keycloak again',
+        'auth.return_home': 'Return home',
         'app.name': 'News Dashboard',
         'app.tagline': 'Your private news platform',
       };
@@ -564,6 +575,53 @@ describe('LoginPage', () => {
       const registerLink = screen.getByRole('link', { name: /create account/i });
       expect(registerLink).toBeTruthy();
       expect(registerLink.getAttribute('href')).toBe('/auth/register');
+    });
+  });
+
+  it.each([
+    ['oauth_state', /sign-in link expired/i],
+    ['oauth_code', /didn't complete/i],
+    ['oauth_denied', /cancelled or denied/i],
+    ['oauth_exchange_failed', /couldn't finish signing you in/i],
+    ['some_unknown_code', /something went wrong signing you in/i],
+  ])('renders branded recovery copy for auth_error=%s', async (authError, expected) => {
+    renderWithRouter(
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+      </Routes>,
+      { initialPath: `/login?auth_error=${authError}` }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toMatch(expected);
+    });
+    expect(screen.getByRole('button', { name: /return home/i })).toBeTruthy();
+  });
+
+  it('appends the original path as a next param to the Keycloak login link', async () => {
+    vi.spyOn(api, 'fetchAuthConfig').mockResolvedValue({
+      provider: 'keycloak',
+      keycloak_enabled: true,
+      login_url: '/auth/login',
+      logout_url: '/auth/logout',
+      registration_url: '/auth/register',
+    });
+
+    render(
+      <QueryClientProvider client={makeQc()}>
+        <AuthProvider>
+          <MemoryRouter initialEntries={[{ pathname: '/login', state: { from: '/articles/42' } }]}>
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+            </Routes>
+          </MemoryRouter>
+        </AuthProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      const loginLink = screen.getByRole('link', { name: /sign in with keycloak/i });
+      expect(loginLink.getAttribute('href')).toBe('/auth/login?next=%2Farticles%2F42');
     });
   });
 

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "الموجز",

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Přehled",

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Overblik",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Übersicht",

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Σύνοψη",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -32,7 +32,14 @@
     "verify_code": "Verify code",
     "signing_in": "Signing in…",
     "sign_in_with_keycloak": "Sign in with Keycloak",
-    "create_account": "Create Account"
+    "create_account": "Create Account",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Brief",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Resumen",

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Yhteenveto",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Résumé",

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "תקציר",

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "ब्रीफ़",

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Összefoglaló",

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Ringkasan",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Riepilogo",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "ブリーフ",

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "브리핑",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Overzicht",

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Oversikt",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Podsumowanie",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Resumo",

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Rezumat",

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Сводка",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Överblick",

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "สรุปข่าว",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Özet",

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Огляд",

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "Tóm tắt",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "简报",

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -32,7 +32,14 @@
     "error_server": "The auth service is having trouble. Try again shortly.",
     "code_expires_in": "Codes expire after 10 minutes.",
     "resend_available_soon": "Resend in {{seconds}}s",
-    "change_email": "Change email"
+    "change_email": "Change email",
+    "error_oauth_state": "Your sign-in link expired or was already used. Try signing in again.",
+    "error_oauth_code": "Sign-in didn't complete. Try signing in again.",
+    "error_oauth_denied": "Sign-in was cancelled or denied. Try again, or use an email code instead.",
+    "error_oauth_exchange_failed": "We couldn't finish signing you in with Keycloak. Try again, or use an email code instead.",
+    "error_oauth_generic": "Something went wrong signing you in. Try again, or use an email code instead.",
+    "retry_keycloak": "Try Keycloak again",
+    "return_home": "Return home"
   },
   "nav": {
     "brief": "簡報",

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -23,6 +23,23 @@ function isNetworkError(error: unknown) {
   return error instanceof TypeError;
 }
 
+const OAUTH_ERROR_KEYS: Record<string, string> = {
+  oauth_state: 'auth.error_oauth_state',
+  oauth_code: 'auth.error_oauth_code',
+  oauth_denied: 'auth.error_oauth_denied',
+  oauth_exchange_failed: 'auth.error_oauth_exchange_failed',
+};
+
+function oauthErrorKey(authError: string) {
+  return OAUTH_ERROR_KEYS[authError] ?? 'auth.error_oauth_generic';
+}
+
+function withNextParam(url: string, from: string) {
+  if (from === '/') return url;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}next=${encodeURIComponent(from)}`;
+}
+
 function authErrorKey(action: AuthAction, error: unknown) {
   if (isNetworkError(error)) return 'auth.error_network';
 
@@ -50,6 +67,7 @@ export function LoginPage() {
   const location = useLocation();
   const locationState = location.state as { from?: string; sessionExpired?: boolean } | null;
   const from = locationState?.from ?? '/';
+  const oauthError = new URLSearchParams(location.search).get('auth_error');
 
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
   const [authConfigStatus, setAuthConfigStatus] = useState<AuthConfigStatus>('loading');
@@ -163,7 +181,9 @@ export function LoginPage() {
   }
 
   const keycloakEnabled = authConfig?.provider === 'keycloak';
-  const keycloakLoginUrl = keycloakEnabled ? (authConfig.login_url ?? '/auth/login') : null;
+  const keycloakLoginUrl = keycloakEnabled
+    ? withNextParam(authConfig.login_url ?? '/auth/login', from)
+    : null;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
@@ -175,6 +195,21 @@ export function LoginPage() {
             <p className="mt-1 text-sm text-muted-foreground">{t('app.tagline')}</p>
           </div>
         </div>
+
+        {oauthError && (
+          <div className="mb-4 space-y-2 rounded-md border border-border bg-surface p-3 text-center">
+            <p role="alert" className="text-xs text-[color:var(--err)]">
+              {t(oauthErrorKey(oauthError))}
+            </p>
+            <button
+              type="button"
+              onClick={() => void navigate('/', { replace: true })}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+            >
+              {t('auth.return_home')}
+            </button>
+          </div>
+        )}
 
         {authConfigStatus === 'loading' ? (
           <div role="status" className="text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes #1174.

- `/auth/callback` (backend/news_dashboard/auth_routes/router.py) no longer returns raw `HTTPException` JSON to the browser. Invalid/missing OAuth state, a missing authorization code, a provider-side denial (`?error=...`), and token-exchange failures now redirect to `/login?auth_error=<code>` instead.
- `LoginPage` (frontend/src/pages/LoginPage.tsx) reads `auth_error` and renders branded, non-sensitive recovery copy with a "return home" action, alongside the existing "try Keycloak again" / "use email code" paths already on the login screen.
- `/auth/login` and `/auth/register` accept an app-relative-only `next` query param, preserved via a short-lived httponly cookie, so a successful Keycloak login redirects back to the originally requested route instead of always going to `/`. Open-redirect protection: `next` is rejected unless it starts with `/` (and not `//`) and contains no `://`.
- Centralized the Keycloak theme's hardcoded brand mark/tagline (`deploy/keycloak-theme/news-dashboard/login/resources/css/login.css`) into `:root` custom properties (`--nd-brand-mark`, `--nd-brand-tagline`) instead of scattering literal strings across selectors.
- Added `deploy/keycloak-theme/README.md` documenting the Keycloak auth-state matrix (login, invalid credentials, locked account, required action, OTP/MFA, verify email, registration, reset credentials, session timeout, generic error) and a manual verification checklist, since this theme relies on CSS-only inheritance from `keycloak.v2` rather than custom FreeMarker templates.
- Added new `auth.error_oauth_*` / `auth.retry_keycloak` / `auth.return_home` i18n keys to `en` with English placeholder text in all other locales (matching the existing pattern for other `auth.error_*` keys in this repo).

## Scope notes

The parent issue's scope also covers Keycloak-side templates for locked-account/MFA/etc. copy. This repo's theme currently inherits `keycloak.v2` with CSS-only overrides (no custom `.ftl` templates), and those default templates already render acceptably with this theme's shared selectors (form controls, alerts, buttons). Introducing custom FreeMarker templates is a larger, separate change; the README documents the current coverage and a manual verification checklist for those states as a substitute for automated screenshot fixtures, per the issue's stated fallback ("otherwise add a documented manual verification checklist").

## Test plan

- [x] `pytest backend/tests/test_main_oauth.py` — new/updated tests for invalid state, missing code, provider denial, token-exchange failure, successful redirect with/without `next`, and unsafe `next` rejection.
- [x] Full backend suite: `pytest backend/tests` — 2423 passed (one unrelated transient Postgres timeout on rerun, passed in isolation).
- [x] `vitest run frontend/src/__tests__/auth.test.tsx frontend/src/__tests__/locales.test.ts frontend/src/__tests__/i18n.test.tsx` — new tests for each `auth_error` state and the Keycloak `next` link.
- [x] `npm run test:frontend:smoke`
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] pre-commit (ruff, mypy, ty, pyrefly, eslint, prettier, knip, tsc) — all passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)