### PR TITLE
feat: migrate runtime prompts to Langfuse

### DIFF
--- a/.superpowers/sdd/chat-idempotency-report.md
+++ b/.superpowers/sdd/chat-idempotency-report.md
@@ -1,0 +1,40 @@
+# Chat prompt synchronization idempotency report
+
+## Status
+
+Fixed live-discovered Langfuse chat prompt synchronization churn. SDK chat messages carrying
+`type="text"` now compare against catalog messages by their supported semantic fields without
+creating duplicate production versions.
+
+## TDD evidence
+
+- RED: the realistic SDK regression recreated all 9 chat prompts while leaving text prompts
+  unchanged.
+- GREEN: `backend/tests/test_prompt_catalog.py` passes with SDK-shaped `role`, `content`, and
+  `type="text"` messages.
+- Contract coverage confirms that prompt type, role, content, and message order remain exact;
+  unsupported message types and malformed message dictionaries safely compare as changed.
+
+## Implementation
+
+- Chat comparison validates that the SDK value is a list of message mappings.
+- Each supported message may contain only `role`, `content`, and the SDK's optional `type` field;
+  `role` and `content` must be strings, and `type` must be `text` when present.
+- The comparison removes only the validated SDK representation detail (`type="text"`) before
+  comparing the ordered role/content message list with the catalog fallback.
+- Text prompt comparison and production prompt type comparison are unchanged.
+
+## Verification
+
+- `dotenv run -- .venv/bin/pytest backend/tests/test_prompt_catalog.py -q` — 9 passed.
+- `dotenv run -- .venv/bin/pytest backend/tests/test_prompt_catalog.py backend/tests/test_ai_client.py -q`
+  with parallel PostgreSQL workers disabled — 40 passed.
+- `make lint` — passed.
+- `make typecheck` — passed (mypy, ty, pyrefly, and frontend typecheck).
+- Direct Ruff lint and format checks for the synchronization script and catalog tests — passed.
+- `git diff --check` — passed.
+
+## Concerns
+
+None. Unknown future message fields intentionally compare as changed instead of being silently
+discarded, preserving the synchronization command's safe failure behavior.

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,0 +1,34 @@
+# Task 2 report
+
+## Status
+
+Implemented and committed-ready.
+
+## Red/green evidence
+
+- Red: focused suite reported 5 expected managed-prompt wiring failures and 99 passes.
+- Green: focused suite reported 104 passes and 1 pre-existing deprecation warning.
+
+## Implementation
+
+- `ai-body-fetch`: text prompt with bounded `html`.
+- `translate-body`: chat prompt with `from_lang` and `body`.
+- `summarize-media-article`: chat prompt with `title`, `description`, and `transcript`.
+- `translate-article`: chat prompt with `title` and `summary`.
+- `topic-cluster-label`: text prompt with bounded `articles_text`.
+- All five calls pass the resolved `ManagedPrompt` to `chat_create()` and use its compiled content.
+- Existing models, response formats, temperatures, token limits, input caps, and parsing behavior are preserved.
+
+## Verification
+
+- Owned-file Ruff check: pass.
+- Owned-file Ruff format check: pass (7 files already formatted).
+- Owned-file strict mypy: pass (7 source files).
+- Focused pytest: 104 passed, 1 warning.
+- Full pytest: 2588 passed, 6 failed, 5 errors; failures are shared PostgreSQL/concurrent-worktree contamination (`out of shared memory`, duplicate rows) plus unrelated concurrently edited tests.
+- Repository-wide lint/typecheck are blocked by concurrent Task 3/4 changes outside Task 2 ownership; Task 2-owned files are clean.
+
+## Concerns
+
+- `.env` cannot safely be sourced as shell because an existing value is interpreted as a command; verification used the repository-supported `dotenv run --` loader without exposing or changing credentials.
+- Full-suite failures are not caused by Task 2; the focused Task 2 suite is green after the full-suite attempt.

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -32,3 +32,15 @@ Implemented and committed-ready.
 
 - `.env` cannot safely be sourced as shell because an existing value is interpreted as a command; verification used the repository-supported `dotenv run --` loader without exposing or changing credentials.
 - Full-suite failures are not caused by Task 2; the focused Task 2 suite is green after the full-suite attempt.
+
+## Review fix verification
+
+- Added an explicit `label="production"` to all five Task 2 `get_prompt()` calls.
+- Added an explicit `prompt_type="text"` to `ai-body-fetch` and `topic-cluster-label`; the three chat prompts retain explicit `prompt_type="chat"`.
+- Strengthened all five regression tests to assert the exact prompt name, fallback, type, label, and variables.
+- Red: the five exact-call tests failed because the new explicit arguments were absent.
+- Green: the five exact-call tests passed.
+- Focused Task 2 pytest: 104 passed, 1 pre-existing Starlette deprecation warning.
+- Owned-file Ruff check: pass.
+- Owned-file Ruff format check: pass (7 files already formatted).
+- Owned-source strict mypy: pass (3 source files).

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -14,3 +14,12 @@ Wired the eight reader-facing utility calls to managed prompts through `get_prom
 
 - Directly sourcing `.env` is currently unsafe because line 11 contains an unquoted value parsed as shell syntax; tests were run without printing or modifying credentials.
 - A parallel focused run exposed an unrelated shared-database duplicate-key collision in an existing quiz test; the required serial rerun passed.
+
+## Review follow-up
+
+- Added explicit `label="production"` and `prompt_type="text"` arguments at all eight Task 3 application boundaries.
+- Strengthened all eight wiring tests to assert the exact resolver contract and that the identical `ManagedPrompt` returned by `get_prompt()` is passed to `chat_create(prompt=...)`.
+- Focused serial suite: `165 passed, 1 warning in 24.85s`.
+- `make lint`: passed (`ruff`, formatting, vulture, ESLint, Prettier, and dead-code checks).
+- `make typecheck`: passed (`mypy`, `ty`, `pyrefly`, and frontend typecheck).
+- `git diff --check`: passed.

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,0 +1,16 @@
+# Task 3 report
+
+## Outcome
+
+Wired the eight reader-facing utility calls to managed prompts through `get_prompt()` and `chat_create()`, passing only the bounded variables specified by the task and linking each completion to its resolved prompt.
+
+## TDD evidence
+
+- RED: focused suite produced 6 expected missing-prompt failures, with 157 tests passing.
+- GREEN: focused suite passed serially: 165 passed, 1 pre-existing Starlette deprecation warning.
+- Refactor/gates: `make lint`, `make typecheck`, and `git diff --check` passed.
+
+## Notes
+
+- Directly sourcing `.env` is currently unsafe because line 11 contains an unquoted value parsed as shell syntax; tests were run without printing or modifying credentials.
+- A parallel focused run exposed an unrelated shared-database duplicate-key collision in an existing quiz test; the required serial rerun passed.

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,0 +1,23 @@
+# Task 4 report
+
+## Status
+
+Implemented all six native chat-prompt call sites and preserved existing JSON parsing,
+response schemas, exception handling, and Python-side chat-history ordering.
+
+## TDD evidence
+
+- Red: focused suite reported 6 expected native-chat wiring failures and 161 passes.
+- Green: focused suite reported 167 passes.
+- Ruff: affected-file lint and format checks passed.
+- Mypy: all 3 modified production modules passed.
+
+The requested `source .env` form could not launch pytest because one local value is not
+shell-sourceable. Verification used `dotenv run -- pytest ...` instead; no credential
+values were printed or modified.
+
+## Notes
+
+- Lesson and briefing histories remain outside the managed prompt and are inserted
+  between the compiled prompt's leading messages and final user message.
+- Existing FastAPI/Starlette dependency warnings remain: 18 warnings in the focused run.

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -21,3 +21,17 @@ values were printed or modified.
 - Lesson and briefing histories remain outside the managed prompt and are inserted
   between the compiled prompt's leading messages and final user message.
 - Existing FastAPI/Starlette dependency warnings remain: 18 warnings in the focused run.
+
+## Review follow-up
+
+Added regression assertions for the native-chat fallback roles and ordering, and for
+forwarding the compiled managed messages, across `lesson-slide-deck`,
+`lesson-infographic`, `lesson-relevance`, `lesson-chat`, and `briefing-chat`. The lesson
+and briefing chat tests now also prove history is inserted by Python between compiled
+messages and is absent from the fallback templates. No production defect was found.
+
+Commands and results:
+
+- `.venv/bin/ruff format backend/tests/test_lesson_slide_deck.py backend/tests/test_lesson_infographic.py backend/tests/test_learn_from_link.py backend/tests/test_briefings_api.py` — 4 files formatted.
+- `.venv/bin/ruff check backend/tests/test_lesson_slide_deck.py backend/tests/test_lesson_infographic.py backend/tests/test_learn_from_link.py backend/tests/test_briefings_api.py` — passed.
+- `dotenv run -- pytest backend/tests/test_tts.py backend/tests/test_lesson_slide_deck.py backend/tests/test_lesson_infographic.py backend/tests/test_learn_from_link.py backend/tests/test_briefings_api.py -q` — 167 passed, 18 existing Starlette deprecation warnings.

--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -1,0 +1,40 @@
+# Task 5 report
+
+## Status
+
+Implemented the immutable 19-entry prompt catalog, idempotent Langfuse synchronization command,
+feature-module catalog adoption, and operator documentation.
+
+## TDD evidence
+
+- RED: `backend/tests/test_prompt_catalog.py` failed at collection because
+  `news_dashboard.prompt_catalog` did not exist.
+- GREEN: focused catalog tests pass: 7 passed.
+- Affected behavior suite: 443 passed with 1 pre-existing Starlette deprecation warning.
+
+## Implementation
+
+- Frozen catalog entries contain a unique name, prompt type, immutable text/chat prompt content,
+  and an optional commit message.
+- All 19 Task 2–4 feature call sites resolve their local fallbacks from the same catalog used by
+  the synchronization script; existing private test compatibility constants are derived from the
+  catalog rather than duplicating prompt text.
+- The sync command reads its host and credentials only from environment variables, compares each
+  current production prompt before writing, creates changed or missing versions with
+  `labels=["production"]`, and prints names, versions, and status only.
+- README operations cover offline verification, synchronization, production-label rollback, and
+  disabling Langfuse to return to local fallbacks.
+
+## Verification
+
+- `make lint`: passed.
+- `make typecheck`: passed (mypy, ty, pyrefly, and frontend typecheck).
+- `git diff --check`: passed.
+- Full repository pytest intentionally deferred to Task 6; the complete affected prompt behavior
+  suite passed.
+
+## Concerns
+
+- The affected suite retains one existing Starlette/httpx deprecation warning.
+- `.env` remains unsafe to source directly because of an existing unquoted value; verification
+  used the repository-supported `dotenv run --` loader without printing or modifying credentials.

--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -38,3 +38,29 @@ feature-module catalog adoption, and operator documentation.
 - The affected suite retains one existing Starlette/httpx deprecation warning.
 - `.env` remains unsafe to source directly because of an existing unquoted value; verification
   used the repository-supported `dotenv run --` loader without printing or modifying credentials.
+
+## Review follow-up
+
+- Replaced the synchronization command's broad prompt-lookup exception handling with the
+  Langfuse SDK's public `NotFoundError` from
+  `langfuse.api.commons.errors.not_found_error`. Only that response now means a prompt is absent;
+  authentication, network, server, and unexpected failures propagate without creating a version.
+- Replaced the missing-prompt test's generic `RuntimeError` with an actual SDK `NotFoundError` and
+  added a regression proving a generic lookup failure is re-raised with zero create calls.
+- Documented why the synchronization script's catalog import requires `# noqa: E402`: it follows
+  the explicit backend path setup needed when running the script directly.
+
+### Review TDD and verification evidence
+
+- RED: the generic-failure regression failed because the command swallowed `RuntimeError` and
+  issued 19 create calls.
+- GREEN: `dotenv run -- .venv/bin/pytest backend/tests/test_prompt_catalog.py -q` — 8 passed.
+- Affected behavior suite excluding the known legacy body-fetch database-isolation tests — 356
+  passed with 18 existing Starlette/httpx deprecation warnings.
+- `make lint` — passed, including Ruff, formatting, vulture, ESLint, Prettier, and dead-code checks.
+- `make typecheck` — passed, including mypy, ty, pyrefly, and frontend type checking.
+- A wider 408-test affected-file run had 404 passes and four failures in
+  `backend/tests/test_body_fetch.py`; those legacy tests pass `tmp_path` as a database path despite
+  the PostgreSQL-only test environment, causing parallel workers to collide on shared constraints
+  and article URLs. The failures are unrelated to this review patch and remain for Task 6 or a
+  dedicated test-isolation fix.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,34 @@ For technical documentation (architecture, deployment, authentication), see the
 
 To preview the docs site locally: `cd website && npm install && npm run start`.
 
+## Synchronizing managed prompts
+
+The application keeps its 19 managed-prompt fallbacks in
+`backend/news_dashboard/prompt_catalog.py`. To verify catalog shape and sync behavior without
+contacting Langfuse, run:
+
+```bash
+dotenv run -- pytest backend/tests/test_prompt_catalog.py -q
+```
+
+To publish changed prompts, provide credentials only through your environment or secret manager:
+
+```bash
+export LANGFUSE_HOST="https://your-langfuse-host.example"
+export LANGFUSE_PUBLIC_KEY="<public-key>"
+export LANGFUSE_SECRET_KEY="<secret-key>"
+python scripts/sync_langfuse_prompts.py
+```
+
+The command compares every catalog entry with its current `production` version. Matching entries
+are left unchanged; changed or missing entries get one new version labeled `production`. Output is
+limited to prompt names, versions, and status and never prints credentials or prompt content.
+
+To roll back, open the prompt in Langfuse and move the `production` label from the new version to
+the previously known-good version. To disable Langfuse entirely and use the catalog fallbacks,
+remove `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` from the application environment and restart
+the application.
+
 ## Deployment
 
 The production image serves the built frontend through FastAPI on port `8080`.

--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -548,10 +548,23 @@ def _managed_chat_prompt(compiled: object, langfuse_prompt: Any | None) -> _Mana
 
 def _compile_fallback(template: str, variables: dict[str, Any]) -> str:
     """Substitute ``{{var}}`` placeholders locally (Langfuse-compatible syntax)."""
-    text = template
-    for key, val in variables.items():
-        text = text.replace("{{" + key + "}}", str(val))
-    return text
+    parts: list[str] = []
+    cursor = 0
+    while (start := template.find("{{", cursor)) != -1:
+        end = template.find("}}", start + 2)
+        if end == -1:
+            break
+        placeholder_end = end + 2
+        name = template[start + 2 : end].strip()
+        parts.append(template[cursor:start])
+        if name in variables:
+            value = variables[name]
+            parts.append("" if value is None else str(value))
+        else:
+            parts.append(template[start:placeholder_end])
+        cursor = placeholder_end
+    parts.append(template[cursor:])
+    return "".join(parts)
 
 
 # ── Metrics ────────────────────────────────────────────────────────────────

--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -21,7 +21,7 @@ import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeGuard, cast, overload
 
 if TYPE_CHECKING:
     from openai import OpenAI
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ScoreDataType = Literal["NUMERIC", "CATEGORICAL", "BOOLEAN"]
+type PromptMessage = dict[str, str]
+type PromptFallback = str | list[PromptMessage]
+type PromptType = Literal["text", "chat"]
 _DEFAULT_AI_REQUEST_TIMEOUT_SECONDS = 30.0
 _DEFAULT_AI_TTS_TIMEOUT_SECONDS = 120.0
 
@@ -416,45 +419,131 @@ def get_trace_url(trace_id: str) -> str | None:
 class ManagedPrompt:
     """A prompt resolved from Langfuse, or a local fallback.
 
-    ``text`` is the compiled prompt string ready to use. ``langfuse_prompt`` is
-    the underlying Langfuse prompt object when the prompt was fetched from
-    Langfuse (used to link generations to the prompt version), or ``None`` for
-    the local fallback.
+    Exactly one of ``text`` and ``messages`` contains compiled prompt content.
+    ``langfuse_prompt`` is the exact underlying SDK object when the prompt was
+    fetched from Langfuse (used to link generations to the prompt version), or
+    ``None`` for a local fallback.
     """
 
-    text: str
+    text: str | None
+    messages: list[PromptMessage] | None = None
     langfuse_prompt: Any | None = None
+
+    def __post_init__(self) -> None:
+        if (self.text is None) == (self.messages is None):
+            message = "exactly one of text and messages must be populated"
+            raise ValueError(message)
+
+
+@dataclass(frozen=True)
+class _ManagedTextPrompt(ManagedPrompt):
+    text: str
+    messages: None = None
+
+
+@dataclass(frozen=True)
+class _ManagedChatPrompt(ManagedPrompt):
+    text: None = None
+    messages: list[PromptMessage] = field(default_factory=list)
+
+
+@overload
+def get_prompt(
+    name: str,
+    *,
+    fallback: str,
+    prompt_type: Literal["text"] = "text",
+    label: str = "production",
+    variables: dict[str, Any] | None = None,
+) -> _ManagedTextPrompt: ...
+
+
+@overload
+def get_prompt(
+    name: str,
+    *,
+    fallback: list[PromptMessage],
+    prompt_type: Literal["chat"],
+    label: str = "production",
+    variables: dict[str, Any] | None = None,
+) -> _ManagedChatPrompt: ...
 
 
 def get_prompt(
     name: str,
     *,
-    fallback: str,
+    fallback: PromptFallback,
+    prompt_type: PromptType = "text",
     label: str = "production",
     variables: dict[str, Any] | None = None,
-) -> ManagedPrompt:
-    """Fetch a managed text prompt from Langfuse, falling back to *fallback*.
+) -> _ManagedTextPrompt | _ManagedChatPrompt:
+    """Fetch a managed text or chat prompt, falling back to *fallback*.
 
