### PR TITLE
fix: stop leaking per-test PostgreSQL schemas (#1192)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@
 # --- Database (required) -----------------------------------------------------
 # Either set DATABASE_URL directly, or the split POSTGRES_* parts below.
 DATABASE_URL=postgresql://news_dashboard:news-dashboard-local-password@localhost:5432/news_dashboard
+# Internal pytest coordination file used to clean Path-backed test schemas.
+NEWS_DASHBOARD_PATH_TEST_SCHEMA_REGISTRY=
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=news_dashboard

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -29,6 +29,8 @@ _INITIALIZED_DATABASES: set[tuple[str, str | None, str]] = set()
 _POOL_LOCK = threading.Lock()
 _POOL: ConnectionPool[Any] | None = None
 _POOL_DSN: str | None = None
+_PATH_TEST_SCHEMAS_LOCK = threading.Lock()
+_PATH_TEST_SCHEMAS_CREATED: dict[str, set[str]] = {}
 
 
 class SchemaInitializationError(RuntimeError):
@@ -1315,6 +1317,7 @@ def connect(
         if isinstance(db_path, Path):
             schema = _schema_name(db_path)
             conn.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(schema)))
+            _register_path_test_schema(schema, database_url)
             # `public` stays on the path (after the test schema) so extension
             # types/operators pgvector installs there — e.g. `vector`,
             # `<=>` — resolve even though tables/functions still isolate per
@@ -1519,6 +1522,53 @@ def init_db(db_path: Path | str | None = None, database_url: str | None = None) 
 def _schema_name(token: Path) -> str:
     digest = sha256(str(token).encode("utf-8")).hexdigest()[:16]
     return f"test_{digest}"
+
+
+def _path_test_schema_registry_key(database_url: str | None) -> str:
+    dsn = database_url or os.environ.get("DATABASE_URL") or ""
+    if not dsn:
+        return ""
+    parsed = urlsplit(dsn)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+
+def _register_path_test_schema(schema: str, database_url: str | None) -> None:
+    registry_key = _path_test_schema_registry_key(database_url)
+    with _PATH_TEST_SCHEMAS_LOCK:
+        _PATH_TEST_SCHEMAS_CREATED.setdefault(registry_key, set()).add(schema)
+    registry_file = os.environ.get("NEWS_DASHBOARD_PATH_TEST_SCHEMA_REGISTRY")
+    if registry_file:
+        with Path(registry_file).open("a", encoding="utf-8") as handle:
+            handle.write(f"{registry_key}\t{schema}\n")
+
+
+def drop_registered_path_test_schemas(database_url: str | None = None) -> None:
+    """Drop hash-style schemas created by Path-backed test connections."""
+    registry_key = _path_test_schema_registry_key(database_url)
+    with _PATH_TEST_SCHEMAS_LOCK:
+        schemas = sorted(_PATH_TEST_SCHEMAS_CREATED.pop(registry_key, set()))
+    if not schemas:
+        return
+
+    drop_path_test_schemas(schemas, database_url)
+
+
+def drop_path_test_schemas(schemas: Sequence[str], database_url: str | None = None) -> None:
+    """Drop the given hash-style Path-backed test schemas."""
+    if not schemas:
+        return
+    try:
+        with _open_connection(database_url) as conn:
+            for schema in schemas:
+                conn.execute(
+                    sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(schema))
+                )
+                conn.commit()
+    except Exception:
+        with _PATH_TEST_SCHEMAS_LOCK:
+            registry_key = _path_test_schema_registry_key(database_url)
+            _PATH_TEST_SCHEMAS_CREATED.setdefault(registry_key, set()).update(schemas)
+        raise
 
 
 def get_setting(key: str, default: str | None = None) -> str | None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 import pytest
 
-import news_dashboard.db as db_module
 from news_dashboard.db import init_db
 
 # Load .env from the repo root when running locally (no-op in CI where the
@@ -67,19 +66,6 @@ _TESTCONTAINERS_PG_IMAGE = "pgvector/pgvector:pg16"
 
 _SCHEMA_SWEEP_LOCK_KEY = 727271
 _WORKER_SCHEMA_RE = re.compile(r"^test_[A-Za-z0-9]+_(\d+)$")
