### PR TITLE
perf: batch recommendation score persistence (#1188)

### DIFF
--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -155,6 +155,19 @@ class RecommendationPreferences:
     novelty_weight: float = 1.0
 
 
+@dataclass(frozen=True)
+class RecommendationScoreRecord:
+    """Persistable recommendation score metadata for one user/article pair."""
+
+    user_id: int
+    article_id: int
+    recommendation_score: float
+    cold_start_score: float | None = None
+    signals: dict[str, Any] = field(default_factory=dict)
+    model_version: str = COLD_START_MODEL_VERSION
+    explanation: str | None = None
+
+
 def _normalize_affinity(weighted_sum: float, count: int) -> float:
     """Smoothed, normalized affinity in [-1, 1] for one feature value."""
     smoothed = weighted_sum / (count + AFFINITY_SMOOTHING)
@@ -304,14 +317,19 @@ def get_recommendation_preferences(
     """Return persisted manual recommendation preferences for ``user_id``."""
     init_db(db_path, database_url=database_url)
     with connect(db_path, database_url=database_url) as conn:
-        row = conn.execute(
-            """
-            SELECT category_weights, novelty_weight
-            FROM user_settings
-            WHERE user_id = %s
-            """,
-            (user_id,),
-        ).fetchone()
+        return _load_recommendation_preferences(conn, user_id)
+
+
+def _load_recommendation_preferences(conn: Any, user_id: int) -> RecommendationPreferences:
+    """Return manual recommendation preferences using an existing connection."""
+    row = conn.execute(
+        """
+        SELECT category_weights, novelty_weight
+        FROM user_settings
+        WHERE user_id = %s
+        """,
+        (user_id,),
+    ).fetchone()
     if row is None:
         return RecommendationPreferences()
     data = row_to_dict(row)
@@ -471,9 +489,35 @@ def upsert_recommendation_score(  # noqa: PLR0913
     explanation: str | None = None,
 ) -> None:
     """Persist recommendation metadata for one user/article pair."""
+    upsert_recommendation_scores(
+        [
+            RecommendationScoreRecord(
+                user_id=user_id,
+                article_id=article_id,
+                recommendation_score=float(recommendation_score),
+                cold_start_score=cold_start_score,
+                signals=signals or {},
+                model_version=model_version,
+                explanation=explanation,
+            )
+        ],
+        db_path=db_path,
+        database_url=database_url,
+    )
+
+
+def upsert_recommendation_scores(
+    records: list[RecommendationScoreRecord],
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> None:
+    """Persist recommendation metadata for many user/article pairs in one transaction."""
+    if not records:
+        return
     init_db(db_path, database_url=database_url)
     with connect(db_path, database_url=database_url) as conn:
-        conn.execute(
+        conn.executemany(
             """
             INSERT INTO user_article_recommendations(
               user_id, article_id, recommendation_score, cold_start_score,
@@ -491,15 +535,37 @@ def upsert_recommendation_score(  # noqa: PLR0913
               ),
               updated_at = NOW()
             """,
-            (
-                user_id,
-                article_id,
-                float(recommendation_score),
-                cold_start_score,
-                json.dumps(signals or {}),
-                model_version,
-                explanation,
-            ),
+            [
+                (
+                    record.user_id,
+                    record.article_id,
+                    float(record.recommendation_score),
+                    record.cold_start_score,
+                    json.dumps(record.signals),
+                    record.model_version,
+                    record.explanation,
+                )
+                for record in records
+            ],
+        )
+
+
+def update_recommendation_explanations(
+    user_id: int,
+    explanations: list[tuple[int, str]],
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> None:
+    """Fill missing recommendation explanations for a user in one transaction."""
+    if not explanations:
+        return
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn:
+        conn.executemany(
+            "UPDATE user_article_recommendations SET explanation = %s"
+            " WHERE user_id = %s AND article_id = %s AND explanation IS NULL",
+            [(explanation, user_id, article_id) for article_id, explanation in explanations],
         )
 
 
@@ -633,11 +699,7 @@ def recompute_user_recommendations(
     with connect(db_path, database_url=database_url) as conn:
         profile = build_affinity_profile(_load_user_signals(conn, user_id))
         semantic_profile = build_semantic_profile(_load_user_history_vectors(conn, user_id))
-        preferences = get_recommendation_preferences(
-            user_id,
-            db_path=db_path,
-            database_url=database_url,
-        )
+        preferences = _load_recommendation_preferences(conn, user_id)
         candidates = _load_candidates(conn, user_id, limit)
         goal_rows = conn.execute(
             "SELECT description, keywords FROM user_goals WHERE user_id = %s",
@@ -651,7 +713,7 @@ def recompute_user_recommendations(
     # one it degrades to a no-op, so the version only advertises novelty when the
     # semantic profile is present.
     model_version = NOVELTY_MODEL_VERSION if semantic_profile else BEHAVIORAL_MODEL_VERSION
-    scored = 0
+    score_records: list[RecommendationScoreRecord] = []
     scored_items: list[tuple[int, float]] = []
     for candidate in candidates:
         base = float(candidate["base_score"])
@@ -681,33 +743,34 @@ def recompute_user_recommendations(
             0.0,
             100.0,
         )
-        upsert_recommendation_score(
-            user_id,
-            int(candidate["id"]),
-            final_score,
-            db_path=db_path,
-            database_url=database_url,
-            cold_start_score=base,
-            signals={
-                "base_score": round(base, 4),
-                "affinity_adjustment": round(adjustment, 4),
-                "manual_category_adjustment": round(manual_category, 4),
-                "semantic_adjustment": round(semantic, 4),
-                "freshness_adjustment": round(freshness, 4),
-                "novelty_adjustment": round(novelty, 4),
-                "novelty_weight": round(preferences.novelty_weight, 4),
-                "goal_alignment_adjustment": round(goal_boost, 4),
-                "source_slug": source_slug,
-                "category": category,
-            },
-            model_version=model_version,
+        score_records.append(
+            RecommendationScoreRecord(
+                user_id=user_id,
+                article_id=int(candidate["id"]),
+                recommendation_score=final_score,
+                cold_start_score=base,
+                signals={
+                    "base_score": round(base, 4),
+                    "affinity_adjustment": round(adjustment, 4),
+                    "manual_category_adjustment": round(manual_category, 4),
+                    "semantic_adjustment": round(semantic, 4),
+                    "freshness_adjustment": round(freshness, 4),
+                    "novelty_adjustment": round(novelty, 4),
+                    "novelty_weight": round(preferences.novelty_weight, 4),
+                    "goal_alignment_adjustment": round(goal_boost, 4),
+                    "source_slug": source_slug,
+                    "category": category,
+                },
+                model_version=model_version,
+            )
         )
         scored_items.append((int(candidate["id"]), final_score))
-        scored += 1
+    upsert_recommendation_scores(score_records, db_path=db_path, database_url=database_url)
 
     # Generate explanations for the top 20 articles only; the rest are low-signal
     # enough that a generic label suffices and the AI quota stays manageable.
     top_articles = sorted(scored_items, key=lambda x: x[1], reverse=True)[:20]
+    explanations: list[tuple[int, str]] = []
     for article_id, _ in top_articles:
         explanation = generate_recommendation_explanation(
             user_id,
@@ -716,14 +779,15 @@ def recompute_user_recommendations(
             database_url=database_url,
         )
         if explanation:
-            with connect(db_path, database_url=database_url) as conn:
-                conn.execute(
-                    "UPDATE user_article_recommendations SET explanation = %s"
-                    " WHERE user_id = %s AND article_id = %s AND explanation IS NULL",
-                    (explanation, user_id, article_id),
-                )
+            explanations.append((article_id, explanation))
+    update_recommendation_explanations(
+        user_id,
+        explanations,
+        db_path=db_path,
+        database_url=database_url,
+    )
 
-    return scored
+    return len(score_records)
 
 
 def _opt_float(value: Any) -> float | None:

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -21,12 +21,17 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
+from psycopg import errors
 
 from news_dashboard.auth import require_auth
 from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
 from news_dashboard.embeddings import vector_literal
 from news_dashboard.main import app
-from news_dashboard.recommendations import upsert_recommendation_score
+from news_dashboard.recommendations import (
+    RecommendationScoreRecord,
+    upsert_recommendation_score,
+    upsert_recommendation_scores,
+)
 
 pytestmark = pytest.mark.postgres
 
@@ -272,6 +277,104 @@ def test_single_article_read_exposes_recommendation_metadata(
     payload = response.json()
     assert payload["recommendation_score"] == pytest.approx(88.0)
     assert payload["recommendation_signals"] == signals
+
+
+def test_batch_recommendation_score_upsert_matches_single_row_contract(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """Batch writes preserve score columns, JSON signals, stale reset, and explanation rules."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    first = _insert_article(db_path, "src", "batch-first", category="ai", importance=70)
+    second = _insert_article(db_path, "src", "batch-second", category="ai", importance=70)
+
+    upsert_recommendation_score(
+        user_id,
+        first,
+        10.0,
+        db_path=db_path,
+        explanation="Existing explanation.",
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE user_article_recommendations SET stale = TRUE"
+            " WHERE user_id = %s AND article_id = %s",
+            (user_id, first),
+        )
+
+    upsert_recommendation_scores(
+        [
+            RecommendationScoreRecord(
+                user_id=user_id,
+                article_id=first,
+                recommendation_score=91.25,
+                cold_start_score=44.5,
+                signals={"source_slug": "src", "weights": {"ai": 1.2}},
+                model_version="behavioral-affinity-v1",
+            ),
+            RecommendationScoreRecord(
+                user_id=user_id,
+                article_id=second,
+                recommendation_score=72.0,
+                cold_start_score=50.0,
+                signals={"freshness_adjustment": 3.5},
+                model_version="novelty-freshness-v1",
+                explanation="New explanation.",
+            ),
+        ],
+        db_path=db_path,
+    )
+
+    with connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT article_id, recommendation_score, cold_start_score, signals,
+              model_version, stale, explanation
+            FROM user_article_recommendations
+            WHERE user_id = %s
+            ORDER BY article_id
+            """,
+            (user_id,),
+        ).fetchall()
+
+    by_article = {int(row["article_id"]): dict(row) for row in rows}
+    assert by_article[first]["recommendation_score"] == pytest.approx(91.25)
+    assert by_article[first]["cold_start_score"] == pytest.approx(44.5)
+    assert by_article[first]["signals"] == {"source_slug": "src", "weights": {"ai": 1.2}}
+    assert by_article[first]["model_version"] == "behavioral-affinity-v1"
+    assert by_article[first]["stale"] is False
+    assert by_article[first]["explanation"] == "Existing explanation."
+    assert by_article[second]["signals"] == {"freshness_adjustment": 3.5}
+    assert by_article[second]["explanation"] == "New explanation."
+
+
+def test_batch_recommendation_score_upsert_rolls_back_on_error(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """One invalid score aborts the whole batch transaction for that user."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    first = _insert_article(db_path, "src", "rollback-first", category="ai", importance=70)
+    second = _insert_article(db_path, "src", "rollback-second", category="ai", importance=70)
+
+    with pytest.raises(errors.CheckViolation):
+        upsert_recommendation_scores(
+            [
+                RecommendationScoreRecord(user_id, first, 70.0),
+                RecommendationScoreRecord(user_id, second, 101.0),
+            ],
+            db_path=db_path,
+        )
+
+    with connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS n FROM user_article_recommendations WHERE user_id = %s",
+            (user_id,),
+        ).fetchone()
+    assert count is not None
+    assert count["n"] == 0
 
 
 def test_single_article_read_returns_null_score_when_unranked(

--- a/backend/tests/test_recommendation_recalc.py
+++ b/backend/tests/test_recommendation_recalc.py
@@ -382,6 +382,44 @@ def test_own_private_source_is_scored(tmp_path: Path, monkeypatch: Any, pg_clean
     assert _rec_row(db_path, owner, own_article) is not None
 
 
+def test_recompute_batches_score_persistence_connections(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    """Multiple candidates should use a constant number of DB writes/connections."""
+    db_path = _setup_db(monkeypatch, pg_clean)
+    user_id = _make_user(db_path, "alice")
+    _insert_source(db_path, "src")
+    for idx in range(5):
+        _insert_article(db_path, "src", f"batch-{idx}")
+
+    from news_dashboard import recommendations
+
+    connection_count = 0
+
+    def counted_connect(*args: Any, **kwargs: Any) -> Any:
+        nonlocal connection_count
+        connection_count += 1
+        return connect(*args, **kwargs)
+
+    monkeypatch.setattr(recommendations, "connect", counted_connect)
+
+    def no_explanation(
+        _user_id: int,
+        _article_id: int,
+        *,
+        db_path: Path | str | None = None,
+        database_url: str | None = None,
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(recommendations, "generate_recommendation_explanation", no_explanation)
+
+    scored = recommendations.recompute_user_recommendations(user_id, db_path=db_path)
+
+    assert scored == 5
+    assert connection_count == 2
+
+
 def test_health_missing_scores_excludes_invisible_articles(
     tmp_path: Path, monkeypatch: Any, pg_clean: str
 ) -> None:


### PR DESCRIPTION
Closes #1188

## Summary
- Add `RecommendationScoreRecord` and a batch `upsert_recommendation_scores()` helper using psycopg `executemany` in one transaction.
- Keep `upsert_recommendation_score()` behavior by routing single-row callers through the batch helper.
- Rework `recompute_user_recommendations()` to build score records in memory, persist them once per user, and batch generated explanation updates.
- Add PostgreSQL integration coverage for conflict updates, JSON signals, stale reset, explanation preservation, rollback, and constant connection growth during recompute.

## Test results
- `make lint` passed.
- `make typecheck` passed.
- Focused PostgreSQL pytest command could not run locally because `nd-test-pg`/localhost:55432 refused connections after Podman startup attempts; CI should run the DB-backed tests in a healthy service environment.

Generated with Codex.
