### PR TITLE
perf: reuse schema initialization session (#1190)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -1175,17 +1175,22 @@ def _run_schema_statements(
     Isolating each statement in its own transaction means one failure doesn't
     leave later attempts in an aborted transaction.
     """
+    if not statements:
+        return 0
+
     applied = 0
-    for statement in statements:
-        try:
-            with connect(db_path, database_url=database_url) as conn:
+    with connect(db_path, database_url=database_url) as conn:
+        for statement in statements:
+            try:
                 conn.execute(statement)
+                conn.commit()
                 applied += 1
-        except Exception as exc:
-            statement_preview = " ".join(statement.split())[:240]
-            logger.exception("Schema initialization failed on statement: %s", statement_preview)
-            message = f"Schema initialization failed on statement: {statement_preview}"
-            raise SchemaInitializationError(message) from exc
+            except Exception as exc:
+                conn.rollback()
+                statement_preview = " ".join(statement.split())[:240]
+                logger.exception("Schema initialization failed on statement: %s", statement_preview)
+                message = f"Schema initialization failed on statement: {statement_preview}"
+                raise SchemaInitializationError(message) from exc
     return applied
 
 

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -15,17 +15,25 @@ from unittest.mock import patch
 import pytest
 
 _SIMULATED_FAILURE = "simulated: column already exists"
+_UNEXPECTED_ROLLBACK = "rollback should not be called on success"
 
 
 def test_init_db_postgres_applies_all_statements(tmp_path: Any) -> None:
     """Every statement in POSTGRES_SCHEMA + POSTGRES_MULTIUSER_SCHEMA is executed."""
     applied: list[str] = []
+    commits: list[str] = []
 
     @contextmanager
     def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
         class _Conn:
             def execute(self, sql: str, params: Any = None) -> None:  # noqa: ARG002
                 applied.append(sql.strip())
+
+            def commit(self) -> None:
+                commits.append("commit")
+
+            def rollback(self) -> None:
+                raise AssertionError(_UNEXPECTED_ROLLBACK)
 
         yield _Conn()
 
@@ -44,6 +52,7 @@ def test_init_db_postgres_applies_all_statements(tmp_path: Any) -> None:
         init_db()
 
     assert applied == fake_schema
+    assert commits == ["commit"] * len(fake_schema)
 
 
 def test_init_db_postgres_failure_surfaces_and_is_not_cached(
@@ -52,6 +61,8 @@ def test_init_db_postgres_failure_surfaces_and_is_not_cached(
 ) -> None:
     """A failing schema statement must raise and retry on the next init_db()."""
     applied: list[str] = []
+    commits: list[str] = []
+    rollbacks: list[str] = []
 
     @contextmanager
     def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
@@ -60,6 +71,12 @@ def test_init_db_postgres_failure_surfaces_and_is_not_cached(
                 if sql.strip() == "WILL_FAIL":
                     raise RuntimeError(_SIMULATED_FAILURE)
                 applied.append(sql.strip())
+
+            def commit(self) -> None:
+                commits.append("commit")
+
+            def rollback(self) -> None:
+                rollbacks.append("rollback")
 
         yield _Conn()
 
@@ -84,15 +101,18 @@ def test_init_db_postgres_failure_surfaces_and_is_not_cached(
             init_db(token)
 
     assert applied == ["stmt_ok_1", "stmt_ok_1"]
+    assert commits == ["commit", "commit"]
+    assert rollbacks == ["rollback", "rollback"]
     assert "WILL_FAIL" not in applied
     assert "stmt_ok_2" not in applied
     assert "Schema initialization failed on statement: WILL_FAIL" in caplog.text
 
 
-def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> None:
-    """connect() must be called once per statement, not once for all statements."""
+def test_init_db_postgres_reuses_one_connection_per_schema_phase(tmp_path: Any) -> None:
+    """Schema phases reuse sessions while each statement commits independently."""
     connect_calls: list[str] = []
     statements_per_call: list[list[str]] = []
+    commits: list[str] = []
 
     @contextmanager
     def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
@@ -104,15 +124,22 @@ def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> N
             def execute(self, sql: str, params: Any = None) -> None:  # noqa: ARG002
                 this_call.append(sql.strip())
 
+            def commit(self) -> None:
+                commits.append("commit")
+
+            def rollback(self) -> None:
+                raise AssertionError(_UNEXPECTED_ROLLBACK)
+
         yield _Conn()
 
     fake_schema = ["stmt_a", "stmt_b", "stmt_c"]
+    fake_post_backfill_schema = ["stmt_after_backfill"]
 
     with (
         patch("news_dashboard.db.connect", fake_connect),
         patch("news_dashboard.db.POSTGRES_SCHEMA", fake_schema),
         patch("news_dashboard.db.POSTGRES_MULTIUSER_SCHEMA", []),
-        patch("news_dashboard.db.POSTGRES_POST_BACKFILL_SCHEMA", []),
+        patch("news_dashboard.db.POSTGRES_POST_BACKFILL_SCHEMA", fake_post_backfill_schema),
         patch("news_dashboard.db._ensure_vector_extension", lambda *_a, **_k: None),
         patch("news_dashboard.db._backfill_embedding_vectors", lambda *_a, **_k: 0),
     ):
@@ -120,14 +147,15 @@ def test_init_db_postgres_each_statement_uses_own_connection(tmp_path: Any) -> N
 
         init_db()
 
-    assert len(connect_calls) == 3, "expected one connect() call per statement"
-    for per_call in statements_per_call:
-        assert len(per_call) == 1, "each connection must execute exactly one statement"
+    assert len(connect_calls) == 2, "expected one connect() call per schema phase"
+    assert statements_per_call == [fake_schema, fake_post_backfill_schema]
+    assert commits == ["commit"] * (len(fake_schema) + len(fake_post_backfill_schema))
 
 
 def test_init_db_postgres_caches_successful_schema_runs(tmp_path: Any) -> None:
     """Repeated hot-path init_db() calls should not replay every schema statement."""
     connect_calls: list[str] = []
+    commits: list[str] = []
 
     @contextmanager
     def fake_connect(db_path: Any = None, database_url: Any = None) -> Any:
@@ -136,6 +164,12 @@ def test_init_db_postgres_caches_successful_schema_runs(tmp_path: Any) -> None:
         class _Conn:
             def execute(self, sql: str, params: Any = None) -> None:  # noqa: ARG002
                 return None
+
+            def commit(self) -> None:
+                commits.append("commit")
+
+            def rollback(self) -> None:
+                raise AssertionError(_UNEXPECTED_ROLLBACK)
 
         yield _Conn()
 
@@ -155,7 +189,42 @@ def test_init_db_postgres_caches_successful_schema_runs(tmp_path: Any) -> None:
         init_db(token)
         init_db(token)
 
-    assert len(connect_calls) == len(fake_schema)
+    assert len(connect_calls) == 1
+    assert commits == ["commit"] * len(fake_schema)
+
+
+def test_run_schema_statements_rolls_back_failed_postgres_statement(pg_clean: str) -> None:
+    """A failed statement rolls back without losing prior committed statements."""
+    from news_dashboard.db import SchemaInitializationError, _run_schema_statements, connect
+
+    statements = [
+        "CREATE TABLE schema_recovery_before (id INTEGER)",
+        "ALTER TABLE schema_recovery_missing ADD COLUMN value INTEGER",
+        "CREATE TABLE schema_recovery_after (id INTEGER)",
+    ]
+
+    with pytest.raises(SchemaInitializationError, match="schema_recovery_missing"):
+        _run_schema_statements(statements, None, pg_clean)
+
+    with connect(database_url=pg_clean) as conn:
+        rows = conn.execute(
+            """
+            SELECT table_name FROM information_schema.tables
+            WHERE table_schema = current_schema()
+              AND table_name IN ('schema_recovery_before', 'schema_recovery_after')
+            ORDER BY table_name
+            """
+        ).fetchall()
+
+    assert [row["table_name"] for row in rows] == ["schema_recovery_before"]
+
+    _run_schema_statements(["CREATE TABLE schema_recovery_after (id INTEGER)"], None, pg_clean)
+
+    with connect(database_url=pg_clean) as conn:
+        row = conn.execute("SELECT to_regclass('schema_recovery_after')").fetchone()
+
+    assert row is not None
+    assert row["to_regclass"] == "schema_recovery_after"
 
 
 def test_postgres_schema_adds_entities_column() -> None:


### PR DESCRIPTION
Closes #1190

## Summary
- Reuse one PostgreSQL session for each schema initialization phase instead of opening one connection per statement.
- Commit each successful schema statement independently and roll back before surfacing `SchemaInitializationError` on failure.
- Update init-db tests for bounded connection count, commit/rollback behavior, hot-path caching, and PostgreSQL recovery after a failed statement.

## Test results
- `make lint`
- `make typecheck`
- `python -m pytest backend/tests/test_db_init.py` (passed before bootstrap while test DB was reachable)
- `TEST_DATABASE_URL= DATABASE_URL= python -m pytest backend/tests/test_db_init.py -m 'not db'`\n- `npm run test:frontend --silent`\n\nLocal full `dotenv run -- make test` is blocked because `TEST_DATABASE_URL` points at `localhost:55432`, but the local `nd-test-pg` service is not accepting connections and Podman is currently using a stale refused connection. CI should run the full DB-backed suite.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)