-    Prompts live in Langfuse (type ``text``) so they can be edited and
-    versioned without redeploying. When tracing is disabled, the prompt is
-    missing, or the fetch fails, the hardcoded *fallback* is used so behaviour
-    is never blocked on Langfuse availability. ``{{variable}}`` placeholders are
-    substituted from *variables* (Langfuse's ``compile`` for fetched prompts; a
-    simple local substitution for the fallback).
+    The default remains ``text`` for source compatibility with existing callers.
+    Langfuse output is validated before it crosses this boundary; unavailable or
+    malformed SDK output logs a warning and uses the locally compiled fallback.
     """
     variables = variables or {}
+    fallback_prompt = _managed_fallback(fallback, prompt_type, variables)
     if not langfuse_enabled():
-        return ManagedPrompt(_compile_fallback(fallback, variables))
+        return fallback_prompt
     try:
         client = _client()
-        prompt = client.get_prompt(name, label=label, type="text", fallback=fallback)
-        compiled = prompt.compile(**variables) if variables else prompt.prompt
+        prompt = client.get_prompt(name, label=label, type=prompt_type, fallback=fallback)
+        compiled = prompt.compile(**variables)
         # A fallback-resolved prompt has no real version to link against.
         is_fallback = getattr(prompt, "is_fallback", False)
-        return ManagedPrompt(str(compiled), None if is_fallback else prompt)
+        langfuse_prompt = None if is_fallback else prompt
+        if prompt_type == "text":
+            return _managed_text_prompt(compiled, langfuse_prompt)
+        return _managed_chat_prompt(compiled, langfuse_prompt)
     except Exception as exc:
         logger.warning("langfuse get_prompt(%s) failed, using fallback: %s", name, exc)
-        return ManagedPrompt(_compile_fallback(fallback, variables))
+        return fallback_prompt
+
+
+def _managed_fallback(
+    fallback: PromptFallback,
+    prompt_type: PromptType,
+    variables: dict[str, Any],
+) -> _ManagedTextPrompt | _ManagedChatPrompt:
+    if prompt_type == "text":
+        if not isinstance(fallback, str):
+            message = "text prompts require a string fallback"
+            raise TypeError(message)
+        return _ManagedTextPrompt(text=_compile_fallback(fallback, variables))
+    if isinstance(fallback, str):
+        message = "chat prompts require a message-list fallback"
+        raise TypeError(message)
+    messages = [
+        {key: _compile_fallback(value, variables) for key, value in message.items()}
+        for message in fallback
+    ]
+    return _ManagedChatPrompt(messages=messages)
+
+
+def _is_prompt_messages(value: object) -> TypeGuard[list[PromptMessage]]:
+    return isinstance(value, list) and all(
+        isinstance(message, dict)
+        and isinstance(message.get("role"), str)
+        and isinstance(message.get("content"), str)
+        and all(isinstance(key, str) and isinstance(item, str) for key, item in message.items())
+        for message in value
+    )
+
+
+def _managed_text_prompt(compiled: object, langfuse_prompt: Any | None) -> _ManagedTextPrompt:
+    if not isinstance(compiled, str):
+        message = "compiled text prompt must be a string"
+        raise TypeError(message)
+    return _ManagedTextPrompt(text=compiled, langfuse_prompt=langfuse_prompt)
+
+
+def _managed_chat_prompt(compiled: object, langfuse_prompt: Any | None) -> _ManagedChatPrompt:
+    if not _is_prompt_messages(compiled):
+        message = "compiled chat prompt must contain role/content string messages"
+        raise TypeError(message)
+    return _ManagedChatPrompt(messages=compiled, langfuse_prompt=langfuse_prompt)
 
 
 def _compile_fallback(template: str, variables: dict[str, Any]) -> str:

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -105,7 +105,13 @@ def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]
         from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
         client = get_chat_client(api_key=api_key, base_url=base_url)
-        prompt = get_prompt("ai-body-fetch", fallback=_AI_PROMPT, variables={"html": html})
+        prompt = get_prompt(
+            "ai-body-fetch",
+            fallback=_AI_PROMPT,
+            prompt_type="text",
+            label="production",
+            variables={"html": html},
+        )
         result = chat_create(
             client,
             name="ai-body-fetch",
@@ -481,6 +487,7 @@ def translate_body(body: str, from_lang: str) -> str:
             "translate-body",
             fallback=_TRANSLATE_BODY_PROMPT,
             prompt_type="chat",
+            label="production",
             variables={"from_lang": from_lang, "body": body},
         )
 

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -33,8 +33,19 @@ _AI_FETCH_BYTE_CAP = 200_000
 _AI_MODEL = "gpt-4o-mini"
 _AI_PROMPT = (
     "Extract the main article text from this HTML. "
-    "Return only the article body as plain text, no HTML tags."
+    "Return only the article body as plain text, no HTML tags.\n\n{{html}}"
 )
+_TRANSLATE_BODY_PROMPT = [
+    {
+        "role": "system",
+        "content": (
+            "You are a translation assistant. Translate the following body text from "
+            "language code '{{from_lang}}' to English. Return only the translated plain text, "
+            "preserving paragraph breaks, and no additional commentary."
+        ),
+    },
+    {"role": "user", "content": "{{body}}"},
+]
 
 
 def _fetch_capped_html(url: str, *, byte_cap: int) -> str:
@@ -91,16 +102,18 @@ def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]
         return "", "error"
 
     try:
-        from news_dashboard.ai_client import chat_create, get_chat_client
+        from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
         client = get_chat_client(api_key=api_key, base_url=base_url)
+        prompt = get_prompt("ai-body-fetch", fallback=_AI_PROMPT, variables={"html": html})
         result = chat_create(
             client,
             name="ai-body-fetch",
             tags=["body-fetch"],
             user_id=user_id,
+            prompt=prompt,
             model=model,
-            messages=[{"role": "user", "content": f"{_AI_PROMPT}\n\n{html}"}],
+            messages=[{"role": "user", "content": prompt.text}],
             max_tokens=2048,
         )
         text = (result.choices[0].message.content or "").strip()
@@ -461,24 +474,23 @@ def translate_body(body: str, from_lang: str) -> str:
         return body
 
     try:
-        from news_dashboard.ai_client import chat_create, get_chat_client
+        from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
         client = get_chat_client(api_key=api_key, base_url=base_url)
-        prompt = (
-            f"You are a translation assistant. Translate the following body text from "
-            f"language code '{from_lang}' to English. Return only the translated plain text, "
-            f"preserving paragraph breaks, and no additional commentary."
+        prompt = get_prompt(
+            "translate-body",
+            fallback=_TRANSLATE_BODY_PROMPT,
+            prompt_type="chat",
+            variables={"from_lang": from_lang, "body": body},
         )
 
         result = chat_create(
             client,
             name="translate-body",
             tags=["translation"],
+            prompt=prompt,
             model="gpt-4o-mini",
-            messages=[
-                {"role": "system", "content": prompt},
-                {"role": "user", "content": body},
-            ],
+            messages=prompt.messages,
             max_tokens=2048,
             temperature=0.0,
         )

--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.db import connect, init_db, row_to_dict
+from news_dashboard.prompt_catalog import get_chat_prompt, get_text_prompt
 from news_dashboard.scraper import TIMEOUT_SECS, USER_AGENT
 from news_dashboard.url_safety import (
     UnsafeUrlError,
@@ -31,21 +32,8 @@ _AI_HTML_LIMIT = 15_000
 # to tolerate multi-byte charsets while still bounding worst-case memory/network use.
 _AI_FETCH_BYTE_CAP = 200_000
 _AI_MODEL = "gpt-4o-mini"
-_AI_PROMPT = (
-    "Extract the main article text from this HTML. "
-    "Return only the article body as plain text, no HTML tags.\n\n{{html}}"
-)
-_TRANSLATE_BODY_PROMPT = [
-    {
-        "role": "system",
-        "content": (
-            "You are a translation assistant. Translate the following body text from "
-            "language code '{{from_lang}}' to English. Return only the translated plain text, "
-            "preserving paragraph breaks, and no additional commentary."
-        ),
-    },
-    {"role": "user", "content": "{{body}}"},
-]
+_AI_PROMPT = get_text_prompt("ai-body-fetch")
+_TRANSLATE_BODY_PROMPT = get_chat_prompt("translate-body")
 
 
 def _fetch_capped_html(url: str, *, byte_cap: int) -> str:
@@ -107,7 +95,7 @@ def _ai_extract_body(url: str, *, user_id: int | None = None) -> tuple[str, str]
         client = get_chat_client(api_key=api_key, base_url=base_url)
         prompt = get_prompt(
             "ai-body-fetch",
-            fallback=_AI_PROMPT,
+            fallback=get_text_prompt("ai-body-fetch"),
             prompt_type="text",
             label="production",
             variables={"html": html},
@@ -485,7 +473,7 @@ def translate_body(body: str, from_lang: str) -> str:
         client = get_chat_client(api_key=api_key, base_url=base_url)
         prompt = get_prompt(
             "translate-body",
-            fallback=_TRANSLATE_BODY_PROMPT,
+            fallback=get_chat_prompt("translate-body"),
             prompt_type="chat",
             label="production",
             variables={"from_lang": from_lang, "body": body},

--- a/backend/news_dashboard/briefings/service.py
+++ b/backend/news_dashboard/briefings/service.py
@@ -929,16 +929,26 @@ def chat_with_briefing(
     else:
         articles_context = "(No articles cited — answer from the briefing summary only.)"
 
-    system = _CHAT_SYSTEM_PROMPT.format(
-        briefing_context=briefing_context,
-        articles_context=articles_context,
-    )
-
+    from news_dashboard.ai_client import get_prompt
     from news_dashboard.ai_orchestration import invoke_chat_chain
 
-    messages: list[dict[str, str]] = [{"role": "system", "content": system}]
-    messages.extend(history)
-    messages.append({"role": "user", "content": message})
+    fallback_system = _CHAT_SYSTEM_PROMPT.replace(
+        "{briefing_context}", "{{briefing_context}}"
+    ).replace("{articles_context}", "{{articles_context}}")
+    prompt = get_prompt(
+        "briefing-chat",
+        fallback=[
+            {"role": "system", "content": fallback_system},
+            {"role": "user", "content": "{{question}}"},
+        ],
+        prompt_type="chat",
+        variables={
+            "briefing_context": briefing_context,
+            "articles_context": articles_context,
+            "question": message,
+        },
+    )
+    messages = [*prompt.messages[:-1], *history, prompt.messages[-1]]
 
     return invoke_chat_chain(
         name="briefing-chat",
@@ -947,4 +957,5 @@ def chat_with_briefing(
         session_id=f"briefing:{briefing_id}:user:{user_id}" if user_id is not None else None,
         model=model,
         messages=messages,
+        prompt=prompt,
     )

--- a/backend/news_dashboard/briefings/service.py
+++ b/backend/news_dashboard/briefings/service.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from news_dashboard import briefing_agent
 from news_dashboard.db import connect, row_to_dict
+from news_dashboard.prompt_catalog import get_chat_prompt
 from news_dashboard.reading_list import service as reading_list_service
 
 CANDIDATE_LIMIT = 40
@@ -882,18 +883,11 @@ def list_briefings_with_script(
         return briefings
 
 
-_CHAT_SYSTEM_PROMPT = """\
-You are the Briefing Q&A Assistant. Your job is to answer follow-up questions \
-about the daily briefing provided below. Ground every answer in the briefing \
-summary and the full article texts supplied. If information is not present in \
-the provided context, say so clearly rather than guessing.
-
---- BRIEFING ---
-{briefing_context}
-
---- CITED ARTICLES ---
-{articles_context}
-"""
+_CHAT_SYSTEM_PROMPT = (
+    get_chat_prompt("briefing-chat")[0]["content"]
+    .replace("{{briefing_context}}", "{briefing_context}")
+    .replace("{{articles_context}}", "{articles_context}")
+)
 
 
 def chat_with_briefing(
@@ -932,15 +926,9 @@ def chat_with_briefing(
     from news_dashboard.ai_client import get_prompt
     from news_dashboard.ai_orchestration import invoke_chat_chain
 
-    fallback_system = _CHAT_SYSTEM_PROMPT.replace(
-        "{briefing_context}", "{{briefing_context}}"
-    ).replace("{articles_context}", "{{articles_context}}")
     prompt = get_prompt(
         "briefing-chat",
-        fallback=[
-            {"role": "system", "content": fallback_system},
-            {"role": "user", "content": "{{question}}"},
-        ],
+        fallback=get_chat_prompt("briefing-chat"),
         prompt_type="chat",
         variables={
             "briefing_context": briefing_context,

--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -734,6 +734,7 @@ def _media_summary(title: str, description: str, entry: dict[str, Any]) -> str:
                 "summarize-media-article",
                 fallback=_MEDIA_SUMMARY_PROMPT,
                 prompt_type="chat",
+                label="production",
                 variables={
                     "title": title,
                     "description": description,
@@ -801,6 +802,7 @@ def detect_and_translate_article(
             "translate-article",
             fallback=_TRANSLATE_ARTICLE_PROMPT,
             prompt_type="chat",
+            label="production",
             variables={"title": title, "summary": summary},
         )
 

--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -23,6 +23,7 @@ import psycopg
 from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.db import connect, init_db, insert_article_sql, placeholders, row_to_dict
 from news_dashboard.ingest_events import ingest_events
+from news_dashboard.prompt_catalog import get_chat_prompt
 from news_dashboard.recommendations import COLD_START_MODEL_VERSION
 from news_dashboard.sources.service import DEFAULT_SOURCES, SourceDefinition
 from news_dashboard.url_safety import (
@@ -203,35 +204,8 @@ _MEDIA_SOURCE_KINDS: frozenset[str] = frozenset({"youtube_channel", "podcast_fee
 
 # Cap the number of page fetches per ingest run to keep ingest fast.
 _MAX_SNIPPET_FETCHES_PER_RUN: int = 10
-_MEDIA_SUMMARY_PROMPT = [
-    {
-        "role": "system",
-        "content": (
-            "Summarize this podcast or video transcript as a concise readable "
-            "article summary for a news reader."
-        ),
-    },
-    {
-        "role": "user",
-        "content": "Title: {{title}}\nDescription: {{description}}\nTranscript:\n{{transcript}}",
-    },
-]
-_TRANSLATE_ARTICLE_PROMPT = [
-    {
-        "role": "system",
-        "content": (
-            "You are a translation assistant. Detect the language of the following text. "
-            "If it is not English, translate both the title and the summary/description to "
-            "English. Return a JSON object with the following keys:\n"
-            '- "detected_lang": the 2-letter ISO 639-1 language code '
-            '(e.g. "ja", "zh", "ru", "fr", "de", "en")\n'
-            '- "translated_title": the translated title in English\n'
-            '- "translated_summary": the translated summary/description in English\n'
-            '- "needs_translation": boolean indicating if it was translated\n'
-        ),
-    },
-    {"role": "user", "content": "Title: {{title}}\nSummary: {{summary}}"},
-]
+_MEDIA_SUMMARY_PROMPT = get_chat_prompt("summarize-media-article")
+_TRANSLATE_ARTICLE_PROMPT = get_chat_prompt("translate-article")
 
 
 def now_iso() -> str:
@@ -732,7 +706,7 @@ def _media_summary(title: str, description: str, entry: dict[str, Any]) -> str:
             client = get_chat_client(api_key=api_key, base_url=base_url)
             prompt = get_prompt(
                 "summarize-media-article",
-                fallback=_MEDIA_SUMMARY_PROMPT,
+                fallback=get_chat_prompt("summarize-media-article"),
                 prompt_type="chat",
                 label="production",
                 variables={
@@ -800,7 +774,7 @@ def detect_and_translate_article(
         client = get_chat_client(api_key=api_key, base_url=base_url)
         prompt = get_prompt(
             "translate-article",
-            fallback=_TRANSLATE_ARTICLE_PROMPT,
+            fallback=get_chat_prompt("translate-article"),
             prompt_type="chat",
             label="production",
             variables={"title": title, "summary": summary},

--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -203,6 +203,35 @@ _MEDIA_SOURCE_KINDS: frozenset[str] = frozenset({"youtube_channel", "podcast_fee
 
 # Cap the number of page fetches per ingest run to keep ingest fast.
 _MAX_SNIPPET_FETCHES_PER_RUN: int = 10
+_MEDIA_SUMMARY_PROMPT = [
+    {
+        "role": "system",
+        "content": (
+            "Summarize this podcast or video transcript as a concise readable "
+            "article summary for a news reader."
+        ),
+    },
+    {
+        "role": "user",
+        "content": "Title: {{title}}\nDescription: {{description}}\nTranscript:\n{{transcript}}",
+    },
+]
+_TRANSLATE_ARTICLE_PROMPT = [
+    {
+        "role": "system",
+        "content": (
+            "You are a translation assistant. Detect the language of the following text. "
+            "If it is not English, translate both the title and the summary/description to "
+            "English. Return a JSON object with the following keys:\n"
+            '- "detected_lang": the 2-letter ISO 639-1 language code '
+            '(e.g. "ja", "zh", "ru", "fr", "de", "en")\n'
+            '- "translated_title": the translated title in English\n'
+            '- "translated_summary": the translated summary/description in English\n'
+            '- "needs_translation": boolean indicating if it was translated\n'
+        ),
+    },
+    {"role": "user", "content": "Title: {{title}}\nSummary: {{summary}}"},
+]
 
 
 def now_iso() -> str:
@@ -698,29 +727,26 @@ def _media_summary(title: str, description: str, entry: dict[str, Any]) -> str:
     api_key, base_url = free_llm_config()
     if api_key and transcript:
         try:
-            from news_dashboard.ai_client import chat_create, get_chat_client
+            from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
             client = get_chat_client(api_key=api_key, base_url=base_url)
+            prompt = get_prompt(
+                "summarize-media-article",
+                fallback=_MEDIA_SUMMARY_PROMPT,
+                prompt_type="chat",
+                variables={
+                    "title": title,
+                    "description": description,
+                    "transcript": transcript,
+                },
+            )
             response = chat_create(
                 client,
                 name="summarize-media-article",
                 tags=["ingest", "media"],
+                prompt=prompt,
                 model=os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini"),
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "Summarize this podcast or video transcript as a concise readable "
-                            "article summary for a news reader."
-                        ),
-                    },
-                    {
-                        "role": "user",
-                        "content": (
-                            f"Title: {title}\nDescription: {description}\nTranscript:\n{transcript}"
-                        ),
-                    },
-                ],
+                messages=prompt.messages,
                 max_tokens=500,
                 temperature=0.2,
             )
@@ -744,7 +770,7 @@ def detect_and_translate_article(
     """Detect language and translate title and summary to English if needed."""
     import json
 
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     is_non_eng = source_lang != "en"
     if not is_non_eng:
@@ -771,28 +797,21 @@ def detect_and_translate_article(
 
     try:
         client = get_chat_client(api_key=api_key, base_url=base_url)
-        prompt = (
-            "You are a translation assistant. Detect the language of the following text. "
-            "If it is not English, translate both the title and the "
-            "summary/description to English. "
-            "Return a JSON object with the following keys:\n"
-            '- "detected_lang": the 2-letter ISO 639-1 language code '
-            '(e.g. "ja", "zh", "ru", "fr", "de", "en")\n'
-            '- "translated_title": the translated title in English\n'
-            '- "translated_summary": the translated summary/description in English\n'
-            '- "needs_translation": boolean indicating if it was translated\n'
+        prompt = get_prompt(
+            "translate-article",
+            fallback=_TRANSLATE_ARTICLE_PROMPT,
+            prompt_type="chat",
+            variables={"title": title, "summary": summary},
         )
 
         result = chat_create(
             client,
             name="translate-article",
             tags=["translation"],
+            prompt=prompt,
             model="gpt-4o-mini",
             response_format={"type": "json_object"},
-            messages=[
-                {"role": "system", "content": prompt},
-                {"role": "user", "content": f"Title: {title}\nSummary: {summary}"},
-            ],
+            messages=prompt.messages,
             max_tokens=1024,
             temperature=0.0,
         )

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -331,6 +331,8 @@ def _generate_cluster_label(
     prompt = get_prompt(
         "topic-cluster-label",
         fallback=_CLUSTER_LABEL_PROMPT,
+        prompt_type="text",
+        label="production",
         variables={"articles_text": articles_text},
     )
     result = chat_create(

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -186,7 +186,8 @@ _CLUSTER_LABEL_PROMPT = (
     "articles are connected.\n\n"
     "Respond in this exact format:\n"
     "HEADLINE: <headline here>\n"
-    "SUMMARY: <one-sentence summary here>"
+    "SUMMARY: <one-sentence summary here>\n\n"
+    "Articles:\n{{articles_text}}"
 )
 
 DEFAULT_CLUSTER_MODEL = "gpt-4o-mini"
@@ -324,20 +325,25 @@ def _generate_cluster_label(
         f"- Title: {a.get('title', '')}\n  Summary: {a.get('summary', '')}" for a in articles[:10]
     )
 
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
+    prompt = get_prompt(
+        "topic-cluster-label",
+        fallback=_CLUSTER_LABEL_PROMPT,
+        variables={"articles_text": articles_text},
+    )
     result = chat_create(
         client,
         name="topic-cluster-label",
         tags=["clustering"],
         user_id=user_id,
-        prompt=None,
+        prompt=prompt,
         model=model,
         messages=[
             {
                 "role": "user",
-                "content": f"{_CLUSTER_LABEL_PROMPT}\n\nArticles:\n{articles_text}",
+                "content": prompt.text,
             },
         ],
         max_tokens=200,

--- a/backend/news_dashboard/insights.py
+++ b/backend/news_dashboard/insights.py
@@ -18,6 +18,7 @@ from typing import Any
 from news_dashboard.body_fetch import get_article
 from news_dashboard.db import connect, init_db
 from news_dashboard.embeddings import parse_vector
+from news_dashboard.prompt_catalog import get_text_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -178,17 +179,7 @@ def get_or_generate_insights(
 _CLUSTER_THRESHOLD = 0.72  # cosine similarity threshold for same-cluster assignment
 _MIN_CLUSTER_SIZE = 3  # minimum articles per cluster to surface
 _MAX_ARTICLES = 300  # cap to keep computation bounded
-_CLUSTER_LABEL_PROMPT = (
-    "You are analyzing a group of related news articles that cover the same story or topic arc. "
-    "Based ONLY on the article titles and summaries provided below, generate:\n"
-    "1. A concise Story Headline (max 8 words) capturing the central theme.\n"
-    "2. A one-sentence Trend Summary explaining the story arc or why these "
-    "articles are connected.\n\n"
-    "Respond in this exact format:\n"
-    "HEADLINE: <headline here>\n"
-    "SUMMARY: <one-sentence summary here>\n\n"
-    "Articles:\n{{articles_text}}"
-)
+_CLUSTER_LABEL_PROMPT = get_text_prompt("topic-cluster-label")
 
 DEFAULT_CLUSTER_MODEL = "gpt-4o-mini"
 
@@ -330,7 +321,7 @@ def _generate_cluster_label(
     client = get_chat_client(api_key=api_key, base_url=base_url)
     prompt = get_prompt(
         "topic-cluster-label",
-        fallback=_CLUSTER_LABEL_PROMPT,
+        fallback=get_text_prompt("topic-cluster-label"),
         prompt_type="text",
         label="production",
         variables={"articles_text": articles_text},

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -577,20 +577,27 @@ def generate_slide_deck_content(lesson: dict[str, Any], user_id: int) -> dict[st
 
     import json
 
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
-    messages = [
-        {"role": "system", "content": _LESSON_SLIDE_DECK_SYSTEM_PROMPT},
-        {"role": "user", "content": _build_slide_deck_prompt(lesson)},
-    ]
+    lesson_content = _build_slide_deck_prompt(lesson)
+    prompt = get_prompt(
+        "lesson-slide-deck",
+        fallback=[
+            {"role": "system", "content": _LESSON_SLIDE_DECK_SYSTEM_PROMPT},
+            {"role": "user", "content": "{{lesson_content}}"},
+        ],
+        prompt_type="chat",
+        variables={"lesson_content": lesson_content},
+    )
     response = chat_create(
         client,
         name="lesson-slide-deck",
         tags=["lesson", "slide-deck"],
         user_id=user_id,
         model=os.getenv("OPENAI_LESSON_CHAT_MODEL", DEFAULT_LESSON_CHAT_MODEL),
-        messages=messages,
+        messages=prompt.messages,
+        langfuse_prompt=prompt.langfuse_prompt,
         response_format={"type": "json_object"},
     )
     parsed = json.loads(response.choices[0].message.content or "")
@@ -741,20 +748,27 @@ def generate_infographic_content(lesson: dict[str, Any], user_id: int) -> dict[s
 
     import json
 
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
-    messages = [
-        {"role": "system", "content": _LESSON_INFOGRAPHIC_SYSTEM_PROMPT},
-        {"role": "user", "content": _build_infographic_prompt(lesson)},
-    ]
+    lesson_content = _build_infographic_prompt(lesson)
+    prompt = get_prompt(
+        "lesson-infographic",
+        fallback=[
+            {"role": "system", "content": _LESSON_INFOGRAPHIC_SYSTEM_PROMPT},
+            {"role": "user", "content": "{{lesson_content}}"},
+        ],
+        prompt_type="chat",
+        variables={"lesson_content": lesson_content},
+    )
     response = chat_create(
         client,
         name="lesson-infographic",
         tags=["lesson", "infographic"],
         user_id=user_id,
         model=os.getenv("OPENAI_LESSON_CHAT_MODEL", DEFAULT_LESSON_CHAT_MODEL),
-        messages=messages,
+        messages=prompt.messages,
+        langfuse_prompt=prompt.langfuse_prompt,
         response_format={"type": "json_object"},
     )
     parsed = json.loads(response.choices[0].message.content or "")
@@ -1453,16 +1467,26 @@ def ask_lesson_question(
     model = os.getenv("OPENAI_LESSON_CHAT_MODEL", DEFAULT_LESSON_CHAT_MODEL)
 
     lesson_context, source_context = _lesson_chat_context(lesson)
-    system = _LESSON_CHAT_SYSTEM_PROMPT.format(
-        lesson_context=lesson_context,
-        source_context=source_context,
-    )
-
+    from news_dashboard.ai_client import get_prompt
     from news_dashboard.ai_orchestration import invoke_chat_chain
 
-    messages: list[dict[str, str]] = [{"role": "system", "content": system}]
-    messages.extend(history)
-    messages.append({"role": "user", "content": stripped})
+    fallback_system = _LESSON_CHAT_SYSTEM_PROMPT.replace(
+        "{lesson_context}", "{{lesson_context}}"
+    ).replace("{source_context}", "{{source_context}}")
+    prompt = get_prompt(
+        "lesson-chat",
+        fallback=[
+            {"role": "system", "content": fallback_system},
+            {"role": "user", "content": "{{question}}"},
+        ],
+        prompt_type="chat",
+        variables={
+            "lesson_context": lesson_context,
+            "source_context": source_context,
+            "question": stripped,
+        },
+    )
+    messages = [*prompt.messages[:-1], *history, prompt.messages[-1]]
 
     return invoke_chat_chain(
         name="lesson-chat",
@@ -1471,6 +1495,7 @@ def ask_lesson_question(
         session_id=f"lesson:{lesson_id}:user:{user_id}",
         model=model,
         messages=messages,
+        prompt=prompt,
     )
 
 
@@ -1555,11 +1580,11 @@ def generate_personal_relevance(
 
     import json
 
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     lesson_title = str(lesson_fields.get("title") or lesson_fields.get("original_url"))
     lesson_detail = lesson_fields.get("lesson_detail") or {}
-    messages = [
+    fallback = [
         {
             "role": "system",
             "content": (
@@ -1569,24 +1594,30 @@ def generate_personal_relevance(
         },
         {
             "role": "user",
-            "content": (
-                f"Lesson title: {lesson_title}\n"
-                f"Lesson gist: {lesson_detail.get('gist', '')}\n"
-                f"Interests: {interests}\n"
-                f"Reading DNA categories: {dna_categories}\n"
-                f"Reading DNA sources: {dna_sources}\n"
-                f"Recent article titles: {[item['title'] for item in recent_articles]}"
-            ),
+            "content": ("{{lesson_context}}\n{{profile_context}}"),
         },
     ]
+    lesson_context = f"Lesson title: {lesson_title}\nLesson gist: {lesson_detail.get('gist', '')}"
+    profile_context = (
+        f"Interests: {interests}\nReading DNA categories: {dna_categories}\n"
+        f"Reading DNA sources: {dna_sources}\n"
+        f"Recent article titles: {[item['title'] for item in recent_articles]}"
+    )
     try:
+        prompt = get_prompt(
+            "lesson-relevance",
+            fallback=fallback,
+            prompt_type="chat",
+            variables={"lesson_context": lesson_context, "profile_context": profile_context},
+        )
         response = chat_create(
             get_chat_client(api_key=api_key, base_url=base_url),
             name="lesson-relevance",
             tags=["lesson", "relevance"],
             user_id=user_id,
             model=os.getenv("OPENAI_LESSON_CHAT_MODEL", DEFAULT_LESSON_CHAT_MODEL),
-            messages=messages,
+            messages=prompt.messages,
+            langfuse_prompt=prompt.langfuse_prompt,
             response_format={"type": "json_object"},
         )
         parsed = json.loads(response.choices[0].message.content or "")

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -24,6 +24,7 @@ from news_dashboard.learn_from_link.models import (
     SlideDeck,
     StudyArtifacts,
 )
+from news_dashboard.prompt_catalog import get_chat_prompt
 from news_dashboard.reading_list.metadata import fetch_url_metadata
 from news_dashboard.reading_list.service import normalize_url
 from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
@@ -60,18 +61,11 @@ _PERSONA_FRAMING: dict[str, str] = {
     "preparing_talk": "for someone preparing a talk on this topic",
 }
 
-_LESSON_CHAT_SYSTEM_PROMPT = """\
-You are the Lesson Follow-up Assistant. Answer follow-up questions about the \
-lesson below, grounded in the lesson detail and source article content \
-supplied. If information is not present in the provided context, say so \
-clearly rather than guessing.
-
---- LESSON ---
-{lesson_context}
-
---- SOURCE ARTICLE ---
-{source_context}
-"""
+_LESSON_CHAT_SYSTEM_PROMPT = (
+    get_chat_prompt("lesson-chat")[0]["content"]
+    .replace("{{lesson_context}}", "{lesson_context}")
+    .replace("{{source_context}}", "{source_context}")
+)
 
 _LESSON_ARTIFACT_RESET_ASSIGNMENTS = """\
 podcast_status = NULL,
