### PR TITLE
fix: stop leaking per-test PostgreSQL schemas (#1192)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import pytest
 
+import news_dashboard.db as db_module
 from news_dashboard.db import init_db
 
 # Load .env from the repo root when running locally (no-op in CI where the
@@ -66,6 +67,19 @@ _TESTCONTAINERS_PG_IMAGE = "pgvector/pgvector:pg16"
 
 _SCHEMA_SWEEP_LOCK_KEY = 727271
 _WORKER_SCHEMA_RE = re.compile(r"^test_[A-Za-z0-9]+_(\d+)$")
+_HASH_SCHEMA_RE = re.compile(r"^test_[0-9a-f]{16}$")
+_SESSION_HASH_SCHEMAS: set[str] = set()
+_ORIGINAL_SCHEMA_NAME = db_module._schema_name
+
+
+def _tracking_schema_name(token: Path) -> str:
+    schema_name = _ORIGINAL_SCHEMA_NAME(token)
+    if _HASH_SCHEMA_RE.match(schema_name):
+        _SESSION_HASH_SCHEMAS.add(schema_name)
+    return schema_name
+
+
+db_module._schema_name = _tracking_schema_name  # ty: ignore[invalid-assignment]
 
 
 def _pid_is_alive(pid: int) -> bool:
@@ -122,6 +136,24 @@ def sweep_stale_test_schemas(dsn: str) -> None:
             conn.execute("SELECT pg_advisory_unlock(%s)", (_SCHEMA_SWEEP_LOCK_KEY,))
 
 
+def drop_session_hash_schemas(dsn: str, schema_names: set[str] | None = None) -> None:
+    """Drop hash-style schemas created from Path-backed tests in this session."""
+    import psycopg
+    from psycopg import sql
+
+    names = sorted(schema_names if schema_names is not None else _SESSION_HASH_SCHEMAS)
+    if not names:
+        return
+
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        for schema_name in names:
+            if not _HASH_SCHEMA_RE.match(schema_name):
+                continue
+            conn.execute(
+                sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(schema_name))
+            )
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Sweep leaked test_% schemas once, before any xdist worker spawns.
 
@@ -136,6 +168,14 @@ def pytest_configure(config: pytest.Config) -> None:
     service_url = os.environ.get("TEST_DATABASE_URL")
     if service_url:
         sweep_stale_test_schemas(service_url)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Drop hash-style schemas created by successful Path-backed test helpers."""
+    del session, exitstatus
+    service_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if service_url:
+        drop_session_hash_schemas(service_url)
 
 
 _FAKE_ADMIN = {

--- a/backend/tests/test_conftest_schema_sweep.py
+++ b/backend/tests/test_conftest_schema_sweep.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -164,6 +165,115 @@ def test_sweep_drops_schemas_owned_by_a_dead_process() -> None:
                 (dead_schema,),
             ).fetchone()
             assert row is None
+    finally:
+        with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+            admin_conn.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(scratch_db)
+                )
+            )
+
+
+def test_session_hash_schema_cleanup_drops_only_registered_schemas() -> None:
+    """Session-end cleanup removes only hash schemas registered by this run."""
+    import psycopg
+    from conftest import drop_session_hash_schemas
+    from psycopg import sql
+
+    service_url = os.environ.get("TEST_DATABASE_URL")
+    if not service_url:
+        pytest.skip("TEST_DATABASE_URL not set")
+
+    base_url, _, _dbname = service_url.rpartition("/")
+    scratch_db = f"schema_cleanup_scratch_{uuid.uuid4().hex[:12]}"
+    scratch_url = f"{base_url}/{scratch_db}"
+    admin_url = f"{base_url}/postgres"
+
+    with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+        try:
+            admin_conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(scratch_db)))
+        except psycopg.errors.InsufficientPrivilege:
+            pytest.skip("connected role lacks CREATEDB; cannot build an isolated scratch database")
+    try:
+        registered_schema = f"test_{uuid.uuid4().hex[:16]}"
+        live_other_session_schema = f"test_{uuid.uuid4().hex[:16]}"
+        non_hash_schema = "test_not_a_hash_schema"
+
+        with psycopg.connect(scratch_url, autocommit=True) as conn:
+            for schema_name in (registered_schema, live_other_session_schema, non_hash_schema):
+                conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema_name)))
+
+            drop_session_hash_schemas(scratch_url, {registered_schema, non_hash_schema})
+
+            rows = conn.execute(
+                """
+                SELECT schema_name FROM information_schema.schemata
+                WHERE schema_name = ANY(%s)
+                ORDER BY schema_name
+                """,
+                ([registered_schema, live_other_session_schema, non_hash_schema],),
+            ).fetchall()
+
+        assert [row[0] for row in rows] == [
+            live_other_session_schema,
+            non_hash_schema,
+        ]
+    finally:
+        with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+            admin_conn.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(scratch_db)
+                )
+            )
+
+
+def test_successful_pytest_session_leaves_no_hash_schemas() -> None:
+    """A successful representative Path-backed pytest run cleans up its schema."""
+    import psycopg
+    from psycopg import sql
+
+    service_url = os.environ.get("TEST_DATABASE_URL")
+    if not service_url:
+        pytest.skip("TEST_DATABASE_URL not set")
+
+    base_url, _, _dbname = service_url.rpartition("/")
+    scratch_db = f"schema_session_scratch_{uuid.uuid4().hex[:12]}"
+    scratch_url = f"{base_url}/{scratch_db}"
+    admin_url = f"{base_url}/postgres"
+
+    with psycopg.connect(admin_url, autocommit=True) as admin_conn:
+        try:
+            admin_conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(scratch_db)))
+        except psycopg.errors.InsufficientPrivilege:
+            pytest.skip("connected role lacks CREATEDB; cannot build an isolated scratch database")
+    try:
+        env = os.environ.copy()
+        env["DATABASE_URL"] = scratch_url
+        env["TEST_DATABASE_URL"] = scratch_url
+        env["PYTEST_ADDOPTS"] = ""
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "-n0",
+                "backend/tests/test_pgvector_migration.py::test_vector_extension_is_available",
+            ],
+            check=True,
+            cwd=Path(__file__).parents[2],
+            env=env,
+            timeout=60,
+        )
+
+        with psycopg.connect(scratch_url, autocommit=True) as conn:
+            rows = conn.execute(
+                r"""
+                SELECT schema_name FROM information_schema.schemata
+                WHERE schema_name ~ '^test_[0-9a-f]{16}$'
+                """
+            ).fetchall()
+        assert rows == []
     finally:
         with psycopg.connect(admin_url, autocommit=True) as admin_conn:
             admin_conn.execute(


### PR DESCRIPTION
Closes #1192

## Summary
- track hash-style schemas created by Path-backed pytest helpers during a session
- drop only the registered hash schemas at pytest session finish
- add regression coverage for registered-schema cleanup, live unregistered schema protection, and a successful representative subprocess pytest run leaving no hash schemas

## Tests
- `pytest backend/tests/test_conftest_schema_sweep.py -q`
- `make lint`
- `make typecheck`
- `pytest --cov --cov-report=term-missing` (`2669 passed, 1 skipped`)
- `pytest -n0 --cov --cov-report=term-missing` (`2670 passed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)