### PR TITLE
feat: add guided Substack RSS setup

### DIFF
--- a/backend/news_dashboard/sources/models.py
+++ b/backend/news_dashboard/sources/models.py
@@ -27,6 +27,7 @@ class CreateSourceRequest(BaseModel):
     slug: str | None = None
     kind: str = "rss_feed"
     high_priority: bool = True
+    provider: str | None = None
 
     def validate_kind(self) -> None:
         if self.kind in USER_CREATED_SOURCE_KINDS:
@@ -64,6 +65,10 @@ class PreviewSourceRequest(BaseModel):
             status_code=400,
             detail=f"unsupported source kind '{self.kind}'. Supported kinds: {allowed}",
         )
+
+
+class SubstackPreviewRequest(BaseModel):
+    url: str
 
 
 class SourceCleanupRequest(BaseModel):

--- a/backend/news_dashboard/sources/router.py
+++ b/backend/news_dashboard/sources/router.py
@@ -37,10 +37,13 @@ from news_dashboard.sources.models import (
     HighPriorityUpdate,
     PreviewSourceRequest,
     SourceCleanupRequest,
+    SubstackPreviewRequest,
 )
 from news_dashboard.sources.service import (
     SourceDefinition,
+    SubstackUrlError,
     add_user_source_preference,
+    normalize_substack_feed_url,
     set_user_source_priority,
 )
 from news_dashboard.url_safety import UnsafeUrlError, validate_server_fetch_url