-_HASH_SCHEMA_RE = re.compile(r"^test_[0-9a-f]{16}$")
-_SESSION_HASH_SCHEMAS: set[str] = set()
-_ORIGINAL_SCHEMA_NAME = db_module._schema_name
-
-
-def _tracking_schema_name(token: Path) -> str:
-    schema_name = _ORIGINAL_SCHEMA_NAME(token)
-    if _HASH_SCHEMA_RE.match(schema_name):
-        _SESSION_HASH_SCHEMAS.add(schema_name)
-    return schema_name
-
-
-db_module._schema_name = _tracking_schema_name  # ty: ignore[invalid-assignment]
 
 
 def _pid_is_alive(pid: int) -> bool:
@@ -136,24 +122,6 @@ def sweep_stale_test_schemas(dsn: str) -> None:
             conn.execute("SELECT pg_advisory_unlock(%s)", (_SCHEMA_SWEEP_LOCK_KEY,))
 
 
-def drop_session_hash_schemas(dsn: str, schema_names: set[str] | None = None) -> None:
-    """Drop hash-style schemas created from Path-backed tests in this session."""
-    import psycopg
-    from psycopg import sql
-
-    names = sorted(schema_names if schema_names is not None else _SESSION_HASH_SCHEMAS)
-    if not names:
-        return
-
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        for schema_name in names:
-            if not _HASH_SCHEMA_RE.match(schema_name):
-                continue
-            conn.execute(
-                sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(schema_name))
-            )
-
-
 def pytest_configure(config: pytest.Config) -> None:
     """Sweep leaked test_% schemas once, before any xdist worker spawns.
 
@@ -165,17 +133,36 @@ def pytest_configure(config: pytest.Config) -> None:
     del config
     if os.environ.get("PYTEST_XDIST_WORKER"):
         return
+    registry_file = Path(".pytest_cache") / f"path-test-schemas-{os.getpid()}.tsv"
+    registry_file.parent.mkdir(exist_ok=True)
+    registry_file.write_text("", encoding="utf-8")
+    os.environ["NEWS_DASHBOARD_PATH_TEST_SCHEMA_REGISTRY"] = str(registry_file)
     service_url = os.environ.get("TEST_DATABASE_URL")
     if service_url:
         sweep_stale_test_schemas(service_url)
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Drop hash-style schemas created by successful Path-backed test helpers."""
+    """Drop Path-backed hash schemas created by this pytest process."""
     del session, exitstatus
