### PR TITLE
fix: disable frontend Sentry default PII (#1180)

### DIFF
--- a/frontend/src/__tests__/errorTracking.test.ts
+++ b/frontend/src/__tests__/errorTracking.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ErrorEvent, EventHint } from '@sentry/react';
 
 const sentryInit = vi.fn();
 vi.mock('@sentry/react', () => ({ init: sentryInit }));
@@ -26,7 +27,7 @@ describe('initErrorTracking', () => {
     expect(sentryInit).not.toHaveBeenCalled();
   });
 
-  it('inits Sentry with the DSN returned by the backend', async () => {
+  it('inits Sentry with the DSN returned by the backend without default PII', async () => {
     const dsn = 'https://example@o0.ingest.sentry.io/1';
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -36,7 +37,47 @@ describe('initErrorTracking', () => {
     const { initErrorTracking } = await import('../lib/errorTracking');
     await initErrorTracking();
 
-    expect(sentryInit).toHaveBeenCalledWith({ dsn, sendDefaultPii: true });
+    expect(sentryInit).toHaveBeenCalledWith({
+      dsn,
+      sendDefaultPii: false,
+      beforeSend: expect.any(Function),
+    });
+  });
+
+  it('scrubs obvious PII before Sentry sends browser events', async () => {
+    const dsn = 'https://example@o0.ingest.sentry.io/1';
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sentry_dsn: dsn }),
+    });
+
+    const { initErrorTracking } = await import('../lib/errorTracking');
+    await initErrorTracking();
+
+    const options = sentryInit.mock.calls[0]?.[0] as
+      { beforeSend?: (event: ErrorEvent, hint: EventHint) => ErrorEvent | null } | undefined;
+    const event = {
+      type: undefined,
+      user: { email: 'reader@example.com' },
+      request: {
+        cookies: { session: 'secret' },
+        headers: {
+          Authorization: 'Bearer secret',
+          Cookie: 'session=secret',
+          Accept: 'application/json',
+        },
+      },
+    } satisfies ErrorEvent;
+
+    const scrubbed = options?.beforeSend?.(event, {});
+
+    expect(scrubbed).toEqual({
+      request: {
+        headers: {
+          Accept: 'application/json',
+        },
+      },
+    });
   });
 
   it('does not throw when the config fetch fails', async () => {

--- a/frontend/src/lib/errorTracking.ts
+++ b/frontend/src/lib/errorTracking.ts
@@ -2,11 +2,29 @@
 // backend's public GET /api/config (self-hosters set SENTRY_DSN_FRONTEND);
 // when unset, the SDK is never imported and no telemetry leaves the browser.
 
+import type { ErrorEvent, EventHint } from '@sentry/react';
+
 interface PublicConfig {
   sentry_dsn: string | null;
 }
 
 let sentryEnabled = false;
+
+function scrubPii(event: ErrorEvent, _hint: EventHint): ErrorEvent | null {
+  if (event.request) {
+    delete event.request.cookies;
+    const headers = event.request.headers;
+    if (headers) {
+      for (const key of Object.keys(headers)) {
+        if (['authorization', 'cookie'].includes(key.toLowerCase())) {
+          delete headers[key];
+        }
+      }
+    }
+  }
+  delete event.user;
+  return event;
+}
 
 export async function initErrorTracking(): Promise<void> {
   try {
@@ -16,7 +34,7 @@ export async function initErrorTracking(): Promise<void> {
     if (!config.sentry_dsn) return;
 
     const Sentry = await import('@sentry/react');
-    Sentry.init({ dsn: config.sentry_dsn, sendDefaultPii: true });
+    Sentry.init({ dsn: config.sentry_dsn, sendDefaultPii: false, beforeSend: scrubPii });
     sentryEnabled = true;
   } catch {
     // Network/parse failures must never block app startup.


### PR DESCRIPTION
Closes #1180

## Summary
- Disable frontend Sentry default PII collection by setting `sendDefaultPii: false`.
- Add a browser `beforeSend` scrubber for obvious user, cookie, and auth header metadata.
- Extend frontend error tracking tests for privacy-safe initialization and scrubbing behavior.

## Tests
- `npm run test:frontend -- frontend/src/__tests__/errorTracking.test.ts`
- `npm run lint && npm run format:check && npm run typecheck && npm run test:frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
