### PR TITLE
fix: resolve code scanning alerts

### DIFF
--- a/backend/news_dashboard/auth_routes/router.py
+++ b/backend/news_dashboard/auth_routes/router.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import secrets
 from typing import Annotated, Any
+from urllib.parse import urlsplit
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
@@ -43,11 +44,15 @@ router = APIRouter()
 
 def _safe_next_path(next_path: str | None) -> str | None:
     """Only accept an app-relative path so Keycloak can't be used as an open redirect."""
-    if not next_path or not next_path.startswith("/") or next_path.startswith("//"):
+    if not next_path:
         return None
-    if "://" in next_path:
+    normalized_path = next_path.replace("\\", "/")
+    parsed = urlsplit(normalized_path)
+    if parsed.scheme or parsed.netloc:
         return None
-    return next_path
+    if not normalized_path.startswith("/") or normalized_path.startswith("//"):
+        return None
+    return normalized_path
 
 
 def _login_error_redirect(error_code: str) -> RedirectResponse:

--- a/backend/tests/test_ingest_dedupe_boundaries.py
+++ b/backend/tests/test_ingest_dedupe_boundaries.py
@@ -18,12 +18,11 @@ from typing import Any
 
 import news_dashboard.ingest.service as ingest_module
 from news_dashboard.db import connect
-from news_dashboard.ingest.service import (
-    _attach_also_from,
-    _find_canonical,
-    canonicalize_url,
-)
 from news_dashboard.sources.service import SourceDefinition
+
+_attach_also_from = ingest_module._attach_also_from
+_find_canonical = ingest_module._find_canonical
+canonicalize_url = ingest_module.canonicalize_url
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/backend/tests/test_main_oauth.py
+++ b/backend/tests/test_main_oauth.py
@@ -16,6 +16,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from news_dashboard import main as main_module
+from news_dashboard.auth_routes.router import _safe_next_path
 from news_dashboard.main import app
 
 
@@ -56,6 +57,23 @@ def test_keycloak_login_redirects_to_provider_and_sets_state_cookie() -> None:
 
 
 # ── /auth/callback ────────────────────────────────────────────────────────────
+
+
+def test_safe_next_path_accepts_app_relative_path() -> None:
+    assert _safe_next_path("/articles/42?from=briefs") == "/articles/42?from=briefs"
+
+
+def test_safe_next_path_rejects_missing_or_non_rooted_path() -> None:
+    assert _safe_next_path(None) is None
+    assert _safe_next_path("") is None
+    assert _safe_next_path("articles/42") is None
+
+
+def test_safe_next_path_rejects_network_or_external_path() -> None:
+    assert _safe_next_path("//evil.example/steal") is None
+    assert _safe_next_path("https://evil.example/steal") is None
+    assert _safe_next_path("https:/evil.example/steal") is None
+    assert _safe_next_path("\\\\evil.example\\steal") is None
 
 
 def test_keycloak_callback_rejects_missing_state() -> None:
@@ -131,10 +149,42 @@ def test_keycloak_callback_success_returns_to_next_path() -> None:
     assert resp.headers["location"] == "/articles/42"
 
 
-def test_keycloak_callback_ignores_unsafe_next_path() -> None:
+def test_keycloak_callback_ignores_absolute_next_path() -> None:
     client = _client()
     client.cookies.set("nd_oauth_state", "match")
     client.cookies.set("nd_oauth_next", "https://evil.example/steal")
+    with (
+        patch(
+            "news_dashboard.auth_routes.router.exchange_keycloak_code",
+            new=AsyncMock(return_value={"id": 7, "is_admin": False}),
+        ),
+        patch("news_dashboard.auth_routes.router.create_session_token", return_value="sess-token"),
+    ):
+        resp = client.get("/auth/callback?state=match&code=good")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/"
+
+
+def test_keycloak_callback_ignores_backslash_host_next_path() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "match")
+    client.cookies.set("nd_oauth_next", "\\\\evil.example\\steal")
+    with (
+        patch(
+            "news_dashboard.auth_routes.router.exchange_keycloak_code",
+            new=AsyncMock(return_value={"id": 7, "is_admin": False}),
+        ),
+        patch("news_dashboard.auth_routes.router.create_session_token", return_value="sess-token"),
+    ):
+        resp = client.get("/auth/callback?state=match&code=good")
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/"
+
+
+def test_keycloak_callback_ignores_malformed_scheme_next_path() -> None:
+    client = _client()
+    client.cookies.set("nd_oauth_state", "match")
+    client.cookies.set("nd_oauth_next", "https:/evil.example/steal")
     with (
         patch(
             "news_dashboard.auth_routes.router.exchange_keycloak_code",

--- a/frontend/src/__tests__/briefingsHistory.test.tsx
+++ b/frontend/src/__tests__/briefingsHistory.test.tsx
@@ -139,6 +139,10 @@ describe('BriefingsHistoryPage — list state', () => {
     vi.spyOn(api, 'fetchBriefings').mockResolvedValue({
       items: [COMPLETE_BRIEFING, FAILED_BRIEFING],
     });
+    vi.spyOn(api, 'fetchPodcastFeedToken').mockResolvedValue({
+      token: 'feed-token',
+      url: 'https://example.com/podcast.xml?token=feed-token',
+    });
   });
 
   it('renders briefing title', async () => {
@@ -172,6 +176,13 @@ describe('BriefingsHistoryPage — list state', () => {
       const briefingLinks = links.filter((l) => l.getAttribute('href')?.startsWith('/briefs/'));
       expect(briefingLinks.length).toBe(2);
     });
+  });
+
+  it('enables copying the podcast feed URL after the token loads', async () => {
+    renderHistory();
+    const copyButton = await screen.findByRole('button', { name: /copy feed url/i });
+    expect(copyButton).toBeTruthy();
+    await waitFor(() => expect(copyButton.hasAttribute('disabled')).toBe(false));
   });
 });
 

--- a/frontend/src/pages/BriefingsHistoryPage.tsx
+++ b/frontend/src/pages/BriefingsHistoryPage.tsx
@@ -62,7 +62,7 @@ function BriefingRow({ briefing }: { briefing: Briefing }) {
 function PodcastFeedCard() {
   const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
-  const { data, isLoading, isError, isFetching, refetch } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['briefings', 'podcast-feed-token'],
     queryFn: fetchPodcastFeedToken,
   });


### PR DESCRIPTION
Closes #1219

## Summary
- Harden OAuth `next` redirects to allow only parsed, app-relative paths and reject absolute, malformed-scheme, and backslash-host values.
- Remove unused React Query result fields from the podcast feed card.
- Simplify the ingest dedupe test imports to avoid mixed module/import-from usage.
- Cover the redirect helper branches and podcast feed card loaded state so patch coverage stays green.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_main_oauth.py -q`
- `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_main_oauth.py --cov=news_dashboard.auth_routes.router --cov-report=term-missing --cov-branch -q`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make typecheck`
- `PATH="$PWD/.venv/bin:$PATH" python -m dotenv run -- make test`
- `npm run build`
- `npm run test:frontend -- frontend/src/__tests__/briefingsHistory.test.tsx`
- `npm run lint -- frontend/src/__tests__/briefingsHistory.test.tsx frontend/src/pages/BriefingsHistoryPage.tsx && npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
