### PR TITLE
Enable Neo4j in Compose stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ You can run News Dashboard in two ways:
 docker compose up --build
 ```
 
+This stack now brings up PostgreSQL, Neo4j, and the app together, so the
+knowledge graph is enabled locally by default.
+
 ### Option 2: Run the published image (recommended for production)
 
 First, start PostgreSQL:
@@ -175,6 +178,10 @@ docker run -d \
   ghcr.io/lihor-hub/news-dashboard:latest
 ```
 **Note**: Replace `latest` with a specific version tag (e.g., `v1.21.0`) or commit SHA for pinned deployments. The `news-dashboard-data:/data` volume keeps generated audio and other app data across container recreates; without it, optional TTS and podcast MP3 caches are lost during upgrades. See [Configuration](#configuration) for all required environment variables.
+
+If you also want the knowledge graph enabled in a manual `docker run`
+deployment, run a Neo4j container and pass `NEO4J_URI`, `NEO4J_USER`,
+`NEO4J_PASSWORD`, and optionally `NEO4J_DATABASE=neo4j` to the app container.
 
 Open [http://localhost:8080](http://localhost:8080).
 

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -133,7 +133,9 @@ def test_compose_prod_file_enables_neo4j_for_app() -> None:
     assert not missing, f"Neo4j env vars not declared in prod compose: {sorted(missing)}"
     assert env["NEO4J_URI"] == "bolt://neo4j:7687"
     assert env["NEO4J_USER"] == "neo4j"
-    assert env["NEO4J_PASSWORD"] == "${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+    neo4j_password = str(env["NEO4J_PASSWORD"])
+    assert neo4j_password.startswith("${NEO4J_")
+    assert neo4j_password.endswith(" is required}")
     assert env["NEO4J_DATABASE"] == "neo4j"
 
 

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -24,6 +24,13 @@ _REQUIRED_AUTH_VARS = {
     "BOOTSTRAP_ADMIN_PASSWORD",
 }
 
+_REQUIRED_GRAPH_VARS = {
+    "NEO4J_URI",
+    "NEO4J_USER",
+    "NEO4J_PASSWORD",
+    "NEO4J_DATABASE",
+}
+
 _COMPOSE_OVERRIDE_PATTERN = re.compile(r"^\$\{[A-Z_]+:-(.+)\}$")
 
 
@@ -90,6 +97,44 @@ def test_compose_prod_persists_app_data_dir() -> None:
     assert "news-dashboard-data:/data" in app_service.get("volumes", []), (
         "prod compose must mount news-dashboard-data at /data"
     )
+
+
+def _compose_env_map(compose_path: Path) -> dict[str, object]:
+    compose = yaml.safe_load(compose_path.read_text())
+    services = compose.get("services", {})
+    assert "news-dashboard" in services, f"news-dashboard service missing from {compose_path.name}"
+    env = services["news-dashboard"].get("environment", {})
+    if isinstance(env, list):
+        env = dict(item.split("=", 1) if "=" in item else (item, "") for item in env)
+    return env
+
+
+def test_compose_file_enables_neo4j_for_app() -> None:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text())
+    services = compose.get("services", {})
+
+    assert "neo4j" in services, "neo4j service missing from local compose"
+    env = _compose_env_map(COMPOSE_FILE)
+    missing = _REQUIRED_GRAPH_VARS - set(env)
+    assert not missing, f"Neo4j env vars not declared in local compose: {sorted(missing)}"
+    assert env["NEO4J_URI"] == "bolt://neo4j:7687"
+    assert env["NEO4J_USER"] == "neo4j"
+    assert _resolve_default(env["NEO4J_PASSWORD"]), "NEO4J_PASSWORD must have a local default"
+    assert env["NEO4J_DATABASE"] == "neo4j"
+
+
+def test_compose_prod_file_enables_neo4j_for_app() -> None:
+    compose = yaml.safe_load(COMPOSE_PROD_FILE.read_text())
+    services = compose.get("services", {})
+
+    assert "neo4j" in services, "neo4j service missing from prod compose"
+    env = _compose_env_map(COMPOSE_PROD_FILE)
+    missing = _REQUIRED_GRAPH_VARS - set(env)
+    assert not missing, f"Neo4j env vars not declared in prod compose: {sorted(missing)}"
+    assert env["NEO4J_URI"] == "bolt://neo4j:7687"
+    assert env["NEO4J_USER"] == "neo4j"
+    assert env["NEO4J_PASSWORD"] == "${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+    assert env["NEO4J_DATABASE"] == "neo4j"
 
 
 def test_compose_demo_file_exists() -> None:

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import cast
 
 import yaml  # type: ignore[import-untyped]
 
@@ -106,7 +107,8 @@ def _compose_env_map(compose_path: Path) -> dict[str, object]:
     env = services["news-dashboard"].get("environment", {})
     if isinstance(env, list):
         env = dict(item.split("=", 1) if "=" in item else (item, "") for item in env)
-    return env
+    assert isinstance(env, dict), f"environment in {compose_path.name} must be a mapping or list"
+    return cast("dict[str, object]", env)
 
 
 def test_compose_file_enables_neo4j_for_app() -> None:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,14 @@ services:
       retries: 5
     restart: unless-stopped
 
+  neo4j:
+    image: neo4j:5-community
+    environment:
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
+    volumes:
+      - news-dashboard-neo4j:/data
+    restart: unless-stopped
+
   news-dashboard:
     image: ghcr.io/lihor-hub/news-dashboard:latest
     ports:
@@ -27,6 +35,10 @@ services:
       SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required}
       BOOTSTRAP_ADMIN_USERNAME: ${BOOTSTRAP_ADMIN_USERNAME:?BOOTSTRAP_ADMIN_USERNAME is required}
       BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD:?BOOTSTRAP_ADMIN_PASSWORD is required}
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
+      NEO4J_DATABASE: neo4j
       DATA_DIR: /data
       # Optional AI features (uncomment as needed)
       # OPENAI_API_KEY: ${OPENAI_API_KEY:-}
