### PR TITLE
fix: exclude primary source from also-covered-by

### DIFF
--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -1801,17 +1801,25 @@ def _attach_also_from(
         dup_rows = conn.execute(
             f"""
             SELECT a.canonical_id, a.source_name FROM articles a
+            JOIN articles canonical ON canonical.id = a.canonical_id
             JOIN sources s ON s.slug = a.source_slug
             WHERE a.canonical_id IN ({article_placeholders}) AND a.state = 'archived'
+              AND a.source_name IS DISTINCT FROM canonical.source_name
               AND (s.owner_user_id IS NULL OR s.owner_user_id = %s)
+            GROUP BY a.canonical_id, a.source_name
+            ORDER BY a.canonical_id, MIN(a.id)
             """,
             [*article_ids, user_id],
         ).fetchall()
     else:
         dup_rows = conn.execute(
             f"""
-            SELECT canonical_id, source_name FROM articles
-            WHERE canonical_id IN ({article_placeholders}) AND state = 'archived'
+            SELECT a.canonical_id, a.source_name FROM articles a
+            JOIN articles canonical ON canonical.id = a.canonical_id
+            WHERE a.canonical_id IN ({article_placeholders}) AND a.state = 'archived'
+              AND a.source_name IS DISTINCT FROM canonical.source_name
+            GROUP BY a.canonical_id, a.source_name
+            ORDER BY a.canonical_id, MIN(a.id)
             """,
             article_ids,
         ).fetchall()

--- a/backend/tests/test_ingest_dedupe_boundaries.py
+++ b/backend/tests/test_ingest_dedupe_boundaries.py
@@ -242,6 +242,55 @@ def test_also_from_no_user_includes_all_sources(pg_clean: str) -> None:
     assert "judy-private" in article["also_from"]
 
 
+def test_also_from_excludes_primary_source_and_repeated_source_names(pg_clean: str) -> None:
+    """Only distinct sources other than the canonical source are secondary coverage."""
+    _insert_source(pg_clean, "primary-src")
+    canonical_id = _insert_canonical(
+        pg_clean, "https://j.com/story", "Repeated Coverage", "primary-src"
+    )
+    _insert_duplicate(
+        pg_clean, "https://j.com/story-copy", "Repeated Coverage", "primary-src", canonical_id
+    )
+
+    _insert_source(pg_clean, "secondary-src")
+    _insert_duplicate(
+        pg_clean,
+        "https://secondary.example.com/story",
+        "Repeated Coverage",
+        "secondary-src",
+        canonical_id,
+    )
+    _insert_duplicate(
+        pg_clean,
+        "https://secondary.example.com/story-copy",
+        "Repeated Coverage",
+        "secondary-src",
+        canonical_id,
+    )
+
+    _insert_source(pg_clean, "another-secondary-src")
+    _insert_duplicate(
+        pg_clean,
+        "https://another-secondary.example.com/story",
+        "Repeated Coverage",
+        "another-secondary-src",
+        canonical_id,
+    )
+
+    article: dict[str, Any] = {"id": canonical_id}
+    with connect(database_url=pg_clean) as conn:
+        _attach_also_from(conn, [article])
+
+    assert article["also_from"] == ["secondary-src", "another-secondary-src"]
+
+    uid = _insert_user(pg_clean, "also-from-reader")
+    user_article: dict[str, Any] = {"id": canonical_id}
+    with connect(database_url=pg_clean) as conn:
+        _attach_also_from(conn, [user_article], user_id=uid)
+
+    assert user_article["also_from"] == ["secondary-src", "another-secondary-src"]
+
+
 # ── URL-variant reappearance regression (issue #1215) ─────────────────────────
 
 


### PR DESCRIPTION
Closes #1253

## Summary
- exclude the canonical publisher from `also_from`
- collapse repeated secondary publisher names while preserving first-seen order
- cover both user-scoped feed and legacy enrichment paths with PostgreSQL regression tests

## Verification
- `make lint`
- `make typecheck`
- `dotenv run -- env PGOPTIONS="-c max_parallel_workers_per_gather=0" make test` (2,676 backend passed, 1 skipped; 981 frontend passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)