### PR TITLE
feat: add Helm newsletter IMAP settings (#1179)

### DIFF
--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -397,6 +397,57 @@ def test_helm_template_app_and_ingest_receive_sentry_env() -> None:
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_newsletter_env_defaults_off() -> None:
+    output = _render_chart()
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert "NEWSLETTER_IMAP_HOST" not in deployment_env
+    assert "NEWSLETTER_IMAP_PORT" not in deployment_env
+    assert "NEWSLETTER_IMAP_USERNAME" not in deployment_env
+    assert "NEWSLETTER_IMAP_PASSWORD" not in deployment_env
+    assert "NEWSLETTER_IMAP_FOLDER" not in deployment_env
+    assert "NEWSLETTER_POLL_MINUTES" not in deployment_env
+    assert "NEWSLETTER_MAX_MESSAGE_BYTES" not in deployment_env
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_newsletter_env_uses_existing_secret() -> None:
+    output = _render_chart(
+        "app.newsletter.imapHost=imap.example.test",
+        "app.newsletter.imapPort=1993",
+        "app.newsletter.imapFolder=Newsletters",
+        "app.newsletter.pollMinutes=7",
+        "app.newsletter.maxMessageBytes=1048576",
+        "app.newsletter.existingSecret=newsletter-credentials",
+        "app.newsletter.usernameKey=CUSTOM_IMAP_USERNAME",
+        "app.newsletter.passwordKey=CUSTOM_IMAP_PASSWORD",
+    )
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert _env_entry(deployment_env, "NEWSLETTER_IMAP_HOST") == (
+        '- name: NEWSLETTER_IMAP_HOST\n  value: "imap.example.test"'
+    )
+    assert _env_entry(deployment_env, "NEWSLETTER_IMAP_PORT") == (
+        '- name: NEWSLETTER_IMAP_PORT\n  value: "1993"'
+    )
+    assert _env_entry(deployment_env, "NEWSLETTER_IMAP_FOLDER") == (
+        '- name: NEWSLETTER_IMAP_FOLDER\n  value: "Newsletters"'
+    )
+    assert _env_entry(deployment_env, "NEWSLETTER_POLL_MINUTES") == (
+        '- name: NEWSLETTER_POLL_MINUTES\n  value: "7"'
+    )
+    assert _env_entry(deployment_env, "NEWSLETTER_MAX_MESSAGE_BYTES") == (
+        '- name: NEWSLETTER_MAX_MESSAGE_BYTES\n  value: "1048576"'
+    )
+    username = _env_entry(deployment_env, "NEWSLETTER_IMAP_USERNAME")
+    assert 'name: "newsletter-credentials"' in username
+    assert 'key: "CUSTOM_IMAP_USERNAME"' in username
+    password = _env_entry(deployment_env, "NEWSLETTER_IMAP_PASSWORD")
+    assert 'name: "newsletter-credentials"' in password
+    assert 'key: "CUSTOM_IMAP_PASSWORD"' in password
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
 def test_helm_template_app_config_defaults_off() -> None:
     output = _render_chart()
     deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -415,6 +415,28 @@ the app's own defaults. Sentry DSNs and other secret-bearing values are
 supplied via `app.sentry.existingSecret` (a pre-existing Secret), never
 committed to `values.yaml`.
 
+Newsletter IMAP ingest can also be enabled through structured Helm values.
+Create a Secret for mailbox credentials, then set the non-secret mailbox
+options on `app.newsletter`:
+
+```bash
+kubectl -n news-dashboard create secret generic newsletter-imap \
+  --from-literal=NEWSLETTER_IMAP_USERNAME='inbox@example.com' \
+  --from-literal=NEWSLETTER_IMAP_PASSWORD='replace-with-real-password'
+
+helm upgrade news-dashboard ./helm/news-dashboard \
+  --reuse-values \
+  --set app.newsletter.imapHost=imap.example.com \
+  --set app.newsletter.imapPort=993 \
+  --set app.newsletter.imapFolder=INBOX \
+  --set app.newsletter.pollMinutes=15 \
+  --set app.newsletter.maxMessageBytes=10485760 \
+  --set app.newsletter.existingSecret=newsletter-imap
+```
+
+When `app.newsletter.imapHost` is empty, the chart does not render newsletter
+IMAP env vars and the scheduler does not start the mailbox poller.
+
 Neo4j is available as an optional Helm-managed graph store. See
 [Optional Graph Storage](#optional-graph-storage) for the values and backfill
 commands.

--- a/helm/news-dashboard/templates/_helpers.tpl
+++ b/helm/news-dashboard/templates/_helpers.tpl
@@ -98,6 +98,37 @@
 {{- end }}
 {{- end -}}
 
+{{- define "news-dashboard.newsletterEnv" -}}
+{{- if .Values.app.newsletter.imapHost }}
+- name: NEWSLETTER_IMAP_HOST
+  value: {{ .Values.app.newsletter.imapHost | quote }}
+- name: NEWSLETTER_IMAP_PORT
+  value: {{ .Values.app.newsletter.imapPort | default 993 | quote }}
+- name: NEWSLETTER_IMAP_FOLDER
+  value: {{ .Values.app.newsletter.imapFolder | default "INBOX" | quote }}
+- name: NEWSLETTER_POLL_MINUTES
+  value: {{ .Values.app.newsletter.pollMinutes | default 15 | quote }}
+{{- if .Values.app.newsletter.maxMessageBytes }}
+- name: NEWSLETTER_MAX_MESSAGE_BYTES
+  value: {{ .Values.app.newsletter.maxMessageBytes | quote }}
+{{- end }}
+{{- if .Values.app.newsletter.existingSecret }}
+- name: NEWSLETTER_IMAP_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.newsletter.existingSecret | quote }}
+      key: {{ .Values.app.newsletter.usernameKey | default "NEWSLETTER_IMAP_USERNAME" | quote }}
+      optional: true
+- name: NEWSLETTER_IMAP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.newsletter.existingSecret | quote }}
+      key: {{ .Values.app.newsletter.passwordKey | default "NEWSLETTER_IMAP_PASSWORD" | quote }}
+      optional: true
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "news-dashboard.configEnv" -}}
 {{- if .Values.app.config.metricsEnabled }}
 - name: METRICS_ENABLED

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
 {{- end }}
 {{ include "news-dashboard.aiEnv" . | indent 12 }}
 {{ include "news-dashboard.sentryEnv" . | indent 12 }}