@@ -37,6 +49,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      neo4j:
+        condition: service_started
     healthcheck:
       test:
         [
@@ -53,4 +67,5 @@ services:
 
 volumes:
   news-dashboard-postgres:
+  news-dashboard-neo4j:
   news-dashboard-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
       retries: 5
     restart: unless-stopped
 
+  neo4j:
+    image: neo4j:5-community
+    environment:
+      NEO4J_AUTH: neo4j/news-dashboard-neo4j-local-password
+    volumes:
+      - news-dashboard-neo4j:/data
+    restart: unless-stopped
+
   news-dashboard:
     build: .
     image: news-dashboard:local
@@ -34,12 +42,18 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       FREE_LLM_API_KEY: ${FREE_LLM_API_KEY:-}
       FREE_LLM_BASE_URL: ${FREE_LLM_BASE_URL:-}
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-news-dashboard-neo4j-local-password}
+      NEO4J_DATABASE: neo4j
       DATA_DIR: /data
     volumes:
       - news-dashboard-data:/data
     depends_on:
       postgres:
         condition: service_healthy
+      neo4j:
+        condition: service_started
     healthcheck:
       test:
         [
@@ -56,4 +70,5 @@ services:
 
 volumes:
   news-dashboard-postgres:
+  news-dashboard-neo4j:
   news-dashboard-data:

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -38,7 +38,6 @@ The repository provides two Docker Compose files:
 
 ### Prerequisites
 
-- PostgreSQL database (version 16+)
 - Docker or container runtime
 - Required environment variables (see [Configuration](#configuration))
 
@@ -59,7 +58,7 @@ See the [.env.example reference](#environment-variables) below for all available
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-The compose file will fail fast if required secrets (`SESSION_SECRET`, `BOOTSTRAP_ADMIN_USERNAME`, `BOOTSTRAP_ADMIN_PASSWORD`, `POSTGRES_PASSWORD`) are not set.
+The compose file will fail fast if required secrets (`SESSION_SECRET`, `BOOTSTRAP_ADMIN_USERNAME`, `BOOTSTRAP_ADMIN_PASSWORD`, `POSTGRES_PASSWORD`, `NEO4J_PASSWORD`) are not set.
 
 `docker-compose.prod.yml` also mounts the named `news-dashboard-data` volume at
 `/data` and sets `DATA_DIR=/data`. Generated article audio and briefing podcast
@@ -67,6 +66,18 @@ MP3 caches live under `/data/audio`, so keep that volume backed by persistent
 storage in production. If you run the container manually with `docker run`, pass
 both `-e DATA_DIR=/data` and `-v news-dashboard-data:/data`; otherwise audio
 files are lost when the app container is recreated.
+
+The production Compose stack also starts a bundled `neo4j:5-community`
+container and injects `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, and
+`NEO4J_DATABASE=neo4j` into the app so the knowledge graph is enabled by
+default. After first start, backfill existing cached entities:
+
+```bash
+docker compose -f docker-compose.prod.yml exec news-dashboard \
+  news-dashboard graph-backfill --limit 250 --days 30
+docker compose -f docker-compose.prod.yml exec news-dashboard \
+  news-dashboard graph-relationship-backfill --limit 50 --days 7
+```
 
 ### Verifying the Deployment
 

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -230,7 +230,7 @@ flowchart LR
 - `backend/news_dashboard/digest.py`: daily digest email and signed mark-read links.
 - `backend/news_dashboard/cli.py`: maintenance commands.
 - `Dockerfile`: multi-stage build, React frontend first, Python runtime second.
-- `docker-compose.yml`: local container topology with app plus Postgres.
+- `docker-compose.yml`: local container topology with app plus Postgres and Neo4j.
 - `helm/news-dashboard`: Kubernetes Deployment, Service, CronJob, Postgres StatefulSet, secrets, and storage.
 - `.github/workflows/ci.yml`: tests, frontend build, image publish, and mini PC deployment.
 

--- a/website/docs/self-hosting/index.md
+++ b/website/docs/self-hosting/index.md
@@ -19,7 +19,7 @@ insecure local defaults.
 
 1. Copy `.env.example` to `.env`.
 2. Set strong values for `SESSION_SECRET`, `BOOTSTRAP_ADMIN_USERNAME`,
-   `BOOTSTRAP_ADMIN_PASSWORD`, and `POSTGRES_PASSWORD`.
+   `BOOTSTRAP_ADMIN_PASSWORD`, `POSTGRES_PASSWORD`, and `NEO4J_PASSWORD`.
 3. Start the stack:
 
    ```bash
@@ -31,6 +31,17 @@ insecure local defaults.
    ```bash
    curl http://localhost:8080/api/health
    ```
+
+The production Compose stack includes a bundled Neo4j container and wires the
+app to it with `NEO4J_*`, so the knowledge graph is enabled as soon as the
+stack is up. Backfill existing entities after first start:
+
+```bash
+docker compose -f docker-compose.prod.yml exec news-dashboard \
+  news-dashboard graph-backfill --limit 250 --days 30
+docker compose -f docker-compose.prod.yml exec news-dashboard \
+  news-dashboard graph-relationship-backfill --limit 50 --days 7
+```
 
 The application image is published as:
 
@@ -56,6 +67,7 @@ At minimum, a production instance also needs:
 | `BOOTSTRAP_ADMIN_USERNAME` | First admin username when no users exist. |
 | `BOOTSTRAP_ADMIN_PASSWORD` | First admin password when no users exist. |
 | `POSTGRES_PASSWORD` | Password for the bundled or configured PostgreSQL user. |
+| `NEO4J_PASSWORD` | Password for the bundled Neo4j graph store. |
 
 See [Configuration](/docs/configuration) for authentication, HTTPS, backup, and
 integration guides.
@@ -84,5 +96,6 @@ same pull/up commands.
 
 - [CI Runner Setup](ci-runner-setup)
 - [Authentication](/docs/configuration/authentication)
+- [Neo4j Knowledge Graph](/docs/configuration/neo4j-knowledge-graph)
 - [HTTPS with Caddy](/docs/configuration/https-caddy)
 - [PostgreSQL Backup and Restore](/docs/configuration/postgres-backup)


### PR DESCRIPTION
## Summary

Enable Neo4j by default in the local and production Docker Compose stacks.

This adds a bundled Neo4j service to both compose files, wires the app container with the required `NEO4J_*` environment variables, and documents the new Compose behavior in the repo and website self-hosting docs.

## Why

The app already supported Neo4j in code and in the Helm chart, but the Compose stacks never started Neo4j or injected the app-side configuration. That left the knowledge graph effectively disabled for Compose-based installs.

## Changes

- add regression tests that assert the compose files define a Neo4j service and inject `NEO4J_*` into `news-dashboard`
- add `neo4j:5-community` services and persistent volumes to `docker-compose.yml` and `docker-compose.prod.yml`
- inject `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, and `NEO4J_DATABASE` into the app container in both compose files
- update README and self-hosting docs to describe the new Compose topology and required `NEO4J_PASSWORD` for production

## Validation

- `pytest backend/tests/test_compose_auth_env.py -q`
- `docker compose -f docker-compose.yml config`
- `env POSTGRES_PASSWORD=dummy-postgres SESSION_SECRET=dummy-session BOOTSTRAP_ADMIN_USERNAME=admin BOOTSTRAP_ADMIN_PASSWORD=dummy-admin NEO4J_PASSWORD=dummy-neo4j docker compose -f docker-compose.prod.yml config`
