### PR TITLE
feat: add high-priority RSS feeds

### DIFF
--- a/backend/news_dashboard/article_visibility.py
+++ b/backend/news_dashboard/article_visibility.py
@@ -28,7 +28,7 @@ def get_visible_article_row(conn: Any, article_id: int, user_id: int | None) -> 
 
     return conn.execute(
         f"""
-        SELECT a.*
+        SELECT a.*, COALESCE(a_us.high_priority, FALSE) AS high_priority
         FROM articles a
         JOIN sources a_src ON a_src.slug = a.source_slug
         LEFT JOIN user_sources a_us

--- a/backend/news_dashboard/db.py
+++ b/backend/news_dashboard/db.py
@@ -341,6 +341,7 @@ POSTGRES_MULTIUSER_SCHEMA = [
       user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       source_slug TEXT    NOT NULL REFERENCES sources(slug) ON DELETE CASCADE,
       enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+      high_priority BOOLEAN NOT NULL DEFAULT FALSE,
       added_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       PRIMARY KEY (user_id, source_slug)
     )
@@ -360,6 +361,10 @@ POSTGRES_MULTIUSER_SCHEMA = [
       END IF;
       ALTER TABLE user_sources ALTER COLUMN enabled SET DEFAULT TRUE;
     END $$;
+    """,
+    """
+    ALTER TABLE user_sources
+    ADD COLUMN IF NOT EXISTS high_priority BOOLEAN NOT NULL DEFAULT FALSE
     """,
     "CREATE INDEX IF NOT EXISTS idx_user_sources_user ON user_sources(user_id, enabled)",
     """

--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -983,7 +983,12 @@ def _ingest_source(
         # Apply per-source item limit; tweets are short/frequent so cap lower by default
         noise_rule = NOISE_FILTERS.get(source.slug, {})
         default_max = 15 if source.kind == "nitter_feed" else 50
-        max_items = noise_rule.get("max_items", default_max)
+        max_items = noise_rule.get(
+            "max_items",
+            len(entries)
+            if source.owner_user_id is not None and source.kind == "rss_feed"
+            else default_max,
+        )
         entries = entries[:max_items]
         fetched = len(entries)
 
@@ -1629,6 +1634,7 @@ def _list_articles_for_user(  # noqa: PLR0913
           uar.model_version        AS _uar_recommendation_model,
           uar.signals              AS _uar_recommendation_signals,
           uar.explanation          AS _uar_recommendation_explanation,
+          COALESCE(us_src.high_priority, false) AS _source_high_priority,
           {_COLD_START_RECOMMENDATION_SCORE_SQL} AS _cold_start_score
         FROM articles a
         LEFT JOIN sources src ON src.slug = a.source_slug
@@ -1658,6 +1664,7 @@ def _list_articles_for_user(  # noqa: PLR0913
             d["archived_at"] = d.pop("_uas_archived_at", None)
             d["later_until"] = d.pop("_uas_later_until", None)
             d["restored_at"] = d.pop("_uas_restored_at", None)
+            d["high_priority"] = bool(d.pop("_source_high_priority", False))
             _apply_recommendation_fields(d)
             articles.append(d)
         _attach_also_from(conn, articles, user_id=user_id)
@@ -1706,6 +1713,7 @@ def _list_today_articles_for_user(
             uar.model_version        AS _uar_recommendation_model,
             uar.signals              AS _uar_recommendation_signals,
             uar.explanation          AS _uar_recommendation_explanation,
+            COALESCE(us_src.high_priority, false) AS _source_high_priority,
             NULL::double precision AS _cold_start_score
           FROM user_article_recommendations uar
           JOIN articles a ON a.id = uar.article_id
@@ -1723,7 +1731,7 @@ def _list_today_articles_for_user(
           LIMIT %s
         ),
         cold_candidate_ids AS (
-          SELECT a.id
+          SELECT a.id, COALESCE(us_src.high_priority, false) AS high_priority
           FROM articles a
           LEFT JOIN sources src ON src.slug = a.source_slug
           LEFT JOIN user_sources us_src
@@ -1754,6 +1762,7 @@ def _list_today_articles_for_user(
             NULL::text             AS _uar_recommendation_model,
             NULL::jsonb            AS _uar_recommendation_signals,
             NULL::text             AS _uar_recommendation_explanation,
+            c.high_priority        AS _source_high_priority,
             {_COLD_START_RECOMMENDATION_SCORE_SQL} AS _cold_start_score
           FROM cold_candidate_ids c
           JOIN articles a ON a.id = c.id
@@ -1784,6 +1793,7 @@ def _list_today_articles_for_user(
             d["archived_at"] = d.pop("_uas_archived_at", None)
             d["later_until"] = d.pop("_uas_later_until", None)
             d["restored_at"] = d.pop("_uas_restored_at", None)
+            d["high_priority"] = bool(d.pop("_source_high_priority", False))
             _apply_recommendation_fields(d)
             articles.append(d)
         _attach_also_from(conn, articles, user_id=user_id)

--- a/backend/news_dashboard/sources/models.py
+++ b/backend/news_dashboard/sources/models.py
@@ -16,12 +16,17 @@ class EnabledUpdate(BaseModel):
     enabled: bool
 
 
+class HighPriorityUpdate(BaseModel):
+    high_priority: bool
+
+
 class CreateSourceRequest(BaseModel):
     url: str
     name: str
     category: str = "tech"
     slug: str | None = None
     kind: str = "rss_feed"
+    high_priority: bool = True
 
     def validate_kind(self) -> None:
         if self.kind in USER_CREATED_SOURCE_KINDS:

--- a/backend/news_dashboard/sources/router.py
+++ b/backend/news_dashboard/sources/router.py
@@ -34,10 +34,15 @@ from news_dashboard.source_health import (
 from news_dashboard.sources.models import (
     CreateSourceRequest,
     EnabledUpdate,
+    HighPriorityUpdate,
     PreviewSourceRequest,
     SourceCleanupRequest,
 )
-from news_dashboard.sources.service import SourceDefinition
+from news_dashboard.sources.service import (
+    SourceDefinition,
+    add_user_source_preference,
+    set_user_source_priority,
+)
 from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
 
 router = APIRouter()
@@ -93,7 +98,8 @@ def sources(
             """
             SELECT s.*,
               CASE WHEN s.owner_user_id IS NULL THEN COALESCE(us.enabled, true)
-                   ELSE (s.enabled IS TRUE) END AS user_enabled
+                   ELSE (s.enabled IS TRUE) END AS user_enabled,
+              COALESCE(us.high_priority, false) AS high_priority
             FROM sources s
             LEFT JOIN user_sources us ON us.source_slug = s.slug AND us.user_id = %s
             WHERE (s.owner_user_id IS NULL OR s.owner_user_id = %s)
@@ -145,8 +151,14 @@ def create_source(
             """,
             (slug, payload.name.strip(), payload.url, payload.category, payload.kind, uid),
         )
+        add_user_source_preference(
+            conn,
+            user_id=int(uid),
+            source_slug=slug,
+            high_priority=payload.high_priority,
+        )
         row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
-    return row_to_dict(row)
+    return {**row_to_dict(row), "subscribed": True, "high_priority": payload.high_priority}
 
 
 @router.post("/api/sources/preview")
@@ -458,3 +470,21 @@ def set_source_enabled(
             )
         row = conn.execute("SELECT * FROM sources WHERE slug = %s", (slug,)).fetchone()
     return {**row_to_dict(row), "subscribed": payload.enabled}
+
+
+@router.patch("/api/sources/{slug}/priority")
+def set_source_priority(
+    slug: str,
+    payload: HighPriorityUpdate,
+    current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Set the current user's attention priority for a visible source."""
+    uid = int(current_user["id"])
+    source = set_user_source_priority(
+        user_id=uid,
+        source_slug=slug,
+        high_priority=payload.high_priority,
+    )
+    if source is None:
+        raise HTTPException(status_code=404, detail="source not found")
+    return source

--- a/backend/news_dashboard/sources/service.py
+++ b/backend/news_dashboard/sources/service.py
@@ -1,6 +1,59 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
+
+from news_dashboard.db import connect, init_db, row_to_dict
+
+
+def add_user_source_preference(
+    conn: Any,
+    *,
+    user_id: int,
+    source_slug: str,
+    high_priority: bool,
+) -> None:
+    """Create the current user's preference row for a newly added source."""
+    conn.execute(
+        """
+        INSERT INTO user_sources(user_id, source_slug, enabled, high_priority)
+        VALUES (%s, %s, TRUE, %s)
+        """,
+        (user_id, source_slug, high_priority),
+    )
+
+
+def set_user_source_priority(
+    *,
+    user_id: int,
+    source_slug: str,
+    high_priority: bool,
+) -> dict[str, Any] | None:
+    """Set a user's priority for a visible source, returning None when hidden."""
+    init_db()
+    with connect() as conn:
+        row = conn.execute(
+            """
+            SELECT *
+            FROM sources
+            WHERE slug = %s
+              AND (owner_user_id IS NULL OR owner_user_id = %s)
+              AND deleted_at IS NULL
+            """,
+            (source_slug, user_id),
+        ).fetchone()
+        if row is None:
+            return None
+        conn.execute(
+            """
+            INSERT INTO user_sources(user_id, source_slug, enabled, high_priority)
+            VALUES (%s, %s, TRUE, %s)
+            ON CONFLICT(user_id, source_slug)
+            DO UPDATE SET high_priority = excluded.high_priority
+            """,
+            (user_id, source_slug, high_priority),
+        )
+    return {**row_to_dict(row), "high_priority": high_priority}
 
 
 @dataclass(frozen=True)

--- a/backend/tests/test_main_feature_modules.py
+++ b/backend/tests/test_main_feature_modules.py
@@ -179,6 +179,7 @@ EXPECTED_METHOD_PATHS = {
     ("POST", "/api/sources/preview"),
     ("DELETE", "/api/sources/{slug}"),
     ("PATCH", "/api/sources/{slug}/enabled"),
+    ("PATCH", "/api/sources/{slug}/priority"),
     ("GET", "/api/stats/article-counts"),
     ("GET", "/api/stats/articles-over-time"),
     ("GET", "/api/stats/category-mix"),

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 from news_dashboard.auth import create_user
 from news_dashboard.db import connect, row_to_dict
 from news_dashboard.ingest.service import list_articles, sync_sources
+from news_dashboard.sources.service import SourceDefinition
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -476,6 +477,145 @@ def test_api_toggle_subscription(pg_clean: str, monkeypatch: pytest.MonkeyPatch)
         resp2 = client.patch(f"/api/sources/{slug}/enabled", json={"enabled": True})
         assert resp2.status_code == 200
         assert resp2.json()["subscribed"] is True
+
+
+def test_private_source_starts_high_priority_and_applies_to_all_its_articles(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        created = client.post(
+            "/api/sources",
+            json={
+                "url": "https://mariozechner.at/recommended-reading/rss.xml",
+                "name": "Mario Zechner Recommended Reading",
+                "slug": "mario-zechner-recommended-reading",
+            },
+        )
+        assert created.status_code == 200
+        source = created.json()
+        assert source["high_priority"] is True
+
+        article_id = _insert_article(pg_clean, source_slug=source["slug"])
+        article = next(
+            item
+            for item in list_articles(state="today", db_path=pg_clean, user_id=uid)
+            if item["id"] == article_id
+        )
+        assert article["high_priority"] is True
+        detail = client.get(f"/api/articles/{article_id}")
+        assert detail.status_code == 200
+        assert detail.json()["high_priority"] is True
+
+
+def test_priority_toggle_relabels_existing_articles(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        created = client.post(
+            "/api/sources",
+            json={
+                "url": "https://example.com/priority.xml",
+                "name": "Priority Source",
+                "high_priority": True,
+            },
+        ).json()
+        article_id = _insert_article(pg_clean, source_slug=created["slug"])
+
+        response = client.patch(
+            f"/api/sources/{created['slug']}/priority",
+            json={"high_priority": False},
+        )
+        assert response.status_code == 200
+        assert response.json()["high_priority"] is False
+
+        article = next(
+            item
+            for item in list_articles(state="today", db_path=pg_clean, user_id=uid)
+            if item["id"] == article_id
+        )
+        assert article["high_priority"] is False
+
+
+def test_global_source_priority_is_isolated_per_user(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    alice = _make_user(pg_clean, "alice")
+    bob = _make_user(pg_clean, "bob")
+    slug = _global_slug(pg_clean)
+    article_id = _insert_article(pg_clean, source_slug=slug)
+
+    with _api_client(pg_clean, alice) as client:
+        response = client.patch(
+            f"/api/sources/{slug}/priority",
+            json={"high_priority": True},
+        )
+        assert response.status_code == 200
+
+    alice_article = next(
+        item
+        for item in list_articles(state="today", db_path=pg_clean, user_id=alice)
+        if item["id"] == article_id
+    )
+    bob_article = next(
+        item
+        for item in list_articles(state="today", db_path=pg_clean, user_id=bob)
+        if item["id"] == article_id
+    )
+    assert alice_article["high_priority"] is True
+    assert bob_article["high_priority"] is False
+
+
+def test_private_rss_ingest_keeps_complete_feed_history(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import patch
+
+    from news_dashboard.ingest.service import _ingest_source
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+    source = SourceDefinition(
+        slug=f"user-{uid}-complete-feed",
+        name="Complete Feed",
+        url="https://example.com/complete.xml",
+        category="tech",
+        owner_user_id=uid,
+    )
+    _add_private_source(pg_clean, slug=source.slug, owner_user_id=uid)
+    entries = [
+        {
+            "url": f"https://example.com/article-{index}",
+            "title": f"Article {index}",
+            "description": "Full history item",
+            "date": "2026-01-01T00:00:00+00:00",
+        }
+        for index in range(75)
+    ]
+
+    with patch(
+        "news_dashboard.ingest.service._fetch_entries_by_kind",
+        return_value=entries,
+    ):
+        outcome = _ingest_source(source, pg_clean)
+
+    assert outcome.articles_found == 75
+    with connect(pg_clean) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM articles WHERE source_slug = %s",
+            (source.slug,),
+        ).fetchone()
+    assert count["count"] == 75
 
 
 # ── Validation ────────────────────────────────────────────────────────────────

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -390,6 +390,13 @@ describe('sources, summary, ingest', () => {
     expect(calls[0].init?.body).toBe(JSON.stringify({ enabled: false }));
   });
 
+  it('updateSourcePriority PATCHes high priority', async () => {
+    const { calls } = stubFetch(() => jsonOk({ slug: 's', high_priority: false }));
+    await api.updateSourcePriority('s', false);
+    expect(calls[0].url).toBe('/api/sources/s/priority');
+    expect(calls[0].init?.body).toBe(JSON.stringify({ high_priority: false }));
+  });
+
   it('previewSource POSTs url and kind and returns the preview result', async () => {
     const { calls } = stubFetch(() =>
       jsonOk({ kind: 'rss_feed', entry_count: 2, items: [{ title: 'A', url: 'u', date: null }] })

--- a/frontend/src/__tests__/articleRow.test.tsx
+++ b/frontend/src/__tests__/articleRow.test.tsx
@@ -9,6 +9,11 @@ vi.mock('../hooks/useTriageMutations', () => ({
   useTriageMutations: () => ({ setState: vi.fn(), toggleStar: vi.fn(), sendLater: vi.fn() }),
   ARTICLES_KEY: 'articles',
 }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === 'priorityFeeds.highPriority' ? 'High priority' : key),
+  }),
+}));
 
 function makeArticle(overrides: Partial<WorkflowArticle> = {}): WorkflowArticle {
   return {
@@ -76,5 +81,21 @@ describe('ArticleRow — also covered by duplicate sources (#929)', () => {
     expect(screen.getByText('Readable article')).toBeTruthy();
     expect(screen.getByTestId('recommendation-label')).toBeTruthy();
     expect(screen.getByText('Also covered by The Verge')).toBeTruthy();
+  });
+});
+
+describe('ArticleRow — high-priority sources', () => {
+  it('renders an accessible urgent treatment for a high-priority source', () => {
+    renderRow(makeArticle({ highPriority: true }));
+
+    const row = screen.getByRole('link', { name: /high priority.*readable article/i });
+    expect(row.className).toContain('border-l');
+    expect(screen.getByText('High priority')).toBeTruthy();
+  });
+
+  it('does not render urgent treatment for a normal source', () => {
+    renderRow(makeArticle({ highPriority: false }));
+
+    expect(screen.queryByText('High priority')).toBeNull();
   });
 });

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -25,6 +25,7 @@ const apiMock = vi.hoisted(() => {
     fetchSources: vi.fn(),
     fetchSourceCleanupSuggestions: vi.fn(),
     updateSourceEnabled: vi.fn(),
+    updateSourcePriority: vi.fn(),
     applySourceCleanup: vi.fn(),
     createSource: vi.fn(),
     previewSource: vi.fn(),
@@ -56,6 +57,19 @@ vi.mock('sonner', () => ({
     warning: vi.fn(),
     error: vi.fn(),
     loading: vi.fn(() => 'id'),
+  }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { source?: string }) => {
+      if (key === 'priorityFeeds.highPriority') return 'High priority';
+      if (key === 'priorityFeeds.description') {
+        return 'Make every article from this source stand out.';
+      }
+      if (key === 'priorityFeeds.priority') return 'Priority';
+      if (key === 'priorityFeeds.sourceLabel') return `High priority ${values?.source ?? ''}`;
+      return key;
+    },
   }),
 }));
 
@@ -205,6 +219,17 @@ describe('SourcesPage', () => {
     await waitFor(() => expect(apiMock.updateSourceEnabled).toHaveBeenCalledWith('acme', false));
   });
 
+  it('toggles high priority independently from subscription state', async () => {
+    apiMock.fetchSources.mockResolvedValue([source({ high_priority: true })]);
+    apiMock.updateSourcePriority.mockResolvedValue(source({ high_priority: false }));
+    withProviders(<SourcesPage />);
+
+    const toggles = await screen.findAllByRole('switch', { name: /high priority acme news/i });
+    fireEvent.click(toggles[0]);
+
+    await waitFor(() => expect(apiMock.updateSourcePriority).toHaveBeenCalledWith('acme', false));
+  });
+
   it('notifies and reverts the switch when a toggle fails', async () => {
     apiMock.fetchSources.mockResolvedValue([source({ enabled: 1 })]);
     apiMock.updateSourceEnabled.mockRejectedValue(new Error('network down'));
@@ -228,6 +253,10 @@ describe('SourcesPage', () => {
     expect(await screen.findByRole('dialog')).toBeTruthy();
     expect(screen.getByLabelText(/name/i)).toBeTruthy();
     expect(screen.getByLabelText(/feed url/i)).toBeTruthy();
+    expect(screen.getByRole('switch', { name: /high priority/i })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
   });
 
   it('calls createSource with form data and closes dialog on success', async () => {

--- a/frontend/src/api/sources.ts
+++ b/frontend/src/api/sources.ts
@@ -34,6 +34,7 @@ export interface CreateSourcePayload {
   category?: string;
   slug?: string;
   kind?: string;
+  high_priority?: boolean;
 }
 
 export async function createSource(payload: CreateSourcePayload): Promise<Source> {
@@ -75,6 +76,13 @@ export async function updateSourceEnabled(slug: string, enabled: boolean): Promi
   return requestJson<Source>(`/api/sources/${slug}/enabled`, {
     method: 'PATCH',
     body: JSON.stringify({ enabled }),
+  });
+}
+
+export async function updateSourcePriority(slug: string, highPriority: boolean): Promise<Source> {
+  return requestJson<Source>(`/api/sources/${slug}/priority`, {
+    method: 'PATCH',
+    body: JSON.stringify({ high_priority: highPriority }),
   });
 }
 

--- a/frontend/src/api/workflowApi.ts
+++ b/frontend/src/api/workflowApi.ts
@@ -70,6 +70,7 @@ export function adaptArticle(a: LegacyArticle): WorkflowArticle {
     reason: a.reason,
     summary: a.summary,
     signal: scoreToSignal(a.importance_score),
+    highPriority: a.high_priority ?? false,
     recommendationScore: a.recommendation_score ?? undefined,
     recommendationModel: a.recommendation_model ?? undefined,
     recommendationSignals: a.recommendation_signals ?? undefined,

--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -1,6 +1,7 @@
 import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Star, Info } from 'lucide-react';
+import { Star, Info, Siren } from 'lucide-react';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
 import { relativeTime, signalLabel } from '@/lib/format';
 import { recommendationLabel, RECOMMENDATION_LABEL_TEXT } from '@/lib/recommendation';
@@ -24,6 +25,7 @@ function formatAlsoFrom(names: string[]): string {
 }
 
 function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
+  const { t } = useTranslation();
   const { setState, toggleStar } = useTriageMutations();
 
   const handleDone = () => setState(article, 'done', 'Read');
@@ -54,6 +56,8 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
           to={`/a/${article.id}`}
           className={cn(
             'motion-fade-up block px-4 py-3 border-b border-border transition-colors hover:bg-surface md:px-5',
+            article.highPriority &&
+              'border-l-4 border-l-[color:var(--err)] bg-[color:color-mix(in_srgb,var(--err)_7%,transparent)]',
             focused && 'bg-surface-2 focus-row'
           )}
         >
@@ -64,6 +68,15 @@ function ArticleRowComponent({ article, focused, showLaterUntil }: Props) {
               <span className="shrink-0">{relativeTime(article.publishedAt)}</span>
               <span>·</span>
               <span className="truncate">{article.category}</span>
+              {article.highPriority && (
+                <>
+                  <span>·</span>
+                  <span className="inline-flex shrink-0 items-center gap-1 font-semibold text-[color:var(--err)]">
+                    <Siren className="size-3" aria-hidden="true" />
+                    {t('priorityFeeds.highPriority')}
+                  </span>
+                </>
+              )}
               {article.detectedLang && article.detectedLang !== 'en' && article.originalTitle && (
                 <>
                   <span>·</span>

--- a/frontend/src/lib/workflowTypes.ts
+++ b/frontend/src/lib/workflowTypes.ts
@@ -30,6 +30,7 @@ export interface WorkflowArticle {
   reason: string;
   summary: string;
   signal: Signal;
+  highPriority?: boolean;
   /** Per-user recommendation score (0–100); undefined when not yet ranked. */
   recommendationScore?: number;
   /** Model version that produced the score; undefined when not yet ranked. */

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "إعادة الإنشاء",
       "slideLabel": "الشريحة {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Vygenerovat znovu",
       "slideLabel": "Snímek {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Genopret",
       "slideLabel": "Dias {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Erneut generieren",
       "slideLabel": "Folie {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Αναδημιουργία",
       "slideLabel": "Διαφάνεια {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -101,6 +101,12 @@
     "more": "More",
     "log_out": "Log out"
   },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
+  },
   "settings": {
     "title": "Settings",
     "about_heading": "About",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Regenerar",
       "slideLabel": "Diapositiva {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Luo uudelleen",
       "slideLabel": "Dia {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Régénérer",
       "slideLabel": "Diapositive {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "צור מחדש",
       "slideLabel": "שקופית {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "पुनः उत्पन्न करें",
       "slideLabel": "स्लाइड {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Újragenerálás",
       "slideLabel": "Dia {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Buat ulang",
       "slideLabel": "Slide {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Rigenera",
       "slideLabel": "Diapositiva {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "再生成",
       "slideLabel": "スライド {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "다시 생성",
       "slideLabel": "슬라이드 {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Opnieuw genereren",
       "slideLabel": "Dia {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Regenerer",
       "slideLabel": "Lysbilde {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Wygeneruj ponownie",
       "slideLabel": "Slajd {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Regenerar",
       "slideLabel": "Slide {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Regenerează",
       "slideLabel": "Diapozitiv {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Сгенерировать заново",
       "slideLabel": "Слайд {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Återskapa",
       "slideLabel": "Bild {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "สร้างใหม่",
       "slideLabel": "สไลด์ {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Yeniden oluştur",
       "slideLabel": "Slayt {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Створити знову",
       "slideLabel": "Слайд {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "Tạo lại",
       "slideLabel": "Slide {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "重新生成",
       "slideLabel": "幻灯片 {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -210,5 +210,11 @@
       "regenerate": "重新生成",
       "slideLabel": "投影片 {{number}}"
     }
+  },
+  "priorityFeeds": {
+    "highPriority": "High priority",
+    "priority": "Priority",
+    "description": "Make every article from this source stand out.",
+    "sourceLabel": "High priority {{source}}"
   }
 }

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -27,6 +28,7 @@ import {
   importOpml,
   previewSource,
   updateSourceEnabled,
+  updateSourcePriority,
 } from '@/api';
 import type { SourcePreviewResult } from '@/api';
 import { relativeTime } from '@/lib/format';
@@ -106,6 +108,7 @@ interface AddSourceFormState {
   category: string;
   slug: string;
   kind: string;
+  highPriority: boolean;
 }
 
 const EMPTY_FORM: AddSourceFormState = {
@@ -114,6 +117,7 @@ const EMPTY_FORM: AddSourceFormState = {
   category: 'tech',
   slug: '',
   kind: 'rss_feed',
+  highPriority: true,
 };
 
 function AddSourceDialog({
@@ -125,6 +129,7 @@ function AddSourceDialog({
   onClose: () => void;
   onCreated: () => void;
 }) {
+  const { t } = useTranslation();
   const [form, setForm] = useState<AddSourceFormState>(EMPTY_FORM);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<SourcePreviewResult | null>(null);
@@ -138,6 +143,7 @@ function AddSourceDialog({
         category: form.category || 'tech',
         slug: form.slug || undefined,
         kind: form.kind,
+        high_priority: form.highPriority,
       }),
     onSuccess: () => {
       setForm(EMPTY_FORM);
@@ -294,6 +300,19 @@ function AddSourceDialog({
               />
             </div>
           </div>
+          <div className="flex items-center justify-between gap-3 rounded-md border border-input px-3 py-2">
+            <div>
+              <div className="text-sm font-medium">{t('priorityFeeds.highPriority')}</div>
+              <div className="text-xs text-muted-foreground">{t('priorityFeeds.description')}</div>
+            </div>
+            <Switch
+              checked={form.highPriority}
+              onCheckedChange={(checked) =>
+                setForm((current) => ({ ...current, highPriority: checked }))
+              }
+              aria-label={t('priorityFeeds.highPriority')}
+            />
+          </div>
           {error && <p className="text-xs text-[color:var(--err)]">{error}</p>}
           <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="outline" size="sm" onClick={handleClose}>
@@ -310,6 +329,7 @@ function AddSourceDialog({
 }
 
 export function SourcesPage() {
+  const { t } = useTranslation();
   const [wizardOpen, setWizardOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   const [importResult, setImportResult] = useState<OpmlImportResult | null>(null);
@@ -340,6 +360,27 @@ export function SourcesPage() {
             ? { ...s, subscribed: enabled, enabled: enabled ? 1 : 0 }
             : { ...s, enabled: enabled ? 1 : 0 };
         })
+      );
+      return { prev };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData([SOURCES_KEY], ctx.prev);
+      toast.error(sourceActionErrorMessage(err, 'toggle'));
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: [SOURCES_KEY] });
+    },
+  });
+  const priorityMutation = useMutation({
+    mutationFn: ({ slug, highPriority }: { slug: string; highPriority: boolean }) =>
+      updateSourcePriority(slug, highPriority),
+    onMutate: async ({ slug, highPriority }) => {
+      await qc.cancelQueries({ queryKey: [SOURCES_KEY] });
+      const prev = qc.getQueryData<Source[]>([SOURCES_KEY]);
+      qc.setQueryData<Source[]>([SOURCES_KEY], (old = []) =>
+        old.map((source) =>
+          source.slug === slug ? { ...source, high_priority: highPriority } : source
+        )
       );
       return { prev };
     },
@@ -593,6 +634,7 @@ export function SourcesPage() {
               <th className="px-3 py-2 font-medium">Last success</th>
               <th className="px-3 py-2 font-medium text-right">Items (run)</th>
               <th className="px-3 py-2 font-medium text-right">On</th>
+              <th className="px-3 py-2 font-medium text-right">{t('priorityFeeds.priority')}</th>
               <th className="px-3 py-2 font-medium" />
             </tr>
           </thead>
@@ -643,6 +685,15 @@ export function SourcesPage() {
                     />
                   </td>
                   <td className="px-3 py-3 text-right">
+                    <Switch
+                      checked={!!s.high_priority}
+                      onCheckedChange={(checked) =>
+                        priorityMutation.mutate({ slug: s.slug, highPriority: checked })
+                      }
+                      aria-label={t('priorityFeeds.sourceLabel', { source: s.name })}
+                    />
+                  </td>
+                  <td className="px-3 py-3 text-right">
                     {isOwned && (
                       <Button
                         size="sm"
@@ -684,6 +735,13 @@ export function SourcesPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
+                  <Switch
+                    checked={!!s.high_priority}
+                    onCheckedChange={(checked) =>
+                      priorityMutation.mutate({ slug: s.slug, highPriority: checked })
+                    }
+                    aria-label={t('priorityFeeds.sourceLabel', { source: s.name })}
+                  />
                   {isOwned && (
                     <Button
                       size="sm"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,6 +46,7 @@ export interface Article {
   recommendation_model?: string | null;
   recommendation_signals?: RecommendationSignals | null;
   recommendation_explanation?: string | null;
+  high_priority?: boolean;
 }
 
 export interface User {
@@ -134,6 +135,7 @@ export interface Source {
   priority: number;
   enabled: number;
   subscribed?: boolean;
+  high_priority?: boolean;
   owner_user_id?: number | null;
   last_checked_at?: string | null;
   last_success_at?: string | null;


### PR DESCRIPTION
Closes #1283

## Summary
- add per-user high-priority source preferences and a reversible feed-management toggle
- default newly created private sources to high priority and expose the flag on source, list, and article-detail APIs
- render a red attention rail, subtle tint, siren icon, and text label on every high-priority article
- ingest the complete history exposed by private RSS feeds instead of truncating them at 50 entries

## Verification
- backend: 2,834 passed, 2 skipped
- frontend: 995 passed
- lint, formatting, mypy, ty, pyrefly, TypeScript, production build, PWA generation, and bundle budget pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)