### PR TITLE
fix: accept custom-domain Substack feeds

### DIFF
--- a/backend/news_dashboard/sources/service.py
+++ b/backend/news_dashboard/sources/service.py
@@ -8,7 +8,7 @@ from news_dashboard.db import connect, init_db, row_to_dict
 
 
 class SubstackUrlError(ValueError):
-    """Raised when a submitted URL is not a Substack publication URL."""
+    """Raised when a submitted URL cannot identify a Substack publication."""
 
 
 @dataclass(frozen=True)
@@ -26,21 +26,32 @@ def normalize_substack_feed_url(submitted_url: str) -> SubstackFeed:
     if "://" not in candidate:
         candidate = f"https://{candidate}"
 
-    parsed = urlsplit(candidate)
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError as exc:
+        message = "Enter a Substack publication or post link."
+        raise SubstackUrlError(message) from exc
     hostname = (parsed.hostname or "").lower().rstrip(".")
     labels = hostname.split(".")
-    if parsed.scheme != "https" or len(labels) != 3 or labels[1:] != ["substack", "com"]:
+    if (
+        parsed.scheme != "https"
+        or parsed.username is not None
+        or parsed.password is not None
+        or len(labels) < 2
+        or any(not label for label in labels)
+    ):
         message = "Enter a Substack publication or post link."
         raise SubstackUrlError(message)
 
-    publication = labels[0]
-    if not publication or publication in {"www", "api"}:
+    is_substack_host = labels[-2:] == ["substack", "com"]
+    if is_substack_host and (len(labels) != 3 or labels[0] in {"www", "api"}):
         message = "Enter a Substack publication or post link."
         raise SubstackUrlError(message)
 
+    publication = labels[1] if labels[0] == "www" else labels[0]
     suggested_name = publication.replace("-", " ").title()
     return SubstackFeed(
-        feed_url=f"https://{publication}.substack.com/feed",
+        feed_url=f"https://{hostname}/feed",
         suggested_name=suggested_name,
     )
 

--- a/backend/tests/test_substack_sources.py
+++ b/backend/tests/test_substack_sources.py
@@ -27,6 +27,16 @@ from news_dashboard.sources import service
             "https://pragmaticengineer.substack.com/feed",
             "Pragmaticengineer",
         ),
+        (
+            "https://www.platformer.news/p/a-post?utm_source=post-email-title",
+            "https://www.platformer.news/feed",
+            "Platformer",
+        ),
+        (
+            "https://newsletter.example.com",
+            "https://newsletter.example.com/feed",
+            "Newsletter",
+        ),
     ],
 )
 def test_normalize_substack_feed_url_accepts_publication_and_post_links(
@@ -44,10 +54,11 @@ def test_normalize_substack_feed_url_accepts_publication_and_post_links(
     "submitted_url",
     [
         "",
-        "https://example.com/feed",
+        "https://[",
         "https://substack.com/@writer",
+        "https://user:password@writer.example.com/p/post",
         "ftp://writer.substack.com/feed",
-        "https://evil.test/?next=writer.substack.com",
+        "https://localhost/p/post",
     ],
 )
 def test_normalize_substack_feed_url_rejects_non_publication_links(submitted_url: str) -> None:
@@ -111,13 +122,31 @@ def test_substack_preview_explains_invalid_publication_link() -> None:
         with TestClient(app) as client:
             response = client.post(
                 "/api/sources/substack/preview",
-                json={"url": "https://example.com/not-substack"},
+                json={"url": "http://writer.example.com/p/post"},
             )
     finally:
         app.dependency_overrides.pop(require_auth, None)
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Enter a Substack publication or post link."
+
+
+def test_substack_preview_blocks_unsafe_custom_domain_feed() -> None:
+    from news_dashboard.auth import require_auth
+    from news_dashboard.main import app
+
+    app.dependency_overrides[require_auth] = lambda: {"id": 7, "username": "alice"}
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/sources/substack/preview",
+                json={"url": "https://127.0.0.1/p/post"},
+            )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 400
+    assert "unsafe host address" in response.json()["detail"].lower()
 
 
 def test_substack_preview_explains_unreachable_feed(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #1288

## Summary
- accept HTTPS custom publication domains in the Substack RSS wizard
- normalize publication and post links to the same host at `/feed`
- preserve malformed URL rejection, credential rejection, and server-fetch safety checks
- cover bare and `www` custom domains plus private-address blocking

## Verification
- `make lint`
- `make typecheck`
- `PGOPTIONS="-c max_parallel_workers_per_gather=0" dotenv run -- make test` (2,851 passed, 2 skipped; frontend 1,000 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)