### PR TITLE
feat: unify email visual identity

### DIFF
--- a/backend/news_dashboard/briefing_email/rendering.py
+++ b/backend/news_dashboard/briefing_email/rendering.py
@@ -11,6 +11,13 @@ from urllib.parse import urlparse
 
 from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 
+from news_dashboard.email_theme import (
+    EMAIL_COLORS,
+    FONT_SERIF,
+    compact_text,
+    render_email_shell,
+)
+
 _WORDS_PER_MINUTE = 200
 _ENVIRONMENT = Environment(
     loader=PackageLoader("news_dashboard.briefing_email", "templates"),
@@ -79,7 +86,7 @@ def render_briefing_email(
                 if article is not None:
                     cited_articles.append(
                         {
-                            "title": str(article.get("title") or "Source"),
+                            "title": compact_text(article.get("title"), fallback="Source"),
                             "source_name": str(article.get("source_name") or ""),
                             "url": _safe_link(article.get("url")),
                         }
@@ -100,10 +107,18 @@ def render_briefing_email(
         "briefing_url": _safe_link(briefing_url),
         "preferences_url": _safe_link(preferences_url),
         "unsubscribe_url": _safe_link(unsubscribe_url),
+        "colors": {name: color.email_hex for name, color in EMAIL_COLORS.items()},
+        "font_serif": FONT_SERIF,
     }
+    body_html = _ENVIRONMENT.get_template("briefing.html.j2").render(context)
     return RenderedEmail(
         subject=f"Daily briefing: {context['title']}",
-        html_body=_ENVIRONMENT.get_template("briefing.html.j2").render(context),
+        html_body=render_email_shell(
+            preheader=str(context["summary"]),
+            eyebrow="Current-day report",
+            heading=str(context["title"]),
+            body_html=body_html,
+        ),
         text_body=_ENVIRONMENT.get_template("briefing.txt.j2").render(context),
         estimated_minutes=estimated_minutes,
     )

--- a/backend/news_dashboard/briefing_email/templates/briefing.html.j2
+++ b/backend/news_dashboard/briefing_email/templates/briefing.html.j2
@@ -1,16 +1,38 @@
-<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>
-<body style="margin:0;background:#f1f5f9;font-family:Arial,sans-serif;color:#172033">
-<div style="display:none;max-height:0;overflow:hidden">{{ summary }}</div>
-<table role="presentation" width="100%" cellspacing="0" cellpadding="0"><tr><td align="center" style="padding:24px">
-<table role="presentation" width="640" cellspacing="0" cellpadding="0" style="max-width:640px;width:100%;background:#fff">
-<tr><td style="padding:28px;background:#172033;color:#fff"><strong>News Dashboard</strong><h1 style="margin:12px 0 0">{{ title }}</h1></td></tr>
-<tr><td style="padding:24px"><p>{{ local_date }} · {{ timezone_name }} · {{ estimated_minutes }} min read</p>
-<div style="padding:18px;background:#eff6ff;border-left:4px solid #2563eb"><strong>Executive summary</strong><p>{{ summary }}</p></div>
-{% for story in stories %}<div style="padding:22px 0;border-bottom:1px solid #e2e8f0"><h2>{{ story.title }}</h2><p style="line-height:1.6">{{ story.body }}</p>
-{% for article in story.articles %}<p>{% if article.url %}<a href="{{ article.url }}">{{ article.title }}</a>{% else %}{{ article.title }}{% endif %}{% if article.source_name %} — {{ article.source_name }}{% endif %}</p>{% endfor %}</div>{% endfor %}
-{% if briefing_url %}<p style="padding:20px 0"><a href="{{ briefing_url }}" style="background:#2563eb;color:#fff;padding:12px 18px;text-decoration:none">Open web briefing</a></p>{% endif %}
-</td></tr><tr><td style="padding:20px;background:#f8fafc;font-size:12px;color:#64748b">
-{% if preferences_url %}<a href="{{ preferences_url }}">Email preferences</a>{% endif %}{% if preferences_url and unsubscribe_url %} · {% endif %}{% if unsubscribe_url %}<a href="{{ unsubscribe_url }}">Unsubscribe</a>{% endif %}
-</td></tr></table></td></tr></table></body></html>
+<p style="margin:0 0 18px;color:{{ colors.muted }};font-size:12px;line-height:1.5;">
+  {{ local_date }} &middot; {{ timezone_name }} &middot; {{ estimated_minutes }} min read
+</p>
+<div style="margin:0 0 8px;padding:18px;background:{{ colors.surface_muted }};
+            border-left:4px solid {{ colors.accent }};border-radius:8px;">
+  <strong style="color:{{ colors.primary }};font-size:12px;letter-spacing:.08em;
+                 text-transform:uppercase;">Executive summary</strong>
+  <p style="margin:9px 0 0;color:{{ colors.foreground }};font-family:{{ font_serif }};
+            font-size:15px;line-height:1.6;">{{ summary }}</p>
+</div>
+{% for story in stories %}
+<div style="padding:22px 0;border-bottom:1px solid {{ colors.border }};">
+  <h2 style="margin:0 0 9px;color:{{ colors.primary }};font-size:18px;
+             line-height:1.35;">{{ story.title }}</h2>
+  <p style="margin:0;color:{{ colors.foreground }};font-family:{{ font_serif }};
+            font-size:14px;line-height:1.65;">{{ story.body }}</p>
+  {% for article in story.articles %}
+  <p style="margin:10px 0 0;color:{{ colors.muted }};font-size:11px;line-height:1.45;">
+    {% if article.url %}<a href="{{ article.url }}" style="color:{{ colors.accent }};
+      font-size:12px;font-weight:600;text-decoration:none;">{{ article.title }}</a>
+    {% else %}<span style="font-size:12px;font-weight:600;">{{ article.title }}</span>{% endif %}
+    {% if article.source_name %}<span> &middot; {{ article.source_name }}</span>{% endif %}
+  </p>
+  {% endfor %}
+</div>
+{% endfor %}
+{% if briefing_url %}
+<p style="margin:24px 0 8px;"><a href="{{ briefing_url }}"
+  style="display:inline-block;padding:11px 16px;background:{{ colors.primary }};
+         border-radius:8px;color:#ffffff;font-size:13px;font-weight:700;
+         text-decoration:none;">Open web briefing</a></p>
+{% endif %}
+<p style="margin:22px 0 0;padding-top:16px;border-top:1px solid {{ colors.border }};
+          color:{{ colors.muted }};font-size:11px;line-height:1.5;">
+  {% if preferences_url %}<a href="{{ preferences_url }}" style="color:{{ colors.muted }};">Email preferences</a>{% endif %}
+  {% if preferences_url and unsubscribe_url %} &middot; {% endif %}
+  {% if unsubscribe_url %}<a href="{{ unsubscribe_url }}" style="color:{{ colors.muted }};">Unsubscribe</a>{% endif %}
+</p>

--- a/backend/news_dashboard/digest.py
+++ b/backend/news_dashboard/digest.py
@@ -15,6 +15,12 @@ from email.mime.text import MIMEText
 from typing import Any
 
 from news_dashboard.db import init_db
+from news_dashboard.email_theme import (
+    EMAIL_COLORS,
+    FONT_SERIF,
+    render_action_link,
+    render_email_shell,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,41 +103,79 @@ def _base_url() -> str:
     return os.getenv("APP_BASE_URL", "http://localhost:8000")
 
 
+def _display_title(value: object, *, limit: int = 120) -> str:
+    """Return a normalized title bounded for compact email presentation."""
+    normalized = " ".join(str(value).split()) if value else "Untitled"
+    if len(normalized) <= limit:
+        return normalized
+
+    prefix = normalized[: limit - 1].rstrip()
+    if " " in prefix:
+        word_boundary = prefix.rsplit(" ", 1)[0]
+        if word_boundary:
+            prefix = word_boundary
+    return f"{prefix}…"
+
+
 def _render_html(articles: list[dict[str, Any]], *, user_id: int) -> str:
     base = _base_url()
     rows = ""
     for a in articles:
         token = _make_token(user_id, a["id"])
         mark_read_url = f"{base}/api/articles/{a['id']}/read?token={token}"
-        title = html.escape(a.get("title") or "Untitled")
+        title = html.escape(_display_title(a.get("title")))
         url = html.escape(a.get("url") or "#", quote=True)
         source = html.escape(a.get("source_name") or "")
         summary = html.escape(a.get("summary") or "")
-        score = a.get("importance_score", 0)
+        score = html.escape(str(a.get("importance_score", 0)))
+        summary_html = ""
+        if summary:
+            summary_html = f"""
+            <p style="margin:9px 0 12px;color:{EMAIL_COLORS["foreground"].email_hex};
+                      font-family:{FONT_SERIF};font-size:14px;line-height:1.55;">
+              {summary}
+            </p>"""
         rows += f"""
         <tr>
-          <td style="padding:12px 0;border-bottom:1px solid #eee;">
+          <td style="padding:20px 0;border-bottom:1px solid
+                     {EMAIL_COLORS["border"].email_hex};">
             <a href="{url}"
-               style="font-size:15px;font-weight:bold;color:#1a1a1a;text-decoration:none;"
+               style="color:{EMAIL_COLORS["primary"].email_hex};font-size:16px;
+                      font-weight:700;line-height:1.35;text-decoration:none;"
             >{title}</a><br>
-            <span style="font-size:12px;color:#888;">{source} &middot; score {score}</span><br>
-            <p style="margin:6px 0;font-size:13px;color:#444;">{summary}</p>
-            <a href="{mark_read_url}" style="font-size:12px;color:#0066cc;">Mark as read &rarr;</a>
+            <span style="display:inline-block;margin-top:6px;color:
+                         {EMAIL_COLORS["muted"].email_hex};font-size:11px;
+                         letter-spacing:.02em;text-transform:uppercase;">
+              {source} &middot; score {score}
+            </span>
+            {summary_html}
+            {render_action_link(url=mark_read_url, label="Mark as read")}
           </td>
         </tr>
         """
     date_str = datetime.now(timezone.utc).strftime("%A, %B %-d %Y")
-    return f"""
-    <html><body style="font-family:Arial,sans-serif;max-width:640px;margin:auto;padding:24px;">
-      <h2 style="color:#1a1a1a;">News Digest &mdash; {date_str}</h2>
-      <p style="color:#555;">Your top {len(articles)}
-        new article{"s" if len(articles) != 1 else ""} today:</p>
-      <table width="100%" cellpadding="0" cellspacing="0">{rows}</table>
-      <p style="margin-top:24px;font-size:12px;color:#aaa;">
+    article_word = f"article{'s' if len(articles) != 1 else ''}"
+    body_html = f"""
+      <div style="margin:0 0 8px;padding:16px 18px;border-radius:10px;
+                  background:{EMAIL_COLORS["surface_muted"].email_hex};">
+        <p style="margin:0;color:{EMAIL_COLORS["muted"].email_hex};
+                  font-size:13px;line-height:1.5;">Your top <strong style="color:
+                  {EMAIL_COLORS["foreground"].email_hex};">{len(articles)}
+        new {article_word} today</strong>, selected by importance.</p>
+      </div>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        {rows}
+      </table>
+      <p style="margin:22px 0 0;color:{EMAIL_COLORS["muted"].email_hex};
+                font-size:11px;line-height:1.5;">
         You received this because you set up the News Dashboard digest.
-      </p>
-    </body></html>
-    """
+      </p>"""
+    return render_email_shell(
+        preheader=f"Your top {len(articles)} {article_word} for today",
+        eyebrow="Daily briefing",
+        heading=f"News Digest — {date_str}",
+        body_html=body_html,
+    )
 
 
 def _render_text(articles: list[dict[str, Any]], *, user_id: int) -> str:
@@ -140,7 +184,7 @@ def _render_text(articles: list[dict[str, Any]], *, user_id: int) -> str:
     for i, a in enumerate(articles, 1):
         token = _make_token(user_id, a["id"])
         mark_read_url = f"{base}/api/articles/{a['id']}/read?token={token}"
-        title = a.get("title") or "Untitled"
+        title = _display_title(a.get("title"))
         url = a.get("url") or ""
         source = a.get("source_name") or ""
         summary = a.get("summary") or ""

--- a/backend/news_dashboard/digest.py
+++ b/backend/news_dashboard/digest.py
@@ -18,6 +18,7 @@ from news_dashboard.db import init_db
 from news_dashboard.email_theme import (
     EMAIL_COLORS,
     FONT_SERIF,
+    compact_text,
     render_action_link,
     render_email_shell,
 )
@@ -105,16 +106,7 @@ def _base_url() -> str:
 
 def _display_title(value: object, *, limit: int = 120) -> str:
     """Return a normalized title bounded for compact email presentation."""
-    normalized = " ".join(str(value).split()) if value else "Untitled"
-    if len(normalized) <= limit:
-        return normalized
-
-    prefix = normalized[: limit - 1].rstrip()
-    if " " in prefix:
-        word_boundary = prefix.rsplit(" ", 1)[0]
-        if word_boundary:
-            prefix = word_boundary
-    return f"{prefix}…"
+    return compact_text(value, fallback="Untitled", limit=limit)
 
 
 def _render_html(articles: list[dict[str, Any]], *, user_id: int) -> str:
@@ -149,7 +141,7 @@ def _render_html(articles: list[dict[str, Any]], *, user_id: int) -> str:
               {source} &middot; score {score}
             </span>
             {summary_html}
-            {render_action_link(url=mark_read_url, label="Mark as read")}
+            {render_action_link(url=mark_read_url, label="Move to Done")}
           </td>
         </tr>
         """
@@ -194,7 +186,7 @@ def _render_text(articles: list[dict[str, Any]], *, user_id: int) -> str:
         lines.append(f"   {url}")
         if summary:
             lines.append(f"   {summary}")
-        lines.append(f"   Mark read: {mark_read_url}")
+        lines.append(f"   Move to Done: {mark_read_url}")
         lines.append("")
     return "\n".join(lines)
 

--- a/backend/news_dashboard/email.py
+++ b/backend/news_dashboard/email.py
@@ -17,6 +17,8 @@ from collections.abc import Mapping
 from email.message import EmailMessage
 from typing import NamedTuple
 
+from news_dashboard.email_theme import EMAIL_COLORS, render_email_shell, render_highlight_panel
+
 logger = logging.getLogger(__name__)
 
 _GMAIL_HOST = "smtp.gmail.com"
@@ -156,84 +158,25 @@ def send_otp_email(to_email: str, otp: str) -> None:
         )
         raise RuntimeError(err)
 
-    html_body = f"""\
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Your News Dashboard sign-in code</title>
-</head>
-<body style="margin:0;padding:0;background:#f0f4f8;font-family:'Helvetica Neue',Arial,sans-serif">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0"
-         style="background:#f0f4f8;padding:32px 0">
-    <tr>
-      <td align="center">
-        <table role="presentation" width="480" cellspacing="0" cellpadding="0"
-               style="max-width:480px;width:100%;background:#ffffff;border-radius:12px;
-                      overflow:hidden;box-shadow:0 4px 24px rgba(0,0,0,.08)">
-
-          <!-- Branded header -->
-          <tr>
-            <td style="background:#1e293b;padding:28px 32px;text-align:center">
-              <p style="margin:0;font-size:26px">📰</p>
-              <h1 style="margin:8px 0 4px;color:#ffffff;font-size:22px;
-                         font-weight:700;letter-spacing:-.3px">News Dashboard</h1>
-              <p style="margin:0;color:#94a3b8;font-size:13px">
-                Your personalised news intelligence platform
-              </p>
-            </td>
-          </tr>
-
-          <!-- Body -->
-          <tr>
-            <td style="padding:36px 32px 24px">
-              <h2 style="margin:0 0 12px;color:#1e293b;font-size:20px;font-weight:700">
-                Your sign-in code
-              </h2>
-              <p style="margin:0 0 28px;color:#475569;font-size:15px;line-height:1.6">
-                Use the one-time code below to sign in to&nbsp;<strong>News&nbsp;Dashboard</strong>.
-                It expires in&nbsp;<strong>10&nbsp;minutes</strong>.
-              </p>
-
-              <!-- OTP block -->
-              <div style="background:#eff6ff;border:2px solid #2563eb;border-radius:10px;
-                          padding:24px;text-align:center;margin-bottom:28px">
-                <p style="margin:0 0 6px;color:#3b82f6;font-size:11px;
-                           font-weight:600;letter-spacing:1.5px;text-transform:uppercase">
-                  One-time code
-                </p>
-                <span style="display:inline-block;font-size:40px;font-weight:800;
-                             letter-spacing:10px;color:#1e40af;line-height:1">
-                  {otp}
-                </span>
-              </div>
-
-              <p style="margin:0;color:#94a3b8;font-size:12px;line-height:1.6;
-                         border-top:1px solid #e2e8f0;padding-top:20px">
-                If you did not request this code, you can safely ignore this email.
-                Someone may have entered your email address by mistake.
-              </p>
-            </td>
-          </tr>
-
-          <!-- Footer -->
-          <tr>
-            <td style="background:#f8fafc;padding:16px 32px;text-align:center;
-                       border-top:1px solid #e2e8f0">
-              <p style="margin:0;color:#94a3b8;font-size:11px">
-                This email was sent by <strong>News Dashboard</strong>.
-                Do not reply to this email.
-              </p>
-            </td>
-          </tr>
-
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>"""
+    body_html = f"""
+      <p style="margin:0 0 24px;color:{EMAIL_COLORS["foreground"].email_hex};
+                font-size:15px;line-height:1.65;">
+        Use the one-time code below to sign in to <strong>News Dashboard</strong>.
+        It expires in <strong>10 minutes</strong>.
+      </p>
+      {render_highlight_panel(label="One-time code", value=otp)}
+      <p style="margin:0;padding-top:18px;border-top:1px solid
+                {EMAIL_COLORS["border"].email_hex};color:{EMAIL_COLORS["muted"].email_hex};
+                font-size:12px;line-height:1.6;">
+        If you did not request this code, you can safely ignore this email.
+        Someone may have entered your email address by mistake.
+      </p>"""
+    html_body = render_email_shell(
+        preheader="Your News Dashboard sign-in code expires in 10 minutes.",
+        eyebrow="Secure sign-in",
+        heading="Your sign-in code",
+        body_html=body_html,
+    )
 
     result = send_email(
         recipient=to_email,

--- a/backend/news_dashboard/email_theme.py
+++ b/backend/news_dashboard/email_theme.py
@@ -10,19 +10,20 @@ from typing import NamedTuple
 class EmailColor(NamedTuple):
     """An email-safe color paired with its canonical application token."""
 
+    css_variable: str
     app_token: str
     email_hex: str
 
 
 EMAIL_COLORS: Mapping[str, EmailColor] = {
-    "background": EmailColor("oklch(0.985 0.003 80)", "#faf8f5"),
-    "foreground": EmailColor("oklch(0.2 0.012 70)", "#312e29"),
-    "surface": EmailColor("oklch(1 0 0)", "#ffffff"),
-    "surface_muted": EmailColor("oklch(0.945 0.006 80)", "#f1ede8"),
-    "primary": EmailColor("oklch(0.32 0.04 60)", "#594532"),
-    "muted": EmailColor("oklch(0.5 0.012 70)", "#77716a"),
-    "accent": EmailColor("oklch(0.55 0.13 45)", "#a95125"),
-    "border": EmailColor("oklch(0.9 0.008 80)", "#e4ded7"),
+    "background": EmailColor("--background", "oklch(0.985 0.003 80)", "#faf8f5"),
+    "foreground": EmailColor("--foreground", "oklch(0.2 0.012 70)", "#312e29"),
+    "card": EmailColor("--card", "oklch(1 0 0)", "#ffffff"),
+    "surface_muted": EmailColor("--surface-2", "oklch(0.945 0.006 80)", "#f1ede8"),
+    "primary": EmailColor("--primary", "oklch(0.32 0.04 60)", "#594532"),
+    "muted": EmailColor("--muted-foreground", "oklch(0.5 0.012 70)", "#77716a"),
+    "accent": EmailColor("--accent", "oklch(0.55 0.13 45)", "#a95125"),
+    "border": EmailColor("--border", "oklch(0.9 0.008 80)", "#e4ded7"),
 }
 
 FONT_SANS = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif"
@@ -30,12 +31,31 @@ FONT_SERIF = "'Source Serif 4', 'Iowan Old Style', Georgia, serif"
 FONT_MONO = "'JetBrains Mono', 'SFMono-Regular', Consolas, monospace"
 
 
+def _escape(value: str) -> str:
+    """Escape email text using the entity spelling Jinja emits."""
+    return html.escape(value, quote=True).replace("&#x27;", "&#39;")
+
+
+def compact_text(value: object, *, fallback: str, limit: int = 120) -> str:
+    """Normalize and bound user-facing text at the nearest word boundary."""
+    normalized = " ".join(str(value).split()) if value else fallback
+    if len(normalized) <= limit:
+        return normalized
+
+    prefix = normalized[: limit - 1].rstrip()
+    if " " in prefix:
+        word_boundary = prefix.rsplit(" ", 1)[0]
+        if word_boundary:
+            prefix = word_boundary
+    return f"{prefix}…"
+
+
 def render_email_shell(*, preheader: str, eyebrow: str, heading: str, body_html: str) -> str:
     """Wrap trusted message HTML in the shared News Dashboard email shell."""
     colors = EMAIL_COLORS
-    safe_preheader = html.escape(preheader, quote=True)
-    safe_eyebrow = html.escape(eyebrow, quote=True)
-    safe_heading = html.escape(heading, quote=True)
+    safe_preheader = _escape(preheader)
+    safe_eyebrow = _escape(eyebrow)
+    safe_heading = _escape(heading)
     return f"""\
 <!DOCTYPE html>
 <html lang="en">
@@ -73,7 +93,7 @@ def render_email_shell(*, preheader: str, eyebrow: str, heading: str, body_html:
             </td>
           </tr>
           <tr>
-            <td style="background:{colors["surface"].email_hex};
+            <td style="background:{colors["card"].email_hex};
                        border:1px solid {colors["border"].email_hex};border-radius:14px;
                        box-shadow:0 8px 28px rgba(49,46,41,.07);overflow:hidden;">
               <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
@@ -113,8 +133,8 @@ def render_email_shell(*, preheader: str, eyebrow: str, heading: str, body_html:
 def render_highlight_panel(*, label: str, value: str) -> str:
     """Render a warm highlighted value panel, escaping all caller content."""
     colors = EMAIL_COLORS
-    safe_label = html.escape(label, quote=True)
-    safe_value = html.escape(value, quote=True)
+    safe_label = _escape(label)
+    safe_value = _escape(value)
     return f"""
     <div style="margin:0 0 26px;padding:22px;text-align:center;
                 background:{colors["surface_muted"].email_hex};
@@ -131,8 +151,8 @@ def render_highlight_panel(*, label: str, value: str) -> str:
 
 def render_action_link(*, url: str, label: str) -> str:
     """Render the shared compact secondary action link."""
-    safe_url = html.escape(url, quote=True)
-    safe_label = html.escape(label, quote=True)
+    safe_url = _escape(url)
+    safe_label = _escape(label)
     return f"""<a href="{safe_url}"
       style="color:{EMAIL_COLORS["accent"].email_hex};font-size:12px;
              font-weight:600;text-decoration:none;">{safe_label} &rarr;</a>"""

--- a/backend/news_dashboard/email_theme.py
+++ b/backend/news_dashboard/email_theme.py
@@ -1,0 +1,138 @@
+"""Shared visual identity and HTML primitives for transactional emails."""
+
+from __future__ import annotations
+
+import html
+from collections.abc import Mapping
+from typing import NamedTuple
+
+
+class EmailColor(NamedTuple):
+    """An email-safe color paired with its canonical application token."""
+
+    app_token: str
+    email_hex: str
+
+
+EMAIL_COLORS: Mapping[str, EmailColor] = {
+    "background": EmailColor("oklch(0.985 0.003 80)", "#faf8f5"),
+    "foreground": EmailColor("oklch(0.2 0.012 70)", "#312e29"),
+    "surface": EmailColor("oklch(1 0 0)", "#ffffff"),
+    "surface_muted": EmailColor("oklch(0.945 0.006 80)", "#f1ede8"),
+    "primary": EmailColor("oklch(0.32 0.04 60)", "#594532"),
+    "muted": EmailColor("oklch(0.5 0.012 70)", "#77716a"),
+    "accent": EmailColor("oklch(0.55 0.13 45)", "#a95125"),
+    "border": EmailColor("oklch(0.9 0.008 80)", "#e4ded7"),
+}
+
+FONT_SANS = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif"
+FONT_SERIF = "'Source Serif 4', 'Iowan Old Style', Georgia, serif"
+FONT_MONO = "'JetBrains Mono', 'SFMono-Regular', Consolas, monospace"
+
+
+def render_email_shell(*, preheader: str, eyebrow: str, heading: str, body_html: str) -> str:
+    """Wrap trusted message HTML in the shared News Dashboard email shell."""
+    colors = EMAIL_COLORS
+    safe_preheader = html.escape(preheader, quote=True)
+    safe_eyebrow = html.escape(eyebrow, quote=True)
+    safe_heading = html.escape(heading, quote=True)
+    return f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <title>{safe_heading}</title>
+</head>
+<body style="margin:0;padding:0;background:{colors["background"].email_hex};
+             color:{colors["foreground"].email_hex};font-family:{FONT_SANS};">
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">
+    {safe_preheader}
+  </div>
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0"
+         style="width:100%;background:{colors["background"].email_hex};">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0"
+               style="width:100%;max-width:640px;">
+          <tr>
+            <td style="padding:0 4px 18px;">
+              <table role="presentation" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td style="width:34px;height:34px;border-radius:9px;
+                             background:{colors["primary"].email_hex};color:#ffffff;
+                             font-family:{FONT_SANS};font-size:12px;font-weight:700;
+                             text-align:center;vertical-align:middle;">ND</td>
+                  <td style="padding-left:11px;color:{colors["primary"].email_hex};
+                             font-size:14px;font-weight:700;letter-spacing:.01em;">
+                    News Dashboard
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="background:{colors["surface"].email_hex};
+                       border:1px solid {colors["border"].email_hex};border-radius:14px;
+                       box-shadow:0 8px 28px rgba(49,46,41,.07);overflow:hidden;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td style="padding:30px 32px 22px;border-bottom:1px solid
+                             {colors["border"].email_hex};">
+                    <p style="margin:0 0 8px;color:{colors["accent"].email_hex};
+                              font-size:11px;font-weight:700;letter-spacing:.12em;
+                              text-transform:uppercase;">{safe_eyebrow}</p>
+                    <h1 style="margin:0;color:{colors["foreground"].email_hex};
+                               font-size:25px;line-height:1.2;font-weight:700;
+                               letter-spacing:-.02em;">{safe_heading}</h1>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:28px 32px;">{body_html}</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 12px 0;color:{colors["muted"].email_hex};
+                       font-size:11px;line-height:1.55;text-align:center;">
+              Sent by <strong style="color:{colors["primary"].email_hex};">
+                News Dashboard
+              </strong> &middot; Your personal news intelligence workspace
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+
+def render_highlight_panel(*, label: str, value: str) -> str:
+    """Render a warm highlighted value panel, escaping all caller content."""
+    colors = EMAIL_COLORS
+    safe_label = html.escape(label, quote=True)
+    safe_value = html.escape(value, quote=True)
+    return f"""
+    <div style="margin:0 0 26px;padding:22px;text-align:center;
+                background:{colors["surface_muted"].email_hex};
+                border:2px solid {colors["accent"].email_hex};border-radius:10px;">
+      <p style="margin:0 0 8px;color:{colors["accent"].email_hex};font-size:11px;
+                font-weight:700;letter-spacing:.14em;text-transform:uppercase;">
+        {safe_label}
+      </p>
+      <span style="display:inline-block;color:{colors["primary"].email_hex};
+                   font-family:{FONT_MONO};font-size:38px;font-weight:700;
+                   line-height:1;letter-spacing:.18em;">{safe_value}</span>
+    </div>"""
+
+
+def render_action_link(*, url: str, label: str) -> str:
+    """Render the shared compact secondary action link."""
+    safe_url = html.escape(url, quote=True)
+    safe_label = html.escape(label, quote=True)
+    return f"""<a href="{safe_url}"
+      style="color:{EMAIL_COLORS["accent"].email_hex};font-size:12px;
+             font-weight:600;text-decoration:none;">{safe_label} &rarr;</a>"""

--- a/backend/tests/test_briefing_email_rendering.py
+++ b/backend/tests/test_briefing_email_rendering.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
+from news_dashboard import email_theme
 from news_dashboard.briefing_email.rendering import render_briefing_email
+from news_dashboard.email_theme import EMAIL_COLORS
 
 
 def _briefing(*, body: str = "First story body.") -> dict[str, Any]:
@@ -72,6 +74,30 @@ def test_rendering_includes_summary_reading_time_and_footer_links() -> None:
     assert "https://news.example/briefings/7" in rendered.text_body
     assert "https://news.example/settings/notifications" in rendered.text_body
     assert "https://news.example/unsubscribe/token" in rendered.text_body
+
+
+def test_rendering_uses_shared_warm_email_identity() -> None:
+    rendered = render_briefing_email(_briefing(), **_urls())
+
+    assert EMAIL_COLORS["background"].email_hex in rendered.html_body
+    assert EMAIL_COLORS["primary"].email_hex in rendered.html_body
+    assert "#2563eb" not in rendered.html_body
+    assert "#f1f5f9" not in rendered.html_body
+
+
+def test_rendering_bounds_article_titles_in_html_and_text() -> None:
+    briefing = _briefing()
+    long_title = "An excessively detailed article title " * 12
+    briefing["articles"][1]["title"] = long_title
+    displayed = email_theme.compact_text(long_title, fallback="Source")
+
+    rendered = render_briefing_email(briefing, **_urls())
+
+    assert len(displayed) <= 120
+    assert displayed in rendered.html_body
+    assert displayed in rendered.text_body
+    assert long_title.strip() not in rendered.html_body
+    assert long_title.strip() not in rendered.text_body
 
 
 def test_rendering_suppresses_unsafe_footer_links() -> None:

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -150,6 +150,8 @@ def test_digest_uses_shared_warm_shell_and_small_action_link() -> None:
     assert EMAIL_COLORS["background"].email_hex in rendered
     assert EMAIL_COLORS["primary"].email_hex in rendered
     assert "font-size:12px" in rendered
+    assert "Move to Done" in rendered
+    assert "Mark as read" not in rendered
 
 
 # ── _send_email ───────────────────────────────────────────────────────────────

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -7,6 +7,7 @@ Postgres via the ``pg_clean`` fixture.
 
 from __future__ import annotations
 
+import html
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +17,7 @@ from fastapi.testclient import TestClient
 
 from news_dashboard import digest
 from news_dashboard.auth import create_user
+from news_dashboard.email_theme import EMAIL_COLORS
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -120,6 +122,34 @@ def test_render_text_lists_articles_in_order() -> None:
     assert "1. First Headline" in text
     assert "2. Untitled" in text
     assert "Source: Example News | Score: 90" in text
+
+
+def test_display_title_normalizes_and_truncates_at_word_boundary() -> None:
+    title = "  " + "word " * 40
+
+    rendered = digest._display_title(title)
+
+    assert len(rendered) <= 120
+    assert rendered.endswith("…")
+    assert "  " not in rendered
+    assert rendered.removesuffix("…").endswith("word")
+
+
+def test_renderers_use_the_same_bounded_title() -> None:
+    articles = [{**_ARTICLES[0], "title": "Headline " * 40}]
+    expected = digest._display_title(articles[0]["title"])
+
+    assert expected in digest._render_html(articles, user_id=7)
+    assert expected in digest._render_text(articles, user_id=7)
+    assert articles[0]["title"].strip() not in digest._render_html(articles, user_id=7)
+
+
+def test_digest_uses_shared_warm_shell_and_small_action_link() -> None:
+    rendered = digest._render_html(_ARTICLES, user_id=7)
+
+    assert EMAIL_COLORS["background"].email_hex in rendered
+    assert EMAIL_COLORS["primary"].email_hex in rendered
+    assert "font-size:12px" in rendered
 
 
 # ── _send_email ───────────────────────────────────────────────────────────────
@@ -292,6 +322,18 @@ def test_render_html_escapes_script_in_title() -> None:
     html = digest._render_html(articles, user_id=7)
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
+
+
+def test_render_html_escapes_long_title_before_displaying_it() -> None:
+    malicious_title = f"{'safe word ' * 13}<script>alert(1)</script>"
+    articles = [{**_ARTICLES[0], "title": malicious_title}]
+
+    rendered = digest._render_html(articles, user_id=7)
+    displayed_title = digest._display_title(malicious_title)
+
+    assert len(displayed_title) <= 120
+    assert "<script>" not in rendered
+    assert html.escape(displayed_title) in rendered
 
 
 def test_render_html_escapes_quotes_in_url() -> None:

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from news_dashboard.email import send_email, smtp_configured
+from news_dashboard.email_theme import EMAIL_COLORS
 
 
 class _FakeSMTP:
@@ -115,6 +116,25 @@ def test_otp_email_html_body_contains_otp_code() -> None:
     html_body = _extract_html_body(msg)
     assert html_body is not None, "No HTML part found in the email"
     assert otp in html_body, f"OTP code {otp!r} not found in HTML body"
+
+
+def test_otp_email_uses_shared_warm_identity() -> None:
+    msg = _capture_sent_message("user@example.com", "123456")
+    html_body = _extract_html_body(msg)
+
+    assert html_body is not None
+    assert EMAIL_COLORS["background"].email_hex in html_body
+    assert EMAIL_COLORS["primary"].email_hex in html_body
+    assert "#2563eb" not in html_body
+
+
+def test_otp_email_escapes_code() -> None:
+    msg = _capture_sent_message("user@example.com", "<12345")
+    html_body = _extract_html_body(msg)
+
+    assert html_body is not None
+    assert "<12345" not in html_body
+    assert "&lt;12345" in html_body
 
 
 def test_otp_email_from_header_uses_smtp_username() -> None:

--- a/backend/tests/test_email_theme.py
+++ b/backend/tests/test_email_theme.py
@@ -9,13 +9,18 @@ def test_email_theme_references_canonical_application_tokens() -> None:
     css = Path("frontend/src/globals.css").read_text()
 
     for color in email_theme.EMAIL_COLORS.values():
-        assert f"{color.app_token};" in css
+        assert f"{color.css_variable}: {color.app_token};" in css
 
 
 def test_email_theme_uses_application_font_families() -> None:
+    css = Path("frontend/src/globals.css").read_text()
+
     assert "Inter" in email_theme.FONT_SANS
     assert "Source Serif 4" in email_theme.FONT_SERIF
     assert "JetBrains Mono" in email_theme.FONT_MONO
+    assert "--font-sans: 'Inter Variable'" in css
+    assert "--font-serif: 'Source Serif 4 Variable'" in css
+    assert "--font-mono: 'JetBrains Mono Variable'" in css
 
 
 def test_shell_escapes_text_and_includes_shared_identity() -> None:
@@ -44,3 +49,12 @@ def test_highlight_panel_and_action_link_escape_dynamic_values() -> None:
     assert "&lt;12345" in panel
     assert "value=&quot;unsafe&quot;" in link
     assert "Open &lt;article&gt;" in link
+
+
+def test_compact_text_normalizes_and_truncates_at_word_boundary() -> None:
+    rendered = email_theme.compact_text("  " + "article title " * 20, fallback="Source")
+
+    assert len(rendered) <= 120
+    assert rendered.endswith("…")
+    assert "  " not in rendered
+    assert rendered.removesuffix("…").endswith("title")

--- a/backend/tests/test_email_theme.py
+++ b/backend/tests/test_email_theme.py
@@ -1,0 +1,46 @@
+"""Contract tests for the shared transactional-email visual identity."""
+
+from pathlib import Path
+
+from news_dashboard import email_theme
+
+
+def test_email_theme_references_canonical_application_tokens() -> None:
+    css = Path("frontend/src/globals.css").read_text()
+
+    for color in email_theme.EMAIL_COLORS.values():
+        assert f"{color.app_token};" in css
+
+
+def test_email_theme_uses_application_font_families() -> None:
+    assert "Inter" in email_theme.FONT_SANS
+    assert "Source Serif 4" in email_theme.FONT_SERIF
+    assert "JetBrains Mono" in email_theme.FONT_MONO
+
+
+def test_shell_escapes_text_and_includes_shared_identity() -> None:
+    rendered = email_theme.render_email_shell(
+        preheader="<preview>",
+        eyebrow="News Dashboard",
+        heading="Hello <reader>",
+        body_html="<p>Safe body</p>",
+    )
+
+    assert "&lt;preview&gt;" in rendered
+    assert "Hello &lt;reader&gt;" in rendered
+    assert "<p>Safe body</p>" in rendered
+    assert email_theme.EMAIL_COLORS["background"].email_hex in rendered
+    assert email_theme.EMAIL_COLORS["primary"].email_hex in rendered
+
+
+def test_highlight_panel_and_action_link_escape_dynamic_values() -> None:
+    panel = email_theme.render_highlight_panel(label="Code <now>", value="<12345")
+    link = email_theme.render_action_link(
+        url='https://example.com/?value="unsafe"',
+        label="Open <article>",
+    )
+
+    assert "Code &lt;now&gt;" in panel
+    assert "&lt;12345" in panel
+    assert "value=&quot;unsafe&quot;" in link
+    assert "Open &lt;article&gt;" in link

--- a/docs/superpowers/plans/2026-07-20-email-visual-identity.md
+++ b/docs/superpowers/plans/2026-07-20-email-visual-identity.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Give the digest and OTP messages one reusable News Dashboard email identity and prevent oversized digest titles.
+**Goal:** Give scheduled briefing, digest, and OTP messages one reusable News Dashboard email identity and prevent oversized article titles.
 
-**Architecture:** A new `email_theme.py` module owns semantic app-token references, email-safe color/font values, and reusable HTML shell/components. Existing digest and OTP modules supply escaped, message-specific content to that shared renderer. Contract tests bind the email palette and fonts to `frontend/src/globals.css`, while focused renderer tests cover shared identity, escaping, and title bounds.
+**Architecture:** A new `email_theme.py` module owns exact semantic app-token references, email-safe color/font values, compact-text behavior, and reusable HTML shell/components. Scheduled briefing, digest, and OTP modules supply escaped, message-specific content to that shared renderer. Contract tests bind CSS variable/value pairs and fonts to `frontend/src/globals.css`, while focused renderer tests cover shared identity, escaping, and title bounds.
 
 **Tech Stack:** Python 3.14, standard-library HTML/email modules, pytest, Ruff, mypy, ty, pyrefly.
 
@@ -64,7 +64,7 @@ def test_shell_escapes_text_and_includes_shared_identity() -> None:
 
 - [ ] **Step 2: Run the tests and verify RED**
 
-Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email_theme.py -q`
+Run: `PATH="$PWD/.venv/bin:$PATH" dotenv run -- pytest backend/tests/test_email_theme.py -q`
 
 Expected: collection fails because `news_dashboard.email_theme` does not exist.
 
@@ -74,7 +74,7 @@ Create an immutable `EmailColor` named tuple with `app_token` and `email_hex`, t
 
 - [ ] **Step 4: Run shared-theme tests and verify GREEN**
 
-Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email_theme.py -q`
+Run: `PATH="$PWD/.venv/bin:$PATH" dotenv run -- pytest backend/tests/test_email_theme.py -q`
 
 Expected: all tests pass.
 
@@ -128,7 +128,7 @@ Extend the existing escaping test with a long title containing `<script>` near t
 
 - [ ] **Step 2: Run focused digest tests and verify RED**
 
-Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_digest.py -q -k 'display_title or bounded_title or shared_warm_shell or escapes_script'`
+Run: `PATH="$PWD/.venv/bin:$PATH" dotenv run -- pytest backend/tests/test_digest.py -q -k 'display_title or bounded_title or shared_warm_shell or escapes_script'`
 
 Expected: failures because `_display_title` and the shared digest shell are absent.
 
@@ -138,7 +138,7 @@ Implement `_display_title` by converting a missing/false value to `"Untitled"`, 
 
 - [ ] **Step 4: Run the entire digest test module and verify GREEN**
 
-Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_digest.py -q`
+Run: `PATH="$PWD/.venv/bin:$PATH" dotenv run -- pytest backend/tests/test_digest.py -q`
 
 Expected: all digest tests pass.
 
@@ -151,17 +151,21 @@ PATH="$PWD/.venv/bin:$PATH" git commit -m "feat: restyle digest email and bound 
 
 ---
 
-### Task 3: OTP Migration and End-to-End Verification
+### Task 3: Scheduled Briefing and OTP Migration
 
 **Files:**
+- Modify: `backend/news_dashboard/briefing_email/rendering.py`
+- Modify: `backend/news_dashboard/briefing_email/templates/briefing.html.j2`
+- Test: `backend/tests/test_briefing_email_rendering.py`
 - Modify: `backend/news_dashboard/email.py`
 - Modify: `backend/tests/test_email.py`
 
 **Interfaces:**
 - Consumes: `EMAIL_COLORS`, `render_email_shell`, and `render_highlight_panel` from `news_dashboard.email_theme`.
+- Scheduled briefing also consumes `compact_text`, `FONT_SERIF`, and `render_email_shell` while preserving Jinja autoescaping and safe-link filtering.
 - Preserves: `send_otp_email(to_email: str, otp: str) -> None` and all SMTP configuration behavior.
 
-- [ ] **Step 1: Write failing OTP identity and escaping tests**
+- [ ] **Step 1: Write failing scheduled-briefing and OTP identity tests**
 
 ```python
 def test_otp_email_uses_shared_warm_identity() -> None:
@@ -179,37 +183,52 @@ def test_otp_email_escapes_code() -> None:
     assert html_body is not None
     assert "<12345" not in html_body
     assert "&lt;12345" in html_body
+
+
+def test_rendering_uses_shared_warm_email_identity() -> None:
+    rendered = render_briefing_email(_briefing(), **_urls())
+    assert EMAIL_COLORS["background"].email_hex in rendered.html_body
+    assert EMAIL_COLORS["primary"].email_hex in rendered.html_body
+    assert "#2563eb" not in rendered.html_body
+
+
+def test_rendering_bounds_article_titles_in_html_and_text() -> None:
+    briefing = _briefing()
+    long_title = "An excessively detailed article title " * 12
+    briefing["articles"][1]["title"] = long_title
+    displayed = compact_text(long_title, fallback="Source")
+    rendered = render_briefing_email(briefing, **_urls())
+    assert displayed in rendered.html_body
+    assert displayed in rendered.text_body
+    assert long_title.strip() not in rendered.html_body
 ```
 
-- [ ] **Step 2: Run focused OTP tests and verify RED**
+- [ ] **Step 2: Run focused email tests and verify RED**
 
-Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email.py -q -k 'shared_warm_identity or escapes_code'`
+Run: `PATH="$PWD/.venv/bin:$PATH" dotenv run -- pytest backend/tests/test_briefing_email_rendering.py backend/tests/test_email.py -q -k 'shared_warm_identity or shared_warm_email_identity or bounds_article_titles or escapes_code'`
 
-Expected: warm-identity and escaping assertions fail against the current inline blue template.
+Expected: scheduled-briefing and OTP identity/bounds assertions fail against the current blue templates.
 
-- [ ] **Step 3: Migrate OTP content onto the shared shell**
+- [ ] **Step 3: Migrate scheduled briefing and OTP content onto the shared shell**
 
-Build only the OTP-specific explanatory copy and highlighted code panel in `email.py`. Use `render_highlight_panel` for the escaped code and `render_email_shell` for the document, retaining the current subject, expiry copy, safety guidance, MIME construction, SMTP branching, login, and send behavior.
+Render the Jinja briefing template as a content fragment, bound cited-article titles with `compact_text`, and wrap it with `render_email_shell`; retain safe-link filtering, summary, story content, reading-time calculation, and footer links. Build only the OTP-specific explanatory copy and highlighted code panel in `email.py`. Use `render_highlight_panel` for the escaped code and `render_email_shell` for the document, retaining the current subject, expiry copy, safety guidance, MIME construction, SMTP branching, login, and send behavior.
 
 - [ ] **Step 4: Run email-focused tests and verify GREEN**
 
-Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email_theme.py backend/tests/test_email.py backend/tests/test_digest.py -q`
+Run: `PATH="$PWD/.venv/bin:$PATH" dotenv run -- pytest backend/tests/test_email_theme.py backend/tests/test_briefing_email_rendering.py backend/tests/test_email.py backend/tests/test_digest.py -q`
 
 Expected: all focused tests pass.
 
 - [ ] **Step 5: Inspect representative rendered messages**
 
-Generate one digest with an overlong title and one OTP message through their pure render paths, save temporary HTML outside the repository, and inspect them at desktop and narrow widths. Confirm a warm cream shell, shared branded header/footer, bounded digest title, readable intact summary, compact action, and escaped OTP panel. Do not commit temporary files.
+Generate one scheduled briefing and one digest with overlong titles plus one OTP message through their pure render paths, save temporary HTML outside the repository, and inspect them at desktop and narrow widths. Confirm a warm cream shell, shared branded header/footer, bounded titles, readable intact summaries, compact links/actions, and escaped OTP panel. Do not commit temporary files.
 
 - [ ] **Step 6: Run mandatory repository gates**
 
 ```bash
 export PATH="$PWD/.venv/bin:$PATH"
-make lint
-make typecheck
-source .env
 export PGOPTIONS='-c max_parallel_workers_per_gather=0'
-make test
+dotenv run -- make check
 ```
 
 Expected: every command exits 0 with no lint/type errors or pytest failures.
@@ -217,8 +236,8 @@ Expected: every command exits 0 with no lint/type errors or pytest failures.
 - [ ] **Step 7: Commit final implementation and plan**
 
 ```bash
-git add backend/news_dashboard/email.py backend/tests/test_email.py docs/superpowers/plans/2026-07-20-email-visual-identity.md
-PATH="$PWD/.venv/bin:$PATH" git commit -m "feat: align OTP email with shared theme (#1273)"
+git add backend/news_dashboard/briefing_email backend/news_dashboard/email.py backend/tests/test_briefing_email_rendering.py backend/tests/test_email.py docs/superpowers/plans/2026-07-20-email-visual-identity.md
+PATH="$PWD/.venv/bin:$PATH" git commit -m "feat: align scheduled emails with shared theme (#1273)"
 ```
 
 - [ ] **Step 8: Review, rebase, publish, and merge**
@@ -229,7 +248,7 @@ Review `git diff origin/main...HEAD` against the specification and repository st
 git fetch origin
 git rebase origin/main
 git push -u origin HEAD
-gh pr create --base main --title "feat: unify email visual identity" --body $'Closes #1273\n\n## Summary\n- add a reusable app-aligned email theme\n- migrate digest and OTP emails to the shared identity\n- truncate normalized digest titles to 120 characters\n\n## Testing\n- make lint\n- make typecheck\n- source .env && make test\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+gh pr create --base main --title "feat: unify email visual identity" --body $'Closes #1273\n\n## Summary\n- add a reusable app-aligned email theme\n- migrate briefing, digest, and OTP emails to the shared identity\n- truncate normalized article titles to 120 characters\n\n## Testing\n- dotenv run -- make check\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)'
 gh pr merge --squash --auto
 gh pr checks --watch
 ```

--- a/docs/superpowers/plans/2026-07-20-email-visual-identity.md
+++ b/docs/superpowers/plans/2026-07-20-email-visual-identity.md
@@ -1,0 +1,237 @@
+# Shared Email Visual Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the digest and OTP messages one reusable News Dashboard email identity and prevent oversized digest titles.
+
+**Architecture:** A new `email_theme.py` module owns semantic app-token references, email-safe color/font values, and reusable HTML shell/components. Existing digest and OTP modules supply escaped, message-specific content to that shared renderer. Contract tests bind the email palette and fonts to `frontend/src/globals.css`, while focused renderer tests cover shared identity, escaping, and title bounds.
+
+**Tech Stack:** Python 3.14, standard-library HTML/email modules, pytest, Ruff, mypy, ty, pyrefly.
+
+## Global Constraints
+
+- The final displayed digest title never exceeds 120 characters and ends with one ellipsis when truncated.
+- Digest HTML and plain text use the same normalized, bounded title.
+- Dynamic titles, sources, summaries, and OTP codes are HTML-escaped.
+- Existing SMTP, signed-link, delivery, ranking, recipient, and authentication behavior remains unchanged.
+- Email HTML uses inline styles and presentation tables, without remote fonts, images, scripts, or CSS.
+- The application CSS remains canonical; production email rendering must not read frontend files.
+
+---
+
+### Task 1: Shared Email Theme Foundation
+
+**Files:**
+- Create: `backend/news_dashboard/email_theme.py`
+- Create: `backend/tests/test_email_theme.py`
+
+**Interfaces:**
+- Produces: `EMAIL_COLORS: Mapping[str, EmailColor]`, `FONT_SANS: str`, `FONT_SERIF: str`, `FONT_MONO: str`.
+- Produces: `render_email_shell(*, preheader: str, eyebrow: str, heading: str, body_html: str) -> str`.
+- Produces: `render_highlight_panel(*, label: str, value: str) -> str` and `render_action_link(*, url: str, label: str) -> str`.
+- `body_html` is trusted HTML assembled by a renderer; all other string arguments are escaped inside the helper.
+
+- [ ] **Step 1: Write failing shared-theme contract tests**
+
+```python
+from pathlib import Path
+
+from news_dashboard import email_theme
+
+
+def test_email_theme_references_canonical_application_tokens() -> None:
+    css = Path("frontend/src/globals.css").read_text()
+    for color in email_theme.EMAIL_COLORS.values():
+        assert f"{color.app_token};" in css
+
+
+def test_email_theme_uses_application_font_families() -> None:
+    assert "Inter" in email_theme.FONT_SANS
+    assert "Source Serif 4" in email_theme.FONT_SERIF
+    assert "JetBrains Mono" in email_theme.FONT_MONO
+
+
+def test_shell_escapes_text_and_includes_shared_identity() -> None:
+    rendered = email_theme.render_email_shell(
+        preheader="<preview>", eyebrow="News Dashboard", heading="Hello <reader>", body_html="<p>Safe body</p>"
+    )
+    assert "&lt;preview&gt;" in rendered
+    assert "Hello &lt;reader&gt;" in rendered
+    assert "<p>Safe body</p>" in rendered
+    assert email_theme.EMAIL_COLORS["background"].email_hex in rendered
+    assert email_theme.EMAIL_COLORS["primary"].email_hex in rendered
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email_theme.py -q`
+
+Expected: collection fails because `news_dashboard.email_theme` does not exist.
+
+- [ ] **Step 3: Implement the minimal shared theme**
+
+Create an immutable `EmailColor` named tuple with `app_token` and `email_hex`, then define semantic colors whose `app_token` strings exactly match the light-theme OKLCH values in `frontend/src/globals.css`. Define the three email-safe font stacks. Implement a complete responsive presentation-table document in `render_email_shell`, and small reusable highlighted-panel/action-link helpers. Escape every helper text/URL argument using `html.escape(..., quote=True)`; interpolate `body_html` unchanged by its documented contract.
+
+- [ ] **Step 4: Run shared-theme tests and verify GREEN**
+
+Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email_theme.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the independently testable foundation**
+
+```bash
+git add backend/news_dashboard/email_theme.py backend/tests/test_email_theme.py
+PATH="$PWD/.venv/bin:$PATH" git commit -m "feat: add shared email visual identity (#1273)"
+```
+
+---
+
+### Task 2: Digest Hierarchy and Bounded Titles
+
+**Files:**
+- Modify: `backend/news_dashboard/digest.py`
+- Modify: `backend/tests/test_digest.py`
+
+**Interfaces:**
+- Consumes: `EMAIL_COLORS`, `FONT_SERIF`, `render_action_link`, and `render_email_shell` from `news_dashboard.email_theme`.
+- Produces: `_display_title(value: object, *, limit: int = 120) -> str`.
+- Preserves: `_render_html(articles: list[dict[str, Any]], *, user_id: int) -> str` and `_render_text(...) -> str`.
+
+- [ ] **Step 1: Write failing digest behavior tests**
+
+```python
+def test_display_title_normalizes_and_truncates_at_word_boundary() -> None:
+    title = "  " + "word " * 40
+    rendered = digest._display_title(title)
+    assert len(rendered) <= 120
+    assert rendered.endswith("…")
+    assert "  " not in rendered
+
+
+def test_renderers_use_the_same_bounded_title() -> None:
+    articles = [{**_ARTICLES[0], "title": "Headline " * 40}]
+    expected = digest._display_title(articles[0]["title"])
+    assert expected in digest._render_html(articles, user_id=7)
+    assert expected in digest._render_text(articles, user_id=7)
+    assert articles[0]["title"].strip() not in digest._render_html(articles, user_id=7)
+
+
+def test_digest_uses_shared_warm_shell_and_small_action_link() -> None:
+    rendered = digest._render_html(_ARTICLES, user_id=7)
+    assert EMAIL_COLORS["background"].email_hex in rendered
+    assert EMAIL_COLORS["primary"].email_hex in rendered
+    assert "font-size:12px" in rendered
+```
+
+Extend the existing escaping test with a long title containing `<script>` near the truncation boundary and assert neither raw markup nor an over-120-character displayed title appears.
+
+- [ ] **Step 2: Run focused digest tests and verify RED**
+
+Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_digest.py -q -k 'display_title or bounded_title or shared_warm_shell or escapes_script'`
+
+Expected: failures because `_display_title` and the shared digest shell are absent.
+
+- [ ] **Step 3: Implement title bounding and migrate digest HTML**
+
+Implement `_display_title` by converting a missing/false value to `"Untitled"`, collapsing whitespace with `" ".join(str(value).split())`, reserving one character for `…`, preferring `rsplit(" ", 1)[0]`, and falling back to a hard boundary. Call it before HTML escaping in `_render_html` and directly in `_render_text`. Replace the standalone HTML document with `render_email_shell`, render an intro count panel, warm-bordered article rows, serif summaries, compact metadata, and `render_action_link` for the signed mark-read URL.
+
+- [ ] **Step 4: Run the entire digest test module and verify GREEN**
+
+Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_digest.py -q`
+
+Expected: all digest tests pass.
+
+- [ ] **Step 5: Commit the digest change**
+
+```bash
+git add backend/news_dashboard/digest.py backend/tests/test_digest.py
+PATH="$PWD/.venv/bin:$PATH" git commit -m "feat: restyle digest email and bound titles (#1273)"
+```
+
+---
+
+### Task 3: OTP Migration and End-to-End Verification
+
+**Files:**
+- Modify: `backend/news_dashboard/email.py`
+- Modify: `backend/tests/test_email.py`
+
+**Interfaces:**
+- Consumes: `EMAIL_COLORS`, `render_email_shell`, and `render_highlight_panel` from `news_dashboard.email_theme`.
+- Preserves: `send_otp_email(to_email: str, otp: str) -> None` and all SMTP configuration behavior.
+
+- [ ] **Step 1: Write failing OTP identity and escaping tests**
+
+```python
+def test_otp_email_uses_shared_warm_identity() -> None:
+    msg = _capture_sent_message("user@example.com", "123456")
+    html_body = _extract_html_body(msg)
+    assert html_body is not None
+    assert EMAIL_COLORS["background"].email_hex in html_body
+    assert EMAIL_COLORS["primary"].email_hex in html_body
+    assert "#2563eb" not in html_body
+
+
+def test_otp_email_escapes_code() -> None:
+    msg = _capture_sent_message("user@example.com", "<12345")
+    html_body = _extract_html_body(msg)
+    assert html_body is not None
+    assert "<12345" not in html_body
+    assert "&lt;12345" in html_body
+```
+
+- [ ] **Step 2: Run focused OTP tests and verify RED**
+
+Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email.py -q -k 'shared_warm_identity or escapes_code'`
+
+Expected: warm-identity and escaping assertions fail against the current inline blue template.
+
+- [ ] **Step 3: Migrate OTP content onto the shared shell**
+
+Build only the OTP-specific explanatory copy and highlighted code panel in `email.py`. Use `render_highlight_panel` for the escaped code and `render_email_shell` for the document, retaining the current subject, expiry copy, safety guidance, MIME construction, SMTP branching, login, and send behavior.
+
+- [ ] **Step 4: Run email-focused tests and verify GREEN**
+
+Run: `PATH="$PWD/.venv/bin:$PATH" pytest backend/tests/test_email_theme.py backend/tests/test_email.py backend/tests/test_digest.py -q`
+
+Expected: all focused tests pass.
+
+- [ ] **Step 5: Inspect representative rendered messages**
+
+Generate one digest with an overlong title and one OTP message through their pure render paths, save temporary HTML outside the repository, and inspect them at desktop and narrow widths. Confirm a warm cream shell, shared branded header/footer, bounded digest title, readable intact summary, compact action, and escaped OTP panel. Do not commit temporary files.
+
+- [ ] **Step 6: Run mandatory repository gates**
+
+```bash
+export PATH="$PWD/.venv/bin:$PATH"
+make lint
+make typecheck
+source .env
+export PGOPTIONS='-c max_parallel_workers_per_gather=0'
+make test
+```
+
+Expected: every command exits 0 with no lint/type errors or pytest failures.
+
+- [ ] **Step 7: Commit final implementation and plan**
+
+```bash
+git add backend/news_dashboard/email.py backend/tests/test_email.py docs/superpowers/plans/2026-07-20-email-visual-identity.md
+PATH="$PWD/.venv/bin:$PATH" git commit -m "feat: align OTP email with shared theme (#1273)"
+```
+
+- [ ] **Step 8: Review, rebase, publish, and merge**
+
+Review `git diff origin/main...HEAD` against the specification and repository standards, repair confirmed findings, rerun affected gates, then execute:
+
+```bash
+git fetch origin
+git rebase origin/main
+git push -u origin HEAD
+gh pr create --base main --title "feat: unify email visual identity" --body $'Closes #1273\n\n## Summary\n- add a reusable app-aligned email theme\n- migrate digest and OTP emails to the shared identity\n- truncate normalized digest titles to 120 characters\n\n## Testing\n- make lint\n- make typecheck\n- source .env && make test\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+gh pr merge --squash --auto
+gh pr checks --watch
+```
+
+Confirm the pull request is merged, issue #1273 is closed, and delete the remote feature branch if GitHub did not remove it.

--- a/docs/superpowers/specs/2026-07-20-email-visual-identity-design.md
+++ b/docs/superpowers/specs/2026-07-20-email-visual-identity-design.md
@@ -2,9 +2,9 @@
 
 ## Context
 
-The scheduled digest and one-time-password email currently look unrelated to
+The scheduled current-day briefing, legacy digest, and one-time-password email look unrelated to
 each other and to News Dashboard. Their blue and neutral styling conflicts with
-the application's warm cream, charcoal, and coffee palette. Digest article
+the application's warm cream, charcoal, and coffee palette. Briefing citation and digest article
 titles can also contain article-body-sized text, overwhelming the message.
 
 ## Goals
@@ -13,7 +13,7 @@ titles can also contain article-body-sized text, overwhelming the message.
 - Make that identity reusable by future transactional email templates.
 - Align email colors and typography with the application's light theme while
   retaining email-client-safe fallbacks.
-- Improve the digest's visual hierarchy and bound oversized article titles.
+- Improve briefing/digest hierarchy and bound oversized article titles.
 - Preserve SMTP configuration, delivery, authentication, signed links, article
   selection, summaries, and plain-text availability.
 
@@ -22,7 +22,7 @@ titles can also contain article-body-sized text, overwhelming the message.
 Add a backend email-theme module as the single rendering foundation for email.
 It owns named palette and typography constants plus reusable helpers for the
 document shell, branded header, content card, metadata, actions, highlighted
-content, and footer. The digest and OTP renderers compose their content through
+content, and footer. The briefing, digest, and OTP renderers compose their content through
 that foundation instead of defining independent visual systems.
 
 The frontend remains the canonical application theme. A focused contract test
@@ -52,27 +52,27 @@ The light email identity maps to the application as follows:
 
 The shell has a compact branded header, rounded content card, restrained shadow,
 and shared footer. The OTP code appears in a warm highlighted panel rather than
-a blue security panel. The digest begins with a compact count/intro treatment,
+a blue security panel. The briefing keeps its executive summary prominent, and the digest begins with a compact count/intro treatment,
 then presents articles as separated rows with title, source/score metadata,
 summary, and a small action link.
 
-## Digest Content Bounds
+## Article Content Bounds
 
-Article titles are normalized by collapsing whitespace. Titles longer than 120
+Briefing citation and digest article titles are normalized by collapsing whitespace. Titles longer than 120
 characters are truncated at the last available word boundary and end with a
 single ellipsis character. If no useful boundary exists, truncation occurs at
 the character boundary. The final displayed title never exceeds 120 characters.
-The same bounded title is used in HTML and plain-text digest representations so
-one malformed feed entry cannot dominate either version.
+The same bounded title is used in HTML and plain-text briefing/digest
+representations so one malformed feed entry cannot dominate either version.
 
 Summaries remain intact and visually secondary. Article titles remain the
-primary link to the source article. The signed “Mark as read” action is rendered
-as smaller secondary link text.
+primary link to the source article. The legacy digest's signed workflow action
+is rendered as smaller secondary link text using the application's Done state.
 
 ## Safety and Compatibility
 
 - Dynamic titles, sources, summaries, and codes remain HTML-escaped.
-- Existing signed mark-read URLs and SMTP paths are unchanged.
+- Existing signed workflow-action URLs and SMTP paths are unchanged.
 - The OTP lifetime and security guidance remain unchanged.
 - No remote web fonts, images, scripts, or CSS are required.
 - Layout stays readable when rounded corners, shadows, or preferred fonts are
@@ -85,7 +85,7 @@ Development follows red-green-refactor:
 1. Add failing focused tests for the shared theme, application-token alignment,
    both emails consuming the same shell, warm/non-blue styling, HTML escaping,
    and 120-character word-boundary truncation in HTML and text.
-2. Implement the shared theme and migrate the digest and OTP renderers.
+2. Implement the shared theme and migrate briefing, digest, and OTP renderers.
 3. Run focused email tests, then backend lint, type checks, and the full Postgres
    test suite.
 4. Inspect representative rendered HTML for hierarchy, spacing, long-title

--- a/docs/superpowers/specs/2026-07-20-email-visual-identity-design.md
+++ b/docs/superpowers/specs/2026-07-20-email-visual-identity-design.md
@@ -1,0 +1,100 @@
+# Shared Email Visual Identity
+
+## Context
+
+The scheduled digest and one-time-password email currently look unrelated to
+each other and to News Dashboard. Their blue and neutral styling conflicts with
+the application's warm cream, charcoal, and coffee palette. Digest article
+titles can also contain article-body-sized text, overwhelming the message.
+
+## Goals
+
+- Give every News Dashboard email one recognizable visual identity.
+- Make that identity reusable by future transactional email templates.
+- Align email colors and typography with the application's light theme while
+  retaining email-client-safe fallbacks.
+- Improve the digest's visual hierarchy and bound oversized article titles.
+- Preserve SMTP configuration, delivery, authentication, signed links, article
+  selection, summaries, and plain-text availability.
+
+## Architecture
+
+Add a backend email-theme module as the single rendering foundation for email.
+It owns named palette and typography constants plus reusable helpers for the
+document shell, branded header, content card, metadata, actions, highlighted
+content, and footer. The digest and OTP renderers compose their content through
+that foundation instead of defining independent visual systems.
+
+The frontend remains the canonical application theme. A focused contract test
+compares the email theme's semantic values and font families with the relevant
+tokens in `frontend/src/globals.css`. This prevents accidental visual drift
+without coupling production email rendering to frontend source files or adding
+a cross-language asset-generation step.
+
+Email HTML uses tables and inline styles for broad client compatibility. The
+shared renderer escapes caller-provided text by default; URLs remain escaped at
+their existing rendering boundary.
+
+## Visual System
+
+The light email identity maps to the application as follows:
+
+- Page background: warm off-white/cream.
+- Content surface: white with a warm muted border.
+- Primary text and header: charcoal and deep coffee.
+- Accent and links: the application's warm brown/orange accent family.
+- Secondary text: muted warm gray.
+- Sans typography: Inter first, then system and Arial fallbacks.
+- Reading text: Source Serif 4 first, then Georgia and serif fallbacks where
+  appropriate.
+- Codes and numeric metadata: JetBrains Mono first, then standard monospace
+  fallbacks.
+
+The shell has a compact branded header, rounded content card, restrained shadow,
+and shared footer. The OTP code appears in a warm highlighted panel rather than
+a blue security panel. The digest begins with a compact count/intro treatment,
+then presents articles as separated rows with title, source/score metadata,
+summary, and a small action link.
+
+## Digest Content Bounds
+
+Article titles are normalized by collapsing whitespace. Titles longer than 120
+characters are truncated at the last available word boundary and end with a
+single ellipsis character. If no useful boundary exists, truncation occurs at
+the character boundary. The final displayed title never exceeds 120 characters.
+The same bounded title is used in HTML and plain-text digest representations so
+one malformed feed entry cannot dominate either version.
+
+Summaries remain intact and visually secondary. Article titles remain the
+primary link to the source article. The signed “Mark as read” action is rendered
+as smaller secondary link text.
+
+## Safety and Compatibility
+
+- Dynamic titles, sources, summaries, and codes remain HTML-escaped.
+- Existing signed mark-read URLs and SMTP paths are unchanged.
+- The OTP lifetime and security guidance remain unchanged.
+- No remote web fonts, images, scripts, or CSS are required.
+- Layout stays readable when rounded corners, shadows, or preferred fonts are
+  unsupported.
+
+## Testing
+
+Development follows red-green-refactor:
+
+1. Add failing focused tests for the shared theme, application-token alignment,
+   both emails consuming the same shell, warm/non-blue styling, HTML escaping,
+   and 120-character word-boundary truncation in HTML and text.
+2. Implement the shared theme and migrate the digest and OTP renderers.
+3. Run focused email tests, then backend lint, type checks, and the full Postgres
+   test suite.
+4. Inspect representative rendered HTML for hierarchy, spacing, long-title
+   behavior, and narrow-width readability before opening the pull request.
+
+## Out of Scope
+
+- Dark-mode email variants.
+- User-selectable email themes.
+- Changes to delivery schedules, recipients, SMTP configuration, or digest
+  ranking.
+- A general-purpose templating dependency or frontend build-pipeline change.


### PR DESCRIPTION
Closes #1273

## Summary
- add a reusable email theme bound to the application’s exact palette and font tokens
- migrate scheduled briefing, legacy digest, and OTP emails to the shared cream/coffee identity
- normalize and truncate article/citation titles to 120 characters in HTML and text
- preserve summaries, safe-link filtering, SMTP behavior, signed workflow actions, and OTP guidance

## Testing
- `dotenv run -- make check`
- rendered desktop and 375px previews for scheduled briefing, digest, and OTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)