### PR TITLE
fix: recover stale pending lesson generations (#1178)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,10 @@ ENTITY_EXTRACTION_INTERVAL_MINUTES=30
 ENTITY_RELATIONSHIP_EXTRACTION_INTERVAL_MINUTES=60
 # Interval for the reading-list metadata sweep retrying pending link previews. Default 5.
 READING_LIST_FETCH_INTERVAL_MINUTES=5
+# Age in minutes after which pending lesson generations are considered interrupted. Default 15.
+LESSON_GENERATION_STALE_MINUTES=15
+# Interval for recovering interrupted pending lesson generations. Default 5.
+LESSON_GENERATION_RECOVERY_INTERVAL_MINUTES=5
 # Interval for the proactive AI watchlist evaluator (watchlist_agent.py). Default 15.
 WATCHLIST_EVALUATION_INTERVAL_MINUTES=15
 # Interval for the post-ingest embedding-similarity dedup pass (embedding_dedup.py). Default 60.

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -36,6 +36,10 @@ class StudyArtifactsValidationError(ValueError):
 logger = logging.getLogger(__name__)
 
 DEFAULT_LESSON_CHAT_MODEL = "gpt-4o-mini"
+DEFAULT_STALE_PENDING_LESSON_MINUTES = 15
+STALE_PENDING_LESSON_ERROR = (
+    "Lesson generation was interrupted before it could finish. Please retry generation."
+)
 
 _DEPTH_EXPLANATION_LIMITS: dict[str, int] = {
     "tiny": 150,
@@ -325,6 +329,59 @@ def _update_lesson_failure(
             (error_message, lesson_id, user_id),
         ).fetchone()
     return _serialize_lesson(row)
+
+
+def recover_stale_pending_lessons(
+    *,
+    stale_after_minutes: int = DEFAULT_STALE_PENDING_LESSON_MINUTES,
+    batch_limit: int = 50,
+    database_url: str | None = None,
+) -> int:
+    """Mark stale pending lesson generations failed so users can retry them.
+
+    Uses PostgreSQL row locking so multiple app workers can run recovery without
+    processing the same pending lessons.
+    """
+    safe_minutes = max(1, stale_after_minutes)
+    safe_limit = max(1, min(batch_limit, 500))
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            WITH stale AS (
+                SELECT id
+                FROM lessons
+                WHERE generation_status = 'pending'
+                  AND updated_at < NOW() - (%s * INTERVAL '1 minute')
+                ORDER BY updated_at ASC
+                LIMIT %s
+                FOR UPDATE SKIP LOCKED
+            ),
+            recovered AS (
+                UPDATE lessons
+                SET generation_status = 'failed',
+                    generation_error = %s,
+                    updated_at = NOW()
+                WHERE id IN (SELECT id FROM stale)
+                RETURNING id
+            ),
+            failed_runs AS (
+                UPDATE learning_agent_runs
+                SET status = 'failed',
+                    failed_step = COALESCE(failed_step, 'recovery'),
+                    error = COALESCE(error, %s),
+                    updated_at = NOW()
+                WHERE status = 'running'
+                  AND lesson_id IN (SELECT id FROM recovered)
+                RETURNING id
+            )
+            SELECT COUNT(*) AS recovered_count FROM recovered
+            """,
+            (safe_minutes, safe_limit, STALE_PENDING_LESSON_ERROR, STALE_PENDING_LESSON_ERROR),
+        ).fetchone()
+    if row is None:
+        return 0
+    return int(row_to_dict(row)["recovered_count"])
 
 
 def _update_lesson_podcast_success(

--- a/backend/news_dashboard/scheduler/service.py
+++ b/backend/news_dashboard/scheduler/service.py
@@ -443,6 +443,21 @@ def _run_reading_list_fetch() -> tuple[str, str | None] | None:
     return "success", f"fetched {processed} item(s)"
 
 
+def _run_lesson_generation_recovery() -> tuple[str, str | None] | None:
+    from news_dashboard.learn_from_link import service
+
+    stale_minutes = int(os.getenv("LESSON_GENERATION_STALE_MINUTES", "15"))
+    try:
+        recovered = service.recover_stale_pending_lessons(stale_after_minutes=stale_minutes)
+    except Exception as exc:
+        logger.exception("Stale lesson generation recovery failed")
+        return "failure", str(exc)[:500]
+    if recovered == 0:
+        return None
+    logger.info("Stale lesson generation recovery marked %d lesson(s) failed.", recovered)
+    return "success", f"recovered {recovered} stale lesson generation(s)"
+
+
 def _run_newsletter_poll() -> tuple[str, str | None] | None:
     from news_dashboard.newsletter_ingest import poll_newsletters
 
@@ -549,6 +564,10 @@ def _job_reading_list_fetch() -> None:
     _run_and_record("reading_list_fetch", _run_reading_list_fetch)
 
 
+def _job_lesson_generation_recovery() -> None:
+    _run_and_record("lesson_generation_recovery", _run_lesson_generation_recovery)
+
+
 def _job_watchlist_evaluation() -> None:
     _run_and_record("watchlist_evaluation", _run_watchlist_evaluation)
 
@@ -643,6 +662,14 @@ def _register_recurring_jobs(scheduler: Any) -> None:
         trigger="interval",
         minutes=int(os.getenv("READING_LIST_FETCH_INTERVAL_MINUTES", "5")),
         id="reading_list_fetch",
+        replace_existing=True,
+    )
+
+    scheduler.add_job(
+        _job_lesson_generation_recovery,
+        trigger="interval",
+        minutes=int(os.getenv("LESSON_GENERATION_RECOVERY_INTERVAL_MINUTES", "5")),
+        id="lesson_generation_recovery",
         replace_existing=True,
     )
 

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 
 from news_dashboard.auth import require_admin, require_auth
 from news_dashboard.db import connect, init_db
-from news_dashboard.learn_from_link import service
+from news_dashboard.learn_from_link import agent_runs, service
 from news_dashboard.learn_from_link.models import LessonDepth
 from news_dashboard.main import app
 from news_dashboard.url_safety import UnsafeUrlError
@@ -1104,6 +1104,74 @@ def test_regenerate_lesson_raises_not_found_for_other_users_lesson(pg_clean: str
             persona="developer",
             database_url=pg_clean,
         )
+
+
+def test_recover_stale_pending_lessons_marks_old_pending_failed(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    stale = service.create_lesson(
+        user_id, "https://example.com/stale", database_url=pg_clean, extract=False
+    )
+    fresh = service.create_lesson(
+        user_id, "https://example.com/fresh", database_url=pg_clean, extract=False
+    )
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            UPDATE lessons
+            SET updated_at = NOW() - INTERVAL '20 minutes'
+            WHERE id = %s
+            """,
+            (stale["id"],),
+        )
+
+    recovered = service.recover_stale_pending_lessons(stale_after_minutes=15, database_url=pg_clean)
+
+    assert recovered == 1
+    stale_after = service.get_lesson(int(stale["id"]), user_id, database_url=pg_clean)
+    fresh_after = service.get_lesson(int(fresh["id"]), user_id, database_url=pg_clean)
+    assert stale_after is not None
+    assert stale_after["generation_status"] == "failed"
+    assert stale_after["generation_error"] == service.STALE_PENDING_LESSON_ERROR
+    assert fresh_after is not None
+    assert fresh_after["generation_status"] == "pending"
+    assert fresh_after["generation_error"] is None
+
+
+def test_recover_stale_pending_lessons_fails_interrupted_agent_run(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(
+        user_id, "https://example.com/interrupted", database_url=pg_clean, extract=False
+    )
+    run_id = agent_runs.start_run(
+        pg_clean,
+        lesson_id=int(lesson["id"]),
+        user_id=user_id,
+        prompt_version=agent_runs.SYNTHESIS_PROMPT_VERSION,
+        model_version=service.DEFAULT_LESSON_CHAT_MODEL,
+        config={"depth": lesson["depth"], "persona": lesson["persona"]},
+    )
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            UPDATE lessons
+            SET updated_at = NOW() - INTERVAL '16 minutes'
+            WHERE id = %s
+            """,
+            (lesson["id"],),
+        )
+
+    recovered = service.recover_stale_pending_lessons(stale_after_minutes=15, database_url=pg_clean)
+
+    assert recovered == 1
+    with connect(database_url=pg_clean) as conn:
+        run = conn.execute(
+            "SELECT status, failed_step, error FROM learning_agent_runs WHERE id = %s",
+            (run_id,),
+        ).fetchone()
+    assert run is not None
+    assert run["status"] == "failed"
+    assert run["failed_step"] == "recovery"
+    assert run["error"] == service.STALE_PENDING_LESSON_ERROR
 
 
 def test_generate_lesson_from_url_records_generation_history(

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1257,6 +1257,34 @@ def test_run_reading_list_fetch_reports_count() -> None:
     assert "2" in (message or "")
 
 
+def test_start_scheduler_registers_lesson_generation_recovery_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LESSON_GENERATION_RECOVERY_INTERVAL_MINUTES", "7")
+    mock_sched = _start_with_env(monkeypatch)
+    jobs = {c.kwargs.get("id"): c.kwargs for c in mock_sched.add_job.call_args_list}
+    assert "lesson_generation_recovery" in jobs
+    assert jobs["lesson_generation_recovery"]["trigger"] == "interval"
+    assert jobs["lesson_generation_recovery"]["minutes"] == 7
+
+
+def test_run_lesson_generation_recovery_reports_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.scheduler.service import _run_lesson_generation_recovery
+
+    monkeypatch.setenv("LESSON_GENERATION_STALE_MINUTES", "22")
+    with patch(
+        "news_dashboard.learn_from_link.service.recover_stale_pending_lessons",
+        return_value=3,
+    ) as mock_recover:
+        result = _run_lesson_generation_recovery()
+
+    mock_recover.assert_called_once_with(stale_after_minutes=22)
+    assert result is not None
+    status, message = result
+    assert status == "success"
+    assert "3" in (message or "")
+
+
 def test_start_scheduler_registers_watchlist_evaluation_job(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #1178

## Summary
- add PostgreSQL-backed recovery for stale pending lessons using `FOR UPDATE SKIP LOCKED`
- mark interrupted running learning agent runs failed when their lesson is recovered
- register a recurring scheduler job with configurable stale threshold and interval
- cover stale/fresh pending behavior, interrupted run bookkeeping, and scheduler wiring

## Test results
- `make lint` passed
- `make typecheck` passed
- `pytest backend/tests/test_learn_from_link.py -k recover_stale_pending_lessons backend/tests/test_scheduler.py -k lesson_generation_recovery` could not run locally because `nd-test-pg` was not reachable on `localhost:55432` after bootstrap/Podman startup attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)