### PR TITLE
fix: extract content after void elements in skipped HTML

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -281,26 +281,35 @@ _BLOCK_TAGS = frozenset(
 class _BodyExtractor(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
-        self._skip_depth = 0
+        self._skip_tag: str | None = None
+        self._skip_tag_depth = 0
         self._chunks: list[str] = []
         self._current: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: ARG002
-        if self._skip_depth or tag in _SKIP_TAGS:
-            self._skip_depth += 1
+        if self._skip_tag is not None:
+            if tag == self._skip_tag:
+                self._skip_tag_depth += 1
+            return
+        if tag in _SKIP_TAGS:
+            self._skip_tag = tag
+            self._skip_tag_depth = 1
             return
         if tag in _BLOCK_TAGS:
             self._flush()
 
     def handle_endtag(self, tag: str) -> None:
-        if self._skip_depth:
-            self._skip_depth -= 1
+        if self._skip_tag is not None:
+            if tag == self._skip_tag:
+                self._skip_tag_depth -= 1
+                if self._skip_tag_depth == 0:
+                    self._skip_tag = None
             return
         if tag in _BLOCK_TAGS:
             self._flush()
 
     def handle_data(self, data: str) -> None:
-        if self._skip_depth:
+        if self._skip_tag is not None:
             return
         text = data.strip()
         if text:

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -109,6 +109,26 @@ def test_extract_body_ok() -> None:
     assert "skip footer" not in body
 
 
+def test_extract_body_resumes_after_void_elements_in_skipped_header() -> None:
+    html = b"""
+    <html><body>
+      <header>
+        <img src="logo.png">
+        <div><img src="banner.png"></div>
+      </header>
+      <main>
+        <p>This article paragraph follows a skipped header containing void elements.</p>
+      </main>
+    </body></html>
+    """
+    url, thread = _start_server(html)
+    with _allow_local_body_fetches():
+        body, status = extract_body(url)
+    thread.join(timeout=2)
+    assert status == "ok"
+    assert "article paragraph follows" in body
+
+
 def test_extract_body_error_on_network_failure() -> None:
     body, status = extract_body("http://127.0.0.1:1/")
     assert status == "error"


### PR DESCRIPTION
Closes #1257

## Summary
- track the active skipped container instead of incrementing depth for every nested tag
- resume extraction after headers containing HTML void elements such as `<img>`
- cover the Cap’n Proto page structure with an offline regression test

## Verification
- `make lint`
- `make typecheck`
- `PGOPTIONS="-c max_parallel_workers_per_gather=0" dotenv run -- make test`
- live extraction of `https://capnproto.org/` returns 5,674 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)