@@ -139,10 +142,32 @@ def create_source(
 
     init_db()
     with connect() as conn:
-        existing = conn.execute("SELECT 1 FROM sources WHERE slug = %s", (slug,)).fetchone()
+        if payload.provider == "substack":
+            existing = conn.execute(
+                """
+                SELECT slug, url
+                FROM sources
+                WHERE deleted_at IS NULL
+                  AND (
+                    slug = %s
+                    OR (url = %s AND (owner_user_id IS NULL OR owner_user_id = %s))
+                  )
+                """,
+                (slug, payload.url, uid),
+            ).fetchone()
+        else:
+            existing = conn.execute(
+                "SELECT slug, url FROM sources WHERE slug = %s",
+                (slug,),
+            ).fetchone()
         if existing:
+            if existing["slug"] == slug:
+                raise HTTPException(
+                    status_code=409, detail=f"source slug '{requested_slug}' already exists"
+                )
             raise HTTPException(
-                status_code=409, detail=f"source slug '{requested_slug}' already exists"
+                status_code=409,
+                detail="This feed is already in your sources.",
             )
         conn.execute(
             """
@@ -194,6 +219,45 @@ def preview_source(
         "kind": payload.kind,
         "entry_count": len(entries),
         "items": items,
+    }
+
+
+@router.post("/api/sources/substack/preview")
+def preview_substack_source(
+    payload: SubstackPreviewRequest,
+    _current_user: Annotated[dict[str, Any], Depends(require_auth)],
+) -> dict[str, Any]:
+    """Normalize and preview a Substack publication without saving it."""
+    try:
+        substack_feed = normalize_substack_feed_url(payload.url)
+        validate_server_fetch_url(substack_feed.feed_url)
+    except (SubstackUrlError, UnsafeUrlError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    source = SourceDefinition(
+        slug="preview-substack",
+        name=substack_feed.suggested_name,
+        url=substack_feed.feed_url,
+        category="newsletter",
+        kind="rss_feed",
+    )
+    try:
+        entries = preview_source_entries(source)
+    except FeedFetchError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return {
+        "feed_url": substack_feed.feed_url,
+        "suggested_name": substack_feed.suggested_name,
+        "entry_count": len(entries),
+        "items": [
+            {
+                "title": clean_html(entry.get("title") or "Untitled")[:200],
+                "url": entry.get("url", ""),
+                "date": entry.get("date"),
+            }
+            for entry in entries[:_PREVIEW_MAX_ITEMS]
+        ],
     }
 
 

--- a/backend/news_dashboard/sources/service.py
+++ b/backend/news_dashboard/sources/service.py
@@ -2,8 +2,47 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit
 
 from news_dashboard.db import connect, init_db, row_to_dict
+
+
+class SubstackUrlError(ValueError):
+    """Raised when a submitted URL is not a Substack publication URL."""
+
+
+@dataclass(frozen=True)
+class SubstackFeed:
+    feed_url: str
+    suggested_name: str
+
+
+def normalize_substack_feed_url(submitted_url: str) -> SubstackFeed:
+    """Turn a Substack publication or post URL into its canonical RSS feed URL."""
+    candidate = submitted_url.strip()
+    if not candidate:
+        message = "Enter a Substack publication or post link."
+        raise SubstackUrlError(message)
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+
+    parsed = urlsplit(candidate)
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    labels = hostname.split(".")
+    if parsed.scheme != "https" or len(labels) != 3 or labels[1:] != ["substack", "com"]:
+        message = "Enter a Substack publication or post link."
+        raise SubstackUrlError(message)
+
+    publication = labels[0]
+    if not publication or publication in {"www", "api"}:
+        message = "Enter a Substack publication or post link."
+        raise SubstackUrlError(message)
+
+    suggested_name = publication.replace("-", " ").title()
+    return SubstackFeed(
+        feed_url=f"https://{publication}.substack.com/feed",
+        suggested_name=suggested_name,
+    )
 
 
 def add_user_source_preference(

--- a/backend/tests/test_main_feature_modules.py
+++ b/backend/tests/test_main_feature_modules.py
@@ -177,6 +177,7 @@ EXPECTED_METHOD_PATHS = {
     ("GET", "/api/sources/health"),
     ("POST", "/api/sources/import"),
     ("POST", "/api/sources/preview"),
+    ("POST", "/api/sources/substack/preview"),
     ("DELETE", "/api/sources/{slug}"),
     ("PATCH", "/api/sources/{slug}/enabled"),
     ("PATCH", "/api/sources/{slug}/priority"),

--- a/backend/tests/test_source_subscriptions.py
+++ b/backend/tests/test_source_subscriptions.py
@@ -688,6 +688,59 @@ def test_api_create_source_duplicate_slug_returns_409(
         assert "already exists" in resp2.json()["detail"]
 
 
+def test_api_create_source_duplicate_url_for_same_user_returns_409(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        first = client.post(
+            "/api/sources",
+            json={
+                "url": "https://writer.substack.com/feed",
+                "name": "Writer",
+                "slug": "writer",
+                "provider": "substack",
+            },
+        )
+        duplicate = client.post(
+            "/api/sources",
+            json={
+                "url": "https://writer.substack.com/feed",
+                "name": "Writer Renamed",
+                "slug": "writer-renamed",
+                "provider": "substack",
+            },
+        )
+
+    assert first.status_code == 200
+    assert duplicate.status_code == 409
+    assert duplicate.json()["detail"] == "This feed is already in your sources."
+
+
+def test_api_create_source_preserves_duplicate_url_support_for_generic_sources(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", str(pg_clean))
+    sync_sources(pg_clean)
+    uid = _make_user(pg_clean)
+
+    with _api_client(pg_clean, uid) as client:
+        first = client.post(
+            "/api/sources",
+            json={"url": "https://example.com/feed", "name": "First", "slug": "first"},
+        )
+        second = client.post(
+            "/api/sources",
+            json={"url": "https://example.com/feed", "name": "Second", "slug": "second"},
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+
 def test_api_create_source_allows_cross_user_slug_reuse(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_substack_sources.py
+++ b/backend/tests/test_substack_sources.py
@@ -1,0 +1,144 @@
+"""Tests for guided Substack RSS source setup."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.ingest.service import FeedFetchError
+from news_dashboard.sources import service
+
+
+@pytest.mark.parametrize(
+    ("submitted_url", "expected_feed_url", "expected_name"),
+    [
+        (
+            "https://pragmaticengineer.substack.com",
+            "https://pragmaticengineer.substack.com/feed",
+            "Pragmaticengineer",
+        ),
+        (
+            "https://pragmaticengineer.substack.com/p/a-post?utm_source=post-email-title",
+            "https://pragmaticengineer.substack.com/feed",
+            "Pragmaticengineer",
+        ),
+        (
+            "pragmaticengineer.substack.com/archive",
+            "https://pragmaticengineer.substack.com/feed",
+            "Pragmaticengineer",
+        ),
+    ],
+)
+def test_normalize_substack_feed_url_accepts_publication_and_post_links(
+    submitted_url: str,
+    expected_feed_url: str,
+    expected_name: str,
+) -> None:
+    result = service.normalize_substack_feed_url(submitted_url)
+
+    assert result.feed_url == expected_feed_url
+    assert result.suggested_name == expected_name
+
+
+@pytest.mark.parametrize(
+    "submitted_url",
+    [
+        "",
+        "https://example.com/feed",
+        "https://substack.com/@writer",
+        "ftp://writer.substack.com/feed",
+        "https://evil.test/?next=writer.substack.com",
+    ],
+)
+def test_normalize_substack_feed_url_rejects_non_publication_links(submitted_url: str) -> None:
+    with pytest.raises(service.SubstackUrlError, match="Substack publication"):
+        service.normalize_substack_feed_url(submitted_url)
+
+
+def test_substack_preview_normalizes_post_link_and_returns_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+    from news_dashboard.sources import router as sources_router
+
+    monkeypatch.setattr(
+        sources_router,
+        "preview_source_entries",
+        lambda source: [
+            {
+                "title": "A useful post",
+                "url": f"{source.url}/../p/useful",
+                "date": None,
+            }
+        ],
+    )
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": 7,
+        "username": "alice",
+        "is_admin": False,
+    }
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/sources/substack/preview",
+                json={"url": "https://writer.substack.com/p/useful?utm_source=email"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "feed_url": "https://writer.substack.com/feed",
+        "suggested_name": "Writer",
+        "entry_count": 1,
+        "items": [
+            {
+                "title": "A useful post",
+                "url": "https://writer.substack.com/feed/../p/useful",
+                "date": None,
+            }
+        ],
+    }
+
+
+def test_substack_preview_explains_invalid_publication_link() -> None:
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    app.dependency_overrides[require_auth] = lambda: {"id": 7, "username": "alice"}
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/sources/substack/preview",
+                json={"url": "https://example.com/not-substack"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Enter a Substack publication or post link."
+
+
+def test_substack_preview_explains_unreachable_feed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+    from news_dashboard.sources import router as sources_router
+
+    def fail_preview(_source: object) -> list[dict[str, object]]:
+        message = "The publication feed could not be reached."
+        raise FeedFetchError(message)
+
+    monkeypatch.setattr(sources_router, "preview_source_entries", fail_preview)
+    app.dependency_overrides[require_auth] = lambda: {"id": 7, "username": "alice"}
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/sources/substack/preview",
+                json={"url": "https://writer.substack.com"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "The publication feed could not be reached."

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -413,6 +413,26 @@ describe('sources, summary, ingest', () => {
     expect(result.entry_count).toBe(2);
     expect(result.items).toEqual([{ title: 'A', url: 'u', date: null }]);
   });
+
+  it('previewSubstackSource submits a publication link for normalization and preview', async () => {
+    const { calls } = stubFetch(() =>
+      jsonOk({
+        feed_url: 'https://writer.substack.com/feed',
+        suggested_name: 'Writer',
+        entry_count: 1,
+        items: [{ title: 'A post', url: 'https://writer.substack.com/p/a-post', date: null }],
+      })
+    );
+
+    const result = await api.previewSubstackSource('https://writer.substack.com/p/a-post');
+
+    expect(calls[0].url).toBe('/api/sources/substack/preview');
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].init?.body).toBe(
+      JSON.stringify({ url: 'https://writer.substack.com/p/a-post' })
+    );
+    expect(result.feed_url).toBe('https://writer.substack.com/feed');
+  });
 });
 
 describe('scheduler endpoints', () => {

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -29,6 +29,7 @@ const apiMock = vi.hoisted(() => {
     applySourceCleanup: vi.fn(),
     createSource: vi.fn(),
     previewSource: vi.fn(),
+    previewSubstackSource: vi.fn(),
     deleteSource: vi.fn(),
     fetchSchedulerStatus: vi.fn(),
     setSchedulerInterval: vi.fn(),
@@ -61,13 +62,29 @@ vi.mock('sonner', () => ({
 }));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, values?: { source?: string }) => {
+    t: (key: string, values?: { source?: string; count?: number; name?: string }) => {
       if (key === 'priorityFeeds.highPriority') return 'High priority';
       if (key === 'priorityFeeds.description') {
         return 'Make every article from this source stand out.';
       }
       if (key === 'priorityFeeds.priority') return 'Priority';
       if (key === 'priorityFeeds.sourceLabel') return `High priority ${values?.source ?? ''}`;
+      const substackCopy: Record<string, string> = {
+        'substackWizard.open': 'Follow Substack',
+        'substackWizard.title': 'Follow a Substack publication',
+        'substackWizard.description':
+          'Paste the publication homepage or any post link. We’ll find and test its public RSS feed.',
+        'substackWizard.linkLabel': 'Substack link',
+        'substackWizard.linkPlaceholder': 'https://writer.substack.com/p/a-post',
+        'substackWizard.finding': 'Finding publication…',
+        'substackWizard.find': 'Find publication',
+        'substackWizard.nameLabel': 'Publication name',
+        'substackWizard.following': 'Following…',
+        'substackWizard.cancel': 'Cancel',
+      };
+      if (key === 'substackWizard.latestPosts') return `Latest posts (${values?.count ?? 0})`;
+      if (key === 'substackWizard.follow') return `Follow ${values?.name ?? ''}`;
+      if (key in substackCopy) return substackCopy[key];
       return key;
     },
   }),
@@ -394,6 +411,92 @@ describe('SourcesPage', () => {
     expect(await screen.findByText('Found 2 entries')).toBeTruthy();
     expect(screen.getByText('First post')).toBeTruthy();
     expect(screen.getByText('Second post')).toBeTruthy();
+  });
+
+  it('guides a user from a Substack post link to a saved private RSS source', async () => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.previewSubstackSource.mockResolvedValue({
+      feed_url: 'https://writer.substack.com/feed',
+      suggested_name: 'Writer',
+      entry_count: 1,
+      items: [{ title: 'A useful post', url: 'https://writer.substack.com/p/useful', date: null }],
+    });
+    apiMock.createSource.mockResolvedValue(
+      source({
+        slug: 'u2-writer',
+        name: 'Writer',
+        url: 'https://writer.substack.com/feed',
+        owner_user_id: regularUser.id,
+      })
+    );
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /follow substack/i }));
+    fireEvent.change(screen.getByLabelText(/substack link/i), {
+      target: { value: 'https://writer.substack.com/p/useful?utm_source=email' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /find publication/i }));
+
+    expect(await screen.findByText('A useful post')).toBeTruthy();
+    expect(screen.getByDisplayValue('Writer')).toBeTruthy();
+    expect(screen.getByText('https://writer.substack.com/feed')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /follow writer/i }));
+
+    await waitFor(() =>
+      expect(apiMock.createSource).toHaveBeenCalledWith({
+        name: 'Writer',
+        url: 'https://writer.substack.com/feed',
+        category: 'newsletter',
+        kind: 'rss_feed',
+        high_priority: true,
+        provider: 'substack',
+      })
+    );
+  });
+
+  it.each([
+    [400, 'Enter a Substack publication or post link.'],
+    [422, 'The publication feed could not be reached.'],
+  ])('explains a Substack preview error with status %s', async (status, message) => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.previewSubstackSource.mockRejectedValue(new apiMock.HttpError(status, message));
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /follow substack/i }));
+    fireEvent.change(screen.getByLabelText(/substack link/i), {
+      target: { value: 'https://example.com/not-a-publication' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /find publication/i }));
+
+    expect(await screen.findByText(message)).toBeTruthy();
+  });
+
+  it('explains when the Substack feed is already followed', async () => {
+    apiMock.fetchSources.mockResolvedValue([source()]);
+    apiMock.previewSubstackSource.mockResolvedValue({
+      feed_url: 'https://writer.substack.com/feed',
+      suggested_name: 'Writer',
+      entry_count: 1,
+      items: [{ title: 'A post', url: 'https://writer.substack.com/p/a-post', date: null }],
+    });
+    apiMock.createSource.mockRejectedValue(
+      new apiMock.HttpError(409, 'This feed is already in your sources.')
+    );
+    withProviders(<SourcesPage />, '/', regularUser);
+    await screen.findAllByText('Acme News');
+
+    fireEvent.click(screen.getByRole('button', { name: /follow substack/i }));
+    fireEvent.change(screen.getByLabelText(/substack link/i), {
+      target: { value: 'https://writer.substack.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /find publication/i }));
+    await screen.findByText('A post');
+    fireEvent.click(screen.getByRole('button', { name: /follow writer/i }));
+
+    expect(await screen.findByText('This feed is already in your sources.')).toBeTruthy();
   });
 
   it('shows an empty-feed message when preview finds no entries', async () => {

--- a/frontend/src/api/sources.ts
+++ b/frontend/src/api/sources.ts
@@ -35,6 +35,7 @@ export interface CreateSourcePayload {
   slug?: string;
   kind?: string;
   high_priority?: boolean;
+  provider?: string;
 }
 
 export async function createSource(payload: CreateSourcePayload): Promise<Source> {
@@ -65,6 +66,18 @@ export async function previewSource(payload: PreviewSourcePayload): Promise<Sour
   return requestJson<SourcePreviewResult>('/api/sources/preview', {
     method: 'POST',
     body: JSON.stringify(payload),
+  });
+}
+
+export interface SubstackPreviewResult extends SourcePreviewResult {
+  feed_url: string;
+  suggested_name: string;
+}
+
+export async function previewSubstackSource(url: string): Promise<SubstackPreviewResult> {
+  return requestJson<SubstackPreviewResult>('/api/sources/substack/preview', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
   });
 }
 

--- a/frontend/src/components/SubstackSourceWizard.tsx
+++ b/frontend/src/components/SubstackSourceWizard.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMutation } from '@tanstack/react-query';
+import { Rss } from 'lucide-react';
+import { createSource, previewSubstackSource } from '@/api';
+import type { SubstackPreviewResult } from '@/api';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { sourceActionErrorMessage } from '@/lib/errorPresentation';
+
+interface SubstackSourceWizardProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function SubstackSourceWizard({ open, onClose, onCreated }: SubstackSourceWizardProps) {
+  const { t } = useTranslation();
+  const [submittedUrl, setSubmittedUrl] = useState('');
+  const [name, setName] = useState('');
+  const [preview, setPreview] = useState<SubstackPreviewResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const previewMutation = useMutation({
+    mutationFn: () => previewSubstackSource(submittedUrl),
+    onSuccess: (result) => {
+      setPreview(result);
+      setName(result.suggested_name);
+      setError(null);
+    },
+    onError: (err: Error) => {
+      setPreview(null);
+      setError(sourceActionErrorMessage(err, 'add'));
+    },
+  });
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createSource({
+        name,
+        url: preview?.feed_url ?? '',
+        category: 'newsletter',
+        kind: 'rss_feed',
+        high_priority: true,
+        provider: 'substack',
+      }),
+    onSuccess: () => {
+      onCreated();
+      handleClose();
+    },
+    onError: (err: Error) => setError(sourceActionErrorMessage(err, 'add')),
+  });
+
+  function handleClose() {
+    setSubmittedUrl('');
+    setName('');
+    setPreview(null);
+    setError(null);
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && handleClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('substackWizard.title')}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 pt-1">
+          <p className="text-sm text-muted-foreground">{t('substackWizard.description')}</p>
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="substack-url" className="text-xs font-medium text-muted-foreground">
+              {t('substackWizard.linkLabel')}
+            </label>
+            <Input
+              id="substack-url"
+              placeholder={t('substackWizard.linkPlaceholder')}
+              value={submittedUrl}
+              onChange={(event) => {
+                setSubmittedUrl(event.target.value);
+                setPreview(null);
+                setError(null);
+              }}
+            />
+          </div>
+          {!preview && (
+            <Button
+              onClick={() => previewMutation.mutate()}
+              disabled={!submittedUrl.trim() || previewMutation.isPending}
+            >
+              <Rss className="size-4" />
+              {previewMutation.isPending ? t('substackWizard.finding') : t('substackWizard.find')}
+            </Button>
+          )}
+          {preview && (
+            <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/25 p-4">
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="substack-name"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  {t('substackWizard.nameLabel')}
+                </label>
+                <Input
+                  id="substack-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                />
+                <span className="break-all text-xs text-muted-foreground">{preview.feed_url}</span>
+              </div>
+              <div>
+                <p className="mb-1 text-xs font-medium">
+                  {t('substackWizard.latestPosts', { count: preview.entry_count })}
+                </p>
+                <ul className="flex flex-col gap-1 text-sm text-muted-foreground">
+                  {preview.items.map((item) => (
+                    <li key={item.url}>{item.title}</li>
+                  ))}
+                </ul>
+              </div>
+              <Button
+                onClick={() => createMutation.mutate()}
+                disabled={!name.trim() || createMutation.isPending}
+              >
+                {createMutation.isPending
+                  ? t('substackWizard.following')
+                  : t('substackWizard.follow', { name })}
+              </Button>
+            </div>
+          )}
+          {error && <p className="text-sm text-[color:var(--err)]">{error}</p>}
+          <Button variant="ghost" onClick={handleClose}>
+            {t('substackWizard.cancel')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/errorPresentation.ts
+++ b/frontend/src/lib/errorPresentation.ts
@@ -183,6 +183,7 @@ export type SourceActionKind = 'add' | 'toggle' | 'cleanup' | 'delete';
 /** Friendly copy for source management failures, without leaking raw backend/server strings as the primary message. */
 export function sourceActionErrorMessage(err: unknown, action: SourceActionKind): string {
   if (err instanceof HttpError && err.status === 409) {
+    if (/already in your sources/i.test(err.message)) return err.message;
     return 'That slug is already in use — choose a different slug or source.';
   }
   if (action === 'add' && err instanceof HttpError && (err.status === 400 || err.status === 422)) {

--- a/frontend/src/locales/ar/translation.json
+++ b/frontend/src/locales/ar/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/da/translation.json
+++ b/frontend/src/locales/da/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/el/translation.json
+++ b/frontend/src/locales/el/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -107,6 +107,20 @@
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
   },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
+  },
   "settings": {
     "title": "Settings",
     "about_heading": "About",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/fi/translation.json
+++ b/frontend/src/locales/fi/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/he/translation.json
+++ b/frontend/src/locales/he/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/hi/translation.json
+++ b/frontend/src/locales/hi/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/hu/translation.json
+++ b/frontend/src/locales/hu/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/id/translation.json
+++ b/frontend/src/locales/id/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/ko/translation.json
+++ b/frontend/src/locales/ko/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/no/translation.json
+++ b/frontend/src/locales/no/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/ro/translation.json
+++ b/frontend/src/locales/ro/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/th/translation.json
+++ b/frontend/src/locales/th/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/uk/translation.json
+++ b/frontend/src/locales/uk/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/vi/translation.json
+++ b/frontend/src/locales/vi/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/locales/zh-TW/translation.json
+++ b/frontend/src/locales/zh-TW/translation.json
@@ -216,5 +216,19 @@
     "priority": "Priority",
     "description": "Make every article from this source stand out.",
     "sourceLabel": "High priority {{source}}"
+  },
+  "substackWizard": {
+    "open": "Follow Substack",
+    "title": "Follow a Substack publication",
+    "description": "Paste the publication homepage or any post link. We’ll find and test its public RSS feed.",
+    "linkLabel": "Substack link",
+    "linkPlaceholder": "https://writer.substack.com/p/a-post",
+    "finding": "Finding publication…",
+    "find": "Find publication",
+    "nameLabel": "Publication name",
+    "latestPosts": "Latest posts ({{count}})",
+    "following": "Following…",
+    "follow": "Follow {{name}}",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Download,
   Upload,
+  Rss,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -35,6 +36,7 @@ import { relativeTime } from '@/lib/format';
 import { sourceActionErrorMessage } from '@/lib/errorPresentation';
 import type { Source, SourceCleanupSuggestion, OpmlImportResult } from '@/types';
 import { OnboardingWizard } from '@/components/OnboardingWizard';
+import { SubstackSourceWizard } from '@/components/SubstackSourceWizard';
 import { useAuth } from '@/contexts/auth';
 
 type HealthState = 'ok' | 'stale' | 'error';
@@ -332,6 +334,7 @@ export function SourcesPage() {
   const { t } = useTranslation();
   const [wizardOpen, setWizardOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
+  const [substackOpen, setSubstackOpen] = useState(false);
   const [importResult, setImportResult] = useState<OpmlImportResult | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
@@ -500,6 +503,10 @@ export function SourcesPage() {
             <Plus className="size-4" />
             Add source
           </Button>
+          <Button size="sm" variant="outline" onClick={() => setSubstackOpen(true)}>
+            <Rss className="size-4" />
+            {t('substackWizard.open')}
+          </Button>
           <Button size="sm" variant="outline" onClick={() => setWizardOpen(true)}>
             <Wand2 className="size-4" />
             Personalize
@@ -509,6 +516,11 @@ export function SourcesPage() {
       <AddSourceDialog
         open={addOpen}
         onClose={() => setAddOpen(false)}
+        onCreated={() => void qc.invalidateQueries({ queryKey: [SOURCES_KEY] })}
+      />
+      <SubstackSourceWizard
+        open={substackOpen}
+        onClose={() => setSubstackOpen(false)}
         onCreated={() => void qc.invalidateQueries({ queryKey: [SOURCES_KEY] })}
       />
       <OnboardingWizard


### PR DESCRIPTION
Closes #1286

## Summary
- add a guided Substack flow that accepts publication or post links and previews the canonical RSS feed
- save validated feeds as private, high-priority newsletter sources
- explain invalid, unreachable, and duplicate feeds and preserve generic source behavior
- localize the wizard across the existing locale catalog

## Verification
- `make lint`
- `make typecheck`
- `npm run test:frontend` (1000 passed)
- `npm run build`
- `PGOPTIONS="-c max_parallel_workers_per_gather=0" dotenv run -- make test` (2847 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)