### PR TITLE
feat: add lesson graph context (#1123)

### DIFF
--- a/backend/news_dashboard/learn_from_link/models.py
+++ b/backend/news_dashboard/learn_from_link/models.py
@@ -57,6 +57,34 @@ class LessonCitation(BaseModel):
     source: NonEmptyText
 
 
+class LessonGraphEntity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: NonEmptyText
+    name: NonEmptyText
+    type: Literal["concept", "person", "org", "product", "place"]
+
+
+class LessonGraphRelationship(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: NonEmptyText
+    target: NonEmptyText
+    relationship_type: NonEmptyText
+    label: NonEmptyText
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class LessonGraphContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    available: bool
+    entities: list[LessonGraphEntity] = Field(default_factory=list)
+    relationships: list[LessonGraphRelationship] = Field(default_factory=list)
+    related_article_ids: list[int] = Field(default_factory=list)
+    related_briefing_ids: list[int] = Field(default_factory=list)
+
+
 class ReadWorthiness(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -76,6 +104,7 @@ class LessonDetail(BaseModel):
     who_should_read: list[NonEmptyText] = Field(min_length=1)
     questions_to_keep_in_mind: list[NonEmptyText] = Field(min_length=1)
     citations: list[LessonCitation] = Field(min_length=1)
+    graph_context: LessonGraphContext | None = None
 
 
 class ComprehensionQuestion(BaseModel):

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -22,6 +22,7 @@ from news_dashboard.learn_from_link.models import (
     InfographicArtifact,
     LessonDepth,
     LessonDetail,
+    LessonGraphContext,
     LessonPersona,
     PersonalRelevance,
     SlideDeck,
@@ -93,6 +94,11 @@ slide_deck = NULL,
                 personal_relevance = NULL,
                 relevance_feedback = NULL,
 """
+_MAX_LESSON_GRAPH_ENTITIES = 12
+_MAX_LESSON_GRAPH_RELATIONSHIPS = 16
+_MAX_RELATED_ARTICLES = 8
+_MAX_RELATED_BRIEFINGS = 5
+_LESSON_GRAPH_ENTITY_TYPES = frozenset({"concept", "person", "org", "product", "place"})
 
 
 class LessonUrlError(ValueError):
@@ -1114,6 +1120,214 @@ def _normalized_text(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip().lower()
 
 
+def _graph_entity_id(name: str, entity_type: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return f"{entity_type}:{slug}"
+
+
+def _add_graph_entity(
+    entities: list[dict[str, str]],
+    seen: set[tuple[str, str]],
+    *,
+    name: str,
+    entity_type: str,
+) -> str | None:
+    clean_name = re.sub(r"\s+", " ", name).strip()
+    clean_type = entity_type.strip().lower()
+    if not clean_name or clean_type not in _LESSON_GRAPH_ENTITY_TYPES:
+        return None
+    key = (clean_name.lower(), clean_type)
+    entity_id = _graph_entity_id(clean_name, clean_type)
+    if key not in seen and len(entities) < _MAX_LESSON_GRAPH_ENTITIES:
+        seen.add(key)
+        entities.append({"id": entity_id, "name": clean_name, "type": clean_type})
+    return entity_id
+
+
+def _candidate_named_entities(text: str) -> list[str]:
+    candidates = re.findall(r"\b(?:[A-Z][A-Za-z0-9&.-]+)(?:\s+[A-Z][A-Za-z0-9&.-]+){0,3}\b", text)
+    ignored = {"The", "A", "An", "This", "That", "It", "Context"}
+    seen: set[str] = set()
+    names: list[str] = []
+    for candidate in candidates:
+        clean = candidate.strip()
+        if clean in ignored or clean.lower() in seen:
+            continue
+        seen.add(clean.lower())
+        names.append(clean)
+        if len(names) >= 6:
+            break
+    return names
+
+
+def extract_lesson_graph_context(
+    lesson_detail: dict[str, Any],
+    lesson_fields: dict[str, Any],
+    *,
+    user_id: int,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    """Build graph metadata from a validated lesson and user-visible related content."""
+    entities: list[dict[str, str]] = []
+    seen_entities: set[tuple[str, str]] = set()
+    relationships: list[dict[str, Any]] = []
+
+    concept_ids: list[str] = []
+    for concept in lesson_detail.get("prerequisite_concepts") or []:
+        entity_id = _add_graph_entity(
+            entities,
+            seen_entities,
+            name=str(concept),
+            entity_type="concept",
+        )
+        if entity_id is not None:
+            concept_ids.append(entity_id)
+
+    source_text = "\n".join(
+        str(value)
+        for value in (
+            lesson_fields.get("title"),
+            lesson_fields.get("source_name"),
+            lesson_fields.get("author"),
+            lesson_fields.get("source_content"),
+        )
+        if value
+    )
+    for name in _candidate_named_entities(source_text):
+        _add_graph_entity(entities, seen_entities, name=name, entity_type="org")
+
+    gist_id = concept_ids[0] if concept_ids else None
+    for entity in entities:
+        if entity["type"] != "concept" and gist_id is not None:
+            relationships.append(
+                {
+                    "source": gist_id,
+                    "target": entity["id"],
+                    "relationship_type": "mentions",
+                    "label": "mentions",
+                    "confidence": 0.6,
+                }
+            )
+            if len(relationships) >= _MAX_LESSON_GRAPH_RELATIONSHIPS:
+                break
+
+    related_article_ids, related_briefing_ids = _find_related_graph_content(
+        user_id=user_id,
+        entities=entities,
+        database_url=database_url,
+    )
+    return {
+        "available": bool(entities or related_article_ids or related_briefing_ids),
+        "entities": entities,
+        "relationships": relationships,
+        "related_article_ids": related_article_ids,
+        "related_briefing_ids": related_briefing_ids,
+    }
+
+
+def _find_related_graph_content(
+    *,
+    user_id: int,
+    entities: list[dict[str, str]],
+    database_url: str | None,
+) -> tuple[list[int], list[int]]:
+    terms = [entity["name"] for entity in entities[:6] if entity.get("name")]
+    if not terms:
+        return [], []
+
+    article_ids: list[int] = []
+    briefing_ids: list[int] = []
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        for term in terms:
+            like_term = f"%{term}%"
+            article_rows = conn.execute(
+                """
+                SELECT DISTINCT a.id
+                FROM articles a
+                JOIN sources src ON src.slug = a.source_slug
+                LEFT JOIN user_sources us
+                  ON us.source_slug = src.slug AND us.user_id = %s
+                LEFT JOIN user_article_state uas
+                  ON uas.article_id = a.id AND uas.user_id = %s
+                WHERE COALESCE(uas.state, 'today') != 'archived'
+                  AND (
+                    (src.owner_user_id IS NULL AND COALESCE(us.enabled, TRUE) IS TRUE)
+                    OR (src.owner_user_id = %s AND src.enabled IS TRUE)
+                  )
+                  AND (
+                    a.title ILIKE %s
+                    OR a.summary ILIKE %s
+                    OR a.body ILIKE %s
+                    OR a.entities::text ILIKE %s
+                  )
+                ORDER BY a.id DESC
+                LIMIT %s
+                """,
+                (
+                    user_id,
+                    user_id,
+                    user_id,
+                    like_term,
+                    like_term,
+                    like_term,
+                    like_term,
+                    _MAX_RELATED_ARTICLES,
+                ),
+            ).fetchall()
+            for row in article_rows:
+                article_id = int(row["id"])
+                if article_id not in article_ids:
+                    article_ids.append(article_id)
+                    if len(article_ids) >= _MAX_RELATED_ARTICLES:
+                        break
+            if len(article_ids) >= _MAX_RELATED_ARTICLES:
+                break
+
+        for term in terms:
+            like_term = f"%{term}%"
+            rows = conn.execute(
+                """
+                SELECT DISTINCT id
+                FROM briefings
+                WHERE user_id = %s
+                  AND (title ILIKE %s OR content::text ILIKE %s)
+                ORDER BY id DESC
+                LIMIT %s
+                """,
+                (user_id, like_term, like_term, _MAX_RELATED_BRIEFINGS),
+            ).fetchall()
+            for row in rows:
+                briefing_id = int(row["id"])
+                if briefing_id not in briefing_ids:
+                    briefing_ids.append(briefing_id)
+                    if len(briefing_ids) >= _MAX_RELATED_BRIEFINGS:
+                        break
+            if len(briefing_ids) >= _MAX_RELATED_BRIEFINGS:
+                break
+    return article_ids, briefing_ids
+
+
+def _add_lesson_graph_context(
+    *,
+    user_id: int,
+    lesson_id: int,
+    lesson_fields: dict[str, Any],
+    database_url: str | None,
+) -> None:
+    try:
+        raw_context = extract_lesson_graph_context(
+            lesson_fields["lesson_detail"],
+            lesson_fields,
+            user_id=user_id,
+            database_url=database_url,
+        )
+        graph_context = LessonGraphContext.model_validate(raw_context)
+        lesson_fields["lesson_detail"]["graph_context"] = graph_context.model_dump(mode="json")
+    except Exception as exc:
+        logger.warning("lesson graph extraction failed for lesson %d: %s", lesson_id, exc)
+
+
 def generate_structured_lesson_detail(
     lesson_fields: dict[str, Any],
     *,
@@ -1533,6 +1747,12 @@ def build_lesson_graph() -> Any:  # noqa: PLR0915 - graph wiring is clearest in 
                 "failed_step": agent_runs.STEP_CITATION_VERIFICATION,
             }
         lesson_fields["lesson_detail"] = detail
+        _add_lesson_graph_context(
+            user_id=state["user_id"],
+            lesson_id=state["lesson_id"],
+            lesson_fields=lesson_fields,
+            database_url=state["database_url"],
+        )
         return {"lesson_fields": lesson_fields}
 
     def relevance_node(state: LessonGraphState) -> dict[str, Any]:

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -31,6 +31,50 @@ def _make_user(database_url: str, username: str = "alice") -> int:
     return int(row["id"])
 
 
+def _seed_source(database_url: str, slug: str, *, owner_user_id: int | None = None) -> None:
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(slug, name, url, category, kind, owner_user_id)
+            VALUES (%s, %s, %s, 'tech', 'rss_feed', %s)
+            ON CONFLICT(slug) DO NOTHING
+            """,
+            (slug, slug, f"https://{slug}.example", owner_user_id),
+        )
+
+
+def _seed_article(
+    database_url: str,
+    *,
+    slug: str,
+    title: str,
+    summary: str,
+    owner_user_id: int | None = None,
+) -> int:
+    _seed_source(database_url, slug, owner_user_id=owner_user_id)
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO articles(
+              url, canonical_url, title, source_slug, source_name, category, kind, summary,
+              discovered_at
+            )
+            VALUES (%s, %s, %s, %s, %s, 'tech', 'rss_feed', %s, NOW())
+            RETURNING id
+            """,
+            (
+                f"https://{slug}.example/story",
+                f"https://{slug}.example/story",
+                title,
+                slug,
+                slug,
+                summary,
+            ),
+        ).fetchone()
+    assert row is not None
+    return int(row["id"])
+
+
 @contextmanager
 def _api_client(user_id: int, username: str = "alice") -> Generator[TestClient]:
     fake_user = {"id": user_id, "username": username, "email": None, "is_admin": False}
@@ -120,7 +164,15 @@ def test_create_lesson_completes_with_extracted_content(
     assert lesson["source_content"] == "Paragraph one.\n\nParagraph two."
     assert lesson["depth"] == "normal"
     assert lesson["persona"] == "developer"
-    assert lesson["lesson_detail"] == {
+    detail = dict(lesson["lesson_detail"])
+    graph_context = detail.pop("graph_context")
+    assert graph_context["available"] is True
+    assert graph_context["entities"][0] == {
+        "id": "concept:context-from-example-journal",
+        "name": "Context from Example Journal",
+        "type": "concept",
+    }
+    assert detail == {
         "gist": "Paragraph one.",
         "explanation": "Paragraph one.\n\nParagraph two.",
         "key_claims": ["Paragraph one.", "Paragraph two."],
@@ -226,6 +278,85 @@ def test_get_lesson_scopes_graph_context_to_current_user(pg_clean: str) -> None:
 
     assert service.get_lesson(lesson["id"], user_id, database_url=pg_clean) is not None
     assert service.get_lesson(lesson["id"], other_user_id, database_url=pg_clean) is None
+
+
+def test_create_lesson_adds_user_scoped_graph_context(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    other_id = _make_user(pg_clean, username="bob")
+    visible_article_id = _seed_article(
+        pg_clean,
+        slug="visible-ai",
+        title="OpenAI systems lesson",
+        summary="Background context for OpenAI deployments.",
+    )
+    _seed_article(
+        pg_clean,
+        slug="private-ai",
+        title="OpenAI private note",
+        summary="Hidden context.",
+        owner_user_id=other_id,
+    )
+    with connect(database_url=pg_clean) as conn:
+        briefing_row = conn.execute(
+            """
+            INSERT INTO briefings(user_id, title, content)
+            VALUES (%s, %s, %s::jsonb)
+            RETURNING id
+            """,
+            (user_id, "OpenAI briefing", Jsonb({"summary": "OpenAI context"})),
+        ).fetchone()
+    assert briefing_row is not None
+
+    monkeypatch.setattr(
+        service,
+        "fetch_url_metadata",
+        lambda _url: {
+            "title": "OpenAI article",
+            "site_name": "Example Journal",
+            "author": "Ada Writer",
+            "published_at": "2026-07-09",
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        service,
+        "extract_body",
+        lambda _url: ("OpenAI builds useful systems. Sam Altman discussed them.", "ok"),
+        raising=False,
+    )
+
+    lesson = service.create_lesson(user_id, "https://example.com/openai", database_url=pg_clean)
+
+    graph_context = lesson["lesson_detail"]["graph_context"]
+    assert graph_context["available"] is True
+    assert visible_article_id in graph_context["related_article_ids"]
+    assert int(briefing_row["id"]) in graph_context["related_briefing_ids"]
+    assert {entity["name"] for entity in graph_context["entities"]} >= {
+        "Context from Example Journal",
+        "OpenAI",
+    }
+    assert graph_context["relationships"]
+
+
+def test_create_lesson_detail_graph_extraction_failure_does_not_fail_lesson(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    def fail_graph(**_kwargs: Any) -> None:
+        msg = "graph unavailable"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(service, "extract_lesson_graph_context", fail_graph)
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "complete"
+    assert lesson["lesson_detail"]["graph_context"] is None
 
 
 def test_create_lesson_marks_failed_when_extraction_fails(

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -100,6 +100,26 @@ describe('LessonDetailPage', () => {
     expect(screen.getByText('Graph context')).toBeInTheDocument();
   });
 
+  it('indicates when a completed lesson has graph context', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue({
+      ...COMPLETE_LESSON,
+      lesson_detail: {
+        ...COMPLETE_LESSON.lesson_detail!,
+        graph_context: {
+          available: true,
+          entities: [{ id: 'concept:concept-one', name: 'concept one', type: 'concept' }],
+          relationships: [],
+          related_article_ids: [42],
+          related_briefing_ids: [],
+        },
+      },
+    });
+
+    renderPage(5);
+
+    expect(await screen.findByText('Graph context available')).toBeInTheDocument();
+  });
+
   it('shows an error state when the lesson cannot be loaded', async () => {
     vi.spyOn(api, 'fetchLesson').mockRejectedValue(new Error('lesson fetch failed'));
 

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -15,6 +15,28 @@ export interface LessonCitation {
   source: string;
 }
 
+export interface LessonGraphEntity {
+  id: string;
+  name: string;
+  type: 'concept' | 'person' | 'org' | 'product' | 'place';
+}
+
+export interface LessonGraphRelationship {
+  source: string;
+  target: string;
+  relationship_type: string;
+  label: string;
+  confidence: number;
+}
+
+export interface LessonGraphContext {
+  available: boolean;
+  entities: LessonGraphEntity[];
+  relationships: LessonGraphRelationship[];
+  related_article_ids: number[];
+  related_briefing_ids: number[];
+}
+
 export interface LessonDetail {
   gist: string;
   explanation: string;
@@ -25,6 +47,7 @@ export interface LessonDetail {
   who_should_read: string[];
   questions_to_keep_in_mind: string[];
   citations: LessonCitation[];
+  graph_context?: LessonGraphContext | null;
 }
 
 export interface ComprehensionQuestion {

--- a/frontend/src/components/LessonDetailView.tsx
+++ b/frontend/src/components/LessonDetailView.tsx
@@ -88,6 +88,7 @@ export function LessonDetailView({
   const isCompleteLesson = lesson.generation_status === 'complete';
   const lessonDetail = lesson.lesson_detail ?? null;
   const hasLessonDetail = isCompleteLesson && lessonDetail !== null;
+  const graphContext = lessonDetail?.graph_context;
 
   async function handleGeneratePodcast(force: boolean) {
     setIsGeneratingPodcast(true);
@@ -194,6 +195,12 @@ export function LessonDetailView({
             <Badge variant={verdictBadgeVariant(lessonDetail.read_worthiness.verdict)}>
               {capitalizeLabel(lessonDetail.read_worthiness.verdict)}
             </Badge>
+            {graphContext?.available ? (
+              <Badge variant="outline" className="gap-1">
+                <Network className="size-3" />
+                {t('learn.detail.graph_context_available', 'Graph context available')}
+              </Badge>
+            ) : null}
             <div className="min-w-0 text-sm text-muted-foreground">
               {lessonDetail.read_worthiness.rationale}
             </div>


### PR DESCRIPTION
Closes #1123

## Summary
- adds validated lesson graph context to structured lesson details
- links lesson concepts/entities to visible related articles and briefings
- shows a compact graph-context indicator on completed lesson detail pages

## Tests
- `make lint`
- `make typecheck`
- `npm run test:frontend`
- `npm run build`
- `dotenv run -- pytest backend/tests/test_learn_from_link.py -q` (blocked locally: PostgreSQL on localhost:55432 refused connections because nd-test-pg/Podman is not running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)