### PR TITLE
fix: strengthen URL canonicalization to prevent duplicate article ingestion

### DIFF
--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -104,15 +104,15 @@ class IngestResult:
 
 
 TRACKING_PARAMS = {
-    "utm_source",
-    "utm_medium",
-    "utm_campaign",
-    "utm_term",
-    "utm_content",
     "ref",
     "fbclid",
     "gclid",
     "yclid",
+    "mc_cid",
+    "mc_eid",
+    "igshid",
+    "spm",
+    "ck_subscriber_id",
 }
 
 KEYWORD_TAGS = {
@@ -219,12 +219,25 @@ def clean_html(value: str | None) -> str:
 
 def canonicalize_url(url: str) -> str:
     parsed = urlparse(url.strip())
-    query = [
+    query = sorted(
         (k, v)
         for k, v in parse_qsl(parsed.query, keep_blank_values=True)
-        if k.lower() not in TRACKING_PARAMS
-    ]
-    parsed = parsed._replace(fragment="", query=urlencode(query, doseq=True))
+        if k.lower() not in TRACKING_PARAMS and not k.lower().startswith("utm_")
+    )
+    path = parsed.path
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    # Note: canonical_url is also used to actually fetch/cite the article
+    # (learn_from_link, export), so we only normalize scheme/host casing here
+    # — never rewrite the scheme itself (e.g. http->https), which could break
+    # real requests to an http-only source.
+    parsed = parsed._replace(
+        scheme=parsed.scheme.lower(),
+        netloc=parsed.netloc.lower(),
+        path=path,
+        fragment="",
+        query=urlencode(query, doseq=True),
+    )
     return urlunparse(parsed)
 
 

--- a/backend/tests/test_ingest_dedupe_boundaries.py
+++ b/backend/tests/test_ingest_dedupe_boundaries.py
@@ -13,10 +13,17 @@ Covers:
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import news_dashboard.ingest.service as ingest_module
 from news_dashboard.db import connect
-from news_dashboard.ingest.service import _attach_also_from, _find_canonical
+from news_dashboard.ingest.service import (
+    _attach_also_from,
+    _find_canonical,
+    canonicalize_url,
+)
+from news_dashboard.sources.service import SourceDefinition
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -234,3 +241,92 @@ def test_also_from_no_user_includes_all_sources(pg_clean: str) -> None:
 
     # Admin path sees private source name too
     assert "judy-private" in article["also_from"]
+
+
+# ── URL-variant reappearance regression (issue #1215) ─────────────────────────
+
+
+def _age_article(pg_url: str, article_id: int, days: int) -> None:
+    """Push discovered_at into the past so the 7-day fuzzy-title fallback in
+    _find_canonical can no longer rescue a URL-match miss — isolating the
+    URL-normalization path from the title-fallback path."""
+    with connect(database_url=pg_url) as conn:
+        conn.execute(
+            "UPDATE articles SET discovered_at = %s WHERE id = %s",
+            ((datetime.now(timezone.utc) - timedelta(days=days)).isoformat(), article_id),
+        )
+
+
+def test_find_canonical_matches_scheme_and_trailing_slash_variant(pg_clean: str) -> None:
+    """A URL that differs only by scheme/case/trailing-slash must still match
+    the existing canonical once both sides are canonicalized — otherwise a
+    re-ingested article gets a brand-new id with no user_article_state row,
+    making it reappear in the Today feed after the user already triaged it.
+
+    The canonical is aged past the 7-day fuzzy-title fallback window so this
+    test exercises URL matching specifically, not the title fallback."""
+    _insert_source(pg_clean, "global-src")
+    canonical_url = canonicalize_url("https://Example.test/story/")
+    canonical_id = _insert_canonical(pg_clean, canonical_url, "Big Story", "global-src")
+    _age_article(pg_clean, canonical_id, days=10)
+
+    variant_url = canonicalize_url("HTTPS://example.TEST/story")
+
+    with connect(database_url=pg_clean) as conn:
+        found = _find_canonical(conn, variant_url, "Big Story", owner_user_id=None)
+
+    assert found == canonical_id
+
+
+def test_ingest_all_does_not_duplicate_url_variant_across_runs(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    """Two ingest runs serving the same article as a scheme/trailing-slash/
+    tracking-param variant must not create two distinct (non-archived)
+    articles rows — a second row would have no user_article_state and would
+    reappear in the Today feed even after the first was triaged.
+
+    The first run's article is aged past the fuzzy-title fallback window so
+    this test exercises URL matching specifically, not the title fallback."""
+
+    db_path = tmp_path / "reingest.db"
+    source = SourceDefinition("test-feed", "Test Feed", "https://example.com/feed.xml", "python")
+    monkeypatch.setattr(ingest_module, "DEFAULT_SOURCES", [source])
+
+    urls = iter(
+        [
+            "https://example.com/article/",
+            "HTTPS://Example.com/article?utm_source=rss",
+        ]
+    )
+
+    def fake_parse_url(url: str) -> list[dict[str, object]]:
+        return [
+            {
+                "url": next(urls),
+                "title": "Same Story Twice",
+                "description": "A summary.",
+                "date": None,
+            }
+        ]
+
+    monkeypatch.setattr(ingest_module, "_parse_feed_url", fake_parse_url)
+
+    ingest_module.ingest_all(db_path)
+    with connect(db_path) as conn:
+        first = conn.execute("SELECT id FROM articles WHERE canonical_id IS NULL").fetchone()
+        assert first is not None
+        conn.execute(
+            "UPDATE articles SET discovered_at = %s WHERE id = %s",
+            (
+                (datetime.now(timezone.utc) - timedelta(days=10)).isoformat(),
+                first["id"] if isinstance(first, dict) else first[0],
+            ),
+        )
+
+    ingest_module.ingest_all(db_path)
+
+    with connect(db_path) as conn:
+        rows = conn.execute("SELECT id FROM articles WHERE canonical_id IS NULL").fetchall()
+
+    assert len(rows) == 1

--- a/backend/tests/test_ingest_helpers.py
+++ b/backend/tests/test_ingest_helpers.py
@@ -55,6 +55,31 @@ def test_canonicalize_url_strips_tracking_and_fragment() -> None:
     assert "#frag" not in out
 
 
+def test_canonicalize_url_normalizes_scheme_and_host_case() -> None:
+    assert canonicalize_url("HTTP://X.test/p") == canonicalize_url("http://x.test/p")
+
+
+def test_canonicalize_url_strips_trailing_slash() -> None:
+    assert canonicalize_url("https://x.test/p/") == canonicalize_url("https://x.test/p")
+
+
+def test_canonicalize_url_keeps_root_slash() -> None:
+    assert canonicalize_url("https://x.test/") == "https://x.test/"
+
+
+def test_canonicalize_url_sorts_query_params() -> None:
+    assert canonicalize_url("https://x.test/p?b=2&a=1") == canonicalize_url(
+        "https://x.test/p?a=1&b=2"
+    )
+
+
+def test_canonicalize_url_strips_additional_tracking_params() -> None:
+    out = canonicalize_url(
+        "https://x.test/p?id=5&mc_cid=abc&mc_eid=def&igshid=ghi&ck_subscriber_id=jkl"
+    )
+    assert out == canonicalize_url("https://x.test/p?id=5")
+
+
 # ── parse_date ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #1215

Users saw already-triaged articles (done/skipped/starred/saved) reappear in the Today feed after refreshing or after subsequent ingest runs. The Today feed query correctly filters on `user_article_state` — the bug is upstream in ingestion dedup.

`canonicalize_url()` only stripped the URL fragment and a fixed set of tracking params, so a re-served article with different scheme casing, a trailing slash, unordered query params, or an unrecognized tracking param missed the exact `canonical_url` match. When the 7-day fuzzy-title fallback also missed, ingestion inserted a brand-new `articles` row with no matching `user_article_state`, so it looked untouched again.

Fix: normalize scheme/host casing, strip trailing slashes, sort query params, and broaden tracking-param stripping (any `utm_*` plus more known params). Deliberately did **not** unify `http`/`https` — `canonical_url` is also used to actually fetch/cite the article elsewhere (`learn_from_link`, `export`), and rewriting the scheme could break real requests to an http-only source.

Backed by new regression tests:
- `canonicalize_url` unit tests (scheme/host case, trailing slash, query-param order, extra tracking params)
- `_find_canonical` and `ingest_all` integration tests that reproduce the exact reappearance scenario (aging the canonical article past the 7-day fuzzy-title window to isolate the URL-matching path)

Full backend (2536) + frontend (962) suites pass; lint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)