### PR TITLE
feat: extract lesson graph context (#1123)

### DIFF
--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -689,6 +689,39 @@ POSTGRES_MULTIUSER_SCHEMA = [
     "CREATE INDEX IF NOT EXISTS idx_lesson_generations_lesson_created"
     " ON lesson_generations(lesson_id, created_at DESC)",
     """
+    CREATE TABLE IF NOT EXISTS lesson_graph_nodes (
+      id BIGSERIAL PRIMARY KEY,
+      lesson_id BIGINT NOT NULL REFERENCES lessons(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      node_key TEXT NOT NULL,
+      name TEXT NOT NULL,
+      node_type TEXT NOT NULL
+        CHECK(node_type IN ('concept','entity','article','briefing')),
+      source_field TEXT NOT NULL,
+      related_article_id BIGINT REFERENCES articles(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE(lesson_id, node_key)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_lesson_graph_nodes_user"
+    " ON lesson_graph_nodes(user_id, lesson_id)",
+    """
+    CREATE TABLE IF NOT EXISTS lesson_graph_edges (
+      id BIGSERIAL PRIMARY KEY,
+      lesson_id BIGINT NOT NULL REFERENCES lessons(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      source_key TEXT NOT NULL,
+      target_key TEXT NOT NULL,
+      relationship_type TEXT NOT NULL,
+      label TEXT NOT NULL,
+      confidence REAL NOT NULL DEFAULT 1.0,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE(lesson_id, source_key, target_key, relationship_type)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_lesson_graph_edges_user"
+    " ON lesson_graph_edges(user_id, lesson_id)",
+    """
     CREATE TABLE IF NOT EXISTS user_lesson_suggestion_dismissals (
       user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       article_id  BIGINT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -62,6 +62,8 @@ _PERSONA_FRAMING: dict[str, str] = {
     "new_to_ai": "for readers new to AI who want a clear on-ramp",
     "preparing_talk": "for someone preparing a talk on this topic",
 }
+_GRAPH_NODE_TYPES = {"concept", "entity", "article", "briefing"}
+_GRAPH_RELATIONSHIP_TYPES = {"introduces", "supports", "cites", "related_to"}
 
 _LESSON_CHAT_SYSTEM_PROMPT = """\
 You are the Lesson Follow-up Assistant. Answer follow-up questions about the \
@@ -164,7 +166,220 @@ def _serialize_lesson(row: Any) -> dict[str, Any]:
         value = lesson.get(key)
         if value is not None:
             lesson[key] = value.isoformat()
+    lesson["graph_context_available"] = bool(lesson.get("graph_context_available", False))
     return lesson
+
+
+def _graph_key(node_type: str, name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return f"{node_type}:{slug[:80]}"
+
+
+def _graph_name(value: Any, *, max_length: int = 120) -> str:
+    name = re.sub(r"\s+", " ", str(value or "")).strip()
+    return name[:max_length].strip()
+
+
+def _graph_node(
+    nodes: dict[str, dict[str, Any]],
+    *,
+    name: Any,
+    node_type: str,
+    source_field: str,
+    related_article_id: int | None = None,
+) -> str | None:
+    normalized = _graph_name(name)
+    if not normalized or node_type not in _GRAPH_NODE_TYPES:
+        return None
+    node_key = _graph_key(node_type, normalized)
+    nodes.setdefault(
+        node_key,
+        {
+            "node_key": node_key,
+            "name": normalized,
+            "node_type": node_type,
+            "source_field": source_field,
+            "related_article_id": related_article_id,
+        },
+    )
+    return node_key
+
+
+def _graph_edge(
+    edges: list[dict[str, Any]],
+    *,
+    source_key: str | None,
+    target_key: str | None,
+    relationship_type: str,
+    label: str,
+    confidence: float = 1.0,
+) -> None:
+    if (
+        source_key is None
+        or target_key is None
+        or source_key == target_key
+        or relationship_type not in _GRAPH_RELATIONSHIP_TYPES
+    ):
+        return
+    edges.append(
+        {
+            "source_key": source_key,
+            "target_key": target_key,
+            "relationship_type": relationship_type,
+            "label": label,
+            "confidence": max(0.0, min(confidence, 1.0)),
+        }
+    )
+
+
+def extract_lesson_graph_candidates(
+    lesson_fields: dict[str, Any], *, related_article_id: int | None = None
+) -> dict[str, list[dict[str, Any]]]:
+    detail = lesson_fields.get("lesson_detail")
+    if not isinstance(detail, dict):
+        return {"nodes": [], "edges": []}
+
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+    title_key = _graph_node(
+        nodes,
+        name=lesson_fields.get("title") or lesson_fields.get("original_url"),
+        node_type="article",
+        source_field="title",
+        related_article_id=related_article_id,
+    )
+    source_key = _graph_node(
+        nodes,
+        name=lesson_fields.get("source_name"),
+        node_type="entity",
+        source_field="source_name",
+    )
+    _graph_edge(
+        edges,
+        source_key=title_key,
+        target_key=source_key,
+        relationship_type="cites",
+        label="published by",
+        confidence=0.7,
+    )
+
+    for concept in detail.get("prerequisite_concepts") or []:
+        concept_key = _graph_node(
+            nodes, name=concept, node_type="concept", source_field="prerequisite_concepts"
+        )
+        _graph_edge(
+            edges,
+            source_key=title_key,
+            target_key=concept_key,
+            relationship_type="introduces",
+            label="introduces",
+        )
+
+    for claim in detail.get("key_claims") or []:
+        claim_key = _graph_node(nodes, name=claim, node_type="concept", source_field="key_claims")
+        _graph_edge(
+            edges,
+            source_key=title_key,
+            target_key=claim_key,
+            relationship_type="supports",
+            label="supports",
+            confidence=0.8,
+        )
+
+    for citation in detail.get("citations") or []:
+        if not isinstance(citation, dict):
+            continue
+        citation_key = _graph_node(
+            nodes, name=citation.get("source"), node_type="entity", source_field="citations"
+        )
+        _graph_edge(
+            edges,
+            source_key=title_key,
+            target_key=citation_key,
+            relationship_type="cites",
+            label="cites",
+        )
+
+    unique_edges = {
+        (edge["source_key"], edge["target_key"], edge["relationship_type"]): edge for edge in edges
+    }
+    return {"nodes": list(nodes.values()), "edges": list(unique_edges.values())}
+
+
+def persist_lesson_graph_context(
+    lesson_id: int,
+    user_id: int,
+    lesson_fields: dict[str, Any],
+    *,
+    database_url: str | None = None,
+) -> int:
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        related_article = conn.execute(
+            """
+            SELECT id FROM articles
+            WHERE url = %s OR canonical_url = %s
+            LIMIT 1
+            """,
+            (
+                lesson_fields.get("original_url"),
+                lesson_fields.get("normalized_url") or lesson_fields.get("original_url"),
+            ),
+        ).fetchone()
+        related_article_id = int(related_article["id"]) if related_article is not None else None
+        candidates = extract_lesson_graph_candidates(
+            lesson_fields, related_article_id=related_article_id
+        )
+        nodes = candidates["nodes"]
+        edges = candidates["edges"]
+        conn.execute("DELETE FROM lesson_graph_edges WHERE lesson_id = %s", (lesson_id,))
+        conn.execute("DELETE FROM lesson_graph_nodes WHERE lesson_id = %s", (lesson_id,))
+        for node in nodes:
+            conn.execute(
+                """
+                INSERT INTO lesson_graph_nodes(
+                  lesson_id, user_id, node_key, name, node_type, source_field, related_article_id
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (lesson_id, node_key) DO UPDATE
+                SET name = EXCLUDED.name,
+                    node_type = EXCLUDED.node_type,
+                    source_field = EXCLUDED.source_field,
+                    related_article_id = EXCLUDED.related_article_id
+                """,
+                (
+                    lesson_id,
+                    user_id,
+                    node["node_key"],
+                    node["name"],
+                    node["node_type"],
+                    node["source_field"],
+                    node["related_article_id"],
+                ),
+            )
+        for edge in edges:
+            conn.execute(
+                """
+                INSERT INTO lesson_graph_edges(
+                  lesson_id, user_id, source_key, target_key,
+                  relationship_type, label, confidence
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (lesson_id, source_key, target_key, relationship_type) DO UPDATE
+                SET label = EXCLUDED.label,
+                    confidence = EXCLUDED.confidence
+                """,
+                (
+                    lesson_id,
+                    user_id,
+                    edge["source_key"],
+                    edge["target_key"],
+                    edge["relationship_type"],
+                    edge["label"],
+                    edge["confidence"],
+                ),
+            )
+    return len(nodes)
 
 
 def create_lesson(
@@ -301,7 +516,11 @@ def _update_lesson_success(
                 user_id,
             ),
         ).fetchone()
-    return _serialize_lesson(row)
+    try:
+        persist_lesson_graph_context(lesson_id, user_id, lesson_fields, database_url=database_url)
+    except Exception:
+        logger.exception("lesson graph extraction failed for lesson %d", lesson_id)
+    return get_lesson(lesson_id, user_id, database_url=database_url) or _serialize_lesson(row)
 
 
 def _update_lesson_failure(
@@ -1483,7 +1702,15 @@ def list_lessons(
     database_url: str | None = None,
 ) -> list[dict[str, Any]]:
     init_db(database_url=database_url)
-    query = "SELECT * FROM lessons WHERE user_id = %s"
+    query = """
+        SELECT lessons.*,
+               EXISTS(
+                 SELECT 1 FROM lesson_graph_nodes
+                 WHERE lesson_graph_nodes.lesson_id = lessons.id
+               ) AS graph_context_available
+        FROM lessons
+        WHERE user_id = %s
+    """
     params: list[Any] = [user_id]
     if status is not None:
         query += " AND generation_status = %s"
@@ -1517,7 +1744,15 @@ def get_lesson(
     init_db(database_url=database_url)
     with connect(database_url=database_url) as conn:
         row = conn.execute(
-            "SELECT * FROM lessons WHERE id = %s AND user_id = %s",
+            """
+            SELECT lessons.*,
+                   EXISTS(
+                     SELECT 1 FROM lesson_graph_nodes
+                     WHERE lesson_graph_nodes.lesson_id = lessons.id
+                   ) AS graph_context_available
+            FROM lessons
+            WHERE id = %s AND user_id = %s
+            """,
             (lesson_id, user_id),
         ).fetchone()
     if row is None:

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -176,6 +176,55 @@ def test_create_lesson_completes_with_extracted_content(
             }
         ],
     }
+    assert lesson["graph_context_available"] is True
+
+    with connect(database_url=pg_clean) as conn:
+        nodes = conn.execute(
+            """
+            SELECT name, node_type, source_field
+            FROM lesson_graph_nodes
+            WHERE lesson_id = %s AND user_id = %s
+            ORDER BY node_type, name
+            """,
+            (lesson["id"], user_id),
+        ).fetchall()
+        edges_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM lesson_graph_edges WHERE lesson_id = %s",
+            (lesson["id"],),
+        ).fetchone()
+
+    node_tuples = [(row["name"], row["node_type"], row["source_field"]) for row in nodes]
+    assert ("Context from Example Journal", "concept", "prerequisite_concepts") in node_tuples
+    assert edges_count is not None
+    assert int(edges_count["count"]) > 0
+
+
+def test_lesson_graph_extraction_failure_does_not_fail_core_lesson(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+
+    def fail_graph(*_args: object, **_kwargs: object) -> int:
+        message = "graph unavailable"
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(service, "persist_lesson_graph_context", fail_graph)
+
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert lesson["generation_status"] == "complete"
+    assert lesson["lesson_detail"] is not None
+    assert lesson["graph_context_available"] is False
+
+
+def test_get_lesson_scopes_graph_context_to_current_user(pg_clean: str) -> None:
+    user_id = _make_user(pg_clean, "alice")
+    other_user_id = _make_user(pg_clean, "bob")
+    lesson = service.create_lesson(user_id, "https://example.com/a", database_url=pg_clean)
+
+    assert service.get_lesson(lesson["id"], user_id, database_url=pg_clean) is not None
+    assert service.get_lesson(lesson["id"], other_user_id, database_url=pg_clean) is None
 
 
 def test_create_lesson_marks_failed_when_extraction_fails(

--- a/frontend/src/__tests__/learnPage.test.tsx
+++ b/frontend/src/__tests__/learnPage.test.tsx
@@ -91,6 +91,7 @@ const COMPLETE_LESSON: Lesson = {
   infographic: null,
   infographic_status: null,
   infographic_error: null,
+  graph_context_available: false,
   lesson_detail: {
     gist: 'The article argues that strong source selection matters more than raw volume.',
     explanation:

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -37,6 +37,7 @@ const COMPLETE_LESSON: Lesson = {
   infographic: null,
   infographic_status: null,
   infographic_error: null,
+  graph_context_available: true,
   lesson_detail: {
     gist: 'gist text',
     explanation: 'explanation text',
@@ -96,6 +97,7 @@ describe('LessonDetailPage', () => {
       'href',
       '/learn/library'
     );
+    expect(screen.getByText('Graph context')).toBeInTheDocument();
   });
 
   it('shows an error state when the lesson cannot be loaded', async () => {

--- a/frontend/src/__tests__/lessonLibraryPage.test.tsx
+++ b/frontend/src/__tests__/lessonLibraryPage.test.tsx
@@ -37,6 +37,7 @@ const COMPLETE_LESSON: Lesson = {
   infographic: null,
   infographic_status: null,
   infographic_error: null,
+  graph_context_available: false,
   lesson_detail: {
     gist: 'The article argues that strong source selection matters more than raw volume.',
     explanation: 'explanation',

--- a/frontend/src/__tests__/lessonSuggestions.test.tsx
+++ b/frontend/src/__tests__/lessonSuggestions.test.tsx
@@ -57,6 +57,7 @@ const GENERATED_LESSON: Lesson = {
   infographic: null,
   infographic_status: null,
   infographic_error: null,
+  graph_context_available: false,
   lesson_detail: null,
   study_artifacts: null,
   created_at: '2026-07-08T10:00:00Z',

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -95,6 +95,7 @@ export interface Lesson {
   infographic: InfographicArtifact | null;
   infographic_status: 'complete' | 'failed' | null;
   infographic_error: string | null;
+  graph_context_available: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/components/LessonDetailView.tsx
+++ b/frontend/src/components/LessonDetailView.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react';
-import { AlertCircle, ExternalLink, Headphones, Image, Loader2, Presentation } from 'lucide-react';
+import {
+  AlertCircle,
+  ExternalLink,
+  Headphones,
+  Image,
+  Loader2,
+  Network,
+  Presentation,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -131,6 +139,12 @@ export function LessonDetailView({
               : t('learn.status.pending')}
         </Badge>
         {isPendingLesson ? <Loader2 className="size-4 animate-spin text-muted-foreground" /> : null}
+        {lesson.graph_context_available ? (
+          <Badge variant="outline" className="gap-1">
+            <Network className="size-3.5" />
+            {t('learn.graph_context_available', 'Graph context')}
+          </Badge>
+        ) : null}
       </div>
 
       <div className="space-y-2">


### PR DESCRIPTION
Closes #1123

## Summary
- add PostgreSQL lesson graph node/edge persistence scoped by lesson owner
- extract lesson concepts, claims, citations, source entities, and article links after successful lesson generation
- keep graph extraction best-effort so failed graph persistence does not fail the core lesson
- expose `graph_context_available` in lesson responses and show a lesson detail badge

## Tests
- `make lint`
- `make typecheck`
- `dotenv run -- make test` with `PGOPTIONS=-c max_parallel_workers_per_gather=0`
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)