@@ -531,13 +525,7 @@ def _update_lesson_slide_deck_failure(
     return _serialize_lesson(row)
 
 
-_LESSON_SLIDE_DECK_SYSTEM_PROMPT = """\
-You are the Lesson Slide Deck Generator. Produce a short teaching slide deck \
-summarizing the lesson below as a shareable learning artifact. Return JSON \
-with a "slides" array of 6 to 10 slides, each with a "title" and 1-6 \
-"bullets". Ground every slide in the supplied lesson detail; do not invent \
-facts.
-"""
+_LESSON_SLIDE_DECK_SYSTEM_PROMPT = get_chat_prompt("lesson-slide-deck")[0]["content"]
 
 
 def _build_slide_deck_prompt(lesson: dict[str, Any]) -> str:
@@ -583,10 +571,7 @@ def generate_slide_deck_content(lesson: dict[str, Any], user_id: int) -> dict[st
     lesson_content = _build_slide_deck_prompt(lesson)
     prompt = get_prompt(
         "lesson-slide-deck",
-        fallback=[
-            {"role": "system", "content": _LESSON_SLIDE_DECK_SYSTEM_PROMPT},
-            {"role": "user", "content": "{{lesson_content}}"},
-        ],
+        fallback=get_chat_prompt("lesson-slide-deck"),
         prompt_type="chat",
         variables={"lesson_content": lesson_content},
     )
@@ -706,13 +691,7 @@ def _update_lesson_infographic_failure(
     return _serialize_lesson(row)
 
 
-_LESSON_INFOGRAPHIC_SYSTEM_PROMPT = """\
-You are the Lesson Infographic Generator. Produce a deterministic, text-first \
-infographic artifact from the lesson below. Return JSON with title, subtitle, \
-sections, and footer fields. Each section needs a heading and body. Ground the \
-artifact only in the supplied lesson detail; do not invent facts, image URLs, \
-or external assets.
-"""
+_LESSON_INFOGRAPHIC_SYSTEM_PROMPT = get_chat_prompt("lesson-infographic")[0]["content"]
 
 
 def _build_infographic_prompt(lesson: dict[str, Any]) -> str:
@@ -754,10 +733,7 @@ def generate_infographic_content(lesson: dict[str, Any], user_id: int) -> dict[s
     lesson_content = _build_infographic_prompt(lesson)
     prompt = get_prompt(
         "lesson-infographic",
-        fallback=[
-            {"role": "system", "content": _LESSON_INFOGRAPHIC_SYSTEM_PROMPT},
-            {"role": "user", "content": "{{lesson_content}}"},
-        ],
+        fallback=get_chat_prompt("lesson-infographic"),
         prompt_type="chat",
         variables={"lesson_content": lesson_content},
     )
@@ -1470,15 +1446,9 @@ def ask_lesson_question(
     from news_dashboard.ai_client import get_prompt
     from news_dashboard.ai_orchestration import invoke_chat_chain
 
-    fallback_system = _LESSON_CHAT_SYSTEM_PROMPT.replace(
-        "{lesson_context}", "{{lesson_context}}"
-    ).replace("{source_context}", "{{source_context}}")
     prompt = get_prompt(
         "lesson-chat",
-        fallback=[
-            {"role": "system", "content": fallback_system},
-            {"role": "user", "content": "{{question}}"},
-        ],
+        fallback=get_chat_prompt("lesson-chat"),
         prompt_type="chat",
         variables={
             "lesson_context": lesson_context,
@@ -1584,19 +1554,6 @@ def generate_personal_relevance(
 
     lesson_title = str(lesson_fields.get("title") or lesson_fields.get("original_url"))
     lesson_detail = lesson_fields.get("lesson_detail") or {}
-    fallback = [
-        {
-            "role": "system",
-            "content": (
-                "Explain why a lesson is relevant using only the user's provided reading profile. "
-                "Return JSON with non-empty explanation and a signals array."
-            ),
-        },
-        {
-            "role": "user",
-            "content": ("{{lesson_context}}\n{{profile_context}}"),
-        },
-    ]
     lesson_context = f"Lesson title: {lesson_title}\nLesson gist: {lesson_detail.get('gist', '')}"
     profile_context = (
         f"Interests: {interests}\nReading DNA categories: {dna_categories}\n"
@@ -1606,7 +1563,7 @@ def generate_personal_relevance(
     try:
         prompt = get_prompt(
             "lesson-relevance",
-            fallback=fallback,
+            fallback=get_chat_prompt("lesson-relevance"),
             prompt_type="chat",
             variables={"lesson_context": lesson_context, "profile_context": profile_context},
         )

--- a/backend/news_dashboard/lesson_recaps/narrative.py
+++ b/backend/news_dashboard/lesson_recaps/narrative.py
@@ -37,7 +37,12 @@ def generate_lesson_recap_narrative(recap: dict[str, Any]) -> str:
     fallback = _fallback_narrative(recap)
 
     try:
-        from news_dashboard.ai_client import free_llm_config, get_chat_client
+        from news_dashboard.ai_client import (
+            chat_create,
+            free_llm_config,
+            get_chat_client,
+            get_prompt,
+        )
 
         api_key, base_url = free_llm_config()
         if not api_key:
@@ -48,21 +53,30 @@ def generate_lesson_recap_narrative(recap: dict[str, Any]) -> str:
 
         metrics = {k: v for k, v in recap.items() if k != "generated_at"}
 
-        prompt = (
-            "Write a weekly learning review in the voice of 'here's what you "
-            "learned this week', addressed directly to the reader (second "
-            "person). Write exactly 2 short paragraphs, roughly 60-120 words "
-            "total. Ground everything strictly in the metrics below — do not "
-            "invent lessons, concepts, or numbers that are not present in the "
-            "data. Mention repeated themes and unfinished lessons when present.\n\n"
-            f"Recap metrics (JSON):\n{json.dumps(metrics, default=str)}\n\n"
-            "Reply with only the narrative text, as plain paragraphs separated "
-            "by a blank line."
+        recap_json = json.dumps(metrics, default=str)
+        prompt = get_prompt(
+            "weekly-lesson-recap-narrative",
+            fallback=(
+                "Write a weekly learning review in the voice of 'here's what you "
+                "learned this week', addressed directly to the reader (second "
+                "person). Write exactly 2 short paragraphs, roughly 60-120 words "
+                "total. Ground everything strictly in the metrics below — do not "
+                "invent lessons, concepts, or numbers that are not present in the "
+                "data. Mention repeated themes and unfinished lessons when present.\n\n"
+                "Recap metrics (JSON):\n{{recap_json}}\n\n"
+                "Reply with only the narrative text, as plain paragraphs separated "
+                "by a blank line."
+            ),
+            variables={"recap_json": recap_json},
         )
 
-        response = client.chat.completions.create(
+        response = chat_create(
+            client,
+            name="weekly-lesson-recap-narrative",
+            tags=["lesson-recap"],
+            prompt=prompt,
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": prompt.text}],
             max_tokens=300,
             temperature=0.7,
         )

--- a/backend/news_dashboard/lesson_recaps/narrative.py
+++ b/backend/news_dashboard/lesson_recaps/narrative.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import Any
 
+from news_dashboard.prompt_catalog import get_text_prompt
+
 logger = logging.getLogger(__name__)
 
 
@@ -58,17 +60,7 @@ def generate_lesson_recap_narrative(recap: dict[str, Any]) -> str:
             "weekly-lesson-recap-narrative",
             label="production",
             prompt_type="text",
-            fallback=(
-                "Write a weekly learning review in the voice of 'here's what you "
-                "learned this week', addressed directly to the reader (second "
-                "person). Write exactly 2 short paragraphs, roughly 60-120 words "
-                "total. Ground everything strictly in the metrics below — do not "
-                "invent lessons, concepts, or numbers that are not present in the "
-                "data. Mention repeated themes and unfinished lessons when present.\n\n"
-                "Recap metrics (JSON):\n{{recap_json}}\n\n"
-                "Reply with only the narrative text, as plain paragraphs separated "
-                "by a blank line."
-            ),
+            fallback=get_text_prompt("weekly-lesson-recap-narrative"),
             variables={"recap_json": recap_json},
         )
 

--- a/backend/news_dashboard/lesson_recaps/narrative.py
+++ b/backend/news_dashboard/lesson_recaps/narrative.py
@@ -56,6 +56,8 @@ def generate_lesson_recap_narrative(recap: dict[str, Any]) -> str:
         recap_json = json.dumps(metrics, default=str)
         prompt = get_prompt(
             "weekly-lesson-recap-narrative",
+            label="production",
+            prompt_type="text",
             fallback=(
                 "Write a weekly learning review in the voice of 'here's what you "
                 "learned this week', addressed directly to the reader (second "

--- a/backend/news_dashboard/prompt_catalog.py
+++ b/backend/news_dashboard/prompt_catalog.py
@@ -1,0 +1,258 @@
+"""Canonical local fallbacks for prompts managed in Langfuse."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+PromptType = Literal["text", "chat"]
+
+
+@dataclass(frozen=True, slots=True)
+class PromptMessage:
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class PromptCatalogEntry:
+    name: str
+    type: PromptType
+    prompt: str | tuple[PromptMessage, ...]
+    commit_message: str | None = None
+
+    def fallback(self) -> str | list[dict[str, str]]:
+        if isinstance(self.prompt, str):
+            return self.prompt
+        return [{"role": message.role, "content": message.content} for message in self.prompt]
+
+
+def _text(name: str, prompt: str, commit_message: str | None = None) -> PromptCatalogEntry:
+    return PromptCatalogEntry(name, "text", prompt, commit_message)
+
+
+def _chat(
+    name: str,
+    *messages: tuple[Literal["system", "user", "assistant"], str],
+    commit_message: str | None = None,
+) -> PromptCatalogEntry:
+    return PromptCatalogEntry(
+        name,
+        "chat",
+        tuple(PromptMessage(role, content) for role, content in messages),
+        commit_message,
+    )
+
+
+PROMPT_CATALOG: tuple[PromptCatalogEntry, ...] = (
+    _text(
+        "ai-body-fetch",
+        "Extract the main article text from this HTML. Return only the article body as plain "
+        "text, no HTML tags.\n\n{{html}}",
+    ),
+    _chat(
+        "translate-body",
+        (
+            "system",
+            "You are a translation assistant. Translate the following body text from language "
+            "code '{{from_lang}}' to English. Return only the translated plain text, preserving "
+            "paragraph breaks, and no additional commentary.",
+        ),
+        ("user", "{{body}}"),
+    ),
+    _chat(
+        "summarize-media-article",
+        (
+            "system",
+            "Summarize this podcast or video transcript as a concise readable article summary "
+            "for a news reader.",
+        ),
+        ("user", "Title: {{title}}\nDescription: {{description}}\nTranscript:\n{{transcript}}"),
+    ),
+    _chat(
+        "translate-article",
+        (
+            "system",
+            "You are a translation assistant. Detect the language of the following text. If it "
+            "is not English, translate both the title and the summary/description to English. "
+            "Return a JSON object with the following keys:\n"
+            '- "detected_lang": the 2-letter ISO 639-1 language code (e.g. "ja", "zh", "ru", '
+            '"fr", "de", "en")\n- "translated_title": the translated title in English\n'
+            '- "translated_summary": the translated summary/description in English\n'
+            '- "needs_translation": boolean indicating if it was translated\n',
+        ),
+        ("user", "Title: {{title}}\nSummary: {{summary}}"),
+    ),
+    _text(
+        "topic-cluster-label",
+        "You are analyzing a group of related news articles that cover the same story or topic "
+        "arc. Based ONLY on the article titles and summaries provided below, generate:\n1. A "
+        "concise Story Headline (max 8 words) capturing the central theme.\n2. A one-sentence "
+        "Trend Summary explaining the story arc or why these articles are connected.\n\nRespond "
+        "in this exact format:\nHEADLINE: <headline here>\nSUMMARY: <one-sentence summary "
+        "here>\n\nArticles:\n{{articles_text}}",
+    ),
+    _text(
+        "briefing-push-hook",
+        "Write a single punchy mobile push notification hook (max 15 words) that entices the "
+        "user to open their news briefing. Top headlines:\n{{headline_block}}\n\nReply with only "
+        "the hook text, no quotes or punctuation at the end.",
+    ),
+    _text(
+        "recap-push-hook",
+        "Write a single encouraging mobile push notification hook (max 20 words) summarizing "
+        "this user's weekly reading recap. Articles read: {{articles_read}}. Top category: "
+        "{{top_category}}. Current streak: {{current_streak_days}} day(s).\n\nReply with only the "
+        "hook text, no quotes or punctuation at the end.",
+    ),
+    _text(
+        "recommendation-explanation",
+        "You are a personalized news assistant. Explain in one short sentence (under 20 words) "
+        "why this article matches the user's reading interests.\n\nArticle: "
+        '"{{article_title}}"\nSource: {{article_source}}\nCategory: {{article_category}}\nTags: '
+        "{{article_tags}}\n\nUser's recent reading history:\n{{history_text}}\n\nReply with just "
+        "the explanation sentence, no preamble.",
+    ),
+    _text(
+        "weekly-lesson-recap-narrative",
+        "Write a weekly learning review in the voice of 'here's what you learned this week', "
+        "addressed directly to the reader (second person). Write exactly 2 short paragraphs, "
+        "roughly 60-120 words total. Ground everything strictly in the metrics below — do not "
+        "invent lessons, concepts, or numbers that are not present in the data. Mention repeated "
+        "themes and unfinished lessons when present.\n\nRecap metrics (JSON):\n{{recap_json}}\n\n"
+        "Reply with only the narrative text, as plain paragraphs separated by a blank line.",
+    ),
+    _text(
+        "weekly-quiz",
+        "You are a study-aid assistant. Based ONLY on the articles listed below, generate exactly "
+        "3 multiple-choice questions that test the reader's understanding of key facts or "
+        "arguments. For each question provide:\n- question: the question text\n- options: a JSON "
+        "array of exactly 4 answer strings\n- correct_index: 0-based index of the correct answer\n"
+        "- explanation: one sentence explaining why that answer is correct, citing the article\n"
+        "- article_id: the integer id of the article the question is drawn from\n\nReturn ONLY a "
+        "JSON array of 3 objects with those exact keys. No other text.\n\nArticles:\n"
+        "{{article_blurbs}}",
+    ),
+    _text(
+        "share-context",
+        'Article: "{{article_title}}"\nSummary: {{article_summary}}\n\nSender\'s note: '
+        "{{sender_note}}\nHighlighted sections:\n{{annotation_text}}\n\nRecipient's main reading "
+        "interests: {{recipient_interests}}\n\nWrite exactly 2 sentences explaining why the sender "
+        "highlighted these specific sections and why they are directly relevant to the "
+        "recipient's interests. Be specific and personal, not generic.",
+    ),
+    _text(
+        "reading-list-summary",
+        "You are helping a reader triage their reading list. Based ONLY on the title and "
+        "description below, write one concise sentence (max 40 words) describing what this item "
+        "is about, so the reader can decide whether to open it without reading further. Do not "
+        "invent details that are not present in the text. Return only the sentence.\n\n"
+        "{{reading_list_text}}",
+    ),
+    _text(
+        "weekly-recap-narrative",
+        "Write a weekly reading review in the voice of 'here's your week in reading', addressed "
+        "directly to the reader (second person). Write exactly 2 short paragraphs, roughly 60-120 "
+        "words total. Ground everything strictly in the metrics below — do not invent facts, "
+        "activity, or numbers that are not present in the data. If 'saved' or 'dwell' data is "
+        "present, mention their reading backlog and skim-vs-read balance.\n\n"
+        "Recap metrics (JSON):\n"
+        "{{recap_json}}\n\nReply with only the narrative text, as plain paragraphs separated by a "
+        "blank line.",
+    ),
+    _chat(
+        "podcast-script-generation",
+        (
+            "system",
+            "You are a podcast script writer. Given a news briefing containing a title, summary, "
+            "and several sections, rewrite the content into a natural, conversational dialogue "
+            "script between two co-hosts, Alex and Taylor. Alex is a friendly and curious host, "
+            "and Taylor is an insightful co-host. They alternate talking, explaining the news in "
+            "an engaging and lively way.\nProduce a JSON object with a single key 'script' "
+            "containing a list of dialogue turns. Each turn MUST be an object with these exact "
+            "keys:\n  speaker — either 'Alex' or 'Taylor'\n  voice   — 'onyx' for Alex, 'nova' for "
+            "Taylor\n  text    — the spoken text for this turn\nEnsure they talk about all the "
+            "main "
+            "topics in the sections. Return valid JSON only, no markdown wrapper.",
+        ),
+        ("user", "Please generate a podcast script for the following news:\n\n{{content}}"),
+    ),
+    _chat(
+        "lesson-slide-deck",
+        (
+            "system",
+            "You are the Lesson Slide Deck Generator. Produce a short teaching slide deck "
+            "summarizing the lesson below as a shareable learning artifact. Return JSON with a "
+            '"slides" array of 6 to 10 slides, each with a "title" and 1-6 "bullets". Ground '
+            "every slide in the supplied lesson detail; do not invent facts.\n",
+        ),
+        ("user", "{{lesson_content}}"),
+    ),
+    _chat(
+        "lesson-infographic",
+        (
+            "system",
+            "You are the Lesson Infographic Generator. Produce a deterministic, text-first "
+            "infographic artifact from the lesson below. Return JSON with title, subtitle, "
+            "sections, and footer fields. Each section needs a heading and body. Ground the "
+            "artifact only in the supplied lesson detail; do not invent facts, image URLs, or "
+            "external assets.\n",
+        ),
+        ("user", "{{lesson_content}}"),
+    ),
+    _chat(
+        "lesson-relevance",
+        (
+            "system",
+            "Explain why a lesson is relevant using only the user's provided reading profile. "
+            "Return JSON with non-empty explanation and a signals array.",
+        ),
+        ("user", "{{lesson_context}}\n{{profile_context}}"),
+    ),
+    _chat(
+        "lesson-chat",
+        (
+            "system",
+            "You are the Lesson Follow-up Assistant. Answer follow-up questions about the lesson "
+            "below, grounded in the lesson detail and source article content supplied. If "
+            "information is not present in the provided context, say so clearly rather than "
+            "guessing.\n\n--- LESSON ---\n{{lesson_context}}\n\n--- SOURCE ARTICLE ---\n"
+            "{{source_context}}\n",
+        ),
+        ("user", "{{question}}"),
+    ),
+    _chat(
+        "briefing-chat",
+        (
+            "system",
+            "You are the Briefing Q&A Assistant. Your job is to answer follow-up questions about "
+            "the daily briefing provided below. Ground every answer in the briefing summary and "
+            "the full article texts supplied. If information is not present in the provided "
+            "context, say so clearly rather than guessing.\n\n--- BRIEFING ---\n"
+            "{{briefing_context}}\n\n"
+            "--- CITED ARTICLES ---\n{{articles_context}}\n",
+        ),
+        ("user", "{{question}}"),
+    ),
+)
+
+_PROMPTS_BY_NAME = {entry.name: entry for entry in PROMPT_CATALOG}
+
+
+def get_catalog_prompt(name: str) -> PromptCatalogEntry:
+    """Return a catalog entry by its stable Langfuse name."""
+    return _PROMPTS_BY_NAME[name]
+
+
+def get_text_prompt(name: str) -> str:
+    entry = get_catalog_prompt(name)
+    if not isinstance(entry.prompt, str):
+        raise TypeError(name)
+    return entry.prompt
+
+
+def get_chat_prompt(name: str) -> list[dict[str, str]]:
+    entry = get_catalog_prompt(name)
+    if isinstance(entry.prompt, str):
+        raise TypeError(name)
+    return [{"role": message.role, "content": message.content} for message in entry.prompt]

--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -113,6 +113,8 @@ def generate_push_hook(briefing: dict[str, Any]) -> str:
 
         prompt = get_prompt(
             "briefing-push-hook",
+            label="production",
+            prompt_type="text",
             fallback=(
                 "Write a single punchy mobile push notification hook (max 15 words) "
                 "that entices the user to open their news briefing. "
@@ -185,6 +187,8 @@ def generate_recap_push_hook(recap: dict[str, Any]) -> str:
         }
         prompt = get_prompt(
             "recap-push-hook",
+            label="production",
+            prompt_type="text",
             fallback=(
                 "Write a single encouraging mobile push notification hook (max 20 words) "
                 "summarizing this user's weekly reading recap. "

--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -10,6 +10,8 @@ import re
 from typing import Any, Literal
 from urllib.parse import urlparse
 
+from news_dashboard.prompt_catalog import get_text_prompt
+
 logger = logging.getLogger(__name__)
 
 # Maximum lengths for push subscription fields
@@ -115,12 +117,7 @@ def generate_push_hook(briefing: dict[str, Any]) -> str:
             "briefing-push-hook",
             label="production",
             prompt_type="text",
-            fallback=(
-                "Write a single punchy mobile push notification hook (max 15 words) "
-                "that entices the user to open their news briefing. "
-                "Top headlines:\n{{headline_block}}\n\n"
-                "Reply with only the hook text, no quotes or punctuation at the end."
-            ),
+            fallback=get_text_prompt("briefing-push-hook"),
             variables={"headline_block": headline_block},
         )
 
@@ -189,13 +186,7 @@ def generate_recap_push_hook(recap: dict[str, Any]) -> str:
             "recap-push-hook",
             label="production",
             prompt_type="text",
-            fallback=(
-                "Write a single encouraging mobile push notification hook (max 20 words) "
-                "summarizing this user's weekly reading recap. "
-                "Articles read: {{articles_read}}. Top category: {{top_category}}. "
-                "Current streak: {{current_streak_days}} day(s).\n\n"
-                "Reply with only the hook text, no quotes or punctuation at the end."
-            ),
+            fallback=get_text_prompt("recap-push-hook"),
             variables=variables,
         )
 

--- a/backend/news_dashboard/push.py
+++ b/backend/news_dashboard/push.py
@@ -92,7 +92,12 @@ def generate_push_hook(briefing: dict[str, Any]) -> str:
     fallback = f"Your daily brief: {title}" if title else _DEFAULT_PUSH_TITLE
 
     try:
-        from news_dashboard.ai_client import free_llm_config, get_chat_client
+        from news_dashboard.ai_client import (
+            chat_create,
+            free_llm_config,
+            get_chat_client,
+            get_prompt,
+        )
 
         api_key, base_url = free_llm_config()
         if not api_key:
@@ -106,16 +111,24 @@ def generate_push_hook(briefing: dict[str, Any]) -> str:
         else:
             headline_block = f"- {title}" if title else "(no headlines)"
 
-        prompt = (
-            "Write a single punchy mobile push notification hook (max 15 words) "
-            "that entices the user to open their news briefing. "
-            f"Top headlines:\n{headline_block}\n\n"
-            "Reply with only the hook text, no quotes or punctuation at the end."
+        prompt = get_prompt(
+            "briefing-push-hook",
+            fallback=(
+                "Write a single punchy mobile push notification hook (max 15 words) "
+                "that entices the user to open their news briefing. "
+                "Top headlines:\n{{headline_block}}\n\n"
+                "Reply with only the hook text, no quotes or punctuation at the end."
+            ),
+            variables={"headline_block": headline_block},
         )
 
-        response = client.chat.completions.create(
+        response = chat_create(
+            client,
+            name="briefing-push-hook",
+            tags=["push", "briefing"],
+            prompt=prompt,
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": prompt.text}],
             max_tokens=40,
             temperature=0.7,
         )
@@ -151,7 +164,12 @@ def generate_recap_push_hook(recap: dict[str, Any]) -> str:
         fallback = f"You read {articles_read} articles this week."
 
     try:
-        from news_dashboard.ai_client import free_llm_config, get_chat_client
+        from news_dashboard.ai_client import (
+            chat_create,
+            free_llm_config,
+            get_chat_client,
+            get_prompt,
+        )
 
         api_key, base_url = free_llm_config()
         if not api_key:
@@ -160,18 +178,30 @@ def generate_recap_push_hook(recap: dict[str, Any]) -> str:
         client = get_chat_client(api_key=api_key, base_url=base_url)
         model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
 
-        prompt = (
-            "Write a single encouraging mobile push notification hook (max 20 words) "
-            "summarizing this user's weekly reading recap. "
-            f"Articles read: {articles_read}. "
-            f"Top category: {top_category or 'n/a'}. "
-            f"Current streak: {recap.get('current_streak_days', 0)} day(s).\n\n"
-            "Reply with only the hook text, no quotes or punctuation at the end."
+        variables = {
+            "articles_read": articles_read,
+            "top_category": top_category or "n/a",
+            "current_streak_days": recap.get("current_streak_days", 0),
+        }
+        prompt = get_prompt(
+            "recap-push-hook",
+            fallback=(
+                "Write a single encouraging mobile push notification hook (max 20 words) "
+                "summarizing this user's weekly reading recap. "
+                "Articles read: {{articles_read}}. Top category: {{top_category}}. "
+                "Current streak: {{current_streak_days}} day(s).\n\n"
+                "Reply with only the hook text, no quotes or punctuation at the end."
+            ),
+            variables=variables,
         )
 
-        response = client.chat.completions.create(
+        response = chat_create(
+            client,
+            name="recap-push-hook",
+            tags=["push", "recap"],
+            prompt=prompt,
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": prompt.text}],
             max_tokens=40,
             temperature=0.7,
         )

--- a/backend/news_dashboard/quizzes/service.py
+++ b/backend/news_dashboard/quizzes/service.py
@@ -297,6 +297,8 @@ def generate_weekly_quiz(
     client = get_chat_client(api_key=api_key, base_url=base_url)
     prompt = get_prompt(
         "weekly-quiz",
+        label="production",
+        prompt_type="text",
         fallback=f"{_QUIZ_PROMPT}\n\nArticles:\n{{{{article_blurbs}}}}",
         variables={"article_blurbs": blurbs},
     )

--- a/backend/news_dashboard/quizzes/service.py
+++ b/backend/news_dashboard/quizzes/service.py
@@ -292,19 +292,23 @@ def generate_weekly_quiz(
 
     api_key, base_url, model = _quiz_ai_config()
     blurbs = "\n\n---\n\n".join(_build_article_blurb(a) for a in articles)
-    messages = [{"role": "user", "content": f"{_QUIZ_PROMPT}\n\nArticles:\n{blurbs}"}]
-
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
+    prompt = get_prompt(
+        "weekly-quiz",
+        fallback=f"{_QUIZ_PROMPT}\n\nArticles:\n{{{{article_blurbs}}}}",
+        variables={"article_blurbs": blurbs},
+    )
     logger.info("Generating weekly quiz for user %s from %d articles", user_id, len(articles))
     result = chat_create(
         client,
         name="weekly-quiz",
         tags=["quiz"],
         user_id=user_id,
+        prompt=prompt,
         model=model,
-        messages=messages,
+        messages=[{"role": "user", "content": prompt.text}],
         max_tokens=1024,
     )
     response_text = (result.choices[0].message.content or "").strip()

--- a/backend/news_dashboard/quizzes/service.py
+++ b/backend/news_dashboard/quizzes/service.py
@@ -15,23 +15,14 @@ from pathlib import Path
 from typing import Any
 
 from news_dashboard.db import connect, init_db
+from news_dashboard.prompt_catalog import get_text_prompt
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_QUIZ_MODEL = "gpt-4o-mini"
 GOAL_ALIGNMENT_ADJUSTMENT = 4.0  # points added to recommendation score per matching goal
 _MAX_ARTICLE_CHARS = 3_000
-_QUIZ_PROMPT = (
-    "You are a study-aid assistant. Based ONLY on the articles listed below, generate exactly 3 "
-    "multiple-choice questions that test the reader's understanding of key facts or arguments. "
-    "For each question provide:\n"
-    "- question: the question text\n"
-    "- options: a JSON array of exactly 4 answer strings\n"
-    "- correct_index: 0-based index of the correct answer\n"
-    "- explanation: one sentence explaining why that answer is correct, citing the article\n"
-    "- article_id: the integer id of the article the question is drawn from\n\n"
-    "Return ONLY a JSON array of 3 objects with those exact keys. No other text."
-)
+_QUIZ_PROMPT = get_text_prompt("weekly-quiz").removesuffix("\n\nArticles:\n{{article_blurbs}}")
 
 
 # ── Goal CRUD helpers ─────────────────────────────────────────────────────────
@@ -299,7 +290,7 @@ def generate_weekly_quiz(
         "weekly-quiz",
         label="production",
         prompt_type="text",
-        fallback=f"{_QUIZ_PROMPT}\n\nArticles:\n{{{{article_blurbs}}}}",
+        fallback=get_text_prompt("weekly-quiz"),
         variables={"article_blurbs": blurbs},
     )
     logger.info("Generating weekly quiz for user %s from %d articles", user_id, len(articles))

--- a/backend/news_dashboard/reading_list/service.py
+++ b/backend/news_dashboard/reading_list/service.py
@@ -265,15 +265,21 @@ def _summary_ai_config() -> tuple[str, str | None, str]:
 
 
 def _call_summary_model(api_key: str, base_url: str | None, model: str, text: str) -> str:
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
+    prompt = get_prompt(
+        "reading-list-summary",
+        fallback=f"{_SUMMARY_PROMPT}\n\n{{{{reading_list_text}}}}",
+        variables={"reading_list_text": text},
+    )
     result = chat_create(
         client,
         name="reading-list-summary",
         tags=["reading-list"],
+        prompt=prompt,
         model=model,
-        messages=[{"role": "user", "content": f"{_SUMMARY_PROMPT}\n\n{text}"}],
+        messages=[{"role": "user", "content": prompt.text}],
         max_tokens=120,
     )
     summary = (result.choices[0].message.content or "").strip()

--- a/backend/news_dashboard/reading_list/service.py
+++ b/backend/news_dashboard/reading_list/service.py
@@ -8,6 +8,7 @@ from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from news_dashboard.db import connect, init_db
+from news_dashboard.prompt_catalog import get_text_prompt
 from news_dashboard.reading_list.importers import ImportedItem
 from news_dashboard.reading_list.metadata import detect_kind, fetch_url_metadata
 
@@ -17,12 +18,7 @@ _TRACKING_PARAM_PREFIXES = ("utm_",)
 _TRACKING_PARAMS = {"fbclid", "gclid", "mc_cid", "mc_eid"}
 
 DEFAULT_SUMMARY_MODEL = "gpt-4o-mini"
-_SUMMARY_PROMPT = (
-    "You are helping a reader triage their reading list. Based ONLY on the title and "
-    "description below, write one concise sentence (max 40 words) describing what this "
-    "item is about, so the reader can decide whether to open it without reading further. "
-    "Do not invent details that are not present in the text. Return only the sentence."
-)
+_SUMMARY_PROMPT = get_text_prompt("reading-list-summary").removesuffix("\n\n{{reading_list_text}}")
 
 
 class ReadingListSummaryNotConfiguredError(Exception):
@@ -272,7 +268,7 @@ def _call_summary_model(api_key: str, base_url: str | None, model: str, text: st
         "reading-list-summary",
         label="production",
         prompt_type="text",
-        fallback=f"{_SUMMARY_PROMPT}\n\n{{{{reading_list_text}}}}",
+        fallback=get_text_prompt("reading-list-summary"),
         variables={"reading_list_text": text},
     )
     result = chat_create(

--- a/backend/news_dashboard/reading_list/service.py
+++ b/backend/news_dashboard/reading_list/service.py
@@ -270,6 +270,8 @@ def _call_summary_model(api_key: str, base_url: str | None, model: str, text: st
     client = get_chat_client(api_key=api_key, base_url=base_url)
     prompt = get_prompt(
         "reading-list-summary",
+        label="production",
+        prompt_type="text",
         fallback=f"{_SUMMARY_PROMPT}\n\n{{{{reading_list_text}}}}",
         variables={"reading_list_text": text},
     )

--- a/backend/news_dashboard/recaps/narrative.py
+++ b/backend/news_dashboard/recaps/narrative.py
@@ -57,6 +57,8 @@ def generate_recap_narrative(recap: dict[str, Any]) -> str:
         recap_json = json.dumps(metrics, default=str)
         prompt = get_prompt(
             "weekly-recap-narrative",
+            label="production",
+            prompt_type="text",
             fallback=(
                 "Write a weekly reading review in the voice of 'here's your week in "
                 "reading', addressed directly to the reader (second person). "

--- a/backend/news_dashboard/recaps/narrative.py
+++ b/backend/news_dashboard/recaps/narrative.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import Any
 
+from news_dashboard.prompt_catalog import get_text_prompt
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,18 +61,7 @@ def generate_recap_narrative(recap: dict[str, Any]) -> str:
             "weekly-recap-narrative",
             label="production",
             prompt_type="text",
-            fallback=(
-                "Write a weekly reading review in the voice of 'here's your week in "
-                "reading', addressed directly to the reader (second person). "
-                "Write exactly 2 short paragraphs, roughly 60-120 words total. "
-                "Ground everything strictly in the metrics below — do not invent "
-                "facts, activity, or numbers that are not present in the data. "
-                "If 'saved' or 'dwell' data is present, mention their reading "
-                "backlog and skim-vs-read balance.\n\n"
-                "Recap metrics (JSON):\n{{recap_json}}\n\n"
-                "Reply with only the narrative text, as plain paragraphs separated "
-                "by a blank line."
-            ),
+            fallback=get_text_prompt("weekly-recap-narrative"),
             variables={"recap_json": recap_json},
         )
 

--- a/backend/news_dashboard/recaps/narrative.py
+++ b/backend/news_dashboard/recaps/narrative.py
@@ -38,7 +38,12 @@ def generate_recap_narrative(recap: dict[str, Any]) -> str:
     fallback = _fallback_narrative(recap)
 
     try:
-        from news_dashboard.ai_client import free_llm_config, get_chat_client
+        from news_dashboard.ai_client import (
+            chat_create,
+            free_llm_config,
+            get_chat_client,
+            get_prompt,
+        )
 
         api_key, base_url = free_llm_config()
         if not api_key:
@@ -49,22 +54,31 @@ def generate_recap_narrative(recap: dict[str, Any]) -> str:
 
         metrics = {k: v for k, v in recap.items() if k != "generated_at"}
 
-        prompt = (
-            "Write a weekly reading review in the voice of 'here's your week in "
-            "reading', addressed directly to the reader (second person). "
-            "Write exactly 2 short paragraphs, roughly 60-120 words total. "
-            "Ground everything strictly in the metrics below — do not invent "
-            "facts, activity, or numbers that are not present in the data. "
-            "If 'saved' or 'dwell' data is present, mention their reading "
-            "backlog and skim-vs-read balance.\n\n"
-            f"Recap metrics (JSON):\n{json.dumps(metrics, default=str)}\n\n"
-            "Reply with only the narrative text, as plain paragraphs separated "
-            "by a blank line."
+        recap_json = json.dumps(metrics, default=str)
+        prompt = get_prompt(
+            "weekly-recap-narrative",
+            fallback=(
+                "Write a weekly reading review in the voice of 'here's your week in "
+                "reading', addressed directly to the reader (second person). "
+                "Write exactly 2 short paragraphs, roughly 60-120 words total. "
+                "Ground everything strictly in the metrics below — do not invent "
+                "facts, activity, or numbers that are not present in the data. "
+                "If 'saved' or 'dwell' data is present, mention their reading "
+                "backlog and skim-vs-read balance.\n\n"
+                "Recap metrics (JSON):\n{{recap_json}}\n\n"
+                "Reply with only the narrative text, as plain paragraphs separated "
+                "by a blank line."
+            ),
+            variables={"recap_json": recap_json},
         )
 
-        response = client.chat.completions.create(
+        response = chat_create(
+            client,
+            name="weekly-recap-narrative",
+            tags=["recap"],
+            prompt=prompt,
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": prompt.text}],
             max_tokens=300,
             temperature=0.7,
         )

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -438,6 +438,8 @@ def generate_recommendation_explanation(
     }
     prompt = get_prompt(
         "recommendation-explanation",
+        label="production",
+        prompt_type="text",
         fallback=(
             "You are a personalized news assistant. Explain in one short sentence "
             "(under 20 words) why this article matches the user's reading interests.\n\n"

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -383,7 +383,7 @@ def generate_recommendation_explanation(
     """
     import os
 
-    from news_dashboard.ai_client import chat_create, free_llm_config, get_chat_client
+    from news_dashboard.ai_client import chat_create, free_llm_config, get_chat_client, get_prompt
 
     api_key, base_url = free_llm_config()
     if not api_key:
@@ -429,15 +429,24 @@ def generate_recommendation_explanation(
         history_text = "\n".join(lines)
 
     tags = article.get("tags") or ""
-    prompt = (
-        f"You are a personalized news assistant. Explain in one short sentence (under 20 words) "
-        f"why this article matches the user's reading interests.\n\n"
-        f'Article: "{article.get("title", "")}"\n'
-        f"Source: {article.get('source_name', '')}\n"
-        f"Category: {article.get('category', '')}\n"
-        f"Tags: {tags}\n\n"
-        f"User's recent reading history:\n{history_text}\n\n"
-        f"Reply with just the explanation sentence, no preamble."
+    variables = {
+        "article_title": article.get("title", ""),
+        "article_source": article.get("source_name", ""),
+        "article_category": article.get("category", ""),
+        "article_tags": tags,
+        "history_text": history_text,
+    }
+    prompt = get_prompt(
+        "recommendation-explanation",
+        fallback=(
+            "You are a personalized news assistant. Explain in one short sentence "
+            "(under 20 words) why this article matches the user's reading interests.\n\n"
+            'Article: "{{article_title}}"\nSource: {{article_source}}\n'
+            "Category: {{article_category}}\nTags: {{article_tags}}\n\n"
+            "User's recent reading history:\n{{history_text}}\n\n"
+            "Reply with just the explanation sentence, no preamble."
+        ),
+        variables=variables,
     )
 
     try:
@@ -447,8 +456,9 @@ def generate_recommendation_explanation(
             name="recommendation-explanation",
             tags=["recommendation", "explanation"],
             user_id=user_id,
+            prompt=prompt,
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": prompt.text}],
             max_tokens=60,
             temperature=0.3,
         )

--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from news_dashboard.db import connect, init_db, row_to_dict
+from news_dashboard.prompt_catalog import get_text_prompt
 
 COLD_START_MODEL_VERSION = "cold-start-v1"
 BEHAVIORAL_MODEL_VERSION = "behavioral-affinity-v1"
@@ -440,14 +441,7 @@ def generate_recommendation_explanation(
         "recommendation-explanation",
         label="production",
         prompt_type="text",
-        fallback=(
-            "You are a personalized news assistant. Explain in one short sentence "
-            "(under 20 words) why this article matches the user's reading interests.\n\n"
-            'Article: "{{article_title}}"\nSource: {{article_source}}\n'
-            "Category: {{article_category}}\nTags: {{article_tags}}\n\n"
-            "User's recent reading history:\n{{history_text}}\n\n"
-            "Reply with just the explanation sentence, no preamble."
-        ),
+        fallback=get_text_prompt("recommendation-explanation"),
         variables=variables,
     )
 

--- a/backend/news_dashboard/shares/service.py
+++ b/backend/news_dashboard/shares/service.py
@@ -16,6 +16,7 @@ from typing import Any
 from news_dashboard.article_visibility import get_visible_article_row
 from news_dashboard.body_fetch import fetch_and_cache_body
 from news_dashboard.db import connect, row_to_dict
+from news_dashboard.prompt_catalog import get_text_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -389,21 +390,12 @@ def generate_share_context(share_id: int) -> str | None:
         "annotation_text": annotation_text,
         "recipient_interests": recipient_interests,
     }
-    fallback = (
-        'Article: "{{article_title}}"\nSummary: {{article_summary}}\n\n'
-        "Sender's note: {{sender_note}}\nHighlighted sections:\n{{annotation_text}}\n\n"
-        "Recipient's main reading interests: {{recipient_interests}}\n\n"
-        "Write exactly 2 sentences explaining why the sender highlighted these specific "
-        "sections and why they are directly relevant to the recipient's interests. "
-        "Be specific and personal, not generic."
-    )
-
     from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
     prompt = get_prompt(
         "share-context",
-        fallback=fallback,
+        fallback=get_text_prompt("share-context"),
         label="production",
         prompt_type="text",
         variables=variables,

--- a/backend/news_dashboard/shares/service.py
+++ b/backend/news_dashboard/shares/service.py
@@ -401,7 +401,13 @@ def generate_share_context(share_id: int) -> str | None:
     from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
-    prompt = get_prompt("share-context", fallback=fallback, variables=variables)
+    prompt = get_prompt(
+        "share-context",
+        fallback=fallback,
+        label="production",
+        prompt_type="text",
+        variables=variables,
+    )
     try:
         completion = chat_create(
             client,

--- a/backend/news_dashboard/shares/service.py
+++ b/backend/news_dashboard/shares/service.py
@@ -382,27 +382,34 @@ def generate_share_context(share_id: int) -> str | None:
     article_summary = (share_data.get("summary") or share_data.get("body") or "")[:800]
     recipient_interests = ", ".join(top_categories) if top_categories else "general news"
 
-    prompt = (
-        f'Article: "{article_title}"\n'
-        f"Summary: {article_summary}\n\n"
-        f"Sender's note: {sender_note or '(none)'}\n"
-        f"Highlighted sections:\n{annotation_text}\n\n"
-        f"Recipient's main reading interests: {recipient_interests}\n\n"
+    variables = {
+        "article_title": article_title,
+        "article_summary": article_summary,
+        "sender_note": sender_note or "(none)",
+        "annotation_text": annotation_text,
+        "recipient_interests": recipient_interests,
+    }
+    fallback = (
+        'Article: "{{article_title}}"\nSummary: {{article_summary}}\n\n'
+        "Sender's note: {{sender_note}}\nHighlighted sections:\n{{annotation_text}}\n\n"
+        "Recipient's main reading interests: {{recipient_interests}}\n\n"
         "Write exactly 2 sentences explaining why the sender highlighted these specific "
         "sections and why they are directly relevant to the recipient's interests. "
         "Be specific and personal, not generic."
     )
 
-    from news_dashboard.ai_client import chat_create, get_chat_client
+    from news_dashboard.ai_client import chat_create, get_chat_client, get_prompt
 
     client = get_chat_client(api_key=api_key, base_url=base_url)
+    prompt = get_prompt("share-context", fallback=fallback, variables=variables)
     try:
         completion = chat_create(
             client,
             name="share-context",
             tags=["shares"],
+            prompt=prompt,
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": prompt.text}],
             max_tokens=120,
             temperature=0.7,
         )

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -13,6 +13,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from news_dashboard.prompt_catalog import get_chat_prompt
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_DATA_DIR = Path("/data")
@@ -255,20 +257,7 @@ def generate_lesson_podcast_audio(
     return path
 
 
-_PODCAST_SYSTEM_PROMPT = (
-    "You are a podcast script writer. Given a news briefing containing a title, summary, "
-    "and several sections, rewrite the content into a natural, conversational dialogue script "
-    "between two co-hosts, Alex and Taylor. Alex is a friendly and curious host, and "
-    "Taylor is an insightful co-host. They alternate talking, explaining the news "
-    "in an engaging and lively way.\n"
-    "Produce a JSON object with a single key 'script' containing a list of dialogue turns. "
-    "Each turn MUST be an object with these exact keys:\n"
-    "  speaker — either 'Alex' or 'Taylor'\n"
-    "  voice   — 'onyx' for Alex, 'nova' for Taylor\n"
-    "  text    — the spoken text for this turn\n"
-    "Ensure they talk about all the main topics in the sections. "
-    "Return valid JSON only, no markdown wrapper."
-)
+_PODCAST_SYSTEM_PROMPT = get_chat_prompt("podcast-script-generation")[0]["content"]
 
 
 def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, str]]:
@@ -295,15 +284,7 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
 
     prompt = get_prompt(
         "podcast-script-generation",
-        fallback=[
-            {"role": "system", "content": _PODCAST_SYSTEM_PROMPT},
-            {
-                "role": "user",
-                "content": (
-                    "Please generate a podcast script for the following news:\n\n{{content}}"
-                ),
-            },
-        ],
+        fallback=get_chat_prompt("podcast-script-generation"),
         prompt_type="chat",
         variables={"content": content_str},
     )

--- a/backend/news_dashboard/tts.py
+++ b/backend/news_dashboard/tts.py
@@ -275,7 +275,12 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
     """Generate a conversational podcast script from briefing content using LLM."""
     api_key, base_url = _script_ai_config()
 
-    from news_dashboard.ai_client import chat_create, get_chat_client, strip_markdown_fence
+    from news_dashboard.ai_client import (
+        chat_create,
+        get_chat_client,
+        get_prompt,
+        strip_markdown_fence,
+    )
 
     model = os.getenv("OPENAI_BRIEFING_MODEL", "gpt-4o-mini")
     client = get_chat_client(api_key=api_key, base_url=base_url)
@@ -288,20 +293,28 @@ def generate_podcast_script(briefing_content: dict[str, Any]) -> list[dict[str, 
     for idx, sec in enumerate(sections):
         content_str += f"\nSegment {idx + 1}: {sec.get('title', '')}\n{sec.get('body', '')}\n"
 
-    messages = [
-        {"role": "system", "content": _PODCAST_SYSTEM_PROMPT},
-        {
-            "role": "user",
-            "content": f"Please generate a podcast script for the following news:\n\n{content_str}",
-        },
-    ]
+    prompt = get_prompt(
+        "podcast-script-generation",
+        fallback=[
+            {"role": "system", "content": _PODCAST_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    "Please generate a podcast script for the following news:\n\n{{content}}"
+                ),
+            },
+        ],
+        prompt_type="chat",
+        variables={"content": content_str},
+    )
 
     response = chat_create(
         client,
         name="podcast-script-generation",
         tags=["podcast"],
         model=model,
-        messages=messages,
+        messages=prompt.messages,
+        langfuse_prompt=prompt.langfuse_prompt,
         response_format={"type": "json_object"},
         max_tokens=2048,
     )

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -303,6 +303,35 @@ def test_get_chat_prompt_fetches_compiles_and_retains_sdk_prompt(
     assert prompt.langfuse_prompt is sdk_prompt
 
 
+def test_get_prompt_does_not_link_sdk_resolved_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    sdk_prompt = MagicMock()
+    sdk_prompt.is_fallback = True
+    sdk_prompt.compile.return_value = "Local Postgres"
+    client = MagicMock()
+    client.get_prompt.return_value = sdk_prompt
+
+    with patch("news_dashboard.ai_client._client", return_value=client):
+        prompt = get_prompt("managed", fallback="Local {{topic}}", variables={"topic": "Postgres"})
+
+    assert prompt.text == "Local Postgres"
+    assert prompt.langfuse_prompt is None
+
+    chat_create(
+        client,
+        name="resolved-fallback",
+        prompt=prompt,
+        model="model",
+        messages=[{"role": "user", "content": prompt.text}],
+    )
+    assert "langfuse_prompt" not in client.chat.completions.create.call_args.kwargs
+
+
 @pytest.mark.parametrize(
     ("prompt_type", "fallback", "expected_text", "expected_messages"),
     [
@@ -371,6 +400,27 @@ def test_get_prompt_warns_and_falls_back_for_invalid_compiled_chat(
     assert "using fallback" in caplog.text
 
 
+def test_get_prompt_warns_and_falls_back_for_invalid_compiled_text(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from unittest.mock import patch
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    sdk_prompt = MagicMock()
+    sdk_prompt.compile.return_value = [{"role": "system", "content": "wrong type"}]
+    client = MagicMock()
+    client.get_prompt.return_value = sdk_prompt
+
+    with patch("news_dashboard.ai_client._client", return_value=client):
+        prompt = get_prompt("managed", fallback="Local {{topic}}", variables={"topic": "copy"})
+
+    assert prompt.text == "Local copy"
+    assert prompt.langfuse_prompt is None
+    assert "using fallback" in caplog.text
+
+
 def test_chat_create_forwards_only_real_langfuse_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -407,7 +457,14 @@ def test_fetch_metrics_disabled_returns_enabled_false() -> None:
 
 def test_compile_fallback_substitutes_double_brace_vars() -> None:
     assert _compile_fallback("Hi {{name}}, {{name}}!", {"name": "Sam"}) == "Hi Sam, Sam!"
+    assert _compile_fallback("Hi {{ name }}!", {"name": None}) == "Hi !"
     assert _compile_fallback("no vars here", {}) == "no vars here"
+
+
+def test_compile_fallback_does_not_compile_placeholders_inside_values() -> None:
+    variables = {"first": "{{second}}", "second": "unexpected"}
+
+    assert _compile_fallback("{{first}} / {{missing}}", variables) == "{{second}} / {{missing}}"
 
 
 # ── get_chat_client runtime free-LLM→OpenAI fallback ───────────────────────

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -7,8 +7,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from news_dashboard.ai_client import (
+    ManagedPrompt,
     _compile_fallback,
     _normalise_host_env,
+    chat_create,
     create_score,
     flush,
     get_openai_client,
@@ -211,8 +213,189 @@ def test_get_prompt_uses_fallback_when_disabled() -> None:
         variables={"topic": "Postgres"},
     )
     assert prompt.text == "Answer about Postgres clearly."
+    assert prompt.messages is None
     # No Langfuse prompt object to link against in fallback mode.
     assert prompt.langfuse_prompt is None
+
+
+@pytest.mark.usefixtures("_no_langfuse")
+def test_get_chat_prompt_compiles_local_fallback_in_role_order() -> None:
+    prompt = get_prompt(
+        "ask-chat",
+        fallback=[
+            {"role": "system", "content": "Answer about {{topic}}."},
+            {"role": "user", "content": "Explain {{topic}} to {{audience}}."},
+        ],
+        prompt_type="chat",
+        variables={"topic": "Postgres", "audience": "beginners"},
+    )
+
+    assert prompt.text is None
+    assert prompt.messages == [
+        {"role": "system", "content": "Answer about Postgres."},
+        {"role": "user", "content": "Explain Postgres to beginners."},
+    ]
+    assert prompt.langfuse_prompt is None
+
+
+def test_get_text_prompt_fetches_compiles_and_retains_sdk_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    sdk_prompt = MagicMock()
+    sdk_prompt.is_fallback = False
+    sdk_prompt.compile.return_value = "Answer about Postgres."
+    client = MagicMock()
+    client.get_prompt.return_value = sdk_prompt
+
+    with patch("news_dashboard.ai_client._client", return_value=client):
+        prompt = get_prompt(
+            "ask-system",
+            fallback="Answer about {{topic}}.",
+            variables={"topic": "Postgres"},
+        )
+
+    client.get_prompt.assert_called_once_with(
+        "ask-system",
+        label="production",
+        type="text",
+        fallback="Answer about {{topic}}.",
+    )
+    sdk_prompt.compile.assert_called_once_with(topic="Postgres")
+    assert prompt.text == "Answer about Postgres."
+    assert prompt.messages is None
+    assert prompt.langfuse_prompt is sdk_prompt
+
+
+def test_get_chat_prompt_fetches_compiles_and_retains_sdk_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import patch
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    fallback = [{"role": "system", "content": "Answer about {{topic}}."}]
+    compiled = [{"role": "system", "content": "Answer about Postgres."}]
+    sdk_prompt = MagicMock()
+    sdk_prompt.is_fallback = False
+    sdk_prompt.compile.return_value = compiled
+    client = MagicMock()
+    client.get_prompt.return_value = sdk_prompt
+
+    with patch("news_dashboard.ai_client._client", return_value=client):
+        prompt = get_prompt(
+            "ask-chat",
+            fallback=fallback,
+            prompt_type="chat",
+            label="staging",
+            variables={"topic": "Postgres"},
+        )
+
+    client.get_prompt.assert_called_once_with(
+        "ask-chat", label="staging", type="chat", fallback=fallback
+    )
+    sdk_prompt.compile.assert_called_once_with(topic="Postgres")
+    assert prompt.text is None
+    assert prompt.messages == compiled
+    assert prompt.langfuse_prompt is sdk_prompt
+
+
+@pytest.mark.parametrize(
+    ("prompt_type", "fallback", "expected_text", "expected_messages"),
+    [
+        ("text", "Hi {{name}}", "Hi Sam", None),
+        (
+            "chat",
+            [{"role": "assistant", "content": "Hi {{name}}"}],
+            None,
+            [{"role": "assistant", "content": "Hi Sam"}],
+        ),
+    ],
+)
+def test_get_prompt_uses_typed_fallback_when_sdk_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    prompt_type: str,
+    fallback: str | list[dict[str, str]],
+    expected_text: str | None,
+    expected_messages: list[dict[str, str]] | None,
+) -> None:
+    from unittest.mock import patch
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    client = MagicMock()
+    client.get_prompt.side_effect = RuntimeError("unavailable")
+    prompt: ManagedPrompt
+
+    with patch("news_dashboard.ai_client._client", return_value=client):
+        if prompt_type == "text":
+            assert isinstance(fallback, str)
+            prompt = get_prompt(
+                "managed", fallback=fallback, prompt_type="text", variables={"name": "Sam"}
+            )
+        else:
+            assert isinstance(fallback, list)
+            prompt = get_prompt(
+                "managed", fallback=fallback, prompt_type="chat", variables={"name": "Sam"}
+            )
+
+    assert prompt.text == expected_text
+    assert prompt.messages == expected_messages
+    assert prompt.langfuse_prompt is None
+
+
+def test_get_prompt_warns_and_falls_back_for_invalid_compiled_chat(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from unittest.mock import patch
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    sdk_prompt = MagicMock()
+    sdk_prompt.compile.return_value = [{"role": "system"}]
+    client = MagicMock()
+    client.get_prompt.return_value = sdk_prompt
+    fallback = [{"role": "system", "content": "Local {{topic}}"}]
+
+    with patch("news_dashboard.ai_client._client", return_value=client):
+        prompt = get_prompt(
+            "managed", fallback=fallback, prompt_type="chat", variables={"topic": "copy"}
+        )
+
+    assert prompt.messages == [{"role": "system", "content": "Local copy"}]
+    assert prompt.langfuse_prompt is None
+    assert "using fallback" in caplog.text
+
+
+def test_chat_create_forwards_only_real_langfuse_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    client = MagicMock()
+    sdk_prompt = object()
+
+    chat_create(
+        client,
+        name="managed-chat",
+        prompt=ManagedPrompt(text=None, messages=[], langfuse_prompt=sdk_prompt),
+        model="model",
+        messages=[],
+    )
+    chat_create(
+        client,
+        name="fallback-chat",
+        prompt=ManagedPrompt(text=None, messages=[], langfuse_prompt=None),
+        model="model",
+        messages=[],
+    )
+
+    assert client.chat.completions.create.call_args_list[0].kwargs["langfuse_prompt"] is sdk_prompt
+    assert "langfuse_prompt" not in client.chat.completions.create.call_args_list[1].kwargs
 
 
 @pytest.mark.usefixtures("_no_langfuse")

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.auth import create_user, require_auth
 from news_dashboard.body_fetch import get_article
 from news_dashboard.db import connect
@@ -540,13 +541,11 @@ def test_generate_share_context_stores_summary(db: str, monkeypatch: pytest.Monk
     summary = "Alice highlighted this because it matters. You will find it useful."
     mock_completion.choices[0].message.content = summary
 
+    managed_prompt = ManagedPrompt(text="compiled share context")
     with (
         patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
-        patch("news_dashboard.ai_client.chat_create", return_value=mock_completion),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_completion) as chat_create,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         mock_client_factory.return_value = MagicMock()
         result = generate_share_context(share_id)
@@ -556,14 +555,22 @@ def test_generate_share_context_stores_summary(db: str, monkeypatch: pytest.Monk
     detail = get_share(share_id, bob)
     assert detail is not None
     assert detail["context_summary"] == result
-    assert get_prompt.call_args.args == ("share-context",)
-    assert set(get_prompt.call_args.kwargs["variables"]) == {
-        "article_title",
-        "article_summary",
-        "sender_note",
-        "annotation_text",
-        "recipient_interests",
+    variables = get_prompt.call_args.kwargs["variables"]
+    get_prompt.assert_called_once_with(
+        "share-context",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables=variables,
+    )
+    assert variables == {
+        "article_title": "Article 1",
+        "article_summary": "",
+        "sender_note": "(none)",
+        "annotation_text": '- "the key section": this is relevant',
+        "recipient_interests": "general news",
     }
+    assert chat_create.call_args.kwargs["prompt"] is managed_prompt
 
 
 # ── Payload bounds (#602) ─────────────────────────────────────────────────────

--- a/backend/tests/test_article_shares.py
+++ b/backend/tests/test_article_shares.py
@@ -543,6 +543,10 @@ def test_generate_share_context_stores_summary(db: str, monkeypatch: pytest.Monk
     with (
         patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
         patch("news_dashboard.ai_client.chat_create", return_value=mock_completion),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
     ):
         mock_client_factory.return_value = MagicMock()
         result = generate_share_context(share_id)
@@ -552,6 +556,14 @@ def test_generate_share_context_stores_summary(db: str, monkeypatch: pytest.Monk
     detail = get_share(share_id, bob)
     assert detail is not None
     assert detail["context_summary"] == result
+    assert get_prompt.call_args.args == ("share-context",)
+    assert set(get_prompt.call_args.kwargs["variables"]) == {
+        "article_title",
+        "article_summary",
+        "sender_note",
+        "annotation_text",
+        "recipient_interests",
+    }
 
 
 # ── Payload bounds (#602) ─────────────────────────────────────────────────────

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from news_dashboard.body_fetch import (
+    _AI_PROMPT,
     _crawl4ai_extract_body,
     _normalize_crawl4ai_result,
     extract_body,
@@ -560,6 +561,38 @@ def test_ai_extract_body_calls_openai_on_html(tmp_path: Path) -> None:
     mock_client.chat.completions.create.assert_called_once()
 
 
+def test_ai_extract_body_uses_managed_prompt() -> None:
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from news_dashboard.ai_client import ManagedPrompt
+    from news_dashboard.body_fetch import _ai_extract_body
+
+    html = "<html><body>Managed HTML</body></html>"
+    managed = ManagedPrompt(text="compiled extraction prompt", langfuse_prompt=object())
+    completion = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Managed body"))]
+    )
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}),
+        patch("httpx.stream", return_value=_FakeStreamResponse(html)),
+        patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
+    ):
+        body, status = _ai_extract_body("https://example.com/article")
+
+    assert (body, status) == ("Managed body", "ok")
+    get_prompt.assert_called_once_with(
+        "ai-body-fetch", fallback=_AI_PROMPT, variables={"html": html}
+    )
+    assert chat_create.call_args.kwargs["prompt"] is managed
+    assert chat_create.call_args.kwargs["messages"] == [
+        {"role": "user", "content": "compiled extraction prompt"}
+    ]
+
+
 def test_ai_extract_body_returns_error_on_http_failure(tmp_path: Path) -> None:
     from news_dashboard.body_fetch import _ai_extract_body
 
@@ -643,8 +676,8 @@ def test_ai_extract_body_truncates_html_to_limit(tmp_path: Path) -> None:
     assert "B" not in prompt_msg
     # The 'A' portion (within the limit) must be present
     assert "A" * 10 in prompt_msg
-    # Exact length: prompt + '\n\n' + truncated html
-    assert len(prompt_msg) == len(_AI_PROMPT) + 2 + _AI_HTML_LIMIT
+    # Exact length: the compiled prompt template contains the bounded HTML.
+    assert len(prompt_msg) == len(_AI_PROMPT) - len("{{html}}") + _AI_HTML_LIMIT
 
 
 def test_ai_extract_body_stops_streaming_once_byte_cap_reached() -> None:

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -585,7 +585,11 @@ def test_ai_extract_body_uses_managed_prompt() -> None:
 
     assert (body, status) == ("Managed body", "ok")
     get_prompt.assert_called_once_with(
-        "ai-body-fetch", fallback=_AI_PROMPT, variables={"html": html}
+        "ai-body-fetch",
+        fallback=_AI_PROMPT,
+        prompt_type="text",
+        label="production",
+        variables={"html": html},
     )
     assert chat_create.call_args.kwargs["prompt"] is managed
     assert chat_create.call_args.kwargs["messages"] == [

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -830,6 +830,18 @@ def test_chat_inserts_history_between_managed_messages(monkeypatch: Any) -> None
     assert captured["args"] == ("briefing-chat",)
     assert captured["kwargs"]["prompt_type"] == "chat"
     assert captured["kwargs"]["variables"]["question"] == "question"
+    from news_dashboard.briefings import service as briefings_service
+
+    assert captured["kwargs"]["fallback"] == [
+        {
+            "role": "system",
+            "content": briefings_service._CHAT_SYSTEM_PROMPT.replace(
+                "{briefing_context}", "{{briefing_context}}"
+            ).replace("{articles_context}", "{{articles_context}}"),
+        },
+        {"role": "user", "content": "{{question}}"},
+    ]
+    assert all(message not in captured["kwargs"]["fallback"] for message in history)
     assert chat_create.call_args.kwargs["messages"] == [
         managed.messages[0],
         *history,

--- a/backend/tests/test_briefings_api.py
+++ b/backend/tests/test_briefings_api.py
@@ -788,3 +788,50 @@ def test_chat_constructs_prompt_with_article_bodies(monkeypatch: Any) -> None:
     system_msg = next(m for m in captured_messages if m["role"] == "system")
     assert "AI Frameworks Tighten Production Workflows" in system_msg["content"]
     assert article_body in system_msg["content"]
+
+
+def test_chat_inserts_history_between_managed_messages(monkeypatch: Any) -> None:
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, patch
+
+    managed = SimpleNamespace(
+        messages=[
+            {"role": "system", "content": "compiled system"},
+            {"role": "user", "content": "compiled question"},
+        ],
+        langfuse_prompt=object(),
+    )
+    captured: dict[str, Any] = {}
+    history = [{"role": "user", "content": "earlier"}, {"role": "assistant", "content": "reply"}]
+    with (
+        patch(
+            "news_dashboard.briefings.service.get_briefing",
+            return_value=dict(_SAMPLE_BRIEFING, articles=[]),
+        ),
+        patch("news_dashboard.briefings.service._briefing_ai_config", return_value=("key", None)),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            side_effect=lambda *args, **kwargs: (
+                captured.update(args=args, kwargs=kwargs) or managed
+            ),
+        ),
+        patch(
+            "news_dashboard.ai_client.chat_create",
+            return_value=SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="answer"))]
+            ),
+        ) as chat_create,
+        patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
+    ):
+        from news_dashboard.briefings.service import chat_with_briefing
+
+        chat_with_briefing(1, "question", history, user_id=1)
+
+    assert captured["args"] == ("briefing-chat",)
+    assert captured["kwargs"]["prompt_type"] == "chat"
+    assert captured["kwargs"]["variables"]["question"] == "question"
+    assert chat_create.call_args.kwargs["messages"] == [
+        managed.messages[0],
+        *history,
+        managed.messages[1],
+    ]

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -314,6 +314,8 @@ def test_generate_cluster_label_uses_managed_prompt() -> None:
     get_prompt.assert_called_once_with(
         "topic-cluster-label",
         fallback=_CLUSTER_LABEL_PROMPT,
+        prompt_type="text",
+        label="production",
         variables={"articles_text": articles_text},
     )
     assert chat_create.call_args.kwargs["prompt"] is managed

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -14,10 +14,12 @@ import pytest
 
 from news_dashboard.db import connect
 from news_dashboard.insights import (
+    _CLUSTER_LABEL_PROMPT,
     DEFAULT_INSIGHTS_MODEL,
     InsightsNotConfiguredError,
     _build_text,
     _cosine_sim,
+    _generate_cluster_label,
     _greedy_cluster,
     _insights_ai_config,
     _normalize,
@@ -289,6 +291,35 @@ def test_generate_insights_prompt_grounds_in_article_text() -> None:
     assert "ONLY" in prompt_text
     assert "speculation" in prompt_text
     assert "fewer bullets" in prompt_text
+
+
+def test_generate_cluster_label_uses_managed_prompt() -> None:
+    from news_dashboard.ai_client import ManagedPrompt
+
+    articles = [{"title": "One", "summary": "First"}, {"title": "Two", "summary": "Second"}]
+    articles_text = "- Title: One\n  Summary: First\n- Title: Two\n  Summary: Second"
+    managed = ManagedPrompt(text="compiled cluster prompt", langfuse_prompt=object())
+    response = MagicMock()
+    response.choices[0].message.content = "HEADLINE: Managed\nSUMMARY: Managed summary."
+
+    with (
+        patch("news_dashboard.insights._cluster_ai_config", return_value=("key", None, "model")),
+        patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=response) as chat_create,
+    ):
+        result = _generate_cluster_label(articles, user_id=7)
+
+    assert result == ("Managed", "Managed summary.")
+    get_prompt.assert_called_once_with(
+        "topic-cluster-label",
+        fallback=_CLUSTER_LABEL_PROMPT,
+        variables={"articles_text": articles_text},
+    )
+    assert chat_create.call_args.kwargs["prompt"] is managed
+    assert chat_create.call_args.kwargs["messages"] == [
+        {"role": "user", "content": "compiled cluster prompt"}
+    ]
 
 
 # ── get_or_generate_insights ──────────────────────────────────────────────────

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -863,6 +863,16 @@ def test_ask_lesson_question_inserts_history_after_managed_system(
     assert captured["args"] == ("lesson-chat",)
     assert captured["kwargs"]["prompt_type"] == "chat"
     assert captured["kwargs"]["variables"]["question"] == "question"
+    assert captured["kwargs"]["fallback"] == [
+        {
+            "role": "system",
+            "content": service._LESSON_CHAT_SYSTEM_PROMPT.replace(
+                "{lesson_context}", "{{lesson_context}}"
+            ).replace("{source_context}", "{{source_context}}"),
+        },
+        {"role": "user", "content": "{{question}}"},
+    ]
+    assert all(message not in captured["kwargs"]["fallback"] for message in history)
     assert chat_capture["messages"] == [managed.messages[0], *history, managed.messages[1]]
 
 
@@ -1429,6 +1439,7 @@ def test_lesson_relevance_uses_native_chat_prompt(
     import news_dashboard.ai_client as ai_client_mod
 
     captured: dict[str, Any] = {}
+    chat_captured: dict[str, Any] = {}
     managed = SimpleNamespace(
         messages=[{"role": "system", "content": "managed"}], langfuse_prompt=object()
     )
@@ -1440,12 +1451,15 @@ def test_lesson_relevance_uses_native_chat_prompt(
     monkeypatch.setattr(
         ai_client_mod,
         "chat_create",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            choices=[
-                SimpleNamespace(
-                    message=SimpleNamespace(content='{"explanation":"why","signals":[]}')
-                )
-            ]
+        lambda *_args, **kwargs: (
+            chat_captured.update(kwargs)
+            or SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content='{"explanation":"why","signals":[]}')
+                    )
+                ]
+            )
         ),
     )
 
@@ -1453,7 +1467,18 @@ def test_lesson_relevance_uses_native_chat_prompt(
 
     assert captured["args"] == ("lesson-relevance",)
     assert captured["kwargs"]["prompt_type"] == "chat"
+    assert captured["kwargs"]["fallback"] == [
+        {
+            "role": "system",
+            "content": (
+                "Explain why a lesson is relevant using only the user's provided reading profile. "
+                "Return JSON with non-empty explanation and a signals array."
+            ),
+        },
+        {"role": "user", "content": "{{lesson_context}}\n{{profile_context}}"},
+    ]
     assert set(captured["kwargs"]["variables"]) == {"lesson_context", "profile_context"}
+    assert chat_captured["messages"] is managed.messages
 
 
 def test_relevance_feedback_endpoint_is_owned_by_lesson_user(

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -833,6 +833,39 @@ def test_ask_lesson_question_returns_grounded_reply(
     assert messages[-1] == {"role": "user", "content": "Explain this more simply."}
 
 
+def test_ask_lesson_question_inserts_history_after_managed_system(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+    import news_dashboard.ai_client as ai_client_mod
+
+    managed = SimpleNamespace(
+        messages=[
+            {"role": "system", "content": "compiled system"},
+            {"role": "user", "content": "compiled question"},
+        ],
+        langfuse_prompt=object(),
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        ai_client_mod,
+        "get_prompt",
+        lambda *args, **kwargs: captured.update(args=args, kwargs=kwargs) or managed,
+    )
+    mock_chat, chat_capture = _mock_chat_reply("answer")
+    monkeypatch.setattr(ai_client_mod, "chat_create", mock_chat)
+    history = [{"role": "user", "content": "earlier"}, {"role": "assistant", "content": "reply"}]
+
+    service.ask_lesson_question(lesson["id"], user_id, "question", history, database_url=pg_clean)
+
+    assert captured["args"] == ("lesson-chat",)
+    assert captured["kwargs"]["prompt_type"] == "chat"
+    assert captured["kwargs"]["variables"]["question"] == "question"
+    assert chat_capture["messages"] == [managed.messages[0], *history, managed.messages[1]]
+
+
 def test_ask_lesson_question_is_user_scoped(pg_clean: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", pg_clean)
     monkeypatch.setenv("FREE_LLM_API_KEY", "freellmapi-key")
@@ -1381,6 +1414,46 @@ def test_lesson_relevance_uses_profile_and_llm_response(
         "explanation": "Relevant to your AI interests.",
         "signals": ["Interest: AI"],
     }
+
+
+def test_lesson_relevance_uses_native_chat_prompt(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+    user_id = _make_user(pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "INSERT INTO user_interest_profiles (user_id, interests) VALUES (%s, %s::jsonb)",
+            (user_id, '["technology"]'),
+        )
+    import news_dashboard.ai_client as ai_client_mod
+
+    captured: dict[str, Any] = {}
+    managed = SimpleNamespace(
+        messages=[{"role": "system", "content": "managed"}], langfuse_prompt=object()
+    )
+    monkeypatch.setattr(
+        ai_client_mod,
+        "get_prompt",
+        lambda *args, **kwargs: captured.update(args=args, kwargs=kwargs) or managed,
+    )
+    monkeypatch.setattr(
+        ai_client_mod,
+        "chat_create",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content='{"explanation":"why","signals":[]}')
+                )
+            ]
+        ),
+    )
+
+    service.create_lesson(user_id, "https://example.com/relevance", database_url=pg_clean)
+
+    assert captured["args"] == ("lesson-relevance",)
+    assert captured["kwargs"]["prompt_type"] == "chat"
+    assert set(captured["kwargs"]["variables"]) == {"lesson_context", "profile_context"}
 
 
 def test_relevance_feedback_endpoint_is_owned_by_lesson_user(

--- a/backend/tests/test_lesson_infographic.py
+++ b/backend/tests/test_lesson_infographic.py
@@ -17,6 +17,41 @@ from news_dashboard.learn_from_link import service
 from news_dashboard.main import app
 
 
+def test_generate_infographic_content_uses_native_chat_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+    import news_dashboard.ai_client as ai_client_mod
+
+    managed = SimpleNamespace(
+        messages=[{"role": "system", "content": "managed"}], langfuse_prompt=object()
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        ai_client_mod,
+        "get_prompt",
+        lambda *args, **kwargs: captured.update(args=args, kwargs=kwargs) or managed,
+    )
+    monkeypatch.setattr(
+        ai_client_mod,
+        "chat_create",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content=json.dumps(_VALID_INFOGRAPHIC)))
+            ]
+        ),
+    )
+
+    lesson = {"title": "Lesson", "lesson_detail": {"gist": "A gist"}}
+    service.generate_infographic_content(lesson, 7)
+
+    assert captured["args"] == ("lesson-infographic",)
+    assert captured["kwargs"]["prompt_type"] == "chat"
+    assert captured["kwargs"]["variables"] == {
+        "lesson_content": service._build_infographic_prompt(lesson)
+    }
+
+
 def _make_user(database_url: str, username: str = "alice") -> int:
     with connect(database_url=database_url) as conn:
         row = conn.execute(

--- a/backend/tests/test_lesson_infographic.py
+++ b/backend/tests/test_lesson_infographic.py
@@ -27,6 +27,7 @@ def test_generate_infographic_content_uses_native_chat_prompt(
         messages=[{"role": "system", "content": "managed"}], langfuse_prompt=object()
     )
     captured: dict[str, Any] = {}
+    chat_captured: dict[str, Any] = {}
     monkeypatch.setattr(
         ai_client_mod,
         "get_prompt",
@@ -35,10 +36,13 @@ def test_generate_infographic_content_uses_native_chat_prompt(
     monkeypatch.setattr(
         ai_client_mod,
         "chat_create",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            choices=[
-                SimpleNamespace(message=SimpleNamespace(content=json.dumps(_VALID_INFOGRAPHIC)))
-            ]
+        lambda *_args, **kwargs: (
+            chat_captured.update(kwargs)
+            or SimpleNamespace(
+                choices=[
+                    SimpleNamespace(message=SimpleNamespace(content=json.dumps(_VALID_INFOGRAPHIC)))
+                ]
+            )
         ),
     )
 
@@ -47,9 +51,14 @@ def test_generate_infographic_content_uses_native_chat_prompt(
 
     assert captured["args"] == ("lesson-infographic",)
     assert captured["kwargs"]["prompt_type"] == "chat"
+    assert captured["kwargs"]["fallback"] == [
+        {"role": "system", "content": service._LESSON_INFOGRAPHIC_SYSTEM_PROMPT},
+        {"role": "user", "content": "{{lesson_content}}"},
+    ]
     assert captured["kwargs"]["variables"] == {
         "lesson_content": service._build_infographic_prompt(lesson)
     }
+    assert chat_captured["messages"] is managed.messages
 
 
 def _make_user(database_url: str, username: str = "alice") -> int:

--- a/backend/tests/test_lesson_recap_narrative.py
+++ b/backend/tests/test_lesson_recap_narrative.py
@@ -55,10 +55,16 @@ def test_generate_lesson_recap_narrative_returns_llm_text(monkeypatch: pytest.Mo
     with (
         patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
     ):
         result = generate_lesson_recap_narrative(_make_recap())
 
     assert result == narrative_text
+    assert get_prompt.call_args.args == ("weekly-lesson-recap-narrative",)
+    assert set(get_prompt.call_args.kwargs["variables"]) == {"recap_json"}
     mock_client.chat.completions.create.assert_called_once()
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert "gradient descent" in call_kwargs["messages"][0]["content"]

--- a/backend/tests/test_lesson_recap_narrative.py
+++ b/backend/tests/test_lesson_recap_narrative.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.lesson_recaps.narrative import generate_lesson_recap_narrative
 
 
@@ -51,23 +52,28 @@ def test_generate_lesson_recap_narrative_returns_llm_text(monkeypatch: pytest.Mo
     mock_client.chat.completions.create.return_value = MagicMock(
         choices=[MagicMock(message=MagicMock(content=narrative_text))]
     )
+    completion = mock_client.chat.completions.create.return_value
+    managed_prompt = ManagedPrompt(text="compiled lesson recap narrative")
 
     with (
         patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         result = generate_lesson_recap_narrative(_make_recap())
 
     assert result == narrative_text
-    assert get_prompt.call_args.args == ("weekly-lesson-recap-narrative",)
-    assert set(get_prompt.call_args.kwargs["variables"]) == {"recap_json"}
-    mock_client.chat.completions.create.assert_called_once()
-    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-    assert "gradient descent" in call_kwargs["messages"][0]["content"]
+    recap_json = get_prompt.call_args.kwargs["variables"]["recap_json"]
+    assert "gradient descent" in recap_json
+    get_prompt.assert_called_once_with(
+        "weekly-lesson-recap-narrative",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables={"recap_json": recap_json},
+    )
+    assert chat_create.call_args.kwargs["prompt"] is managed_prompt
 
 
 def test_generate_lesson_recap_narrative_falls_back_on_llm_error(

--- a/backend/tests/test_lesson_slide_deck.py
+++ b/backend/tests/test_lesson_slide_deck.py
@@ -27,6 +27,7 @@ def test_generate_slide_deck_content_uses_native_chat_prompt(
         messages=[{"role": "system", "content": "managed"}], langfuse_prompt=object()
     )
     captured: dict[str, Any] = {}
+    chat_captured: dict[str, Any] = {}
     monkeypatch.setattr(
         ai_client_mod,
         "get_prompt",
@@ -35,10 +36,13 @@ def test_generate_slide_deck_content_uses_native_chat_prompt(
     monkeypatch.setattr(
         ai_client_mod,
         "chat_create",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            choices=[
-                SimpleNamespace(message=SimpleNamespace(content=json.dumps(_VALID_SLIDE_DECK)))
-            ]
+        lambda *_args, **kwargs: (
+            chat_captured.update(kwargs)
+            or SimpleNamespace(
+                choices=[
+                    SimpleNamespace(message=SimpleNamespace(content=json.dumps(_VALID_SLIDE_DECK)))
+                ]
+            )
         ),
     )
 
@@ -47,9 +51,14 @@ def test_generate_slide_deck_content_uses_native_chat_prompt(
 
     assert captured["args"] == ("lesson-slide-deck",)
     assert captured["kwargs"]["prompt_type"] == "chat"
+    assert captured["kwargs"]["fallback"] == [
+        {"role": "system", "content": service._LESSON_SLIDE_DECK_SYSTEM_PROMPT},
+        {"role": "user", "content": "{{lesson_content}}"},
+    ]
     assert captured["kwargs"]["variables"] == {
         "lesson_content": service._build_slide_deck_prompt(lesson)
     }
+    assert chat_captured["messages"] is managed.messages
 
 
 def _make_user(database_url: str, username: str = "alice") -> int:

--- a/backend/tests/test_lesson_slide_deck.py
+++ b/backend/tests/test_lesson_slide_deck.py
@@ -17,6 +17,41 @@ from news_dashboard.learn_from_link import service
 from news_dashboard.main import app
 
 
+def test_generate_slide_deck_content_uses_native_chat_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+    import news_dashboard.ai_client as ai_client_mod
+
+    managed = SimpleNamespace(
+        messages=[{"role": "system", "content": "managed"}], langfuse_prompt=object()
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        ai_client_mod,
+        "get_prompt",
+        lambda *args, **kwargs: captured.update(args=args, kwargs=kwargs) or managed,
+    )
+    monkeypatch.setattr(
+        ai_client_mod,
+        "chat_create",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content=json.dumps(_VALID_SLIDE_DECK)))
+            ]
+        ),
+    )
+
+    lesson = {"title": "Lesson", "lesson_detail": {"gist": "A gist"}}
+    service.generate_slide_deck_content(lesson, 7)
+
+    assert captured["args"] == ("lesson-slide-deck",)
+    assert captured["kwargs"]["prompt_type"] == "chat"
+    assert captured["kwargs"]["variables"] == {
+        "lesson_content": service._build_slide_deck_prompt(lesson)
+    }
+
+
 def _make_user(database_url: str, username: str = "alice") -> int:
     with connect(database_url=database_url) as conn:
         row = conn.execute(

--- a/backend/tests/test_media_ingest.py
+++ b/backend/tests/test_media_ingest.py
@@ -119,7 +119,7 @@ def test_youtube_channel_ingests_caption_summary(pg_clean: str) -> None:
 
 
 def test_media_summary_uses_managed_chat_prompt() -> None:
-    from news_dashboard.ingest.service import _media_summary
+    from news_dashboard.ingest.service import _MEDIA_SUMMARY_PROMPT, _media_summary
 
     managed = ManagedPrompt(
         text=None,
@@ -140,14 +140,17 @@ def test_media_summary_uses_managed_chat_prompt() -> None:
         summary = _media_summary("Title", "Description", entry)
 
     assert summary == "Managed summary\n\nSource media: https://example.com/media"
-    get_prompt.assert_called_once()
-    assert get_prompt.call_args.args == ("summarize-media-article",)
-    assert get_prompt.call_args.kwargs["prompt_type"] == "chat"
-    assert get_prompt.call_args.kwargs["variables"] == {
-        "title": "Title",
-        "description": "Description",
-        "transcript": "Transcript",
-    }
+    get_prompt.assert_called_once_with(
+        "summarize-media-article",
+        fallback=_MEDIA_SUMMARY_PROMPT,
+        prompt_type="chat",
+        label="production",
+        variables={
+            "title": "Title",
+            "description": "Description",
+            "transcript": "Transcript",
+        },
+    )
     assert chat_create.call_args.kwargs["prompt"] is managed
     assert chat_create.call_args.kwargs["messages"] == managed.messages
 

--- a/backend/tests/test_media_ingest.py
+++ b/backend/tests/test_media_ingest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.db import connect
 from news_dashboard.ingest.service import _ingest_source
 from news_dashboard.sources.service import SourceDefinition
@@ -115,6 +116,40 @@ def test_youtube_channel_ingests_caption_summary(pg_clean: str) -> None:
         == "A summarized video.\n\nSource media: https://www.youtube.com/watch?v=abc123"
     )
     assert row["tags"] == "media,video"
+
+
+def test_media_summary_uses_managed_chat_prompt() -> None:
+    from news_dashboard.ingest.service import _media_summary
+
+    managed = ManagedPrompt(
+        text=None,
+        messages=[{"role": "user", "content": "compiled media prompt"}],
+        langfuse_prompt=object(),
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Managed summary"))]
+    )
+    entry = {"transcript": "Transcript", "media_url": "https://example.com/media"}
+
+    with (
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("key", None)),
+        patch("news_dashboard.ai_client.get_chat_client", return_value=object()),
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=response) as chat_create,
+    ):
+        summary = _media_summary("Title", "Description", entry)
+
+    assert summary == "Managed summary\n\nSource media: https://example.com/media"
+    get_prompt.assert_called_once()
+    assert get_prompt.call_args.args == ("summarize-media-article",)
+    assert get_prompt.call_args.kwargs["prompt_type"] == "chat"
+    assert get_prompt.call_args.kwargs["variables"] == {
+        "title": "Title",
+        "description": "Description",
+        "transcript": "Transcript",
+    }
+    assert chat_create.call_args.kwargs["prompt"] is managed
+    assert chat_create.call_args.kwargs["messages"] == managed.messages
 
 
 def test_media_ingest_falls_back_when_ai_disabled(pg_clean: str) -> None:

--- a/backend/tests/test_prompt_catalog.py
+++ b/backend/tests/test_prompt_catalog.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import pytest
+from langfuse.api.commons.errors.not_found_error import NotFoundError
 
 from news_dashboard.prompt_catalog import PROMPT_CATALOG, PromptCatalogEntry
 
@@ -34,12 +34,9 @@ EXPECTED_NAMES = {
 
 
 def _load_sync_module(monkeypatch: pytest.MonkeyPatch, client: Any) -> ModuleType:
-    class FakeLangfuseModule(ModuleType):
-        Langfuse: Any
+    import langfuse
 
-    fake_langfuse = FakeLangfuseModule("langfuse")
-    fake_langfuse.Langfuse = lambda **_kwargs: client
-    monkeypatch.setitem(sys.modules, "langfuse", fake_langfuse)
+    monkeypatch.setattr(langfuse, "Langfuse", lambda **_kwargs: client)
     path = Path(__file__).parents[2] / "scripts" / "sync_langfuse_prompts.py"
     spec = importlib.util.spec_from_file_location("sync_langfuse_prompts", path)
     assert spec is not None
@@ -84,8 +81,7 @@ def test_sync_creates_each_missing_prompt_with_production_label(
 
     class FakeClient:
         def get_prompt(self, *_args: Any, **_kwargs: Any) -> Any:
-            message = "not found"
-            raise RuntimeError(message)
+            raise NotFoundError({"message": "not found"})
 
         def create_prompt(self, **kwargs: Any) -> Any:
             calls.append(kwargs)
@@ -103,6 +99,31 @@ def test_sync_creates_each_missing_prompt_with_production_label(
     output = capsys.readouterr().out
     assert "secret-from-environment" not in output
     assert "public-from-environment" not in output
+
+
+def test_sync_propagates_prompt_lookup_failures_without_creating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    create_calls: list[dict[str, Any]] = []
+
+    class FakeClient:
+        def get_prompt(self, *_args: Any, **_kwargs: Any) -> Any:
+            message = "authentication failed"
+            raise RuntimeError(message)
+
+        def create_prompt(self, **kwargs: Any) -> Any:
+            create_calls.append(kwargs)
+            return SimpleNamespace(version=1)
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example")
+    module = _load_sync_module(monkeypatch, FakeClient())
+
+    with pytest.raises(RuntimeError, match="authentication failed"):
+        module.main()
+
+    assert create_calls == []
 
 
 def test_sync_is_idempotent_when_production_content_matches(

--- a/backend/tests/test_prompt_catalog.py
+++ b/backend/tests/test_prompt_catalog.py
@@ -138,7 +138,10 @@ def test_sync_is_idempotent_when_production_content_matches(
             prompt = (
                 entry.prompt
                 if isinstance(entry.prompt, str)
-                else [{"role": item.role, "content": item.content} for item in entry.prompt]
+                else [
+                    {"role": item.role, "content": item.content, "type": "text"}
+                    for item in entry.prompt
+                ]
             )
             return SimpleNamespace(prompt=prompt, type=entry.type, version=7)
 
@@ -153,6 +156,27 @@ def test_sync_is_idempotent_when_production_content_matches(
 
     assert module.main() == 0
     assert create_calls == []
+
+
+def test_sync_chat_comparison_rejects_different_or_unsupported_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_sync_module(monkeypatch, object())
+    entry = next(item for item in PROMPT_CATALOG if item.type == "chat")
+    expected = entry.fallback()
+    assert isinstance(expected, list)
+    sdk_prompt = [{**message, "type": "text"} for message in expected]
+    changed_role = [{**sdk_prompt[0], "role": "assistant"}, *sdk_prompt[1:]]
+    changed_content = [{**sdk_prompt[0], "content": "changed"}, *sdk_prompt[1:]]
+    unsupported_type = [{**sdk_prompt[0], "type": "image"}, *sdk_prompt[1:]]
+    missing_content = [{"role": sdk_prompt[0]["role"], "type": "text"}, *sdk_prompt[1:]]
+
+    assert module._matches(SimpleNamespace(type="text", prompt=sdk_prompt), entry) is False
+    assert module._matches(SimpleNamespace(type="chat", prompt=changed_role), entry) is False
+    assert module._matches(SimpleNamespace(type="chat", prompt=changed_content), entry) is False
+    assert module._matches(SimpleNamespace(type="chat", prompt=sdk_prompt[::-1]), entry) is False
+    assert module._matches(SimpleNamespace(type="chat", prompt=unsupported_type), entry) is False
+    assert module._matches(SimpleNamespace(type="chat", prompt=missing_content), entry) is False
 
 
 @pytest.mark.parametrize("missing", ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"])

--- a/backend/tests/test_prompt_catalog.py
+++ b/backend/tests/test_prompt_catalog.py
@@ -139,7 +139,7 @@ def test_sync_is_idempotent_when_production_content_matches(
                 entry.prompt
                 if isinstance(entry.prompt, str)
                 else [
-                    {"role": item.role, "content": item.content, "type": "text"}
+                    {"role": item.role, "content": item.content, "type": "message"}
                     for item in entry.prompt
                 ]
             )
@@ -165,7 +165,7 @@ def test_sync_chat_comparison_rejects_different_or_unsupported_messages(
     entry = next(item for item in PROMPT_CATALOG if item.type == "chat")
     expected = entry.fallback()
     assert isinstance(expected, list)
-    sdk_prompt = [{**message, "type": "text"} for message in expected]
+    sdk_prompt = [{**message, "type": "message"} for message in expected]
     changed_role = [{**sdk_prompt[0], "role": "assistant"}, *sdk_prompt[1:]]
     changed_content = [{**sdk_prompt[0], "content": "changed"}, *sdk_prompt[1:]]
     unsupported_type = [{**sdk_prompt[0], "type": "image"}, *sdk_prompt[1:]]

--- a/backend/tests/test_prompt_catalog.py
+++ b/backend/tests/test_prompt_catalog.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from news_dashboard.prompt_catalog import PROMPT_CATALOG, PromptCatalogEntry
+
+EXPECTED_NAMES = {
+    "ai-body-fetch",
+    "briefing-chat",
+    "briefing-push-hook",
+    "lesson-chat",
+    "lesson-infographic",
+    "lesson-relevance",
+    "lesson-slide-deck",
+    "podcast-script-generation",
+    "reading-list-summary",
+    "recap-push-hook",
+    "recommendation-explanation",
+    "share-context",
+    "summarize-media-article",
+    "topic-cluster-label",
+    "translate-article",
+    "translate-body",
+    "weekly-lesson-recap-narrative",
+    "weekly-quiz",
+    "weekly-recap-narrative",
+}
+
+
+def _load_sync_module(monkeypatch: pytest.MonkeyPatch, client: Any) -> ModuleType:
+    class FakeLangfuseModule(ModuleType):
+        Langfuse: Any
+
+    fake_langfuse = FakeLangfuseModule("langfuse")
+    fake_langfuse.Langfuse = lambda **_kwargs: client
+    monkeypatch.setitem(sys.modules, "langfuse", fake_langfuse)
+    path = Path(__file__).parents[2] / "scripts" / "sync_langfuse_prompts.py"
+    spec = importlib.util.spec_from_file_location("sync_langfuse_prompts", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_catalog_contains_exactly_the_managed_prompts() -> None:
+    assert len(PROMPT_CATALOG) == 19
+    assert {entry.name for entry in PROMPT_CATALOG} == EXPECTED_NAMES
+    assert all(isinstance(entry, PromptCatalogEntry) for entry in PROMPT_CATALOG)
+
+
+def test_catalog_prompt_shapes_are_valid_and_templates_are_safe() -> None:
+    for entry in PROMPT_CATALOG:
+        if entry.type == "text":
+            assert isinstance(entry.prompt, str)
+            assert entry.prompt.strip()
+            contents = [entry.prompt]
+        else:
+            assert entry.type == "chat"
+            assert isinstance(entry.prompt, tuple)
+            assert entry.prompt
+            assert all(message.role in {"system", "user", "assistant"} for message in entry.prompt)
+            assert all(message.content.strip() for message in entry.prompt)
+            contents = [message.content for message in entry.prompt]
+
+        rendered = "\n".join(contents)
+        assert "{{" in rendered
+        assert "}}" in rendered
+        assert "LANGFUSE_SECRET_KEY" not in rendered
+        assert "sk-" not in rendered
+
+
+def test_sync_creates_each_missing_prompt_with_production_label(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class FakeClient:
+        def get_prompt(self, *_args: Any, **_kwargs: Any) -> Any:
+            message = "not found"
+            raise RuntimeError(message)
+
+        def create_prompt(self, **kwargs: Any) -> Any:
+            calls.append(kwargs)
+            return SimpleNamespace(version=len(calls))
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public-from-environment")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret-from-environment")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example")
+    module = _load_sync_module(monkeypatch, FakeClient())
+
+    assert module.main() == 0
+    assert len(calls) == len(PROMPT_CATALOG)
+    assert {call["name"] for call in calls} == EXPECTED_NAMES
+    assert all(call["labels"] == ["production"] for call in calls)
+    output = capsys.readouterr().out
+    assert "secret-from-environment" not in output
+    assert "public-from-environment" not in output
+
+
+def test_sync_is_idempotent_when_production_content_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    by_name = {entry.name: entry for entry in PROMPT_CATALOG}
+    create_calls: list[dict[str, Any]] = []
+
+    class FakeClient:
+        def get_prompt(self, name: str, **_kwargs: Any) -> Any:
+            entry = by_name[name]
+            prompt = (
+                entry.prompt
+                if isinstance(entry.prompt, str)
+                else [{"role": item.role, "content": item.content} for item in entry.prompt]
+            )
+            return SimpleNamespace(prompt=prompt, type=entry.type, version=7)
+
+        def create_prompt(self, **kwargs: Any) -> Any:
+            create_calls.append(kwargs)
+            return SimpleNamespace(version=8)
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example")
+    module = _load_sync_module(monkeypatch, FakeClient())
+
+    assert module.main() == 0
+    assert create_calls == []
+
+
+@pytest.mark.parametrize("missing", ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"])
+def test_sync_requires_all_environment_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    missing: str,
+) -> None:
+    for name in ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"):
+        monkeypatch.setenv(name, "configured")
+    monkeypatch.delenv(missing)
+    module = _load_sync_module(monkeypatch, object())
+
+    assert module.main() != 0

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.db import POSTGRES_MULTIUSER_SCHEMA, init_db
 from news_dashboard.main import app
 from news_dashboard.push import (
@@ -707,25 +708,25 @@ def test_generate_recap_push_hook_resolves_bounded_prompt_variables(
 ) -> None:
     monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
     completion = MagicMock(choices=[MagicMock(message=MagicMock(content="Keep reading"))])
+    managed_prompt = ManagedPrompt(text="compiled recap prompt")
     with (
         patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
-        patch("news_dashboard.ai_client.chat_create", return_value=completion),
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         generate_recap_push_hook(
             {"articles_read": 7, "categories": [{"category": "science"}], "current_streak_days": 4}
         )
 
-    assert get_prompt.call_args.args == ("recap-push-hook",)
-    assert get_prompt.call_args.kwargs["variables"] == {
-        "articles_read": 7,
-        "top_category": "science",
-        "current_streak_days": 4,
-    }
+    get_prompt.assert_called_once_with(
+        "recap-push-hook",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables={"articles_read": 7, "top_category": "science", "current_streak_days": 4},
+    )
+    assert chat_create.call_args.kwargs["prompt"] is managed_prompt
 
 
 def test_generate_push_hook_falls_back_on_llm_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -763,16 +764,13 @@ def test_generate_push_hook_fallback_no_title() -> None:
 def test_generate_push_hook_uses_section_titles_in_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
 
-    captured_prompt: list[str] = []
-
-    def fake_create(**kwargs: Any) -> Any:
-        captured_prompt.append(kwargs["messages"][0]["content"])
-        return MagicMock(
-            choices=[MagicMock(message=MagicMock(content="Breaking: AI takes over coding"))]
-        )
-
     mock_client = MagicMock()
-    mock_client.chat.completions.create.side_effect = fake_create
+    completion = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="Breaking: AI takes over coding"))]
+    )
+    managed_prompt = ManagedPrompt(
+        text="- AI milestone achieved\n- Economy grows 3%\n- Sports finals tonight"
+    )
 
     sections = [
         {"title": "AI milestone achieved", "body": "", "citations": []},
@@ -783,20 +781,24 @@ def test_generate_push_hook_uses_section_titles_in_prompt(monkeypatch: pytest.Mo
 
     with (
         patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         generate_push_hook(_make_briefing(sections=sections))
 
-    prompt = captured_prompt[0]
+    prompt = chat_create.call_args.kwargs["messages"][0]["content"]
     assert "AI milestone achieved" in prompt
     assert "Economy grows 3%" in prompt
     assert "Sports finals tonight" in prompt
     assert "This one should be excluded" not in prompt
-    assert get_prompt.call_args.args == ("briefing-push-hook",)
-    assert get_prompt.call_args.kwargs["variables"] == {
-        "headline_block": "- AI milestone achieved\n- Economy grows 3%\n- Sports finals tonight"
-    }
+    get_prompt.assert_called_once_with(
+        "briefing-push-hook",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables={
+            "headline_block": "- AI milestone achieved\n- Economy grows 3%\n- Sports finals tonight"
+        },
+    )
+    assert chat_create.call_args.kwargs["prompt"] is managed_prompt

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -14,6 +14,7 @@ from news_dashboard.main import app
 from news_dashboard.push import (
     delete_push_subscriptions,
     generate_push_hook,
+    generate_recap_push_hook,
     get_user_push_subscriptions,
     save_push_subscription,
     send_push_for_user,
@@ -701,6 +702,32 @@ def test_generate_push_hook_returns_llm_hook(monkeypatch: pytest.MonkeyPatch) ->
     assert "Claude 4 released" in call_kwargs["messages"][0]["content"]
 
 
+def test_generate_recap_push_hook_resolves_bounded_prompt_variables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
+    completion = MagicMock(choices=[MagicMock(message=MagicMock(content="Keep reading"))])
+    with (
+        patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
+        patch("news_dashboard.ai_client.chat_create", return_value=completion),
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
+    ):
+        generate_recap_push_hook(
+            {"articles_read": 7, "categories": [{"category": "science"}], "current_streak_days": 4}
+        )
+
+    assert get_prompt.call_args.args == ("recap-push-hook",)
+    assert get_prompt.call_args.kwargs["variables"] == {
+        "articles_read": 7,
+        "top_category": "science",
+        "current_streak_days": 4,
+    }
+
+
 def test_generate_push_hook_falls_back_on_llm_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FREE_LLM_API_KEY", "fake-key")
 
@@ -757,6 +784,10 @@ def test_generate_push_hook_uses_section_titles_in_prompt(monkeypatch: pytest.Mo
     with (
         patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
     ):
         generate_push_hook(_make_briefing(sections=sections))
 
@@ -765,3 +796,7 @@ def test_generate_push_hook_uses_section_titles_in_prompt(monkeypatch: pytest.Mo
     assert "Economy grows 3%" in prompt
     assert "Sports finals tonight" in prompt
     assert "This one should be excluded" not in prompt
+    assert get_prompt.call_args.args == ("briefing-push-hook",)
+    assert get_prompt.call_args.kwargs["variables"] == {
+        "headline_block": "- AI milestone achieved\n- Economy grows 3%\n- Sports finals tonight"
+    }

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -6,11 +6,12 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.auth import require_auth
 from news_dashboard.db import connect, init_db
 from news_dashboard.main import app
@@ -233,15 +234,13 @@ def test_generate_weekly_quiz_with_articles(tmp_path: Path) -> None:
 
     mock_response = MagicMock()
     mock_response.choices[0].message.content = json.dumps(_MOCK_QUESTIONS)
+    managed_prompt = ManagedPrompt(text="compiled quiz prompt")
 
     with (
         patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
         patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
-        patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response) as chat_create,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         mock_client_factory.return_value = MagicMock()
         quiz = generate_weekly_quiz(user_id, db_path=db_path)
@@ -250,11 +249,16 @@ def test_generate_weekly_quiz_with_articles(tmp_path: Path) -> None:
     assert quiz["user_id"] == user_id
     assert len(quiz["questions"]) == 3
     assert quiz["score"] is None
-    assert get_prompt.call_args.args == ("weekly-quiz",)
-    assert get_prompt.call_args.kwargs["variables"] == {
-        "article_blurbs": get_prompt.call_args.kwargs["variables"]["article_blurbs"]
-    }
-    assert "AI Transformer Deep Dive" in get_prompt.call_args.kwargs["variables"]["article_blurbs"]
+    article_blurbs = get_prompt.call_args.kwargs["variables"]["article_blurbs"]
+    assert "AI Transformer Deep Dive" in article_blurbs
+    get_prompt.assert_called_once_with(
+        "weekly-quiz",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables={"article_blurbs": article_blurbs},
+    )
+    assert chat_create.call_args.kwargs["prompt"] is managed_prompt
 
 
 def test_get_latest_quiz_empty(tmp_path: Path) -> None:

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -238,6 +238,10 @@ def test_generate_weekly_quiz_with_articles(tmp_path: Path) -> None:
         patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
         patch("news_dashboard.ai_client.get_openai_client") as mock_client_factory,
         patch("news_dashboard.ai_client.chat_create", return_value=mock_response),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
     ):
         mock_client_factory.return_value = MagicMock()
         quiz = generate_weekly_quiz(user_id, db_path=db_path)
@@ -246,6 +250,11 @@ def test_generate_weekly_quiz_with_articles(tmp_path: Path) -> None:
     assert quiz["user_id"] == user_id
     assert len(quiz["questions"]) == 3
     assert quiz["score"] is None
+    assert get_prompt.call_args.args == ("weekly-quiz",)
+    assert get_prompt.call_args.kwargs["variables"] == {
+        "article_blurbs": get_prompt.call_args.kwargs["variables"]["article_blurbs"]
+    }
+    assert "AI Transformer Deep Dive" in get_prompt.call_args.kwargs["variables"]["article_blurbs"]
 
 
 def test_get_latest_quiz_empty(tmp_path: Path) -> None:

--- a/backend/tests/test_reading_list.py
+++ b/backend/tests/test_reading_list.py
@@ -5,11 +5,12 @@ metadata fetch, prioritization, and mark-as-done.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.auth import require_auth
 from news_dashboard.db import connect, init_db
 from news_dashboard.main import app
@@ -443,26 +444,29 @@ def test_generate_summary_for_item_success(monkeypatch: pytest.MonkeyPatch, pg_c
     mock_completion.choices[0].message.content = "A concise take on why this post matters."
     mock_client = MagicMock()
     mock_client.chat.completions.create.return_value = mock_completion
+    managed_prompt = ManagedPrompt(text="compiled prompt for A great post")
 
     with (
         patch.dict("os.environ", {"FREE_LLM_API_KEY": "test-key"}),
         patch("openai.OpenAI", return_value=mock_client),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_completion) as chat_create,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         service.generate_summary_for_item(item["id"], database_url=database_url)
 
     items = service.list_items(user_id, database_url=database_url)
     assert items[0]["summary_status"] == "ok"
     assert items[0]["summary"] == "A concise take on why this post matters."
-    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    call_kwargs = chat_create.call_args.kwargs
     assert "A great post" in call_kwargs["messages"][0]["content"]
-    assert get_prompt.call_args.args == ("reading-list-summary",)
-    assert get_prompt.call_args.kwargs["variables"] == {
-        "reading_list_text": "Title: A great post\nDescription: It explains things"
-    }
+    get_prompt.assert_called_once_with(
+        "reading-list-summary",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables={"reading_list_text": "Title: A great post\nDescription: It explains things"},
+    )
+    assert chat_create.call_args.kwargs["prompt"] is managed_prompt
 
 
 def test_generate_summary_for_item_records_error_on_ai_failure(

--- a/backend/tests/test_reading_list.py
+++ b/backend/tests/test_reading_list.py
@@ -447,6 +447,10 @@ def test_generate_summary_for_item_success(monkeypatch: pytest.MonkeyPatch, pg_c
     with (
         patch.dict("os.environ", {"FREE_LLM_API_KEY": "test-key"}),
         patch("openai.OpenAI", return_value=mock_client),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
     ):
         service.generate_summary_for_item(item["id"], database_url=database_url)
 
@@ -455,6 +459,10 @@ def test_generate_summary_for_item_success(monkeypatch: pytest.MonkeyPatch, pg_c
     assert items[0]["summary"] == "A concise take on why this post matters."
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert "A great post" in call_kwargs["messages"][0]["content"]
+    assert get_prompt.call_args.args == ("reading-list-summary",)
+    assert get_prompt.call_args.kwargs["variables"] == {
+        "reading_list_text": "Title: A great post\nDescription: It explains things"
+    }
 
 
 def test_generate_summary_for_item_records_error_on_ai_failure(

--- a/backend/tests/test_recap_narrative.py
+++ b/backend/tests/test_recap_narrative.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.recaps.narrative import generate_recap_narrative
 
 
@@ -51,23 +52,29 @@ def test_generate_recap_narrative_returns_llm_text(monkeypatch: pytest.MonkeyPat
     mock_client.chat.completions.create.return_value = MagicMock(
         choices=[MagicMock(message=MagicMock(content=narrative_text))]
     )
+    completion = mock_client.chat.completions.create.return_value
+    managed_prompt = ManagedPrompt(text="compiled recap narrative")
 
     with (
         patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         result = generate_recap_narrative(_make_recap())
 
     assert result == narrative_text
-    mock_client.chat.completions.create.assert_called_once()
-    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-    assert "12" in call_kwargs["messages"][0]["content"]
-    assert get_prompt.call_args.args == ("weekly-recap-narrative",)
-    assert set(get_prompt.call_args.kwargs["variables"]) == {"recap_json"}
+    call_kwargs = chat_create.call_args.kwargs
+    recap_json = get_prompt.call_args.kwargs["variables"]["recap_json"]
+    assert "12" in recap_json
+    get_prompt.assert_called_once_with(
+        "weekly-recap-narrative",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables={"recap_json": recap_json},
+    )
+    assert call_kwargs["prompt"] is managed_prompt
 
 
 def test_generate_recap_narrative_falls_back_on_llm_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_recap_narrative.py
+++ b/backend/tests/test_recap_narrative.py
@@ -55,6 +55,10 @@ def test_generate_recap_narrative_returns_llm_text(monkeypatch: pytest.MonkeyPat
     with (
         patch("news_dashboard.ai_client.get_chat_client", return_value=mock_client),
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
     ):
         result = generate_recap_narrative(_make_recap())
 
@@ -62,6 +66,8 @@ def test_generate_recap_narrative_returns_llm_text(monkeypatch: pytest.MonkeyPat
     mock_client.chat.completions.create.assert_called_once()
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert "12" in call_kwargs["messages"][0]["content"]
+    assert get_prompt.call_args.args == ("weekly-recap-narrative",)
+    assert set(get_prompt.call_args.kwargs["variables"]) == {"recap_json"}
 
 
 def test_generate_recap_narrative_falls_back_on_llm_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.auth import require_auth
 from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
 from news_dashboard.embeddings import vector_literal
@@ -130,25 +131,31 @@ def test_recommendation_explanation_resolves_article_and_history_variables(
             (user_id, history_id),
         )
     completion = MagicMock(choices=[MagicMock(message=MagicMock(content="A match."))])
+    managed_prompt = ManagedPrompt(text="compiled recommendation prompt")
     with (
         patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
         patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
-        patch("news_dashboard.ai_client.chat_create", return_value=completion),
-        patch(
-            "news_dashboard.ai_client.get_prompt",
-            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
-        ) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed_prompt) as get_prompt,
     ):
         generate_recommendation_explanation(user_id, article_id, database_url=db)
 
-    assert get_prompt.call_args.args == ("recommendation-explanation",)
-    assert set(get_prompt.call_args.kwargs["variables"]) == {
-        "article_title",
-        "article_source",
-        "article_category",
-        "article_tags",
-        "history_text",
+    variables = get_prompt.call_args.kwargs["variables"]
+    get_prompt.assert_called_once_with(
+        "recommendation-explanation",
+        fallback=ANY,
+        label="production",
+        prompt_type="text",
+        variables=variables,
+    )
+    assert variables == {
+        "article_title": "Article target",
+        "article_source": "Science-Source",
+        "article_category": "science",
+        "article_tags": "",
+        "history_text": '- read: "Article history" (Science-Source / science)',
     }
+    assert chat_create.call_args.kwargs["prompt"] is managed_prompt
 
 
 # ── Ranking preserves every eligible article ──────────────────────────────────

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -26,7 +27,10 @@ from news_dashboard.auth import require_auth
 from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
 from news_dashboard.embeddings import vector_literal
 from news_dashboard.main import app
-from news_dashboard.recommendations import upsert_recommendation_score
+from news_dashboard.recommendations import (
+    generate_recommendation_explanation,
+    upsert_recommendation_score,
+)
 
 pytestmark = pytest.mark.postgres
 
@@ -110,6 +114,41 @@ def _today_items(client: TestClient) -> list[dict[str, Any]]:
     response = client.get("/api/articles", params={"state": "today", "limit": 50})
     assert response.status_code == 200
     return list(response.json()["items"])
+
+
+def test_recommendation_explanation_resolves_article_and_history_variables(
+    monkeypatch: Any, pg_clean: str
+) -> None:
+    db = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db, "science-source", category="science")
+    user_id = _make_user(db, "reader")
+    article_id = _insert_article(db, "science-source", "target", category="science")
+    history_id = _insert_article(db, "science-source", "history", category="science")
+    with connect(db) as conn:
+        conn.execute(
+            "INSERT INTO user_article_state(user_id, article_id, state) VALUES (%s, %s, 'done')",
+            (user_id, history_id),
+        )
+    completion = MagicMock(choices=[MagicMock(message=MagicMock(content="A match."))])
+    with (
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("fake-key", None)),
+        patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
+        patch("news_dashboard.ai_client.chat_create", return_value=completion),
+        patch(
+            "news_dashboard.ai_client.get_prompt",
+            wraps=__import__("news_dashboard.ai_client", fromlist=["get_prompt"]).get_prompt,
+        ) as get_prompt,
+    ):
+        generate_recommendation_explanation(user_id, article_id, database_url=db)
+
+    assert get_prompt.call_args.args == ("recommendation-explanation",)
+    assert set(get_prompt.call_args.kwargs["variables"]) == {
+        "article_title",
+        "article_source",
+        "article_category",
+        "article_tags",
+        "history_text",
+    }
 
 
 # ── Ranking preserves every eligible article ──────────────────────────────────

--- a/backend/tests/test_translation.py
+++ b/backend/tests/test_translation.py
@@ -63,6 +63,8 @@ def test_translate_body_japanese() -> None:
 
 
 def test_translate_body_uses_managed_chat_prompt() -> None:
+    from news_dashboard.body_fetch import _TRANSLATE_BODY_PROMPT
+
     managed = ManagedPrompt(
         text=None,
         messages=[{"role": "system", "content": "compiled"}, {"role": "user", "content": "本文"}],
@@ -79,15 +81,20 @@ def test_translate_body_uses_managed_chat_prompt() -> None:
     ):
         assert translate_body("本文", "ja") == "Translated"
 
-    get_prompt.assert_called_once()
-    assert get_prompt.call_args.args == ("translate-body",)
-    assert get_prompt.call_args.kwargs["prompt_type"] == "chat"
-    assert get_prompt.call_args.kwargs["variables"] == {"from_lang": "ja", "body": "本文"}
+    get_prompt.assert_called_once_with(
+        "translate-body",
+        fallback=_TRANSLATE_BODY_PROMPT,
+        prompt_type="chat",
+        label="production",
+        variables={"from_lang": "ja", "body": "本文"},
+    )
     assert chat_create.call_args.kwargs["prompt"] is managed
     assert chat_create.call_args.kwargs["messages"] == managed.messages
 
 
 def test_detect_and_translate_article_uses_managed_chat_prompt() -> None:
+    from news_dashboard.ingest.service import _TRANSLATE_ARTICLE_PROMPT
+
     managed = ManagedPrompt(
         text=None,
         messages=[{"role": "system", "content": "compiled translation"}],
@@ -108,13 +115,13 @@ def test_detect_and_translate_article_uses_managed_chat_prompt() -> None:
         result = detect_and_translate_article("日本語タイトル", "日本語要約", "ja")
 
     assert result == ("English title", "English summary", "ja", "日本語タイトル")
-    get_prompt.assert_called_once()
-    assert get_prompt.call_args.args == ("translate-article",)
-    assert get_prompt.call_args.kwargs["prompt_type"] == "chat"
-    assert get_prompt.call_args.kwargs["variables"] == {
-        "title": "日本語タイトル",
-        "summary": "日本語要約",
-    }
+    get_prompt.assert_called_once_with(
+        "translate-article",
+        fallback=_TRANSLATE_ARTICLE_PROMPT,
+        prompt_type="chat",
+        label="production",
+        variables={"title": "日本語タイトル", "summary": "日本語要約"},
+    )
     assert chat_create.call_args.kwargs["prompt"] is managed
     assert chat_create.call_args.kwargs["messages"] == managed.messages
 

--- a/backend/tests/test_translation.py
+++ b/backend/tests/test_translation.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.body_fetch import fetch_and_cache_body, translate_body
 from news_dashboard.db import connect
 from news_dashboard.ingest.service import detect_and_translate_article
@@ -59,6 +60,63 @@ def test_translate_body_japanese() -> None:
 
     assert translated == "Translated Body Text"
     mock_client.chat.completions.create.assert_called_once()
+
+
+def test_translate_body_uses_managed_chat_prompt() -> None:
+    managed = ManagedPrompt(
+        text=None,
+        messages=[{"role": "system", "content": "compiled"}, {"role": "user", "content": "本文"}],
+        langfuse_prompt=object(),
+    )
+    completion = MagicMock()
+    completion.choices[0].message.content = "Translated"
+
+    with (
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("key", None)),
+        patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
+    ):
+        assert translate_body("本文", "ja") == "Translated"
+
+    get_prompt.assert_called_once()
+    assert get_prompt.call_args.args == ("translate-body",)
+    assert get_prompt.call_args.kwargs["prompt_type"] == "chat"
+    assert get_prompt.call_args.kwargs["variables"] == {"from_lang": "ja", "body": "本文"}
+    assert chat_create.call_args.kwargs["prompt"] is managed
+    assert chat_create.call_args.kwargs["messages"] == managed.messages
+
+
+def test_detect_and_translate_article_uses_managed_chat_prompt() -> None:
+    managed = ManagedPrompt(
+        text=None,
+        messages=[{"role": "system", "content": "compiled translation"}],
+        langfuse_prompt=object(),
+    )
+    completion = MagicMock()
+    completion.choices[0].message.content = (
+        '{"detected_lang":"ja","translated_title":"English title",'
+        '"translated_summary":"English summary","needs_translation":true}'
+    )
+
+    with (
+        patch("news_dashboard.ai_client.free_llm_config", return_value=("key", None)),
+        patch("news_dashboard.ai_client.get_chat_client", return_value=MagicMock()),
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=completion) as chat_create,
+    ):
+        result = detect_and_translate_article("日本語タイトル", "日本語要約", "ja")
+
+    assert result == ("English title", "English summary", "ja", "日本語タイトル")
+    get_prompt.assert_called_once()
+    assert get_prompt.call_args.args == ("translate-article",)
+    assert get_prompt.call_args.kwargs["prompt_type"] == "chat"
+    assert get_prompt.call_args.kwargs["variables"] == {
+        "title": "日本語タイトル",
+        "summary": "日本語要約",
+    }
+    assert chat_create.call_args.kwargs["prompt"] is managed
+    assert chat_create.call_args.kwargs["messages"] == managed.messages
 
 
 def test_fetch_and_cache_body_translates_non_english(pg_clean: str) -> None:

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from news_dashboard.tts import (
+    _PODCAST_SYSTEM_PROMPT,
     TTSNotConfiguredError,
     _build_lesson_podcast_text,
     _build_text,
@@ -323,6 +324,37 @@ def test_generate_podcast_script() -> None:
     assert script[1]["speaker"] == "Taylor"
     assert script[1]["voice"] == "nova"
     assert script[1]["text"] == "Hi Alex!"
+
+
+def test_generate_podcast_script_uses_native_chat_prompt() -> None:
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content='{"script": []}'))]
+    managed = MagicMock(
+        messages=[{"role": "system", "content": "managed"}], langfuse_prompt=object()
+    )
+    with (
+        patch.dict("os.environ", {"FREE_LLM_API_KEY": "fake-key"}),
+        patch("news_dashboard.ai_client.get_prompt", return_value=managed) as get_prompt,
+        patch("news_dashboard.ai_client.chat_create", return_value=mock_response) as chat_create,
+    ):
+        generate_podcast_script({"title": "Briefing", "summary": "Summary", "sections": []})
+
+    get_prompt.assert_called_once_with(
+        "podcast-script-generation",
+        fallback=[
+            {"role": "system", "content": _PODCAST_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    "Please generate a podcast script for the following news:\n\n{{content}}"
+                ),
+            },
+        ],
+        prompt_type="chat",
+        variables={"content": "Podcast Title: Briefing\nSummary: Summary\n\nSegments:\n"},
+    )
+    assert chat_create.call_args.kwargs["messages"] == managed.messages
+    assert chat_create.call_args.kwargs["langfuse_prompt"] is managed.langfuse_prompt
 
 
 def test_generate_podcast_script_strips_markdown_fence() -> None:

--- a/docs/superpowers/plans/2026-07-15-langfuse-prompt-migration.md
+++ b/docs/superpowers/plans/2026-07-15-langfuse-prompt-migration.md
@@ -1,0 +1,285 @@
+# Langfuse Prompt Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the 19 remaining runtime feature prompts into Langfuse Prompt Management while preserving offline/local fallback behavior.
+
+**Architecture:** Extend `news_dashboard.ai_client` with one typed resolver for text and chat prompts. Feature modules supply bounded variables and local fallback templates; Langfuse owns production-labeled versions and `chat_create()` links the resolved prompt version to each generation.
+
+**Tech Stack:** Python 3.14, Langfuse Python SDK 4.14+, OpenAI-compatible chat API, pytest, ruff, mypy, ty, pyrefly.
+
+## Global Constraints
+
+- Fetch the explicit Langfuse `production` label.
+- Preserve local fallbacks for outages and installations without Langfuse.
+- Use native chat prompts where system/user boundaries affect behavior.
+- Keep model names, temperatures, token limits, tools, and response schemas in code.
+- Keep dynamic context construction and conditional logic in Python.
+- Never store or print Langfuse credentials.
+- Runtime database behavior remains PostgreSQL-only.
+
+---
+
+### Task 1: Typed text and chat prompt boundary
+
+**Files:**
+- Modify: `backend/news_dashboard/ai_client.py`
+- Test: `backend/tests/test_ai_client.py`
+
+**Interfaces:**
+- Produces: `PromptMessage = dict[str, str]`, `ManagedPrompt(text: str | None, messages: list[PromptMessage] | None, langfuse_prompt: Any | None)`, and `get_prompt(name, fallback, prompt_type="text", label="production", variables=None)`.
+- Invariant: exactly one of `text` and `messages` is populated.
+
+- [ ] **Step 1: Write failing resolver tests**
+
+  Add tests that mock `_client()` and assert text prompts fetch with
+  `label="production", type="text"`, chat prompts fetch with `type="chat"`, both
+  compile variables, and the returned object retains the exact SDK prompt.
+
+- [ ] **Step 2: Write failing fallback and trace tests**
+
+  Cover disabled Langfuse and SDK exceptions for both prompt types. Assert chat
+  fallback role/order is preserved and `chat_create()` forwards
+  `langfuse_prompt` only when the resolver returned a real SDK prompt.
+
+- [ ] **Step 3: Run the red tests**
+
+  Run: `source .env && pytest backend/tests/test_ai_client.py -q`
+
+  Expected: failures because chat resolution and the new typed result do not exist.
+
+- [ ] **Step 4: Implement the minimal shared boundary**
+
+  Add overload-friendly fallback types, local `{{variable}}` compilation for
+  every message, explicit prompt-type fetching, validation of compiled SDK
+  output, and warning-plus-fallback behavior. Keep existing text callers source
+  compatible through the default `prompt_type="text"`.
+
+- [ ] **Step 5: Run the focused tests and commit**
+
+  Run: `source .env && pytest backend/tests/test_ai_client.py -q`
+
+  Expected: PASS.
+
+  Commit: `feat: support managed chat prompts (#1242)`
+
+---
+
+### Task 2: Article ingestion, extraction, and analysis prompts
+
+**Files:**
+- Modify: `backend/news_dashboard/body_fetch.py`
+- Modify: `backend/news_dashboard/ingest/service.py`
+- Modify: `backend/news_dashboard/insights.py`
+- Test: `backend/tests/test_body_fetch.py`
+- Test: `backend/tests/test_translation.py`
+- Test: `backend/tests/test_media_ingest.py`
+- Test: `backend/tests/test_insights.py`
+
+**Interfaces:**
+- Consumes: Task 1 `get_prompt()` and `ManagedPrompt`.
+- Produces prompts: `ai-body-fetch` (text: `html`), `translate-body` (chat: `from_lang`, `body`), `summarize-media-article` (chat: `title`, `description`, `transcript`), `translate-article` (chat: `title`, `summary`), `topic-cluster-label` (text: `articles_text`).
+
+- [ ] **Step 1: Add failing feature wiring tests**
+
+  Patch each module's prompt resolver and capture `chat_create()` arguments.
+  Assert exact prompt name/type/variables, compiled messages, and prompt-version
+  link while retaining existing response formats and bounds.
+
+- [ ] **Step 2: Run the red tests**
+
+  Run: `source .env && pytest backend/tests/test_body_fetch.py backend/tests/test_translation.py backend/tests/test_media_ingest.py backend/tests/test_insights.py -q`
+
+  Expected: managed-prompt assertions fail at the hardcoded call sites.
+
+- [ ] **Step 3: Refactor the five call sites**
+
+  Convert stable instructions into Langfuse-compatible fallback templates.
+  Pass bounded request data through the variables listed above and pass the
+  returned `ManagedPrompt` into `chat_create()`.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+  Run the command from Step 2; expected: PASS.
+
+  Commit: `feat: manage ingestion and analysis prompts (#1242)`
+
+---
+
+### Task 3: Reader-facing utility prompts
+
+**Files:**
+- Modify: `backend/news_dashboard/push.py`
+- Modify: `backend/news_dashboard/quizzes/service.py`
+- Modify: `backend/news_dashboard/reading_list/service.py`
+- Modify: `backend/news_dashboard/recaps/narrative.py`
+- Modify: `backend/news_dashboard/lesson_recaps/narrative.py`
+- Modify: `backend/news_dashboard/recommendations.py`
+- Modify: `backend/news_dashboard/shares/service.py`
+- Test: `backend/tests/test_push_notifications.py`
+- Test: `backend/tests/test_quiz.py`
+- Test: `backend/tests/test_reading_list.py`
+- Test: `backend/tests/test_recap_narrative.py`
+- Test: `backend/tests/test_lesson_recap_narrative.py`
+- Test: `backend/tests/test_recommendation_contracts.py`
+- Test: `backend/tests/test_article_shares.py`
+
+**Interfaces:**
+- Consumes: Task 1 resolver.
+- Produces text prompts: `briefing-push-hook`, `recap-push-hook`, `weekly-quiz`, `reading-list-summary`, `weekly-recap-narrative`, `weekly-lesson-recap-narrative`, `recommendation-explanation`, and `share-context`.
+
+- [ ] **Step 1: Add failing prompt-wiring tests**
+
+  Assert the eight exact names and their bounded variables: headline block;
+  recap counts/category/streak; article blurbs; reading-list text; precomputed
+  recap JSON; article/history fields; and article/note/annotation/interests.
+
+- [ ] **Step 2: Run the red tests**
+
+  Run: `source .env && pytest backend/tests/test_push_notifications.py backend/tests/test_quiz.py backend/tests/test_reading_list.py backend/tests/test_recap_narrative.py backend/tests/test_lesson_recap_narrative.py backend/tests/test_recommendation_contracts.py backend/tests/test_article_shares.py -q`
+
+  Expected: prompt-name/link assertions fail.
+
+- [ ] **Step 3: Refactor the eight call sites**
+
+  Route raw-client calls through `chat_create()` where necessary, retain their
+  tags/user attribution/model options, compile the listed variables, and pass
+  each managed prompt for trace linking.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+  Run the command from Step 2; expected: PASS.
+
+  Commit: `feat: manage reader utility prompts (#1242)`
+
+---
+
+### Task 4: Podcast, lesson, and briefing chat prompts
+
+**Files:**
+- Modify: `backend/news_dashboard/tts.py`
+- Modify: `backend/news_dashboard/learn_from_link/service.py`
+- Modify: `backend/news_dashboard/briefings/service.py`
+- Test: `backend/tests/test_tts.py`
+- Test: `backend/tests/test_lesson_slide_deck.py`
+- Test: `backend/tests/test_lesson_infographic.py`
+- Test: `backend/tests/test_learn_from_link.py`
+- Test: `backend/tests/test_briefings_api.py`
+
+**Interfaces:**
+- Consumes: Task 1 chat resolver.
+- Produces chat prompts: `podcast-script-generation`, `lesson-slide-deck`, `lesson-infographic`, `lesson-chat`, `lesson-relevance`, and `briefing-chat`.
+
+- [ ] **Step 1: Add failing native-chat wiring tests**
+
+  Assert role/order, exact names, and variables. For lesson and briefing chat,
+  assert Python inserts bounded history between the compiled system message and
+  final user question without moving history into the managed template.
+
+- [ ] **Step 2: Run the red tests**
+
+  Run: `source .env && pytest backend/tests/test_tts.py backend/tests/test_lesson_slide_deck.py backend/tests/test_lesson_infographic.py backend/tests/test_learn_from_link.py backend/tests/test_briefings_api.py -q`
+
+  Expected: native chat-prompt assertions fail.
+
+- [ ] **Step 3: Refactor the six call sites**
+
+  Use native chat fallbacks and compile preformatted content variables. Preserve
+  JSON response schemas, parsers, history limits, and current exception behavior.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+  Run the command from Step 2; expected: PASS.
+
+  Commit: `feat: manage lesson and briefing chat prompts (#1242)`
+
+---
+
+### Task 5: Idempotent Langfuse synchronization
+
+**Files:**
+- Create: `scripts/sync_langfuse_prompts.py`
+- Create: `backend/news_dashboard/prompt_catalog.py`
+- Test: `backend/tests/test_prompt_catalog.py`
+- Modify: `README.md`
+
+**Interfaces:**
+- Produces: immutable prompt catalog entries containing `name`, `type`, `prompt`, and optional commit message; CLI exits nonzero when required credentials or host are absent.
+- Consumes: the same fallback templates and names as Tasks 2–4, imported from one catalog rather than duplicated by the script.
+
+- [ ] **Step 1: Add failing catalog and sync tests**
+
+  Assert exactly 19 unique prompt names, valid text/chat shapes, double-brace
+  variables, no secrets, and one `create_prompt(..., labels=["production"])`
+  call per catalog entry using a mocked Langfuse client.
+
+- [ ] **Step 2: Run the red tests**
+
+  Run: `source .env && pytest backend/tests/test_prompt_catalog.py -q`
+
+  Expected: failure because the catalog and sync command do not exist.
+
+- [ ] **Step 3: Implement catalog and synchronization command**
+
+  Centralize the 19 fallback definitions in `prompt_catalog.py`. Make the script
+  initialize the SDK from environment variables, create a new version only when
+  content/type differs from the current production version, promote created
+  versions with `labels=["production"]`, and print names/versions only.
+
+- [ ] **Step 4: Document operation and rollback**
+
+  Document environment setup, dry verification, sync invocation, production
+  label rollback, and disabling Langfuse to use local fallbacks. Never include
+  credential examples containing real values.
+
+- [ ] **Step 5: Run focused tests and commit**
+
+  Run: `source .env && pytest backend/tests/test_prompt_catalog.py -q`
+
+  Expected: PASS.
+
+  Commit: `feat: add Langfuse prompt catalog sync (#1242)`
+
+---
+
+### Task 6: External sync, full verification, and delivery
+
+**Files:**
+- Modify only files required to fix failures caused by Tasks 1–5.
+
+**Interfaces:**
+- Consumes: all preceding tasks.
+- Produces: 19 production-labeled prompts in `https://fuse.lihor.ro` and a merge-ready PR.
+
+- [ ] **Step 1: Bootstrap and verify PostgreSQL test infrastructure**
+
+  Run `scripts/bootstrap-worktree.sh` if `.venv`, `.env`, or dependencies are
+  missing. Confirm `nd-test-pg` is running and `.env` points both database URLs
+  to port `55432` without printing their values.
+
+- [ ] **Step 2: Run repository gates**
+
+  Run: `make lint`
+
+  Run: `make typecheck`
+
+  Run: `export PGOPTIONS='-c max_parallel_workers_per_gather=0'; source .env && make test`
+
+  Expected: all commands exit 0.
+
+- [ ] **Step 3: Synchronize prompts using ephemeral environment values**
+
+  Invoke `scripts/sync_langfuse_prompts.py` with the user-authorized credentials
+  in process environment only. Do not echo commands, enable shell tracing, save
+  credentials, or include them in logs.
+
+- [ ] **Step 4: Verify Langfuse state**
+
+  Query prompt metadata through the SDK/CLI and assert all 19 names have a
+  production version and correct type. Report names and versions only.
+
+- [ ] **Step 5: Review, rebase, push, and merge**
+
+  Review the diff, repair confirmed findings, fetch/rebase `origin/main`, rerun
+  affected gates, push without bypassing hooks, open a PR closing #1242, enable
+  squash auto-merge, watch required CI, and confirm the issue closes.

--- a/docs/superpowers/specs/2026-07-15-langfuse-prompt-migration-design.md
+++ b/docs/superpowers/specs/2026-07-15-langfuse-prompt-migration-design.md
@@ -1,0 +1,90 @@
+# Langfuse Prompt Migration Design
+
+## Goal
+
+Move the 19 remaining runtime LLM prompt templates from Python call sites into
+Langfuse Prompt Management without making Langfuse a runtime dependency for
+otherwise valid installations.
+
+## Scope
+
+The migration covers hardcoded feature prompts used for article extraction and
+translation, cluster labels, push copy, quizzes, reading-list summaries,
+recaps, recommendations, shares, podcast scripts, lesson artifacts and chat,
+and briefing chat. The eight prompts already fetched through `get_prompt()`
+remain compatible.
+
+User-provided instructions and retrieved article or lesson content are prompt
+inputs, not managed templates. Model selection, temperature, token limits,
+tools, and structured-output schemas remain in application code. Prompt
+rewriting, experiments, and evaluation-framework work are out of scope.
+
+## Architecture
+
+`news_dashboard.ai_client` remains the only prompt-management boundary. It will
+resolve both Langfuse text and chat prompts by name and `production` label,
+compile `{{variable}}` placeholders, and return a value containing the compiled
+content plus the underlying Langfuse prompt object used for trace linking.
+
+Each feature owns a local fallback with the same logical content and variable
+names as its Langfuse prompt. When Langfuse is disabled, unavailable, or lacks a
+prompt, the helper compiles that fallback locally. Feature code must not call
+the Langfuse SDK directly.
+
+Text prompts are used when the template is a single message. Native chat
+prompts are used when system/user boundaries are part of the template's
+behavior. Dynamic context construction and conditional sections remain in
+Python and are supplied as precomputed variables.
+
+## Runtime Flow
+
+1. A feature builds bounded dynamic inputs such as article text or lesson
+   context.
+2. It requests a named prompt through the shared helper.
+3. The helper fetches the `production` version and compiles variables, or
+   compiles the local fallback.
+4. The feature passes the compiled text or messages to `chat_create()`.
+5. `chat_create()` links the fetched prompt object to the Langfuse generation.
+
+Prompt fetch failure must never prevent the LLM request when a valid fallback
+exists. Existing gateway fallback behavior is unchanged.
+
+## Prompt Naming and Variables
+
+Names are lowercase and hyphenated, based on the existing feature trace names.
+Variables use Langfuse double-brace syntax. Variables contain request-specific
+data only; stable behavioral instructions remain in the managed template.
+
+The production label is explicit at the application boundary. Creating a new
+version does not affect production until that version receives the label.
+
+## Deployment and Rollback
+
+An idempotent migration command or script creates the initial prompt versions
+in the configured Langfuse project and assigns `production`. It must read
+credentials from environment variables and never store or print secrets.
+
+Deployment order is prompts first, application second. Rollback can move the
+Langfuse `production` label to an earlier version. Disabling Langfuse credentials
+immediately returns every call to its code fallback.
+
+## Verification
+
+Tests cover text and chat prompt fetching, variable compilation, fallback
+compilation, fetch failures, and trace linking. Representative feature tests
+assert that dynamic inputs reach the compiled prompt without changing response
+parsing or schemas.
+
+Before delivery, run `make lint`, `make typecheck`, and the PostgreSQL-backed
+suite with `source .env && make test` and parallel query workers disabled as
+required by `AGENTS.md`. Verify the created Langfuse prompts through the API
+without exposing credentials.
+
+## Acceptance Criteria
+
+- All 19 remaining templates have production-labeled Langfuse prompts.
+- All migrated feature calls use the shared prompt-management boundary.
+- Langfuse-managed generations link to the exact prompt version.
+- Missing or unavailable Langfuse prompts use local fallbacks.
+- Existing model configuration and structured-output behavior remain stable.
+- Migration and rollback are documented and covered by tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,9 @@ ban-relative-imports = "all"
 "scripts/ensure_demo_database.py" = [
   "T201",    # print is the intended CLI output for shell consumption
 ]
+"scripts/sync_langfuse_prompts.py" = [
+  "T201",    # print is the intended CLI output for operator-visible sync status
+]
 "scripts/optimize_screenshots.py" = [
   "T201",    # print is the intended CLI output for shell consumption
 ]

--- a/scripts/sync_langfuse_prompts.py
+++ b/scripts/sync_langfuse_prompts.py
@@ -38,7 +38,11 @@ def _normalize_chat_messages(prompt: Any) -> list[dict[str, str]] | None:
         role = message.get("role")
         content = message.get("content")
         message_type = message.get("type", "text")
-        if not isinstance(role, str) or not isinstance(content, str) or message_type != "text":
+        if (
+            not isinstance(role, str)
+            or not isinstance(content, str)
+            or message_type not in {"message", "text"}
+        ):
             return None
         normalized.append({"role": role, "content": content})
     return normalized

--- a/scripts/sync_langfuse_prompts.py
+++ b/scripts/sync_langfuse_prompts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -26,10 +27,32 @@ def _sdk_prompt(entry: PromptCatalogEntry) -> str | list[dict[str, str]]:
     return entry.fallback()
 
 
+def _normalize_chat_messages(prompt: Any) -> list[dict[str, str]] | None:
+    if not isinstance(prompt, list):
+        return None
+
+    normalized: list[dict[str, str]] = []
+    for message in prompt:
+        if not isinstance(message, Mapping) or not set(message) <= {"role", "content", "type"}:
+            return None
+        role = message.get("role")
+        content = message.get("content")
+        message_type = message.get("type", "text")
+        if not isinstance(role, str) or not isinstance(content, str) or message_type != "text":
+            return None
+        normalized.append({"role": role, "content": content})
+    return normalized
+
+
 def _matches(current: Any, entry: PromptCatalogEntry) -> bool:
-    return getattr(current, "type", entry.type) == entry.type and getattr(
-        current, "prompt", None
-    ) == _sdk_prompt(entry)
+    if getattr(current, "type", entry.type) != entry.type:
+        return False
+
+    current_prompt = getattr(current, "prompt", None)
+    expected_prompt = _sdk_prompt(entry)
+    if entry.type == "chat":
+        return _normalize_chat_messages(current_prompt) == expected_prompt
+    return current_prompt == expected_prompt
 
 
 def _sync(client: Any) -> None:

--- a/scripts/sync_langfuse_prompts.py
+++ b/scripts/sync_langfuse_prompts.py
@@ -8,11 +8,16 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from langfuse.api.commons.errors.not_found_error import NotFoundError
+
 BACKEND_DIR = Path(__file__).resolve().parents[1] / "backend"
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-from news_dashboard.prompt_catalog import PROMPT_CATALOG, PromptCatalogEntry  # noqa: E402
+from news_dashboard.prompt_catalog import (  # noqa: E402 - backend path is configured above
+    PROMPT_CATALOG,
+    PromptCatalogEntry,
+)
 
 _ENVIRONMENT_VARIABLES = ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST")
 
@@ -31,7 +36,7 @@ def _sync(client: Any) -> None:
     for entry in PROMPT_CATALOG:
         try:
             current = client.get_prompt(entry.name, label="production", type=entry.type)
-        except Exception:  # Langfuse uses multiple exception types for an absent prompt.
+        except NotFoundError:
             current = None
 
         if current is not None and _matches(current, entry):

--- a/scripts/sync_langfuse_prompts.py
+++ b/scripts/sync_langfuse_prompts.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Synchronize the canonical local prompt catalog to Langfuse production."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from news_dashboard.prompt_catalog import PROMPT_CATALOG, PromptCatalogEntry  # noqa: E402
+
+_ENVIRONMENT_VARIABLES = ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST")
+
+
+def _sdk_prompt(entry: PromptCatalogEntry) -> str | list[dict[str, str]]:
+    return entry.fallback()
+
+
+def _matches(current: Any, entry: PromptCatalogEntry) -> bool:
+    return getattr(current, "type", entry.type) == entry.type and getattr(
+        current, "prompt", None
+    ) == _sdk_prompt(entry)
+
+
+def _sync(client: Any) -> None:
+    for entry in PROMPT_CATALOG:
+        try:
+            current = client.get_prompt(entry.name, label="production", type=entry.type)
+        except Exception:  # Langfuse uses multiple exception types for an absent prompt.
+            current = None
+
+        if current is not None and _matches(current, entry):
+            print(f"unchanged {entry.name} v{getattr(current, 'version', 'unknown')}")
+            continue
+
+        create_kwargs: dict[str, Any] = {
+            "name": entry.name,
+            "type": entry.type,
+            "prompt": _sdk_prompt(entry),
+            "labels": ["production"],
+        }
+        if entry.commit_message is not None:
+            create_kwargs["commit_message"] = entry.commit_message
+        created = client.create_prompt(**create_kwargs)
+        print(f"synced {entry.name} v{getattr(created, 'version', 'unknown')}")
+
+
+def main() -> int:
+    missing = [name for name in _ENVIRONMENT_VARIABLES if not os.getenv(name)]
+    if missing:
+        print(f"missing required environment variables: {', '.join(missing)}", file=sys.stderr)
+        return 2
+
+    from langfuse import Langfuse
+
+    client = Langfuse(
+        public_key=os.environ["LANGFUSE_PUBLIC_KEY"],
+        secret_key=os.environ["LANGFUSE_SECRET_KEY"],
+        host=os.environ["LANGFUSE_HOST"],
+    )
+    _sync(client)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1242

## Summary
- migrate the 19 remaining runtime LLM prompts to production-labeled Langfuse prompt management
- add native text/chat prompt resolution with local fallbacks and trace-version linking
- add an idempotent prompt catalog sync command and rollback documentation

## Verification
- `make lint`
- `make typecheck`
- `PGOPTIONS=-c max_parallel_workers_per_gather=0 dotenv run -- make test`
- live sync created all 19 prompts; final rerun reported every prompt unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)