### PR TITLE
fix: stabilize token tampering test

### DIFF
--- a/backend/tests/test_briefing_email_tokens.py
+++ b/backend/tests/test_briefing_email_tokens.py
@@ -19,10 +19,14 @@ def test_unsubscribe_token_round_trip() -> None:
     assert verify_unsubscribe_token(make_unsubscribe_token(42)) == 42
 
 
-def test_unsubscribe_token_rejects_tampering() -> None:
+def test_unsubscribe_token_rejects_tampering(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(time, "time", lambda: 1_700_000_006.0)
     token = make_unsubscribe_token(42)
+    payload, timestamp, signature = token.split(".")
+    replacement = "A" if payload[0] != "A" else "B"
+    tampered_token = f"{replacement}{payload[1:]}.{timestamp}.{signature}"
     with pytest.raises(ValueError, match="Invalid unsubscribe token"):
-        verify_unsubscribe_token(f"{token[:-1]}x")
+        verify_unsubscribe_token(tampered_token)
 
 
 def test_unsubscribe_token_expires(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #1280

## Summary

- pin the token timestamp to the signature shape that exposed the flaky assertion
- mutate a significant payload character while preserving the timestamp and signature
- avoid base64url trailing-bit aliases that can decode to unchanged signature bytes

## Verification

- `make lint`
- `make typecheck`
- `PGOPTIONS="-c max_parallel_workers_per_gather=0" dotenv run -- make test` (2,830 backend tests and 991 frontend tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)