### PR TITLE
feat: recommend lesson learning trails (#1125)

### DIFF
--- a/backend/news_dashboard/learn_from_link/models.py
+++ b/backend/news_dashboard/learn_from_link/models.py
@@ -184,3 +184,31 @@ class LessonSuggestionDismissRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     article_id: int
+
+
+class LessonTrailItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    item_type: Literal["lesson", "article"]
+    id: int
+    title: NonEmptyText
+    url: str | None = None
+    source_name: str | None = None
+    explanation: NonEmptyText
+    matched_signals: list[NonEmptyText] = Field(default_factory=list)
+
+
+class LessonTrailGroup(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: Literal["prerequisite", "easier", "adjacent", "deeper"]
+    label: NonEmptyText
+    items: list[LessonTrailItem] = Field(default_factory=list)
+
+
+class LessonTrailResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lesson_id: int
+    groups: list[LessonTrailGroup]
+    empty_message: str | None = None

--- a/backend/news_dashboard/learn_from_link/router.py
+++ b/backend/news_dashboard/learn_from_link/router.py
@@ -14,6 +14,7 @@ from news_dashboard.learn_from_link.models import (
     LessonQuestionRequest,
     LessonRegenerateRequest,
     LessonSuggestionDismissRequest,
+    LessonTrailResponse,
     RelevanceFeedbackRequest,
 )
 
@@ -209,6 +210,18 @@ def ask_lesson_question_endpoint(
     except service.LessonChatNotConfiguredError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     return {"reply": reply}
+
+
+@router.get("/api/learn/lessons/{lesson_id}/trails")
+def get_lesson_trails_endpoint(
+    lesson_id: int,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    try:
+        trails = service.recommend_lesson_trails(lesson_id, current_user["id"])
+    except service.LessonNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="lesson not found") from exc
+    return LessonTrailResponse.model_validate(trails).model_dump(mode="json")
 
 
 @router.post("/api/learn/lessons/{lesson_id}/relevance/feedback")

--- a/backend/news_dashboard/learn_from_link/service.py
+++ b/backend/news_dashboard/learn_from_link/service.py
@@ -2341,6 +2341,14 @@ _SUGGESTION_LIMIT_DEFAULT = 10
 _SUGGESTION_CANDIDATE_POOL = 200
 _NOVELTY_RECENT_DAYS = 7
 _NOVELTY_MEDIUM_DAYS = 30
+_TRAIL_GROUP_LIMIT = 3
+_TRAIL_CANDIDATE_LIMIT = 80
+_TRAIL_GROUP_LABELS = {
+    "prerequisite": "Prerequisite concepts",
+    "easier": "Easier on-ramp",
+    "adjacent": "Adjacent reads",
+    "deeper": "Deeper path",
+}
 
 
 def _novelty_score(age_days: float | None) -> float:
@@ -2351,6 +2359,296 @@ def _novelty_score(age_days: float | None) -> float:
     if age_days <= _NOVELTY_MEDIUM_DAYS:
         return 0.6
     return 0.3
+
+
+def _trail_terms(lesson: dict[str, Any]) -> list[str]:
+    detail = lesson.get("lesson_detail") or {}
+    terms: list[str] = [str(value) for value in detail.get("prerequisite_concepts") or []]
+    for value in detail.get("key_claims") or []:
+        terms.extend(re.findall(r"\b[A-Za-z][A-Za-z0-9&.-]{3,}\b", str(value))[:3])
+    graph_context = detail.get("graph_context") or {}
+    terms.extend(
+        str(entity["name"])
+        for entity in graph_context.get("entities") or []
+        if isinstance(entity, dict) and entity.get("name")
+    )
+
+    seen: set[str] = set()
+    unique_terms: list[str] = []
+    for term in terms:
+        clean = re.sub(r"\s+", " ", term).strip()
+        if len(clean) < 4 or clean.lower() in seen:
+            continue
+        seen.add(clean.lower())
+        unique_terms.append(clean)
+        if len(unique_terms) >= 10:
+            break
+    return unique_terms
+
+
+def _matches_for_text(text: str, terms: list[str]) -> list[str]:
+    lowered = text.lower()
+    matches = [term for term in terms if term.lower() in lowered]
+    return matches[:4]
+
+
+def _lesson_depth_rank(lesson: dict[str, Any]) -> int:
+    detail = lesson.get("lesson_detail") or {}
+    verdict = (detail.get("read_worthiness") or {}).get("verdict")
+    if verdict == "study":
+        return 4
+    if verdict == "read":
+        return 3
+    if verdict == "skim":
+        return 2
+    return 1
+
+
+def _trail_lesson_candidate(
+    candidate: dict[str, Any],
+    *,
+    path: str,
+    matches: list[str],
+) -> dict[str, Any]:
+    title = str(candidate.get("title") or candidate.get("original_url"))
+    if path == "prerequisite":
+        explanation = f"Builds background around {matches[0]} before revisiting this lesson."
+    elif path == "easier":
+        explanation = f"Offers a lighter on-ramp that overlaps on {matches[0]}."
+    elif path == "deeper":
+        explanation = f"Continues into a more demanding follow-up connected by {matches[0]}."
+    else:
+        explanation = f"Shares adjacent context through {matches[0]}."
+    return {
+        "item_type": "lesson",
+        "id": int(candidate["id"]),
+        "title": title,
+        "url": f"/learn/{candidate['id']}",
+        "source_name": candidate.get("source_name"),
+        "explanation": explanation,
+        "matched_signals": matches,
+    }
+
+
+def _trail_article_candidate(
+    article: dict[str, Any],
+    *,
+    path: str,
+    matches: list[str],
+) -> dict[str, Any]:
+    title = str(article.get("title") or article.get("canonical_url"))
+    if path == "prerequisite":
+        explanation = f"Introduces background signal {matches[0]} from your article corpus."
+    elif path == "easier":
+        explanation = f"A shorter article-shaped on-ramp tied to {matches[0]}."
+    elif path == "deeper":
+        explanation = f"High-signal follow-up that develops {matches[0]} further."
+    else:
+        explanation = f"Related article connected by {matches[0]}."
+    return {
+        "item_type": "article",
+        "id": int(article["id"]),
+        "title": title,
+        "url": str(article.get("canonical_url") or article.get("url") or ""),
+        "source_name": article.get("source_name"),
+        "explanation": explanation,
+        "matched_signals": matches,
+    }
+
+
+def _append_trail_item(
+    groups: dict[str, list[dict[str, Any]]],
+    path: str,
+    item: dict[str, Any],
+) -> None:
+    if len(groups[path]) >= _TRAIL_GROUP_LIMIT:
+        return
+    key = (item["item_type"], item["id"])
+    if any(
+        (existing["item_type"], existing["id"]) == key
+        for values in groups.values()
+        for existing in values
+    ):
+        return
+    groups[path].append(item)
+
+
+def _trail_path_for_lesson(
+    candidate: dict[str, Any],
+    *,
+    matches: list[str],
+    prerequisite_concepts: list[str],
+    current_rank: int,
+) -> str:
+    rank = _lesson_depth_rank(candidate)
+    if rank > current_rank:
+        return "deeper"
+    if any(match in prerequisite_concepts for match in matches):
+        return "prerequisite"
+    if rank < current_rank:
+        return "easier"
+    return "adjacent"
+
+
+def _trail_path_for_article(
+    article: dict[str, Any],
+    *,
+    matches: list[str],
+    prerequisite_concepts: list[str],
+    source_length: int,
+) -> str:
+    if any(match in prerequisite_concepts for match in matches):
+        return "prerequisite"
+    body_length = len(str(article.get("body") or article.get("summary") or ""))
+    if body_length < source_length / 2:
+        return "easier"
+    importance = int(article.get("importance_score") or 50)
+    if importance >= 80 or body_length > source_length:
+        return "deeper"
+    return "adjacent"
+
+
+def recommend_lesson_trails(
+    lesson_id: int,
+    user_id: int,
+    *,
+    database_url: str | None = None,
+) -> dict[str, Any]:
+    lesson = get_lesson(lesson_id, user_id, database_url=database_url)
+    if lesson is None:
+        raise LessonNotFoundError
+    if lesson.get("generation_status") != "complete" or not isinstance(
+        lesson.get("lesson_detail"), dict
+    ):
+        return {
+            "lesson_id": lesson_id,
+            "groups": [
+                {"path": path, "label": label, "items": []}
+                for path, label in _TRAIL_GROUP_LABELS.items()
+            ],
+            "empty_message": "Complete this lesson before building a learning trail.",
+        }
+
+    terms = _trail_terms(lesson)
+    if not terms:
+        return {
+            "lesson_id": lesson_id,
+            "groups": [
+                {"path": path, "label": label, "items": []}
+                for path, label in _TRAIL_GROUP_LABELS.items()
+            ],
+            "empty_message": "Not enough lesson concepts were found to recommend a trail yet.",
+        }
+
+    current_rank = _lesson_depth_rank(lesson)
+    prerequisite_concepts = [
+        str(concept)
+        for concept in (lesson.get("lesson_detail") or {}).get("prerequisite_concepts", [])
+    ]
+    source_length = len(str(lesson.get("source_content") or ""))
+    groups: dict[str, list[dict[str, Any]]] = {path: [] for path in _TRAIL_GROUP_LABELS}
+
+    from news_dashboard.article_visibility import visible_article_sql
+
+    init_db(database_url=database_url)
+    with connect(database_url=database_url) as conn:
+        lesson_rows = conn.execute(
+            """
+            SELECT id, title, original_url, source_name, lesson_detail, created_at
+            FROM lessons
+            WHERE user_id = %s
+              AND id != %s
+              AND generation_status = 'complete'
+              AND lesson_detail IS NOT NULL
+            ORDER BY created_at DESC
+            LIMIT %s
+            """,
+            (user_id, lesson_id, _TRAIL_CANDIDATE_LIMIT),
+        ).fetchall()
+        article_rows = conn.execute(
+            f"""
+            SELECT a.id, a.title, a.url, a.canonical_url, a.source_name, a.summary,
+                   a.body, a.importance_score, uas.starred
+            FROM articles a
+            JOIN sources a_src ON a_src.slug = a.source_slug
+            LEFT JOIN user_sources a_us
+              ON a_us.source_slug = a.source_slug AND a_us.user_id = %s
+            LEFT JOIN user_article_state uas
+              ON uas.article_id = a.id AND uas.user_id = %s
+            WHERE ({visible_article_sql("a")})
+            ORDER BY COALESCE(uas.starred, FALSE) DESC, a.importance_score DESC, a.id DESC
+            LIMIT %s
+            """,
+            (user_id, user_id, user_id, _TRAIL_CANDIDATE_LIMIT),
+        ).fetchall()
+
+    for row in lesson_rows:
+        candidate = row_to_dict(row)
+        detail = candidate.get("lesson_detail") or {}
+        text = " ".join(
+            str(value)
+            for value in (
+                candidate.get("title"),
+                detail.get("gist"),
+                detail.get("explanation"),
+                " ".join(detail.get("prerequisite_concepts") or []),
+                " ".join(detail.get("key_claims") or []),
+            )
+            if value
+        )
+        matches = _matches_for_text(text, terms)
+        if not matches:
+            continue
+        path = _trail_path_for_lesson(
+            candidate,
+            matches=matches,
+            prerequisite_concepts=prerequisite_concepts,
+            current_rank=current_rank,
+        )
+        _append_trail_item(
+            groups,
+            path,
+            _trail_lesson_candidate(candidate, path=path, matches=matches),
+        )
+
+    for row in article_rows:
+        article = row_to_dict(row)
+        text = " ".join(
+            str(value)
+            for value in (
+                article.get("title"),
+                article.get("summary"),
+                article.get("body"),
+            )
+            if value
+        )
+        matches = _matches_for_text(text, terms)
+        if not matches:
+            continue
+        path = _trail_path_for_article(
+            article,
+            matches=matches,
+            prerequisite_concepts=prerequisite_concepts,
+            source_length=source_length,
+        )
+        _append_trail_item(
+            groups,
+            path,
+            _trail_article_candidate(article, path=path, matches=matches),
+        )
+
+    response_groups = [
+        {"path": path, "label": label, "items": groups[path]}
+        for path, label in _TRAIL_GROUP_LABELS.items()
+    ]
+    has_items = any(group["items"] for group in response_groups)
+    return {
+        "lesson_id": lesson_id,
+        "groups": response_groups,
+        "empty_message": None
+        if has_items
+        else "No related lessons or articles are available in your corpus yet.",
+    }
 
 
 def _score_suggestion_candidate(

--- a/backend/tests/test_learn_from_link.py
+++ b/backend/tests/test_learn_from_link.py
@@ -1067,6 +1067,137 @@ def test_get_lesson_endpoint_404s_for_other_user(
     assert response.json()["detail"] == "lesson not found"
 
 
+def test_recommend_lesson_trails_groups_related_lessons_and_articles(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    current = service.create_lesson(user_id, "https://example.com/current", database_url=pg_clean)
+
+    def detail_with(*, gist: str, verdict: str, concepts: list[str]) -> dict[str, Any]:
+        return {
+            "gist": gist,
+            "explanation": f"{gist} explains vector search and embeddings.",
+            "key_claims": [f"{gist} uses embeddings."],
+            "prerequisite_concepts": concepts,
+            "why_it_matters": "It matters for retrieval systems.",
+            "read_worthiness": {"verdict": verdict, "rationale": "Useful follow-up."},
+            "who_should_read": ["Builders"],
+            "questions_to_keep_in_mind": ["What connects these ideas?"],
+            "citations": [{"label": "1", "snippet": gist, "source": gist}],
+        }
+
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "UPDATE lessons SET lesson_detail = %s::jsonb, source_content = %s WHERE id = %s",
+            (
+                Jsonb(
+                    detail_with(
+                        gist="Vector search foundation",
+                        verdict="read",
+                        concepts=["Embeddings", "Vector search"],
+                    )
+                ),
+                "Vector search foundation with embeddings.",
+                current["id"],
+            ),
+        )
+    prerequisite = service.create_lesson(
+        user_id, "https://example.com/prerequisite", database_url=pg_clean
+    )
+    deeper = service.create_lesson(user_id, "https://example.com/deeper", database_url=pg_clean)
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "UPDATE lessons SET title = %s, lesson_detail = %s::jsonb WHERE id = %s",
+            (
+                "Embeddings basics",
+                Jsonb(
+                    detail_with(
+                        gist="Embeddings basics",
+                        verdict="skim",
+                        concepts=["Embeddings"],
+                    )
+                ),
+                prerequisite["id"],
+            ),
+        )
+        conn.execute(
+            "UPDATE lessons SET title = %s, lesson_detail = %s::jsonb WHERE id = %s",
+            (
+                "Deep vector retrieval",
+                Jsonb(
+                    detail_with(
+                        gist="Deep vector retrieval",
+                        verdict="study",
+                        concepts=["Vector search"],
+                    )
+                ),
+                deeper["id"],
+            ),
+        )
+    article_id = _seed_article(
+        pg_clean,
+        slug="trail-article",
+        title="Foundation production checklist",
+        summary="Foundation patterns in production retrieval systems.",
+    )
+
+    trails = service.recommend_lesson_trails(current["id"], user_id, database_url=pg_clean)
+
+    groups = {group["path"]: group["items"] for group in trails["groups"]}
+    assert trails["empty_message"] is None
+    assert groups["prerequisite"][0]["title"] == "Embeddings basics"
+    assert groups["prerequisite"][0]["item_type"] == "lesson"
+    assert "Embeddings" in groups["prerequisite"][0]["matched_signals"]
+    assert groups["deeper"][0]["title"] == "Deep vector retrieval"
+    assert groups["deeper"][0]["explanation"]
+    all_items = [item for items in groups.values() for item in items]
+    assert any(item["id"] == article_id and item["item_type"] == "article" for item in all_items)
+
+
+def test_recommend_lesson_trails_returns_empty_state_when_no_candidates(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean)
+    lesson = service.create_lesson(user_id, "https://example.com/current", database_url=pg_clean)
+
+    trails = service.recommend_lesson_trails(lesson["id"], user_id, database_url=pg_clean)
+
+    assert [group["path"] for group in trails["groups"]] == [
+        "prerequisite",
+        "easier",
+        "adjacent",
+        "deeper",
+    ]
+    assert all(group["items"] == [] for group in trails["groups"])
+    assert (
+        trails["empty_message"]
+        == "No related lessons or articles are available in your corpus yet."
+    )
+
+
+def test_get_lesson_trails_endpoint_is_user_scoped(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    init_db(database_url=pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    lesson = service.create_lesson(alice, "https://example.com/a", database_url=pg_clean)
+
+    with _api_client(alice) as client:
+        response = client.get(f"/api/learn/lessons/{lesson['id']}/trails")
+
+    assert response.status_code == 200
+    assert response.json()["lesson_id"] == lesson["id"]
+
+    with _api_client(bob, username="bob") as client:
+        response = client.get(f"/api/learn/lessons/{lesson['id']}/trails")
+
+    assert response.status_code == 404
+
+
 def _mock_chat_reply(reply: str) -> Any:
     captured: dict[str, Any] = {}
 

--- a/backend/tests/test_main_feature_modules.py
+++ b/backend/tests/test_main_feature_modules.py
@@ -100,6 +100,7 @@ EXPECTED_METHOD_PATHS = {
     ("POST", "/api/learn/lessons/{lesson_id}/regenerate"),
     ("POST", "/api/learn/lessons/{lesson_id}/relevance/feedback"),
     ("POST", "/api/learn/lessons/{lesson_id}/slides"),
+    ("GET", "/api/learn/lessons/{lesson_id}/trails"),
     ("GET", "/api/learn/suggestions"),
     ("POST", "/api/learn/suggestions/dismiss"),
     ("GET", "/api/lesson-recaps"),

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -80,6 +80,16 @@ function renderPage(lessonId: number) {
 describe('LessonDetailPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(api, 'fetchLessonTrails').mockResolvedValue({
+      lesson_id: 5,
+      groups: [
+        { path: 'prerequisite', label: 'Prerequisite concepts', items: [] },
+        { path: 'easier', label: 'Easier on-ramp', items: [] },
+        { path: 'adjacent', label: 'Adjacent reads', items: [] },
+        { path: 'deeper', label: 'Deeper path', items: [] },
+      ],
+      empty_message: 'No related lessons or articles are available in your corpus yet.',
+    });
   });
 
   afterEach(() => {
@@ -221,6 +231,75 @@ describe('LessonDetailPage', () => {
     renderPage(5);
 
     expect(await screen.findByText(/No graph nodes were extracted/i)).toBeInTheDocument();
+  });
+
+  it('renders grouped learning trail recommendations', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue(COMPLETE_LESSON);
+    vi.spyOn(api, 'fetchLessonTrails').mockResolvedValue({
+      lesson_id: 5,
+      groups: [
+        {
+          path: 'prerequisite',
+          label: 'Prerequisite concepts',
+          items: [
+            {
+              item_type: 'lesson',
+              id: 2,
+              title: 'Embeddings basics',
+              url: '/learn/2',
+              source_name: 'Example Journal',
+              explanation: 'Builds background around Embeddings before revisiting this lesson.',
+              matched_signals: ['Embeddings'],
+            },
+          ],
+        },
+        { path: 'easier', label: 'Easier on-ramp', items: [] },
+        {
+          path: 'adjacent',
+          label: 'Adjacent reads',
+          items: [
+            {
+              item_type: 'article',
+              id: 42,
+              title: 'Vector search checklist',
+              url: 'https://example.com/vector',
+              source_name: 'Example Journal',
+              explanation: 'Related article connected by Vector search.',
+              matched_signals: ['Vector search'],
+            },
+          ],
+        },
+        { path: 'deeper', label: 'Deeper path', items: [] },
+      ],
+      empty_message: null,
+    });
+
+    renderPage(5);
+
+    expect(await screen.findByText('Learning trail')).toBeInTheDocument();
+    expect(screen.getAllByText('Prerequisite concepts').length).toBeGreaterThan(0);
+    expect(await screen.findByRole('link', { name: 'Embeddings basics' })).toHaveAttribute(
+      'href',
+      '/learn/2'
+    );
+    expect(screen.getByRole('link', { name: 'Vector search checklist' })).toHaveAttribute(
+      'href',
+      'https://example.com/vector'
+    );
+    expect(
+      screen.getByText('Builds background around Embeddings before revisiting this lesson.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Vector search')).toBeInTheDocument();
+  });
+
+  it('shows a learning trail empty state', async () => {
+    vi.spyOn(api, 'fetchLesson').mockResolvedValue(COMPLETE_LESSON);
+
+    renderPage(5);
+
+    expect(
+      await screen.findByText('No related lessons or articles are available in your corpus yet.')
+    ).toBeInTheDocument();
   });
 
   it('shows a degraded lesson graph state when extraction is unavailable', async () => {

--- a/frontend/src/api/learn.ts
+++ b/frontend/src/api/learn.ts
@@ -150,6 +150,28 @@ export interface LessonGeneration {
   created_at: string;
 }
 
+export interface LessonTrailItem {
+  item_type: 'lesson' | 'article';
+  id: number;
+  title: string;
+  url: string | null;
+  source_name: string | null;
+  explanation: string;
+  matched_signals: string[];
+}
+
+export interface LessonTrailGroup {
+  path: 'prerequisite' | 'easier' | 'adjacent' | 'deeper';
+  label: string;
+  items: LessonTrailItem[];
+}
+
+export interface LessonTrailResponse {
+  lesson_id: number;
+  groups: LessonTrailGroup[];
+  empty_message: string | null;
+}
+
 export async function createLessonFromLink(
   url: string,
   depth: LessonDepth = 'normal',
@@ -178,6 +200,10 @@ export async function regenerateLesson(
 
 export async function fetchLessonGenerations(id: number): Promise<LessonGeneration[]> {
   return requestJson<LessonGeneration[]>(`/api/learn/lessons/${id}/generations`);
+}
+
+export async function fetchLessonTrails(id: number): Promise<LessonTrailResponse> {
+  return requestJson<LessonTrailResponse>(`/api/learn/lessons/${id}/trails`);
 }
 
 export async function generateLessonPodcast(id: number, force = false): Promise<Lesson> {

--- a/frontend/src/components/LessonDetailView.tsx
+++ b/frontend/src/components/LessonDetailView.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   AlertCircle,
+  BookOpen,
   ExternalLink,
   Headphones,
   Image,
@@ -19,8 +20,10 @@ import {
   generateLessonInfographic,
   generateLessonPodcast,
   generateLessonSlideDeck,
+  fetchLessonTrails,
   type Lesson,
   type LessonDetail,
+  type LessonTrailResponse,
 } from '@/api';
 import { classifyGenerationError, type FriendlyError } from '@/lib/errorPresentation';
 
@@ -83,6 +86,8 @@ export function LessonDetailView({
   const [slideDeckError, setSlideDeckError] = useState<FriendlyError | null>(null);
   const [isGeneratingInfographic, setIsGeneratingInfographic] = useState(false);
   const [infographicError, setInfographicError] = useState<FriendlyError | null>(null);
+  const [trails, setTrails] = useState<LessonTrailResponse | null>(null);
+  const [trailError, setTrailError] = useState<string | null>(null);
   const publishedLabel = formatPublishedDate(lesson.published_at);
   const isPendingLesson = lesson.generation_status === 'pending';
   const isFailedLesson = lesson.generation_status === 'failed';
@@ -90,6 +95,27 @@ export function LessonDetailView({
   const lessonDetail = lesson.lesson_detail ?? null;
   const hasLessonDetail = isCompleteLesson && lessonDetail !== null;
   const graphContext = lessonDetail?.graph_context;
+
+  useEffect(() => {
+    let cancelled = false;
+    setTrails(null);
+    setTrailError(null);
+    if (!hasLessonDetail) return;
+
+    void fetchLessonTrails(lesson.id)
+      .then((nextTrails) => {
+        if (!cancelled) setTrails(nextTrails);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setTrailError(error instanceof Error ? error.message : 'Failed to load learning trails.');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasLessonDetail, lesson.id]);
 
   async function handleGeneratePodcast(force: boolean) {
     setIsGeneratingPodcast(true);
@@ -284,6 +310,73 @@ export function LessonDetailView({
 
       {hasLessonDetail && lesson.study_artifacts ? (
         <StudyArtifactsView artifacts={lesson.study_artifacts} />
+      ) : null}
+
+      {hasLessonDetail ? (
+        <div className="space-y-3 rounded-lg border border-border bg-card/60 p-4">
+          <div className="flex items-center gap-2">
+            <BookOpen className="size-4 text-muted-foreground" />
+            <h3 className="text-sm font-semibold text-foreground">
+              {t('learn.trails.title', 'Learning trail')}
+            </h3>
+          </div>
+
+          {trailError ? (
+            <div className="text-sm text-muted-foreground">{trailError}</div>
+          ) : trails === null ? (
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-4 w-11/12" />
+            </div>
+          ) : trails.empty_message ? (
+            <div className="text-sm leading-6 text-muted-foreground">{trails.empty_message}</div>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2">
+              {trails.groups
+                .filter((group) => group.items.length > 0)
+                .map((group) => (
+                  <section key={group.path} className="space-y-2">
+                    <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+                      {group.label}
+                    </h4>
+                    <ul className="space-y-2">
+                      {group.items.map((item) => (
+                        <li
+                          key={`${item.item_type}-${item.id}`}
+                          className="rounded-md border border-border bg-background p-3"
+                        >
+                          {item.url ? (
+                            <a
+                              href={item.url}
+                              className="text-sm font-semibold text-foreground hover:underline"
+                            >
+                              {item.title}
+                            </a>
+                          ) : (
+                            <div className="text-sm font-semibold text-foreground">
+                              {item.title}
+                            </div>
+                          )}
+                          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                            {item.explanation}
+                          </p>
+                          {item.matched_signals.length > 0 ? (
+                            <div className="mt-2 flex flex-wrap gap-1">
+                              {item.matched_signals.map((signal) => (
+                                <Badge key={signal} variant="outline" className="text-[11px]">
+                                  {signal}
+                                </Badge>
+                              ))}
+                            </div>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                ))}
+            </div>
+          )}
+        </div>
       ) : null}
 
       {hasLessonDetail ? (


### PR DESCRIPTION
Closes #1125

## Summary
- add a lesson trail recommendation endpoint grouped into prerequisite, easier, adjacent, and deeper paths
- use completed lessons plus visible corpus articles with lesson concepts, graph terms, and relevance signals to explain each recommendation
- show learning trail groups and empty states on the lesson detail page

## Tests
- npm run lint -- --max-warnings 0
- npm run typecheck
- npm run build
- npm run format:check
- npm run test:frontend
- .venv/bin/ruff check backend/news_dashboard/learn_from_link backend/tests/test_learn_from_link.py backend/tests/test_main_feature_modules.py
- .venv/bin/mypy backend/news_dashboard/learn_from_link backend/tests/test_learn_from_link.py
- .venv/bin/ty check backend/news_dashboard/learn_from_link backend/tests/test_learn_from_link.py
- .venv/bin/pyrefly check backend/news_dashboard/learn_from_link backend/tests/test_learn_from_link.py backend/tests/test_main_feature_modules.py
- PGOPTIONS="-c max_parallel_workers_per_gather=0" .venv/bin/dotenv run -- .venv/bin/pytest -q

🤖 Generated with [Claude Code](https://claude.com/claude-code)