-    service_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
-    if service_url:
-        drop_session_hash_schemas(service_url)
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        return
+    from news_dashboard.db import drop_path_test_schemas, drop_registered_path_test_schemas
+
+    database_url = os.environ.get("DATABASE_URL") or os.environ.get("TEST_DATABASE_URL")
+    if database_url:
+        drop_registered_path_test_schemas(database_url)
+        registry_file = os.environ.get("NEWS_DASHBOARD_PATH_TEST_SCHEMA_REGISTRY")
+        if registry_file:
+            path = Path(registry_file)
+            if path.exists():
+                schemas = {
+                    line.split("\t", 1)[1].strip()
+                    for line in path.read_text(encoding="utf-8").splitlines()
+                    if "\t" in line
+                }
+                drop_path_test_schemas(sorted(schemas), database_url)
+                path.unlink(missing_ok=True)
 
 
 _FAKE_ADMIN = {

--- a/backend/tests/test_conftest_schema_sweep.py
+++ b/backend/tests/test_conftest_schema_sweep.py
@@ -6,9 +6,26 @@ import os
 import subprocess
 import sys
 import uuid
+from hashlib import sha256
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+
+
+def test_path_schema_cleanup_commits_each_drop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each schema drop releases PostgreSQL locks before the next drop."""
+    import news_dashboard.db as db_module
+
+    connection = MagicMock()
+    connection_context = MagicMock()
+    connection_context.__enter__.return_value = connection
+    monkeypatch.setattr(db_module, "_open_connection", lambda _dsn: connection_context)
+
+    db_module.drop_path_test_schemas(["test_a", "test_b"], "postgresql://example/test")
+
+    assert connection.execute.call_count == 2
+    assert connection.commit.call_count == 2
 
 
 def test_sweep_stale_test_schemas() -> None:
@@ -174,18 +191,19 @@ def test_sweep_drops_schemas_owned_by_a_dead_process() -> None:
             )
 
 
-def test_session_hash_schema_cleanup_drops_only_registered_schemas() -> None:
-    """Session-end cleanup removes only hash schemas registered by this run."""
+def test_session_cleanup_drops_only_registered_path_schemas() -> None:
+    """Successful sessions drop their own hash schemas without sweeping live workers."""
     import psycopg
-    from conftest import drop_session_hash_schemas
     from psycopg import sql
+
+    from news_dashboard.db import connect, drop_registered_path_test_schemas
 
     service_url = os.environ.get("TEST_DATABASE_URL")
     if not service_url:
         pytest.skip("TEST_DATABASE_URL not set")
 
     base_url, _, _dbname = service_url.rpartition("/")
-    scratch_db = f"schema_cleanup_scratch_{uuid.uuid4().hex[:12]}"
+    scratch_db = f"schema_sweep_scratch_{uuid.uuid4().hex[:12]}"
     scratch_url = f"{base_url}/{scratch_db}"
     admin_url = f"{base_url}/postgres"
 
@@ -195,29 +213,30 @@ def test_session_hash_schema_cleanup_drops_only_registered_schemas() -> None:
         except psycopg.errors.InsufficientPrivilege:
             pytest.skip("connected role lacks CREATEDB; cannot build an isolated scratch database")
     try:
-        registered_schema = f"test_{uuid.uuid4().hex[:16]}"
-        live_other_session_schema = f"test_{uuid.uuid4().hex[:16]}"
-        non_hash_schema = "test_not_a_hash_schema"
+        token = Path("news-dashboard-test-schemas") / uuid.uuid4().hex / "test.db"
+        path_schema = f"test_{sha256(str(token).encode('utf-8')).hexdigest()[:16]}"
+        live_worker_schema = f"test_gw0_{os.getpid()}"
 
         with psycopg.connect(scratch_url, autocommit=True) as conn:
-            for schema_name in (registered_schema, live_other_session_schema, non_hash_schema):
-                conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema_name)))
+            conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(live_worker_schema)))
 
-            drop_session_hash_schemas(scratch_url, {registered_schema, non_hash_schema})
+        with connect(token, database_url=scratch_url):
+            pass
 
-            rows = conn.execute(
-                """
-                SELECT schema_name FROM information_schema.schemata
-                WHERE schema_name = ANY(%s)
-                ORDER BY schema_name
-                """,
-                ([registered_schema, live_other_session_schema, non_hash_schema],),
-            ).fetchall()
+        drop_registered_path_test_schemas(scratch_url)
 
-        assert [row[0] for row in rows] == [
-            live_other_session_schema,
-            non_hash_schema,
-        ]
+        with psycopg.connect(scratch_url, autocommit=True) as conn:
+            path_row = conn.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s",
+                (path_schema,),
+            ).fetchone()
+            live_worker_row = conn.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s",
+                (live_worker_schema,),
+            ).fetchone()
+
+        assert path_row is None
+        assert live_worker_row is not None
     finally:
         with psycopg.connect(admin_url, autocommit=True) as admin_conn:
             admin_conn.execute(
@@ -251,6 +270,7 @@ def test_successful_pytest_session_leaves_no_hash_schemas() -> None:
         env["DATABASE_URL"] = scratch_url
         env["TEST_DATABASE_URL"] = scratch_url
         env["PYTEST_ADDOPTS"] = ""
+        env.pop("PYTEST_XDIST_WORKER", None)
         subprocess.run(
             [
                 sys.executable,


### PR DESCRIPTION
Closes #1192

## Summary
- Track hash-style schemas created by Path-backed PostgreSQL test connections in the current pytest process.
- Drop those registered schemas in `pytest_sessionfinish`, without sweeping unrelated `test_%` schemas or live worker schemas.
- Add a regression test that registered Path schemas are removed while PID-suffixed live worker schemas are preserved.

## Tests
- `make lint`
- `make typecheck`
- `ruff check backend/news_dashboard/db.py backend/tests/conftest.py backend/tests/test_conftest_schema_sweep.py`
- `ruff format --check backend/news_dashboard/db.py backend/tests/conftest.py backend/tests/test_conftest_schema_sweep.py`
- `mypy backend/news_dashboard/db.py backend/tests/conftest.py backend/tests/test_conftest_schema_sweep.py`

DB-backed pytest was not run locally because the configured Podman test database was unreachable: `podman machine start` returned success, but `podman machine inspect` still reported the machine stopped and `podman ps` could not connect to the stale socket. CI should run the PostgreSQL-backed suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)