### PR TITLE
perf: batch recommendation score persistence (#1188)

### DIFF
--- a/backend/news_dashboard/recommendations.py
+++ b/backend/news_dashboard/recommendations.py
@@ -116,6 +116,18 @@ class ArticleSignal:
         return base
 
 
+@dataclass(frozen=True)
+class RecommendationScoreRecord:
+    """Persisted score payload for one user/article recommendation row."""
+
+    article_id: int
+    recommendation_score: float
+    cold_start_score: float | None = None
+    signals: dict[str, Any] | None = None
+    model_version: str = COLD_START_MODEL_VERSION
+    explanation: str | None = None
+
+
 @dataclass
 class AffinityProfile:
     """Per-user, per-feature affinities learned from workflow actions.
@@ -495,9 +507,36 @@ def upsert_recommendation_score(  # noqa: PLR0913
     explanation: str | None = None,
 ) -> None:
     """Persist recommendation metadata for one user/article pair."""
+    upsert_recommendation_scores(
+        user_id,
+        [
+            RecommendationScoreRecord(
+                article_id=article_id,
+                recommendation_score=recommendation_score,
+                cold_start_score=cold_start_score,
+                signals=signals,
+                model_version=model_version,
+                explanation=explanation,
+            )
+        ],
+        db_path=db_path,
+        database_url=database_url,
+    )
+
+
+def upsert_recommendation_scores(
+    user_id: int,
+    records: list[RecommendationScoreRecord],
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> None:
+    """Persist recommendation metadata for one user's article scores in one transaction."""
+    if not records:
+        return
     init_db(db_path, database_url=database_url)
-    with connect(db_path, database_url=database_url) as conn:
-        conn.execute(
+    with connect(db_path, database_url=database_url) as conn, conn.cursor() as cur:
+        cur.executemany(
             """
             INSERT INTO user_article_recommendations(
               user_id, article_id, recommendation_score, cold_start_score,
@@ -515,15 +554,40 @@ def upsert_recommendation_score(  # noqa: PLR0913
               ),
               updated_at = NOW()
             """,
-            (
-                user_id,
-                article_id,
-                float(recommendation_score),
-                cold_start_score,
-                json.dumps(signals or {}),
-                model_version,
-                explanation,
-            ),
+            [
+                (
+                    user_id,
+                    record.article_id,
+                    float(record.recommendation_score),
+                    record.cold_start_score,
+                    json.dumps(record.signals or {}),
+                    record.model_version,
+                    record.explanation,
+                )
+                for record in records
+            ],
+        )
+
+
+def update_recommendation_explanations(
+    user_id: int,
+    explanations: list[tuple[int, str]],
+    *,
+    db_path: Path | str | None = None,
+    database_url: str | None = None,
+) -> None:
+    """Persist generated explanations for one user in one transaction."""
+    if not explanations:
+        return
+    init_db(db_path, database_url=database_url)
+    with connect(db_path, database_url=database_url) as conn, conn.cursor() as cur:
+        cur.executemany(
+            """
+            UPDATE user_article_recommendations
+            SET explanation = %s
+            WHERE user_id = %s AND article_id = %s AND explanation IS NULL
+            """,
+            [(explanation, user_id, article_id) for article_id, explanation in explanations],
         )
 
 
@@ -675,7 +739,7 @@ def recompute_user_recommendations(
     # one it degrades to a no-op, so the version only advertises novelty when the
     # semantic profile is present.
     model_version = NOVELTY_MODEL_VERSION if semantic_profile else BEHAVIORAL_MODEL_VERSION
-    scored = 0
+    score_records: list[RecommendationScoreRecord] = []
     scored_items: list[tuple[int, float]] = []
     for candidate in candidates:
         base = float(candidate["base_score"])
@@ -705,33 +769,40 @@ def recompute_user_recommendations(
             0.0,
             100.0,
         )
-        upsert_recommendation_score(
-            user_id,
-            int(candidate["id"]),
-            final_score,
-            db_path=db_path,
-            database_url=database_url,
-            cold_start_score=base,
-            signals={
-                "base_score": round(base, 4),
-                "affinity_adjustment": round(adjustment, 4),
-                "manual_category_adjustment": round(manual_category, 4),
-                "semantic_adjustment": round(semantic, 4),
-                "freshness_adjustment": round(freshness, 4),
-                "novelty_adjustment": round(novelty, 4),
-                "novelty_weight": round(preferences.novelty_weight, 4),
-                "goal_alignment_adjustment": round(goal_boost, 4),
-                "source_slug": source_slug,
-                "category": category,
-            },
-            model_version=model_version,
+        article_id = int(candidate["id"])
+        score_records.append(
+            RecommendationScoreRecord(
+                article_id=article_id,
+                recommendation_score=final_score,
+                cold_start_score=base,
+                signals={
+                    "base_score": round(base, 4),
+                    "affinity_adjustment": round(adjustment, 4),
+                    "manual_category_adjustment": round(manual_category, 4),
+                    "semantic_adjustment": round(semantic, 4),
+                    "freshness_adjustment": round(freshness, 4),
+                    "novelty_adjustment": round(novelty, 4),
+                    "novelty_weight": round(preferences.novelty_weight, 4),
+                    "goal_alignment_adjustment": round(goal_boost, 4),
+                    "source_slug": source_slug,
+                    "category": category,
+                },
+                model_version=model_version,
+            )
         )
-        scored_items.append((int(candidate["id"]), final_score))
-        scored += 1
+        scored_items.append((article_id, final_score))
+
+    upsert_recommendation_scores(
+        user_id,
+        score_records,
+        db_path=db_path,
+        database_url=database_url,
+    )
 
     # Generate explanations for the top 20 articles only; the rest are low-signal
     # enough that a generic label suffices and the AI quota stays manageable.
     top_articles = sorted(scored_items, key=lambda x: x[1], reverse=True)[:20]
+    explanations: list[tuple[int, str]] = []
     for article_id, _ in top_articles:
         explanation = generate_recommendation_explanation(
             user_id,
@@ -740,14 +811,15 @@ def recompute_user_recommendations(
             database_url=database_url,
         )
         if explanation:
-            with connect(db_path, database_url=database_url) as conn:
-                conn.execute(
-                    "UPDATE user_article_recommendations SET explanation = %s"
-                    " WHERE user_id = %s AND article_id = %s AND explanation IS NULL",
-                    (explanation, user_id, article_id),
-                )
+            explanations.append((article_id, explanation))
+    update_recommendation_explanations(
+        user_id,
+        explanations,
+        db_path=db_path,
+        database_url=database_url,
+    )
 
-    return scored
+    return len(score_records)
 
 
 def _opt_float(value: Any) -> float | None:

--- a/backend/tests/test_recommendation_contracts.py
+++ b/backend/tests/test_recommendation_contracts.py
@@ -22,6 +22,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from psycopg.errors import ForeignKeyViolation
 
 from news_dashboard.ai_client import ManagedPrompt
 from news_dashboard.auth import require_auth
@@ -29,8 +30,10 @@ from news_dashboard.db import EMBEDDING_DIMENSIONS, connect, init_db
 from news_dashboard.embeddings import vector_literal
 from news_dashboard.main import app
 from news_dashboard.recommendations import (
+    RecommendationScoreRecord,
     generate_recommendation_explanation,
     upsert_recommendation_score,
+    upsert_recommendation_scores,
 )
 
 pytestmark = pytest.mark.postgres
@@ -318,6 +321,103 @@ def test_single_article_read_exposes_recommendation_metadata(
     payload = response.json()
     assert payload["recommendation_score"] == pytest.approx(88.0)
     assert payload["recommendation_signals"] == signals
+
+
+def test_batch_score_upsert_matches_single_row_conflict_semantics(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    first = _insert_article(db_path, "src", "batch-first", category="ai", importance=70)
+    second = _insert_article(db_path, "src", "batch-second", category="ai", importance=70)
+    upsert_recommendation_score(
+        user_id,
+        first,
+        10.0,
+        db_path=db_path,
+        explanation="Existing explanation",
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE user_article_recommendations SET stale = TRUE"
+            " WHERE user_id = %s AND article_id = %s",
+            (user_id, first),
+        )
+
+    upsert_recommendation_scores(
+        user_id,
+        [
+            RecommendationScoreRecord(
+                article_id=first,
+                recommendation_score=91.25,
+                cold_start_score=44.5,
+                signals={"base_score": 44.5, "source_slug": "src"},
+                model_version="behavioral-affinity-v1",
+            ),
+            RecommendationScoreRecord(
+                article_id=second,
+                recommendation_score=76.0,
+                cold_start_score=40.0,
+                signals={"base_score": 40.0, "category": "ai"},
+                model_version="novelty-freshness-v1",
+                explanation="Generated explanation",
+            ),
+        ],
+        db_path=db_path,
+    )
+
+    with connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT article_id, recommendation_score, cold_start_score, signals,
+              model_version, stale, explanation
+            FROM user_article_recommendations
+            WHERE user_id = %s AND article_id IN (%s, %s)
+            ORDER BY article_id
+            """,
+            (user_id, first, second),
+        ).fetchall()
+
+    by_article = {int(row["article_id"]): dict(row) for row in rows}
+    assert by_article[first]["recommendation_score"] == pytest.approx(91.25)
+    assert by_article[first]["cold_start_score"] == pytest.approx(44.5)
+    assert by_article[first]["signals"] == {"base_score": 44.5, "source_slug": "src"}
+    assert by_article[first]["model_version"] == "behavioral-affinity-v1"
+    assert by_article[first]["stale"] is False
+    assert by_article[first]["explanation"] == "Existing explanation"
+    assert by_article[second]["recommendation_score"] == pytest.approx(76.0)
+    assert by_article[second]["signals"] == {"base_score": 40.0, "category": "ai"}
+    assert by_article[second]["explanation"] == "Generated explanation"
+
+
+def test_batch_score_upsert_rolls_back_all_rows_on_database_error(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai", priority=80)
+    user_id = _make_user(db_path, "alice")
+    article = _insert_article(db_path, "src", "batch-rollback", category="ai", importance=70)
+    missing_article = article + 999_999
+
+    with pytest.raises(ForeignKeyViolation):
+        upsert_recommendation_scores(
+            user_id,
+            [
+                RecommendationScoreRecord(article_id=article, recommendation_score=60.0),
+                RecommendationScoreRecord(article_id=missing_article, recommendation_score=70.0),
+            ],
+            db_path=db_path,
+        )
+
+    with connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM user_article_recommendations"
+            " WHERE user_id = %s AND article_id = %s",
+            (user_id, article),
+        ).fetchone()
+    assert count is not None
+    assert count["count"] == 0
 
 
 def test_single_article_read_returns_null_score_when_unranked(

--- a/backend/tests/test_recommendation_recalc.py
+++ b/backend/tests/test_recommendation_recalc.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import news_dashboard.recommendation_jobs as jobs
+from news_dashboard import recommendations
 from news_dashboard.db import connect, init_db
 from news_dashboard.ingest.service import list_articles, transition_article_state
 from news_dashboard.recommendation_jobs import (
@@ -184,6 +185,50 @@ def test_missing_score_is_created(tmp_path: Path, monkeypatch: Any, pg_clean: st
     summary = recalculate_stale_recommendations(db_path=db_path)
     assert summary.scores_written >= 1
     assert _rec_row(db_path, user_id, article) is not None
+
+
+def test_recompute_batches_score_and_explanation_persistence_connections(
+    tmp_path: Path, monkeypatch: Any, pg_clean: str
+) -> None:
+    db_path = _setup_db(monkeypatch, pg_clean)
+    _insert_source(db_path, "src", category="ai")
+    user_id = _make_user(db_path, "alice")
+    for index in range(5):
+        _insert_article(db_path, "src", f"batch-{index}", category="ai")
+
+    real_connect = connect
+    calls = 0
+
+    def counted_connect(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(recommendations, "connect", counted_connect)
+
+    def generated_reason(
+        user_id: int,
+        article_id: int,
+        *,
+        db_path: Path | str | None = None,
+        database_url: str | None = None,
+    ) -> str:
+        return "Generated reason"
+
+    monkeypatch.setattr(recommendations, "generate_recommendation_explanation", generated_reason)
+
+    scored = recommendations.recompute_user_recommendations(user_id, db_path=db_path)
+
+    assert scored == 5
+    # Load scoring inputs, load preferences, batch score UPSERT, batch explanation update.
+    assert calls == 4
+    with connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT explanation FROM user_article_recommendations WHERE user_id = %s",
+            (user_id,),
+        ).fetchall()
+    assert len(rows) == 5
+    assert {row["explanation"] for row in rows} == {"Generated reason"}
 
 
 def test_superseded_model_version_is_repaired(


### PR DESCRIPTION
Closes #1188

## Summary
- add a typed recommendation score record and batch score UPSERT helper using one PostgreSQL transaction
- accumulate recomputed scores in memory instead of opening one connection per candidate
- batch generated explanation updates on one connection while preserving existing generation behavior
- add PostgreSQL regression coverage for conflict semantics, rollback, and constant connection growth

## Tests
- `dotenv run -- pytest backend/tests/test_recommendation_contracts.py backend/tests/test_recommendation_recalc.py -q`
- `make lint`
- `make typecheck`
- `dotenv run -- make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)