+{{- if .Values.app.newsletter.imapHost }}
+{{ include "news-dashboard.newsletterEnv" . | indent 12 }}
+{{- end }}
 {{- if .Values.neo4j.enabled }}
 {{ include "news-dashboard.neo4jEnv" . | indent 12 }}
 {{- end }}

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -140,6 +140,20 @@ app:
     smtpFrom: ""
     # starttls (default unless port 465), ssl, or none.
     smtpTlsMode: ""
+  newsletter:
+    # Optional IMAP mailbox used to ingest newsletters via plus-addressed
+    # recipients. Leave imapHost empty to keep the newsletter poller inert.
+    imapHost: ""
+    imapPort: 993
+    imapFolder: INBOX
+    pollMinutes: 15
+    # Max accepted size in bytes for one RFC822 newsletter message. Leave empty
+    # to use the app default.
+    maxMessageBytes: ""
+    # Name of a pre-existing Secret with the IMAP username/password keys below.
+    existingSecret: ""
+    usernameKey: NEWSLETTER_IMAP_USERNAME
+    passwordKey: NEWSLETTER_IMAP_PASSWORD
   sentry:
     # Optional: pre-existing Secret with SENTRY_DSN and/or SENTRY_DSN_FRONTEND.
     existingSecret: ""


### PR DESCRIPTION
Closes #1179

## Summary
- add structured `app.newsletter` Helm values for IMAP host, port, folder, polling interval, max message size, and existing Secret key names
- render newsletter IMAP env vars into the app Deployment only when `app.newsletter.imapHost` is configured
- document a self-hosting Helm example that keeps IMAP credentials in a Kubernetes Secret

## Tests
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make typecheck`
- `TEST_DATABASE_URL="" DATABASE_URL="" PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_chart_render.py -q`
- `helm lint ./helm/news-dashboard`
- `helm template news-dashboard ./helm/news-dashboard ... | rg -n 'NEWSLETTER_|newsletter-credentials|CUSTOM_IMAP'`\n\nNote: `source .env && make test` could not run locally because the required `nd-test-pg` Postgres service on localhost:55432 refused connections after Podman startup; CI should exercise the full suite with its service database.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)