### PR TITLE
feat: paginate lesson library summaries (#1169)

### DIFF
--- a/backend/news_dashboard/learn_from_link/router.py
+++ b/backend/news_dashboard/learn_from_link/router.py
@@ -50,9 +50,14 @@ def list_lessons_endpoint(
     q: Annotated[str | None, Query(max_length=300)] = None,
     status: Annotated[str | None, Query(pattern="^(pending|complete|failed)$")] = None,
     verdict: Annotated[str | None, Query(pattern="^(skip|skim|read|study)$")] = None,
+    limit: Annotated[int, Query(ge=1, le=service.MAX_LESSON_SUMMARY_LIMIT)] = (
+        service.DEFAULT_LESSON_SUMMARY_LIMIT
+    ),
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict[str, Any]:
-    lessons = service.list_lessons(current_user["id"], q=q, status=status, verdict=verdict)
-    return {"lessons": lessons}
+    return service.list_lesson_summaries(
+        current_user["id"], q=q, status=status, verdict=verdict, limit=limit, offset=offset
+    )
 
 
 @router.get("/api/learn/lessons/{lesson_id}")

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -40,6 +40,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_LESSON_CHAT_MODEL = "gpt-4o-mini"
 DEFAULT_STALE_PENDING_LESSON_MINUTES = 15
+DEFAULT_LESSON_SUMMARY_LIMIT = 20
+MAX_LESSON_SUMMARY_LIMIT = 100
 STALE_PENDING_LESSON_ERROR = (
     "Lesson generation was interrupted before it could finish. Please retry generation."
 )
@@ -1733,6 +1735,92 @@ def list_lessons(
     with connect(database_url=database_url) as conn:
         rows = conn.execute(query, params).fetchall()
     return [_serialize_lesson(row) for row in rows]
+
+
+def list_lesson_summaries(
+    user_id: int,
+    *,
+    q: str | None = None,
+    status: str | None = None,
+    verdict: str | None = None,
+    limit: int = DEFAULT_LESSON_SUMMARY_LIMIT,
+    offset: int = 0,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    init_db(database_url=database_url)
+    bounded_limit = max(1, min(limit, MAX_LESSON_SUMMARY_LIMIT))
+    bounded_offset = max(0, offset)
+    where_sql = "WHERE user_id = %s"
+    params: list[Any] = [user_id]
+    if status is not None:
+        where_sql += " AND generation_status = %s"
+        params.append(status)
+    if verdict is not None:
+        where_sql += " AND lesson_detail->'read_worthiness'->>'verdict' = %s"
+        params.append(verdict)
+    if q is not None and q.strip():
+        where_sql += """
+            AND (
+                title ILIKE %s
+                OR original_url ILIKE %s
+                OR source_name ILIKE %s
+                OR lesson_detail::text ILIKE %s
+            )
+        """
+        term = f"%{q.strip()}%"
+        params.extend([term, term, term, term])
+
+    count_query = f"SELECT COUNT(*) AS total_count FROM lessons {where_sql}"
+    query = f"""
+        SELECT id,
+               user_id,
+               original_url,
+               normalized_url,
+               title,
+               source_name,
+               author,
+               published_at,
+               generation_status,
+               generation_error,
+               jsonb_build_object(
+                 'gist', lesson_detail->>'gist',
+                 'read_worthiness', lesson_detail->'read_worthiness'
+               ) AS lesson_detail,
+               depth,
+               persona,
+               podcast_status,
+               podcast_error,
+               slide_deck_status,
+               slide_deck_error,
+               infographic_status,
+               infographic_error,
+               EXISTS(
+                 SELECT 1 FROM lesson_graph_nodes
+                 WHERE lesson_graph_nodes.lesson_id = lessons.id
+               ) AS graph_context_available,
+               created_at,
+               updated_at
+        FROM lessons
+        {where_sql}
+        ORDER BY created_at DESC
+        LIMIT %s OFFSET %s
+    """
+    with connect(database_url=database_url) as conn:
+        total_row = conn.execute(count_query, params).fetchone()
+        rows = conn.execute(query, [*params, bounded_limit, bounded_offset]).fetchall()
+    lessons = [_serialize_lesson(row) for row in rows]
+    total = int(total_row["total_count"]) if total_row is not None else 0
+    for lesson in lessons:
+        if lesson.get("lesson_detail", {}).get("gist") is None:
+            lesson["lesson_detail"] = None
+    next_offset = bounded_offset + bounded_limit if bounded_offset + bounded_limit < total else None
+    return {
+        "lessons": lessons,
+        "total": total,
+        "limit": bounded_limit,
+        "offset": bounded_offset,
+        "next_offset": next_offset,
+    }
 
 
 def get_lesson(

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableLambda
+from psycopg.types.json import Jsonb
 
 from news_dashboard.auth import require_admin, require_auth
 from news_dashboard.db import connect, init_db
@@ -516,6 +517,87 @@ def test_list_lessons_searches_title_url_source_and_concepts(
     assert no_match == []
 
 
+def test_list_lesson_summaries_paginates_and_omits_heavy_fields(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    first = service.create_lesson(user_id, "https://example.com/first", database_url=pg_clean)
+    second = service.create_lesson(user_id, "https://example.com/second", database_url=pg_clean)
+    third = service.create_lesson(user_id, "https://example.com/third", database_url=pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            """
+            UPDATE lessons
+            SET source_content = %s,
+                study_artifacts = %s::jsonb,
+                personal_relevance = %s::jsonb,
+                slide_deck = %s::jsonb
+            WHERE id = %s
+            """,
+            (
+                "large source body",
+                Jsonb({"flashcards": [{"concept": "heavy", "claim": "payload"}]}),
+                Jsonb({"summary": "private relevance"}),
+                Jsonb({"slides": [{"title": "Heavy", "bullets": ["payload"]}]}),
+                third["id"],
+            ),
+        )
+
+    page = service.list_lesson_summaries(user_id, limit=2, offset=0, database_url=pg_clean)
+
+    assert page["total"] == 3
+    assert page["limit"] == 2
+    assert page["offset"] == 0
+    assert page["next_offset"] == 2
+    assert [lesson["id"] for lesson in page["lessons"]] == [third["id"], second["id"]]
+    assert "source_content" not in page["lessons"][0]
+    assert "study_artifacts" not in page["lessons"][0]
+    assert "personal_relevance" not in page["lessons"][0]
+    assert "slide_deck" not in page["lessons"][0]
+    full_lesson = service.get_lesson(first["id"], user_id, database_url=pg_clean)
+    assert full_lesson is not None
+    assert full_lesson["source_content"]
+
+
+def test_list_lesson_summaries_keeps_filters_with_pagination(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    service.create_lesson(user_id, "https://example.com/first", database_url=pg_clean)
+    service.create_lesson(user_id, "https://example.com/second", database_url=pg_clean)
+    monkeypatch.setattr(service, "extract_body", lambda _url: ("", "error"), raising=False)
+    service.create_lesson(user_id, "https://example.com/failed", database_url=pg_clean)
+
+    page = service.list_lesson_summaries(
+        user_id,
+        q="example",
+        status="complete",
+        verdict="skim",
+        limit=1,
+        offset=1,
+        database_url=pg_clean,
+    )
+
+    assert page["total"] == 2
+    assert page["next_offset"] is None
+    assert len(page["lessons"]) == 1
+    assert page["lessons"][0]["generation_status"] == "complete"
+    assert page["lessons"][0]["lesson_detail"]["read_worthiness"]["verdict"] == "skim"
+
+    empty_page = service.list_lesson_summaries(
+        user_id,
+        status="complete",
+        limit=1,
+        offset=10,
+        database_url=pg_clean,
+    )
+    assert empty_page["lessons"] == []
+    assert empty_page["total"] == 2
+    assert empty_page["next_offset"] is None
+
+
 def test_list_lessons_endpoint_is_user_scoped(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -530,8 +612,10 @@ def test_list_lessons_endpoint_is_user_scoped(
         response = client.get("/api/learn/lessons")
 
     assert response.status_code == 200
-    body = response.json()["lessons"]
-    assert [item["id"] for item in body] == [lesson["id"]]
+    body = response.json()
+    assert [item["id"] for item in body["lessons"]] == [lesson["id"]]
+    assert body["total"] == 1
+    assert body["next_offset"] is None
 
 
 def test_list_lessons_endpoint_supports_query_params(
@@ -544,11 +628,22 @@ def test_list_lessons_endpoint_supports_query_params(
 
     with _api_client(user_id) as client:
         response = client.get(
-            "/api/learn/lessons", params={"status": "complete", "verdict": "skim", "q": "example"}
+            "/api/learn/lessons",
+            params={
+                "status": "complete",
+                "verdict": "skim",
+                "q": "example",
+                "limit": 1,
+                "offset": 0,
+            },
         )
 
     assert response.status_code == 200
-    assert len(response.json()["lessons"]) == 1
+    body = response.json()
+    assert len(body["lessons"]) == 1
+    assert body["total"] == 1
+    assert body["limit"] == 1
+    assert body["offset"] == 0
 
 
 def test_create_lesson_duplicate_resets_pending_state(

--- a/frontend/src/__tests__/lessonLibraryPage.test.tsx
+++ b/frontend/src/__tests__/lessonLibraryPage.test.tsx
@@ -50,6 +50,7 @@ const COMPLETE_LESSON: Lesson = {
     citations: [{ label: '1', snippet: 'snippet', source: 'source' }],
   },
   study_artifacts: null,
+  personal_relevance: null,
   created_at: '2026-07-08T10:00:00Z',
   updated_at: '2026-07-08T10:01:00Z',
 };
@@ -87,7 +88,13 @@ describe('LessonLibraryPage', () => {
   });
 
   it('lists lessons with links to their detail page', async () => {
-    vi.spyOn(api, 'listLessons').mockResolvedValue([COMPLETE_LESSON, FAILED_LESSON]);
+    vi.spyOn(api, 'listLessons').mockResolvedValue({
+      lessons: [COMPLETE_LESSON, FAILED_LESSON],
+      total: 2,
+      limit: 20,
+      offset: 0,
+      next_offset: null,
+    });
 
     renderPage();
 
@@ -100,7 +107,13 @@ describe('LessonLibraryPage', () => {
   });
 
   it('shows an empty state when there are no lessons', async () => {
-    vi.spyOn(api, 'listLessons').mockResolvedValue([]);
+    vi.spyOn(api, 'listLessons').mockResolvedValue({
+      lessons: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+      next_offset: null,
+    });
 
     renderPage();
 
@@ -109,12 +122,24 @@ describe('LessonLibraryPage', () => {
 
   it('re-queries with search text after debounce', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    const listSpy = vi.spyOn(api, 'listLessons').mockResolvedValue([COMPLETE_LESSON]);
+    const listSpy = vi.spyOn(api, 'listLessons').mockResolvedValue({
+      lessons: [COMPLETE_LESSON],
+      total: 1,
+      limit: 20,
+      offset: 0,
+      next_offset: null,
+    });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
     renderPage();
     await waitFor(() =>
-      expect(listSpy).toHaveBeenCalledWith({ q: undefined, status: undefined, verdict: undefined })
+      expect(listSpy).toHaveBeenCalledWith({
+        q: undefined,
+        status: undefined,
+        verdict: undefined,
+        limit: 20,
+        offset: 0,
+      })
     );
 
     await user.type(screen.getByLabelText(/search lessons/i), 'signal');
@@ -122,12 +147,24 @@ describe('LessonLibraryPage', () => {
     await vi.advanceTimersByTimeAsync(300);
 
     await waitFor(() =>
-      expect(listSpy).toHaveBeenCalledWith({ q: 'signal', status: undefined, verdict: undefined })
+      expect(listSpy).toHaveBeenCalledWith({
+        q: 'signal',
+        status: undefined,
+        verdict: undefined,
+        limit: 20,
+        offset: 0,
+      })
     );
   });
 
   it('filters by status and verdict', async () => {
-    const listSpy = vi.spyOn(api, 'listLessons').mockResolvedValue([COMPLETE_LESSON]);
+    const listSpy = vi.spyOn(api, 'listLessons').mockResolvedValue({
+      lessons: [COMPLETE_LESSON],
+      total: 1,
+      limit: 20,
+      offset: 0,
+      next_offset: null,
+    });
     const user = userEvent.setup();
 
     renderPage();
@@ -135,13 +172,60 @@ describe('LessonLibraryPage', () => {
 
     await user.selectOptions(screen.getByLabelText(/filter by status/i), 'complete');
     await waitFor(() =>
-      expect(listSpy).toHaveBeenCalledWith({ q: undefined, status: 'complete', verdict: undefined })
+      expect(listSpy).toHaveBeenCalledWith({
+        q: undefined,
+        status: 'complete',
+        verdict: undefined,
+        limit: 20,
+        offset: 0,
+      })
     );
 
     await user.selectOptions(screen.getByLabelText(/filter by read-worthiness/i), 'study');
     await waitFor(() =>
-      expect(listSpy).toHaveBeenCalledWith({ q: undefined, status: 'complete', verdict: 'study' })
+      expect(listSpy).toHaveBeenCalledWith({
+        q: undefined,
+        status: 'complete',
+        verdict: 'study',
+        limit: 20,
+        offset: 0,
+      })
     );
+  });
+
+  it('loads another page without losing filters', async () => {
+    const secondPageLesson = { ...COMPLETE_LESSON, id: 3, title: 'Another careful article' };
+    const listSpy = vi
+      .spyOn(api, 'listLessons')
+      .mockResolvedValueOnce({
+        lessons: [COMPLETE_LESSON],
+        total: 2,
+        limit: 20,
+        offset: 0,
+        next_offset: 20,
+      })
+      .mockResolvedValueOnce({
+        lessons: [secondPageLesson],
+        total: 2,
+        limit: 20,
+        offset: 20,
+        next_offset: null,
+      });
+    const user = userEvent.setup();
+
+    renderPage();
+    expect(await screen.findByText('A careful article')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /load more lessons/i }));
+
+    expect(await screen.findByText('Another careful article')).toBeInTheDocument();
+    expect(listSpy).toHaveBeenLastCalledWith({
+      q: undefined,
+      status: undefined,
+      verdict: undefined,
+      limit: 20,
+      offset: 20,
+    });
   });
 
   it('shows an error state when loading fails', async () => {

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -85,6 +85,7 @@ export interface Lesson {
   generation_error: string | null;
   lesson_detail: LessonDetail | null;
   study_artifacts: StudyArtifacts | null;
+  personal_relevance?: unknown | null;
   depth: LessonDepth;
   persona: LessonPersona;
   podcast_status: 'complete' | 'failed' | null;
@@ -98,6 +99,21 @@ export interface Lesson {
   graph_context_available: boolean;
   created_at: string;
   updated_at: string;
+}
+
+export type LessonSummary = Omit<
+  Lesson,
+  'source_content' | 'study_artifacts' | 'personal_relevance' | 'slide_deck'
+> & {
+  lesson_detail: Pick<LessonDetail, 'gist' | 'read_worthiness'> | null;
+};
+
+export interface ListLessonsResponse {
+  lessons: LessonSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  next_offset: number | null;
 }
 
 export interface LessonGeneration {
@@ -163,18 +179,19 @@ export interface ListLessonsParams {
   q?: string;
   status?: Lesson['generation_status'];
   verdict?: LessonReadWorthiness['verdict'];
+  limit?: number;
+  offset?: number;
 }
 
-export async function listLessons(params: ListLessonsParams = {}): Promise<Lesson[]> {
+export async function listLessons(params: ListLessonsParams = {}): Promise<ListLessonsResponse> {
   const search = new URLSearchParams();
   if (params.q?.trim()) search.set('q', params.q.trim());
   if (params.status) search.set('status', params.status);
   if (params.verdict) search.set('verdict', params.verdict);
+  if (params.limit !== undefined) search.set('limit', String(params.limit));
+  if (params.offset !== undefined) search.set('offset', String(params.offset));
   const query = search.toString();
-  const { lessons } = await requestJson<{ lessons: Lesson[] }>(
-    `/api/learn/lessons${query ? `?${query}` : ''}`
-  );
-  return lessons;
+  return requestJson<ListLessonsResponse>(`/api/learn/lessons${query ? `?${query}` : ''}`);
 }
 
 export interface LessonChatMessage {

--- a/frontend/src/pages/LessonLibraryPage.tsx
+++ b/frontend/src/pages/LessonLibraryPage.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { AlertCircle, ExternalLink, GraduationCap, Loader2, Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { EmptyState } from '@/components/EmptyState';
-import { listLessons, type Lesson, type LessonReadWorthiness } from '@/api';
+import { listLessons, type Lesson, type LessonReadWorthiness, type LessonSummary } from '@/api';
+
+const LESSON_PAGE_SIZE = 20;
 
 const STATUS_FILTERS: { value: Lesson['generation_status'] | 'all'; label: string }[] = [
   { value: 'all', label: 'All statuses' },
@@ -37,7 +40,7 @@ function formatDate(value: string): string {
   return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
-function LessonCard({ lesson }: { lesson: Lesson }) {
+function LessonCard({ lesson }: { lesson: LessonSummary }) {
   const verdict = lesson.lesson_detail?.read_worthiness.verdict;
   const isFailed = lesson.generation_status === 'failed';
   const isPending = lesson.generation_status === 'pending';
@@ -109,17 +112,22 @@ export function LessonLibraryPage() {
     };
   }, [searchInput]);
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['lessons', q, status, verdict],
-    queryFn: () =>
-      listLessons({
-        q: q || undefined,
-        status: status === 'all' ? undefined : status,
-        verdict: verdict === 'all' ? undefined : verdict,
-      }),
-  });
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ['lessons', q, status, verdict],
+      initialPageParam: 0,
+      queryFn: ({ pageParam }) =>
+        listLessons({
+          q: q || undefined,
+          status: status === 'all' ? undefined : status,
+          verdict: verdict === 'all' ? undefined : verdict,
+          limit: LESSON_PAGE_SIZE,
+          offset: pageParam,
+        }),
+      getNextPageParam: (lastPage) => lastPage.next_offset ?? undefined,
+    });
 
-  const lessons = data ?? [];
+  const lessons = data?.pages.flatMap((page) => page.lessons) ?? [];
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
@@ -207,6 +215,25 @@ export function LessonLibraryPage() {
           {lessons.map((lesson) => (
             <LessonCard key={lesson.id} lesson={lesson} />
           ))}
+          {hasNextPage ? (
+            <div className="flex justify-center pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void fetchNextPage()}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Loader2 className="size-4 animate-spin" />
+                    {t('learn.library.loading_more', 'Loading more')}
+                  </span>
+                ) : (
+                  t('learn.library.load_more', 'Load more lessons')
+                )}
+              </Button>
+            </div>
+          ) : null}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #1169

## Summary
- Add a paginated lesson summary contract for GET /api/learn/lessons with bounded limit/offset, total, and next_offset metadata.
- Omit heavy lesson fields from library summaries while keeping GET /api/learn/lessons/{lesson_id} as the full-detail endpoint.
- Update the Lesson Library to request summary pages and load more results without losing filters.

## Tests
- dotenv run -- make lint typecheck test
- npm run build --silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)