### PR TITLE
perf: migrate discovered_at to TIMESTAMPTZ (#1189)

### DIFF
--- a/backend/news_dashboard/ai_stats/service.py
+++ b/backend/news_dashboard/ai_stats/service.py
@@ -386,7 +386,7 @@ def _load_recent_articles(
                 """
                 SELECT id, title, summary, category, (embedding_vec IS NOT NULL) AS embedded
                 FROM articles
-                WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                WHERE discovered_at >= NOW() - INTERVAL '1 day' * %s
                 ORDER BY discovered_at DESC
                 LIMIT %s
                 """,
@@ -403,7 +403,7 @@ def _load_recent_articles(
                   ON us.source_slug = src.slug AND us.user_id = %s
                 LEFT JOIN user_article_state uas
                   ON uas.article_id = a.id AND uas.user_id = %s
-                WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                WHERE a.discovered_at >= NOW() - INTERVAL '1 day' * %s
                   AND COALESCE(uas.state, 'today') != 'archived'
                   AND (
                     (

--- a/backend/news_dashboard/briefings/service.py
+++ b/backend/news_dashboard/briefings/service.py
@@ -142,8 +142,8 @@ _CITED_ARTICLES_SQL = """
 _CANDIDATES_SQL = """
     SELECT id, title, url, source_name, category, summary, importance_score, discovered_at
     FROM articles
-    WHERE discovered_at::timestamptz >= %s
-      AND discovered_at::timestamptz < %s
+    WHERE discovered_at >= %s
+      AND discovered_at < %s
       AND (canonical_id IS NULL OR state != 'archived')
     ORDER BY importance_score DESC NULLS LAST, discovered_at DESC
     LIMIT %s
@@ -156,8 +156,8 @@ _CANDIDATES_SQL_USER = """
     LEFT JOIN user_article_state uas ON uas.article_id = a.id AND uas.user_id = %s
     LEFT JOIN sources src ON src.slug = a.source_slug
     LEFT JOIN user_sources us_src ON us_src.user_id = %s AND us_src.source_slug = a.source_slug
-    WHERE a.discovered_at::timestamptz >= %s
-      AND a.discovered_at::timestamptz < %s
+    WHERE a.discovered_at >= %s
+      AND a.discovered_at < %s
       AND (a.canonical_id IS NULL OR a.state != 'archived')
       AND (
         (src.owner_user_id IS NULL AND COALESCE(us_src.enabled, TRUE) IS TRUE)

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -78,7 +78,7 @@ POSTGRES_SCHEMA = [
       category TEXT NOT NULL,
       kind TEXT NOT NULL,
       published_at TEXT,
-      discovered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      discovered_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
       status TEXT NOT NULL DEFAULT 'new'
         CHECK(status IN ('new','read','saved','skipped','archived')),
       importance_score INTEGER NOT NULL DEFAULT 50,
@@ -92,6 +92,46 @@ POSTGRES_SCHEMA = [
       embedding BYTEA,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     )
+    """,
+    """
+    DO $$
+    DECLARE
+      legacy_article RECORD;
+      parsed_discovered_at TIMESTAMPTZ;
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'articles'
+          AND column_name = 'discovered_at'
+          AND data_type = 'text'
+      ) THEN
+        FOR legacy_article IN
+          SELECT id, url, discovered_at
+          FROM articles
+          ORDER BY id
+        LOOP
+          BEGIN
+            parsed_discovered_at := CAST(legacy_article.discovered_at AS TIMESTAMPTZ);
+          EXCEPTION
+            WHEN invalid_datetime_format OR datetime_field_overflow THEN
+              RAISE EXCEPTION
+                'Cannot migrate articles.discovered_at to TIMESTAMPTZ: '
+                'article id %, url %, value % is not a valid timestamp',
+                legacy_article.id,
+                legacy_article.url,
+                legacy_article.discovered_at
+                USING ERRCODE = '22007';
+          END;
+        END LOOP;
+
+        ALTER TABLE articles
+          ALTER COLUMN discovered_at DROP DEFAULT,
+          ALTER COLUMN discovered_at TYPE TIMESTAMPTZ
+            USING CAST(discovered_at AS TIMESTAMPTZ),
+          ALTER COLUMN discovered_at SET DEFAULT CURRENT_TIMESTAMP;
+      END IF;
+    END $$;
     """,
     "CREATE INDEX IF NOT EXISTS idx_articles_status ON articles(status)",
     "CREATE INDEX IF NOT EXISTS idx_articles_category ON articles(category)",

--- a/backend/news_dashboard/entities.py
+++ b/backend/news_dashboard/entities.py
@@ -420,7 +420,7 @@ def extract_missing_entities(
             """
             SELECT id, url, title, source_slug, summary, body, discovered_at
             FROM articles
-            WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+            WHERE discovered_at >= NOW() - INTERVAL '1 day' * %s
               AND entities IS NULL
             ORDER BY discovered_at DESC
             LIMIT %s
@@ -462,7 +462,7 @@ def sync_cached_entities_to_graph(
             """
             SELECT id, url, title, source_slug, entities, discovered_at
             FROM articles
-            WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+            WHERE discovered_at >= NOW() - INTERVAL '1 day' * %s
               AND entities IS NOT NULL
             ORDER BY discovered_at DESC
             LIMIT %s
@@ -507,7 +507,7 @@ def extract_missing_entity_relationships(
             """
             SELECT id, title, summary, body, entities
             FROM articles
-            WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+            WHERE discovered_at >= NOW() - INTERVAL '1 day' * %s
               AND entities IS NOT NULL
             ORDER BY discovered_at DESC
             LIMIT %s
@@ -577,7 +577,7 @@ def _visible_graph_rows(
                 """
                 SELECT id, title, entities
                 FROM articles
-                WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                WHERE discovered_at >= NOW() - INTERVAL '1 day' * %s
                 ORDER BY discovered_at DESC
                 LIMIT %s
                 """,
@@ -594,7 +594,7 @@ def _visible_graph_rows(
               ON us.source_slug = src.slug AND us.user_id = %s
             LEFT JOIN user_article_state uas
               ON uas.article_id = a.id AND uas.user_id = %s
-            WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+            WHERE a.discovered_at >= NOW() - INTERVAL '1 day' * %s
               AND COALESCE(uas.state, 'today') != 'archived'
               AND (
                 (

--- a/backend/news_dashboard/export.py
+++ b/backend/news_dashboard/export.py
@@ -63,6 +63,7 @@ def _export_articles(conn: Any, user_id: int) -> list[dict[str, Any]]:
         _normalize_timestamps(
             d,
             (
+                "discovered_at",
                 "done_at",
                 "starred_at",
                 "skipped_at",

--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -1300,9 +1300,9 @@ _COLD_START_RECOMMENDATION_SCORE_SQL = """
           ELSE 0.0
         END
       + CASE
-          WHEN a.discovered_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '36 hours' THEN 12.0
-          WHEN a.discovered_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '7 days' THEN 7.0
-          WHEN a.discovered_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '30 days' THEN 3.0
+          WHEN a.discovered_at >= CURRENT_TIMESTAMP - INTERVAL '36 hours' THEN 12.0
+          WHEN a.discovered_at >= CURRENT_TIMESTAMP - INTERVAL '7 days' THEN 7.0
+          WHEN a.discovered_at >= CURRENT_TIMESTAMP - INTERVAL '30 days' THEN 3.0
           ELSE 0.0
         END
     )
@@ -1876,13 +1876,13 @@ def _build_user_search_query(  # noqa: PLR0912, PLR0913
         clauses.append("COALESCE(uas.starred, false) = true")
 
     if date_range == "today":
-        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '1 day'")
+        clauses.append("a.discovered_at >= %s::timestamptz - interval '1 day'")
         where_params.append(now_ts)
     elif date_range == "week":
-        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '7 days'")
+        clauses.append("a.discovered_at >= %s::timestamptz - interval '7 days'")
         where_params.append(now_ts)
     elif date_range == "month":
-        clauses.append("a.discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
+        clauses.append("a.discovered_at >= %s::timestamptz - interval '30 days'")
         where_params.append(now_ts)
 
     if tag_id is not None:
@@ -2003,13 +2003,13 @@ def search_articles(  # noqa: PLR0912, PLR0913
 
     # Date range filter
     if date_range == "today":
-        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '1 day'")
+        clauses.append("discovered_at >= %s::timestamptz - interval '1 day'")
         params.append(now_ts)
     elif date_range == "week":
-        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '7 days'")
+        clauses.append("discovered_at >= %s::timestamptz - interval '7 days'")
         params.append(now_ts)
     elif date_range == "month":
-        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
+        clauses.append("discovered_at >= %s::timestamptz - interval '30 days'")
         params.append(now_ts)
 
     where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
@@ -2269,13 +2269,13 @@ def count_search_articles(  # noqa: PLR0913
         clauses.append("starred IS TRUE")
 
     if date_range == "today":
-        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '1 day'")
+        clauses.append("discovered_at >= %s::timestamptz - interval '1 day'")
         params.append(now_ts)
     elif date_range == "week":
-        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '7 days'")
+        clauses.append("discovered_at >= %s::timestamptz - interval '7 days'")
         params.append(now_ts)
     elif date_range == "month":
-        clauses.append("discovered_at::timestamptz >= %s::timestamptz - interval '30 days'")
+        clauses.append("discovered_at >= %s::timestamptz - interval '30 days'")
         params.append(now_ts)
 
     where = f"WHERE {' AND '.join(clauses)}" if clauses else ""

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -394,7 +394,7 @@ def load_recent_embedded_articles(
                 """
                 SELECT id, title, url, summary, category, embedding_vec
                 FROM articles
-                WHERE discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                WHERE discovered_at >= NOW() - INTERVAL '1 day' * %s
                   AND embedding_vec IS NOT NULL
                 ORDER BY discovered_at DESC
                 LIMIT %s
@@ -411,7 +411,7 @@ def load_recent_embedded_articles(
                   ON us.source_slug = src.slug AND us.user_id = %s
                 LEFT JOIN user_article_state uas
                   ON uas.article_id = a.id AND uas.user_id = %s
-                WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '1 day' * %s
+                WHERE a.discovered_at >= NOW() - INTERVAL '1 day' * %s
                   AND a.embedding_vec IS NOT NULL
                   AND COALESCE(uas.state, 'today') != 'archived'
                   AND (

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -2215,7 +2215,7 @@ def list_lesson_suggestions(
             f"""
             SELECT a.id, a.title, a.canonical_url, a.source_name, a.category,
                    a.importance_score, s.starred,
-                   EXTRACT(EPOCH FROM (NOW() - a.discovered_at::timestamptz)) / 86400.0
+                   EXTRACT(EPOCH FROM (NOW() - a.discovered_at)) / 86400.0
                      AS age_days
             FROM articles a
             JOIN user_article_state s ON s.article_id = a.id

--- a/backend/news_dashboard/personalization/service.py
+++ b/backend/news_dashboard/personalization/service.py
@@ -65,10 +65,10 @@ def generate_nudges(
                 uvs.slug,
                 uvs.name,
                 COUNT(a.id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                 ) AS articles_last_30_days,
                 COUNT(uas.article_id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                     AND uas.state = 'skipped'
                 ) AS skipped_count
               FROM user_visible_sources uvs
@@ -97,10 +97,10 @@ def generate_nudges(
               SELECT
                 a.category,
                 COUNT(a.id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                 ) AS articles_last_30_days,
                 COUNT(uas.article_id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                     AND uas.state = 'skipped'
                 ) AS skipped_count
               FROM articles a

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -679,7 +679,7 @@ def _load_candidates(conn: Any, user_id: int, limit: int) -> list[dict[str, Any]
         f"""
         SELECT a.id, a.title, a.source_slug, a.category, a.tags, a.embedding_vec,
           a.importance_score,
-          EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - a.discovered_at::timestamptz))
+          EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - a.discovered_at))
             / 3600.0 AS age_hours,
           {_COLD_START_RECOMMENDATION_SCORE_SQL} AS base_score
         FROM articles a

--- a/backend/news_dashboard/source_health.py
+++ b/backend/news_dashboard/source_health.py
@@ -190,22 +190,22 @@ def generate_subscription_cleanup_suggestions(
                 uvs.slug,
                 uvs.name,
                 COUNT(a.id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                 ) AS articles_last_30_days,
                 COUNT(uas.article_id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                     AND uas.state = 'skipped'
                 ) AS skipped_count,
                 COUNT(uas.article_id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                     AND uas.state = 'done'
                 ) AS done_count,
                 COUNT(uas.article_id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                     AND uas.starred IS TRUE
                 ) AS starred_count,
                 COUNT(uas.article_id) FILTER (
-                  WHERE a.discovered_at::timestamptz >= NOW() - INTERVAL '30 days'
+                  WHERE a.discovered_at >= NOW() - INTERVAL '30 days'
                     AND uas.state = 'archived'
                 ) AS archived_count,
                 COUNT(a.id) AS lifetime_articles

--- a/backend/tests/test_briefings_db.py
+++ b/backend/tests/test_briefings_db.py
@@ -491,8 +491,8 @@ def test_select_candidates_sql_ignores_global_workflow_state(monkeypatch: Any) -
 
     query, params = fake_conn.calls[0]
     assert "state = 'today'" not in query
-    assert "discovered_at::timestamptz >= %s" in query
-    assert "discovered_at::timestamptz < %s" in query
+    assert "discovered_at >= %s" in query
+    assert "discovered_at < %s" in query
     assert params == (since_at, until_at, CANDIDATE_LIMIT)
     assert candidates[0]["title"] == "Done article"
 

--- a/backend/tests/test_postgres_types.py
+++ b/backend/tests/test_postgres_types.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Generator
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -492,6 +493,180 @@ def test_pg_boolean_column_is_boolean(pg_clean: str, table_name: str, column_nam
         ).fetchone()
     assert row is not None
     assert row[0] == "boolean"
+
+
+def test_pg_articles_discovered_at_is_timestamptz(pg_clean: str) -> None:
+    """Fresh PostgreSQL schema must store articles.discovered_at natively."""
+    import psycopg
+
+    with psycopg.connect(pg_clean) as conn:
+        row = conn.execute(
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'articles'
+              AND column_name = 'discovered_at'
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "timestamp with time zone"
+
+
+def test_pg_init_db_converts_legacy_discovered_at_text(pg_url: str, tmp_path: Any) -> None:
+    """init_db must upgrade existing TEXT discovered_at values in place."""
+    from news_dashboard.db import connect, init_db
+
+    db_path = tmp_path / "legacy-discovered-at-text"
+    with connect(db_path, database_url=pg_url) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sources (
+              slug TEXT PRIMARY KEY,
+              name TEXT NOT NULL,
+              url TEXT NOT NULL,
+              category TEXT NOT NULL,
+              kind TEXT NOT NULL,
+              priority INTEGER NOT NULL DEFAULT 50,
+              enabled BOOLEAN NOT NULL DEFAULT TRUE
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE articles (
+              id BIGSERIAL PRIMARY KEY,
+              url TEXT NOT NULL UNIQUE,
+              canonical_url TEXT NOT NULL,
+              title TEXT NOT NULL,
+              source_slug TEXT NOT NULL REFERENCES sources(slug),
+              source_name TEXT NOT NULL,
+              category TEXT NOT NULL,
+              kind TEXT NOT NULL,
+              published_at TEXT,
+              discovered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              status TEXT NOT NULL DEFAULT 'new',
+              importance_score INTEGER NOT NULL DEFAULT 50,
+              summary TEXT NOT NULL DEFAULT '',
+              reason TEXT NOT NULL DEFAULT '',
+              tags TEXT NOT NULL DEFAULT '',
+              read_at TEXT,
+              saved_at TEXT,
+              skipped_at TEXT,
+              archived_at TEXT,
+              updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              starred BOOLEAN NOT NULL DEFAULT FALSE,
+              starred_at TEXT,
+              body TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind) VALUES"
+            " ('legacy-src', 'Legacy', 'https://example.com/feed', 'tech', 'rss_feed')"
+        )
+        conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name, category, kind, discovered_at
+            )
+            VALUES (
+              'https://example.com/offset',
+              'https://example.com/offset',
+              'Offset',
+              'legacy-src',
+              'Legacy',
+              'tech',
+              'rss_feed',
+              '2026-07-12T15:30:00+03:00'
+            )
+            """
+        )
+        conn.commit()
+
+    init_db(db_path, database_url=pg_url)
+
+    with connect(db_path, database_url=pg_url) as conn:
+        row = conn.execute(
+            """
+            SELECT c.data_type, a.discovered_at
+            FROM information_schema.columns c
+            CROSS JOIN articles a
+            WHERE c.table_schema = current_schema()
+              AND c.table_name = 'articles'
+              AND c.column_name = 'discovered_at'
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row["data_type"] == "timestamp with time zone"
+    assert row["discovered_at"] == datetime(2026, 7, 12, 12, 30, tzinfo=timezone.utc)
+
+
+def test_pg_init_db_rejects_invalid_legacy_discovered_at(pg_url: str, tmp_path: Any) -> None:
+    """Malformed legacy timestamps must fail with article context."""
+    from news_dashboard.db import SchemaInitializationError, connect, init_db
+
+    db_path = tmp_path / "invalid-discovered-at-text"
+    with connect(db_path, database_url=pg_url) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sources (
+              slug TEXT PRIMARY KEY,
+              name TEXT NOT NULL,
+              url TEXT NOT NULL,
+              category TEXT NOT NULL,
+              kind TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE articles (
+              id BIGSERIAL PRIMARY KEY,
+              url TEXT NOT NULL UNIQUE,
+              canonical_url TEXT NOT NULL,
+              title TEXT NOT NULL,
+              source_slug TEXT NOT NULL REFERENCES sources(slug),
+              source_name TEXT NOT NULL,
+              category TEXT NOT NULL,
+              kind TEXT NOT NULL,
+              discovered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              status TEXT NOT NULL DEFAULT 'new'
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sources(slug, name, url, category, kind) VALUES"
+            " ('bad-src', 'Bad', 'https://example.com/feed', 'tech', 'rss_feed')"
+        )
+        conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name, category, kind, discovered_at
+            )
+            VALUES (
+              'https://example.com/bad',
+              'https://example.com/bad',
+              'Bad',
+              'bad-src',
+              'Bad',
+              'tech',
+              'rss_feed',
+              'not-a-timestamp'
+            )
+            """
+        )
+        conn.commit()
+
+    with pytest.raises(SchemaInitializationError) as exc_info:
+        init_db(db_path, database_url=pg_url)
+
+    cause = exc_info.value.__cause__
+    assert cause is not None
+    assert "Cannot migrate articles.discovered_at to TIMESTAMPTZ" in str(cause)
+    assert "https://example.com/bad" in str(cause)
 
 
 def test_pg_init_db_converts_legacy_integer_booleans(pg_url: str, tmp_path: Any) -> None:


### PR DESCRIPTION
Closes #1189

## Summary
- migrate `articles.discovered_at` to native `TIMESTAMPTZ` in the PostgreSQL schema
- add idempotent legacy TEXT conversion with row-level invalid timestamp errors
- remove runtime `discovered_at::timestamptz` column casts from search, briefings, recommendations, AI stats, insights, entities, personalization, source health, and Learn from Link queries
- preserve export JSON stability by serializing native `discovered_at` datetimes
- add PostgreSQL coverage for fresh schema type, legacy in-place conversion, invalid legacy values, and updated briefing SQL expectations

## Tests
- `make lint`
- `make typecheck`
- `export PGOPTIONS='-c max_parallel_workers_per_gather=0' && dotenv run -- make test` (`2667 passed, 1 skipped`; frontend `974 passed`)
- `rg -n "discovered_at::timestamptz" backend/news_dashboard` (no matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
