### PR TITLE
docs: add API reference and development guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,16 @@ Technical documentation for News Dashboard. For end-user documentation (how to
 use the app day to day), see the [User Guide](user-guide/README.md) instead.
 
 Architecture, product spec, authentication, HTTPS, Postgres backup, CI runner,
-contributing, and end-user guides are published at
-**[docs.lihor.ro](https://docs.lihor.ro)** (source in
+contributing, API reference, development guides, and end-user guides are
+published at **[docs.lihor.ro](https://docs.lihor.ro)** (source in
 [`website/docs/`](../website/docs)).
+
+Two sections there are the usual starting points when working on the code:
+
+- **[API reference](../website/docs/api/)** — authentication, response and
+  error conventions, and the endpoint surface by area.
+- **[Development](../website/docs/development/)** — environment setup, the
+  codebase map, the feature-module convention, testing, and releases.
 
 | Doc | Description |
 |-----|--------------|

--- a/website/docs/api/_category_.json
+++ b/website/docs/api/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "API Reference",
+  "position": 7
+}

--- a/website/docs/api/articles-and-search.md
+++ b/website/docs/api/articles-and-search.md
@@ -1,0 +1,162 @@
+---
+title: Articles and search
+sidebar_position: 3
+---
+
+# Articles and search
+
+Articles are the core resource. Every article belongs to a source, carries a
+triage state, and can be annotated with highlights and tags.
+
+## Listing articles
+
+```
+GET /api/articles
+```
+
+Returns the [standard collection envelope](index.md#collections).
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `status` | string | Filter by workflow status. |
+| `state` | string | Filter by triage state (`new`, `read`, `saved`, `skipped`, `archived`). |
+| `starred` | boolean | Restrict to starred articles. |
+| `category` | string | Filter by category. |
+| `tag_id` | integer | Restrict to articles carrying a tag. |
+| `limit` | integer | `1..500`, default `100`. |
+| `offset` | integer | `>= 0`, default `0`. |
+
+## Reading one article
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/articles/{article_id}` | GET | Metadata for a single article. |
+| `/api/articles/{article_id}/body` | GET | The extracted article body. |
+| `/api/articles/{article_id}/body` | POST | Trigger or refresh body extraction. |
+| `/api/articles/{article_id}/audio` | POST | Generate a spoken version. |
+
+Body text is fetched and extracted separately from ingestion, so a freshly
+ingested article may have metadata before it has a body. `GET` returns what is
+stored; `POST` asks the backend to (re-)extract from the source URL.
+
+## Triage
+
+Triage is the primary write path. Each verb is a narrow `PATCH` rather than a
+general article update, which keeps the audit trail meaningful:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/articles/{article_id}/status` | PATCH | Set workflow status. |
+| `/api/articles/{article_id}/state` | PATCH | Set triage state. |
+| `/api/articles/{article_id}/star` | PATCH | Toggle starred. |
+| `/api/articles/{article_id}/later` | PATCH | Mark for later. |
+
+There is also a token-authenticated public route used by email digests, so a
+"mark as read" link works without a login session:
+
+```
+GET /api/articles/{article_id}/read?token=...
+```
+
+## Saving an external URL
+
+```
+POST /api/articles/save-url
+```
+
+Ingests an arbitrary URL as an article for the calling user, without adding a
+recurring source. This is what the browser extension and share targets use.
+
+## Search
+
+```
+GET /api/search
+```
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `q` | string | Space-separated search terms. |
+| `limit` | integer | `1..200`, default `50`. |
+| `offset` | integer | `>= 0`, default `0`. |
+| `states` | string[] | Repeatable; restrict to these triage states. |
+| `categories` | string[] | Repeatable. |
+| `sources` | string[] | Repeatable; source slugs. |
+| `starred_only` | boolean | Default `false`. |
+| `include_archived` | boolean | Default `false`. Archived articles are excluded unless set. |
+| `date_range` | string | Default `all`. |
+| `tag_id` | integer | Restrict to a tag. |
+
+Repeatable parameters are passed by repeating the key:
+`?states=new&states=saved`.
+
+### Saved searches
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/search/saved` | GET | List saved searches. |
+| `/api/search/saved` | POST | Save the current query and filters. |
+| `/api/search/saved/{search_id}` | PATCH | Rename or update. |
+| `/api/search/saved/{search_id}` | DELETE | Remove. |
+
+## Highlights
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/articles/{article_id}/highlights` | GET | List highlights on an article. |
+| `/api/articles/{article_id}/highlights` | POST | Create one. |
+| `/api/articles/{article_id}/highlights/{highlight_id}` | DELETE | Remove one. |
+
+Highlights are per-user and anchor into the extracted body, so re-extracting
+a body can affect how they resolve.
+
+## Tags and collections
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/tags` | GET | List your tags. |
+| `/api/tags` | POST | Create a tag. |
+| `/api/tags/{tag_id}` | PATCH | Rename or restyle. |
+| `/api/tags/{tag_id}` | DELETE | Delete a tag. |
+| `/api/tags/{tag_id}/articles` | GET | Articles carrying a tag. |
+| `/api/articles/{article_id}/tags` | GET | Tags on an article. |
+| `/api/articles/{article_id}/tags` | POST | Attach a tag. |
+| `/api/articles/{article_id}/tags/{tag_id}` | DELETE | Detach a tag. |
+
+## Reading list
+
+An explicitly ordered queue, separate from tags and triage state:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/reading-list` | GET | List queued items in order. |
+| `/api/reading-list` | POST | Add an item. |
+| `/api/reading-list/reorder` | POST | Reorder the queue. |
+| `/api/reading-list/import` | POST | Bulk import. |
+| `/api/reading-list/{item_id}` | PATCH | Update an item. |
+| `/api/reading-list/{item_id}` | DELETE | Remove an item. |
+
+## AI-derived views
+
+These endpoints run retrieval or generation and are slower than plain reads.
+They depend on article embeddings, which are produced during ingestion.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/articles/{article_id}/insights` | GET | Generated insights for an article. |
+| `/api/articles/{article_id}/perspectives` | GET | Contrasting coverage of the same story. |
+| `/api/articles/topic-map` | GET | Topic clustering across your articles. |
+| `/api/ask` | POST | Ask a question across your corpus. |
+| `/api/summary` | GET | A generated summary view. |
+
+Embedding similarity is executed as SQL `<=>` queries against an HNSW index in
+PostgreSQL, which is why the [pgvector
+extension](../architecture/index.md) is a hard requirement rather than an
+optional extra.
+
+## Reading progress
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/users/me/streak` | GET | Current reading streak. |
+| `/api/users/me/achievements` | GET | Unlocked achievements. |
+| `/api/users/me/reading-dna` | GET | Aggregate reading profile. |

--- a/website/docs/api/authentication.md
+++ b/website/docs/api/authentication.md
@@ -1,0 +1,149 @@
+---
+title: Authentication
+sidebar_position: 2
+---
+
+# Authentication
+
+News Dashboard has one primary credential — a signed session cookie — plus two
+narrow token types for integrations that cannot hold cookies.
+
+## Session cookie
+
+Successful login sets an `nd_session` cookie containing a signed token that
+carries the user ID and admin flag. The token is signed, not encrypted: it is
+tamper-evident, and the server re-reads the user record on every request rather
+than trusting the claims inside it.
+
+Sessions last `SESSION_DAYS` days (default `30`). Expiry is enforced against
+the token's own age at verification time, so shortening `SESSION_DAYS`
+immediately invalidates older cookies.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/auth/config` | GET | Which login methods this instance offers. |
+| `/api/auth/metadata` | GET | Identity-provider metadata for the client. |
+| `/api/auth/login` | POST | Username/password login; sets the session cookie. |
+| `/api/auth/logout` | GET | Clears the session cookie. |
+| `/api/auth/me` | GET | The current user. Requires a session. |
+
+Call `/api/auth/config` before rendering a login screen — it reports whether
+this instance uses local passwords, SSO, or both, so clients do not hardcode
+an assumption.
+
+## Email one-time codes
+
+Passwordless login by emailed code, in two steps:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/auth/otp/request` | POST | Sends a one-time code to an email address. |
+| `/api/auth/otp/login` | POST | Exchanges email + code for a session cookie. |
+
+Both steps are throttled per email address and answer `429` with
+`"Too many code requests; try again later"` or `"Too many code attempts; try
+again later"` when tripped. A successful login clears the failure counter.
+
+An invalid or expired code returns `401 "Invalid or expired code"`. The
+request step does not reveal whether an address is registered.
+
+## Keycloak SSO
+
+When `KEYCLOAK_AUTH_ENABLED` is set, browser-redirect SSO routes are mounted
+alongside the local flows:
+
+| Route | Purpose |
+|-------|---------|
+| `/auth/login` | Redirect to the identity provider. |
+| `/auth/register` | Redirect to provider-side registration. |
+| `/auth/callback` | OIDC callback; establishes the session. |
+| `/auth/logout` | Provider-side logout. |
+
+Admin rights can be granted by provider username via
+`KEYCLOAK_ADMIN_USERNAMES`. Configuration is covered in
+[Configuration → Authentication](../configuration/authentication.md).
+
+## Guest accounts
+
+A guest session authenticates normally and can read everything, but middleware
+rejects every mutating request before it reaches a handler:
+
+```json
+{ "detail": "Guest accounts cannot modify data" }
+```
+
+This is enforced centrally rather than per-endpoint, so it applies uniformly
+to routes added later. Clients backed by a guest session should render the UI
+read-only rather than relying on failed writes.
+
+## CSRF protection
+
+Because the session lives in a cookie, cookie-authenticated **mutations** pass
+an origin check. If a request carries the session cookie and presents an
+`Origin` outside the allowed set, it is rejected:
+
+```json
+{ "detail": "Cross-origin request rejected" }
+```
+
+The allowed set derives from the instance's configured CORS origins. Two
+practical consequences:
+
+- Browser clients on a different domain need that domain in the CORS
+  configuration, not just permissive CORS headers.
+- Server-to-server integrations should use a **token** instead of a cookie.
+  Token-authenticated requests do not carry the session cookie and so are not
+  subject to the origin guard.
+
+## Integration tokens
+
+Two token families exist for clients that cannot hold a browser cookie. Both
+are per-user, individually revocable, and scoped to a single integration.
+
+### MCP tokens
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/users/me/mcp-tokens` | GET | List your MCP tokens. |
+| `/api/users/me/mcp-tokens` | POST | Mint a token. |
+| `/api/users/me/mcp-tokens/{token_id}` | DELETE | Revoke a token. |
+
+These authenticate the read-only [MCP tool set](integrations.md#mcp-server).
+The whole surface — including these management routes — returns `403` unless
+`MCP_SERVER_ENABLED` is set.
+
+### Google Reader tokens
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/users/me/greader-tokens` | GET | List sync tokens. |
+| `/api/users/me/greader-tokens` | POST | Mint a token. |
+| `/api/users/me/greader-tokens/{token_id}` | DELETE | Revoke a token. |
+
+These back the [Google Reader-compatible sync
+API](integrations.md#google-reader-sync) used by third-party feed readers.
+
+### Podcast feed tokens
+
+Podcast feeds are consumed by player apps that cannot log in, so the feed URL
+carries its own capability token:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/briefings/podcast-feed-token` | GET | Fetch the current feed token. |
+| `/api/briefings/podcast-feed-token/regenerate` | POST | Rotate it. |
+
+The token grants read access to that user's generated podcast audio and
+nothing else. Regenerating invalidates the previous URL — that is the only way
+to revoke a feed that has been shared.
+
+## Account lifecycle
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/users/me/export` | GET | Export your data. |
+| `/api/users/me/import` | POST | Import a previously exported archive. |
+| `/api/users/me` | DELETE | Delete your account and associated data. |
+
+Import accepts JSON archives up to 20 MiB. Administrative user management is
+separate and documented under [Operations](operations.md#user-administration).

--- a/website/docs/api/index.md
+++ b/website/docs/api/index.md
@@ -1,0 +1,135 @@
+---
+title: API reference
+sidebar_position: 1
+---
+
+# API reference
+
+News Dashboard exposes a JSON HTTP API served by the same FastAPI backend that
+serves the built React frontend. Everything the web UI does, it does through
+this API — there is no private back channel.
+
+This section documents the shape of the API: how requests are authenticated,
+how responses and errors are structured, and what each area of the surface
+covers. It is a hand-written companion to the generated schema, not a
+replacement for it.
+
+## The generated schema is the source of truth
+
+The backend publishes an OpenAPI document derived directly from the route
+handlers. When this page and the schema disagree, the schema is right.
+
+| Endpoint | What it serves |
+|----------|----------------|
+| `/docs` | Interactive Swagger UI for the running instance. |
+| `/openapi.json` | The raw OpenAPI document. |
+| `/api/version` | The running application version. |
+
+The OpenAPI `info.version` and `/api/version` are both read from the `VERSION`
+file at startup, so the documented version always matches the deployed build.
+
+## Base URL
+
+All paths in this section are relative to your instance root. For a
+self-hosted deployment at `https://news.example.com`, the article list is
+`https://news.example.com/api/articles`.
+
+Routes are grouped by the router they mount on, which determines their auth
+behavior:
+
+| Prefix | Router | Access |
+|--------|--------|--------|
+| `/api/*` | authenticated `api` router | Requires a valid session. |
+| `/api/admin/*` | `admin` router | Requires a session belonging to an admin user. |
+| `/api/auth/*`, `/auth/*` | public router | Login, registration, and SSO callbacks. |
+| `/api/mcp/*` | public MCP router | Bearer-token authenticated, opt-in. |
+| `/reader/api/0/*`, `/accounts/ClientLogin` | public GReader router | Google Reader-compatible sync. |
+| `/api/health`, `/api/live`, `/api/ready`, `/metrics` | system router | Unauthenticated probes. |
+
+## Response conventions
+
+### Collections
+
+List endpoints return an envelope rather than a bare array, so clients can
+page without a second count query:
+
+```json
+{
+  "items": [],
+  "limit": 100,
+  "offset": 0,
+  "has_more": false
+}
+```
+
+`has_more` is computed by over-fetching one row past `limit`, so it is exact
+and costs no extra query. Paginate by advancing `offset` until `has_more` is
+`false`.
+
+Both `limit` and `offset` are validated server-side. `limit` is clamped per
+endpoint — `/api/articles` accepts `1..500` (default `100`), `/api/search`
+accepts `1..200` (default `50`). Out-of-range values are rejected with `422`
+rather than silently clamped.
+
+### Errors
+
+Errors use FastAPI's standard envelope:
+
+```json
+{ "detail": "Not Found" }
+```
+
+For request-validation failures (`422`), `detail` is an array of per-field
+objects identifying the offending parameter and the rule it broke.
+
+| Status | Meaning |
+|--------|---------|
+| `400` | The request was understood but rejected by a domain rule. |
+| `401` | No valid session, token, or credential was presented. |
+| `403` | Authenticated, but not permitted — see below. |
+| `404` | The resource does not exist, or is not visible to you. |
+| `422` | Request validation failed (bad query parameter, malformed body). |
+| `429` | A rate limit or generation quota was exceeded. |
+| `5xx` | Server-side failure. |
+
+`404` is used deliberately in place of `403` for resources that exist but
+belong to another user, so the API does not leak their existence.
+
+### Three distinct sources of `403`
+
+A `403` is not always an authorization failure. Check `detail` to tell them
+apart:
+
+- `"Guest accounts cannot modify data"` — the session belongs to a guest
+  account. Guests have full read access and are blocked from every mutating
+  method by middleware.
+- `"Cross-origin request rejected"` — a cookie-authenticated mutation arrived
+  with an `Origin` header outside the allowed set. See
+  [Authentication](authentication.md#csrf-protection).
+- Anything else — the endpoint requires admin rights, or an opt-in feature
+  such as the MCP server is disabled.
+
+## Sections
+
+| Page | Covers |
+|------|--------|
+| [Authentication](authentication.md) | Sessions, SSO, OTP, guests, CSRF, and the token types. |
+| [Articles and search](articles-and-search.md) | The article lifecycle, triage, search, highlights, and tags. |
+| [Sources and ingestion](sources-and-ingestion.md) | Feed management, OPML, ingestion runs, and the scheduler. |
+| [Learning and briefings](learning-and-briefings.md) | Briefings, lessons, quizzes, recaps, and podcast generation. |
+| [Integrations](integrations.md) | MCP tools, Google Reader sync, sharing, and podcast feeds. |
+| [Operations](operations.md) | Health probes, metrics, statistics, and admin endpoints. |
+
+## Stability
+
+The API is versioned with the application, not independently. It is primarily
+a first-party interface for the official web, Android, and desktop clients,
+and it changes alongside them.
+
+Two surfaces are explicitly built for third-party consumption and are the
+safest to integrate against:
+
+- The [MCP tool set](integrations.md#mcp-server) — read-only and deliberately
+  narrow.
+- The [Google Reader API](integrations.md#google-reader-sync) — implements an
+  external, already-stable contract.

--- a/website/docs/api/integrations.md
+++ b/website/docs/api/integrations.md
@@ -1,0 +1,139 @@
+---
+title: Integrations
+sidebar_position: 6
+---
+
+# Integrations
+
+Three surfaces are built for consumption outside the official clients: the MCP
+tool set, the Google Reader-compatible sync API, and sharing. All are opt-in
+or user-initiated.
+
+## MCP server
+
+An intentionally narrow, **read-only** tool set that lets an MCP-aware AI
+client (Claude Desktop, Codex, or similar) search and read the articles
+visible to one user. It exposes no SQL, shell, or file-system access.
+
+Disabled by default. Set `MCP_SERVER_ENABLED=1` on the backend to enable it —
+otherwise every `/api/mcp/*` route and the token-management routes return
+`403 Forbidden`.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/mcp/tools` | GET | Discover available tools and their schemas. |
+| `/api/mcp/rpc` | POST | Invoke a tool. |
+
+Authenticate with an MCP token as a bearer credential. Tokens are minted and
+revoked under `/api/users/me/mcp-tokens` — see
+[Authentication](authentication.md#mcp-tokens).
+
+### Available tools
+
+| Tool | Scope | Does |
+|------|-------|------|
+| `search_articles` | `search` | Search articles visible to the token owner. |
+| `get_article` | `read` | Fetch a single visible article by id. |
+| `list_briefings` | `briefings` | List the owner's recent briefings (metadata only). |
+| `ask` | `ask` | Answer a question via retrieval over the owner's corpus. |
+
+Each tool requires its own **scope**, and a token only carries the scopes it
+was minted with. A token issued for `search` alone cannot call `ask`, so you
+can hand an agent search access without granting it generation budget.
+
+`list_briefings` returns metadata only — briefing bodies are not exposed
+through MCP.
+
+Result limits are clamped server-side, so a client asking for an unbounded
+page gets a bounded one rather than an error.
+
+Setup instructions for specific clients live in
+[Configuration → MCP server](../configuration/mcp-server.md).
+
+## Google Reader sync
+
+A Google Reader-compatible API, so existing feed readers (Reeder, FeedMe,
+NewsFlash, and others) can sync against News Dashboard without bespoke
+support.
+
+Authenticate with a GReader token from
+`/api/users/me/greader-tokens`. Most readers expect the ClientLogin flow:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/accounts/ClientLogin` | POST | Exchange credentials for a session. |
+| `/reader/api/0/token` | GET | Fetch the write token. |
+| `/reader/api/0/user-info` | GET | Account metadata. |
+| `/reader/api/0/subscription/list` | GET | Subscribed feeds. |
+| `/reader/api/0/stream/contents/{stream_id}` | GET | Items in a stream. |
+| `/reader/api/0/stream/items/ids` | GET | Item IDs in a stream. |
+| `/reader/api/0/stream/items/contents` | POST | Fetch items by ID. |
+| `/reader/api/0/edit-tag` | POST | Add or remove tags — read/starred state. |
+
+`edit-tag` is how third-party readers mark items read or starred; those changes
+map onto the same triage state used by the web UI, so the two stay in sync.
+
+Because this implements an external contract that predates this project, it is
+the most stable surface here. Configuration details are in
+[Configuration → GReader sync](../configuration/greader-sync.md).
+
+## Sharing
+
+Sharing sends an article to another user on the same instance, with a threaded
+conversation attached. It is instance-internal — not public link sharing.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/users` | GET | Users you can share with. |
+| `/api/articles/{article_id}/share` | POST | Share an article. |
+| `/api/shares` | GET | Shares you received. |
+| `/api/shares/sent` | GET | Shares you sent. |
+| `/api/shares/unread_count` | GET | Badge count. |
+| `/api/shares/{share_id}` | GET | One share. |
+| `/api/shares/{share_id}/read` | POST | Mark as read. |
+| `/api/shares/{share_id}/revoke` | POST | Revoke a share you sent. |
+
+### Shared article content
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/shares/{share_id}/article` | GET | The shared article. |
+| `/api/shares/{share_id}/article/body` | POST | Extract its body. |
+
+The recipient reads the article through the **share**, not through
+`/api/articles/{id}`. The share is the grant, so revoking it withdraws access
+rather than leaving a dangling readable article.
+
+### Discussion
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/shares/{share_id}/messages` | GET / POST | Conversation on a share. |
+| `/api/shares/{share_id}/annotations` | GET / POST | Inline annotations. |
+
+Messages are share-level discussion; annotations anchor to positions in the
+article body.
+
+## Push notifications
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/notifications/subscribe` | POST | Register a Web Push subscription. |
+| `/api/notifications/subscribe` | DELETE | Unregister it. |
+| `/api/settings/notifications` | GET / PUT | Notification preferences. |
+
+Notification settings include briefing delivery time, timezone, whether push is
+enabled, weekly recap day, and whether to include reading-list items (capped at
+20 per briefing). Briefing time is validated as `HH:MM` in 24-hour form, and
+recap day must be one of `mon`–`sun`.
+
+## Analytics preferences
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/settings/analytics` | GET / PUT | Opt in or out of analytics. |
+| `/api/events` | POST | Record a client-side event. |
+
+Event recording honors the analytics preference — opting out stops collection
+rather than merely hiding it. See [PRIVACY.md](https://github.com/lihor-hub/news-dashboard/blob/main/PRIVACY.md)
+for what is and is not collected.

--- a/website/docs/api/learning-and-briefings.md
+++ b/website/docs/api/learning-and-briefings.md
@@ -1,0 +1,181 @@
+---
+title: Learning and briefings
+sidebar_position: 5
+---
+
+# Learning and briefings
+
+Everything in this section is **generated** rather than fetched. These routes
+call an LLM, cost real time and money per request, and are the slowest part of
+the API. Treat them as asynchronous work, not as reads.
+
+## Briefings
+
+A briefing is a periodic digest assembled from your recent articles.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/briefings` | GET | List briefings. |
+| `/api/briefings` | POST | Generate a briefing now. |
+| `/api/briefings/latest` | GET | The most recent briefing. |
+| `/api/briefings/{briefing_id}` | GET | One briefing. |
+| `/api/briefings/{briefing_id}/chat` | POST | Ask follow-up questions about it. |
+
+### Briefing podcasts
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/briefings/{briefing_id}/podcast` | POST | Generate audio for a briefing. |
+| `/api/briefings/{briefing_id}/podcast` | GET | Generation status / result. |
+
+`POST` starts generation; `GET` reports where it got to. Poll the `GET` rather
+than assuming the `POST` response is final.
+
+Two routes are public because podcast players cannot authenticate:
+
+| Route | Access |
+|-------|--------|
+| `/api/briefings/podcast.rss` | Token in the URL. The subscribable feed. |
+| `/api/briefings/{briefing_id}/podcast-audio` | Token in the URL. The audio file. |
+
+Token management is covered in
+[Authentication → Podcast feed tokens](authentication.md#podcast-feed-tokens).
+
+### Email delivery and unsubscribe
+
+Briefings can be emailed. The unsubscribe endpoints are public by necessity —
+an unsubscribe link in an email must work without a login:
+
+| Route | Method |
+|-------|--------|
+| `/email/briefing/unsubscribe` | GET |
+| `/email/briefing/unsubscribe` | POST |
+
+The `GET` renders a confirmation page; the `POST` performs the opt-out. Email
+clients pre-fetch links, so a one-click `GET` that unsubscribed directly would
+opt users out by accident.
+
+## Lessons
+
+Lessons turn a link or topic into structured learning material.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/learn/lessons` | GET | List lessons. |
+| `/api/learn/lessons` | POST | Create a lesson from a link or topic. |
+| `/api/learn/lessons/{lesson_id}` | GET | One lesson. |
+| `/api/learn/lessons/{lesson_id}/regenerate` | POST | Regenerate content. |
+| `/api/learn/lessons/{lesson_id}/generations` | GET | Generation history. |
+| `/api/learn/lessons/{lesson_id}/trails` | GET | Suggested follow-on paths. |
+| `/api/learn/lessons/{lesson_id}/questions` | POST | Generate questions. |
+
+### Alternate renderings
+
+The same lesson can be rendered into other media:
+
+| Route | Method | Produces |
+|-------|--------|----------|
+| `/api/learn/lessons/{lesson_id}/podcast` | POST / GET | Audio. |
+| `/api/learn/lessons/{lesson_id}/slides` | POST | A slide deck. |
+| `/api/learn/lessons/{lesson_id}/infographic` | POST | An infographic. |
+
+`/generations` exists because these are non-deterministic: it records what was
+produced and when, so a regeneration does not silently discard prior output.
+
+### Suggestions
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/learn/suggestions` | GET | Suggested lessons based on your reading. |
+| `/api/learn/suggestions/dismiss` | POST | Dismiss a suggestion. |
+| `/api/learn/lessons/{lesson_id}/relevance/feedback` | POST | Report whether a lesson was relevant. |
+
+Feedback here feeds ranking — it is the signal that stops the same unwanted
+suggestion from recurring.
+
+## Goals and quizzes
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/goals` | GET | List reading goals. |
+| `/api/goals` | POST | Create a goal. |
+| `/api/goals/{goal_id}` | DELETE | Delete a goal. |
+| `/api/quizzes` | GET | List quizzes. |
+| `/api/quizzes/latest` | GET | Most recent quiz. |
+| `/api/quizzes/candidates` | GET | Articles eligible for a quiz. |
+| `/api/quizzes/generate` | POST | Generate a quiz. |
+| `/api/quizzes/{quiz_id}/submit` | POST | Submit answers. |
+
+Check `/api/quizzes/candidates` before generating — quiz quality depends on
+having enough recently-read material, and this reports whether there is.
+
+## Recaps
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/recaps` | GET | List periodic recaps. |
+| `/api/recaps/latest` | GET | Most recent recap. |
+| `/api/lesson-recaps` | GET | List lesson recaps. |
+| `/api/lesson-recaps/latest` | GET | Most recent lesson recap. |
+| `/api/lesson-recaps/generate` | POST | Generate one now. |
+| `/api/lesson-recaps/{recap_id}/podcast` | POST / GET | Audio for a lesson recap. |
+
+## Assistant and agent actions
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/ask` | POST | Ask a question across your articles. |
+| `/api/summary` | GET | A generated summary view. |
+| `/api/feedback` | POST | Feedback on a generated answer. |
+
+Agent actions are multi-step operations that run under explicit approval:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/agent/actions/plan` | POST | Produce a plan without executing it. |
+| `/api/agent/actions/{run_id}` | GET | Inspect a run. |
+| `/api/agent/actions/{run_id}/approve` | POST | Approve and execute. |
+| `/api/agent/actions/{run_id}/cancel` | POST | Cancel. |
+
+Planning and execution are deliberately separate calls. The agent never
+performs a mutating action without an explicit `approve`.
+
+## Personalization
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/personalization/nudges` | GET | Suggested adjustments to your setup. |
+| `/api/personalization/nudges/apply` | POST | Apply a nudge. |
+| `/api/personalization/nudges/dismiss` | POST | Dismiss it. |
+| `/api/users/me/recommendation-preferences` | GET / PATCH | Tune recommendations. |
+
+### AI memory
+
+Durable, user-editable facts the assistant may use as context:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/users/me/ai-memories` | GET | List memories. |
+| `/api/users/me/ai-memories` | POST | Add one. |
+| `/api/users/me/ai-memories/{memory_id}` | PATCH | Edit one. |
+| `/api/users/me/ai-memories/{memory_id}` | DELETE | Delete one. |
+| `/api/users/me/ai-memories/learn-from-reading` | POST | Derive memories from reading history. |
+
+Memories are inspectable and deletable by design — the assistant should never
+hold context about a user that the user cannot see or remove.
+
+### Feedback on AI output
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/ai-feedback` | GET / POST / DELETE | Record or withdraw feedback on generated output. |
+
+## Onboarding
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/onboarding/status` | GET | Where the user is in onboarding. |
+| `/api/onboarding/interests` | GET / POST | Read or set interests. |
+| `/api/onboarding/recommendations` | POST | Recommendations from interests. |
+| `/api/onboarding/source-recommendations` | GET | Suggested sources to subscribe to. |
+| `/api/onboarding/profile` | POST | Save the onboarding profile. |

--- a/website/docs/api/operations.md
+++ b/website/docs/api/operations.md
@@ -1,0 +1,130 @@
+---
+title: Operations
+sidebar_position: 7
+---
+
+# Operations
+
+Endpoints for monitoring a running instance and administering it. Health and
+metrics routes are unauthenticated; everything under `/api/admin` requires an
+admin session.
+
+## Health probes
+
+Three probes with different meanings — do not point all of them at the same
+check.
+
+| Route | Auth | Use for |
+|-------|------|---------|
+| `/api/live` | none | Liveness. Is the process up? |
+| `/api/ready` | none | Readiness. Can it serve traffic (dependencies reachable)? |
+| `/api/health` | none | General health summary. |
+| `/api/health/details` | session | Per-dependency detail. |
+
+Wire a Kubernetes `livenessProbe` to `/api/live` and a `readinessProbe` to
+`/api/ready`. Using a dependency-checking endpoint for liveness causes the
+orchestrator to restart a healthy process when a downstream dependency blips —
+restarting fixes nothing and turns a partial outage into a crash loop.
+
+`/api/health/details` requires a session because it reports dependency
+topology, which is useful to an operator and useful to an attacker.
+
+## Metrics and version
+
+| Route | Auth | Serves |
+|-------|------|--------|
+| `/metrics` | none | Prometheus metrics. |
+| `/api/version` | session | Running application version. |
+| `/api/config` | session | Client-visible runtime configuration. |
+| `/api/changelog` | session | Release notes for the running version. |
+
+`/api/version` reads the same `VERSION` file that drives the OpenAPI
+`info.version`, so a deployment can be identified unambiguously.
+
+`/api/config` is what the frontend calls at boot to discover which optional
+features are enabled — it reports capability, not secrets.
+
+## Statistics
+
+Read-only aggregates backing the dashboard's charts.
+
+| Route | Reports |
+|-------|---------|
+| `/api/stats/overview` | Headline counts. |
+| `/api/stats/articles-over-time` | Article volume over time. |
+| `/api/stats/article-counts` | Counts by state. |
+| `/api/stats/sources-volume` | Volume per source. |
+| `/api/stats/source-quality` | Source quality signals. |
+| `/api/stats/triage-metrics` | Triage throughput. |
+| `/api/stats/category-mix` | Distribution across categories. |
+| `/api/stats/ingested-vs-handled` | Ingested against triaged — your backlog trend. |
+
+`/api/stats/ingested-vs-handled` is the one to watch on a personal instance: a
+persistent gap means you are subscribed to more than you read, and
+`/api/sources/cleanup-suggestions` is the usual remedy.
+
+### AI statistics
+
+| Route | Reports |
+|-------|---------|
+| `/api/ai-stats/word-cloud` | Term frequency across your corpus. |
+| `/api/ai-stats/embedding-map` | 2-D projection of article embeddings. |
+| `/api/ai-stats/knowledge-graph` | Entity/relationship graph data. |
+
+The knowledge graph route depends on the optional Neo4j integration and
+degrades rather than failing when it is not configured. See
+[Configuration → Neo4j knowledge graph](../configuration/neo4j-knowledge-graph.md).
+
+## Recommendations
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/recommendations/health` | GET | Whether the recommender has enough signal. |
+| `/api/recommendations/recalculate-mine` | POST | Recompute for the calling user. |
+| `/api/recommendations/recalculate` | POST | Recompute across users. |
+
+Recalculation is expensive. Prefer `recalculate-mine`; the instance-wide
+variant is an administrative operation.
+
+## Admin endpoints
+
+Everything below is mounted under `/api/admin` and gated on an admin session.
+A non-admin session receives `403`.
+
+### User administration
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/admin/users` | GET | List users. |
+| `/api/admin/users` | POST | Create a user. |
+| `/api/admin/users/generate` | POST | Generate a user with credentials. |
+| `/api/admin/users/{user_id}` | GET | One user. |
+| `/api/admin/users/{user_id}/password` | PATCH | Reset a password. |
+| `/api/admin/users/{user_id}` | DELETE | Delete a user. |
+
+`/api/admin/users/generate` creates an account with server-generated
+credentials — useful for provisioning a guest or demo account without inventing
+a password by hand.
+
+### Instance analytics
+
+| Route | Method | Reports |
+|-------|--------|---------|
+| `/api/admin/analytics` | GET | Instance-wide usage. |
+| `/api/admin/ai/metrics` | GET | AI call volume and cost. |
+| `/api/admin/ai/quality` | GET | Generation quality signals. |
+| `/api/admin/learning-agent/runs` | GET | Learning-agent run history. |
+
+`/api/admin/ai/metrics` is the endpoint to check when generation costs rise
+unexpectedly — it attributes usage before you go looking at provider bills.
+
+## Operational guidance
+
+- **Scrape `/metrics`, alert on `/api/ready`.** Metrics tell you how the
+  instance behaves; readiness tells you whether it is serving.
+- **Watch source health, not just uptime.** A fully healthy instance with a
+  broken feed produces no articles and raises no alarm. Poll
+  `/api/sources/health`.
+- **Generation endpoints are the slow path.** If request latency degrades,
+  separate `/api/ask`, briefing, and lesson generation from ordinary reads
+  before concluding the instance is undersized.

--- a/website/docs/api/sources-and-ingestion.md
+++ b/website/docs/api/sources-and-ingestion.md
@@ -1,0 +1,117 @@
+---
+title: Sources and ingestion
+sidebar_position: 4
+---
+
+# Sources and ingestion
+
+A **source** is a feed the dashboard polls. **Ingestion** is the scheduled job
+that fetches every enabled source and creates articles.
+
+## Managing sources
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/sources` | GET | List configured sources. |
+| `/api/sources` | POST | Add a source. |
+| `/api/sources/{slug}` | DELETE | Remove a source. |
+| `/api/sources/{slug}/enabled` | PATCH | Enable or disable without deleting. |
+| `/api/sources/{slug}/priority` | PATCH | Change fetch priority. |
+
+Sources are addressed by **slug**, not numeric ID, so URLs stay readable and
+stable across environments.
+
+Disabling is preferable to deleting when you only want to pause a feed —
+delete discards the source's configuration, while disable leaves it in place
+and simply skips it during ingestion.
+
+## Previewing before you commit
+
+```
+POST /api/sources/preview
+POST /api/sources/substack/preview
+```
+
+Both fetch a candidate feed and return a sample of what would be ingested,
+without persisting anything. Use them to validate a URL in the UI before
+creating the source.
+
+Substack has its own preview route because Substack publications can be served
+from custom domains, and resolving the real feed URL takes provider-specific
+logic rather than a generic RSS probe.
+
+## Source health
+
+```
+GET /api/sources/health
+```
+
+Reports per-source fetch health so broken feeds surface before they silently
+stop producing articles.
+
+Two related endpoints help prune dead feeds:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/sources/cleanup-suggestions` | GET | Sources that look dead or duplicated. |
+| `/api/sources/cleanup` | POST | Apply a cleanup selection. |
+
+## OPML import and export
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/sources/export.opml` | GET | Export all sources as OPML. |
+| `/api/sources/import` | POST | Import an OPML file. |
+
+Import is bounded at **5 MiB and 1000 outlines**. Larger uploads are rejected
+rather than streamed, which caps per-request memory and time for oversized or
+hostile files. OPML is plain text and real subscription lists sit far below
+this ceiling.
+
+## Running ingestion
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/ingest` | POST | Trigger an ingestion run now. |
+| `/api/ingest/stream` | GET | Stream progress of a running ingestion. |
+| `/api/ingest/runs` | GET | History of ingestion runs. |
+| `/api/ingest/runs/{run_id}` | GET | Detail for one run. |
+
+`/api/ingest/stream` is a streaming response intended for a live progress view,
+not a polling endpoint — open it once and read events as they arrive.
+
+In Kubernetes deployments, scheduled ingestion runs as a separate CronJob
+workload rather than inside the web process. Triggering `/api/ingest` runs it
+in-process instead, which is convenient for testing but competes with request
+serving on a small instance.
+
+## Scheduler
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/scheduler/status` | GET | Current scheduler state and next run. |
+| `/api/scheduler/interval` | POST | Change the ingestion interval. |
+| `/api/scheduler/pause` | POST | Pause scheduled ingestion. |
+| `/api/scheduler/resume` | POST | Resume it. |
+| `/api/scheduler/job-runs` | GET | History across all scheduled jobs. |
+| `/api/scheduler/jobs/embedding-dedup/run` | POST | Run embedding de-duplication now. |
+
+Pausing the scheduler stops automatic runs but leaves manual `/api/ingest`
+available.
+
+## Watchlists
+
+Watchlists are standing interest definitions evaluated against newly ingested
+articles.
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/watchlists` | GET | List watchlists. |
+| `/api/watchlists` | POST | Create one. |
+| `/api/watchlists/{watchlist_id}` | PATCH | Update one. |
+| `/api/watchlists/{watchlist_id}` | DELETE | Delete one. |
+| `/api/watchlists/preview` | POST | Preview matches before saving. |
+| `/api/watchlists/nudges` | GET | Suggestions derived from watchlist activity. |
+
+As with sources, `preview` lets you check a definition against existing
+articles before committing it.

--- a/website/docs/contributing/index.md
+++ b/website/docs/contributing/index.md
@@ -13,7 +13,17 @@ News Dashboard.
 
 Start with the root
 [README local-development guide](https://github.com/lihor-hub/news-dashboard#local-development)
-for the full setup flow.
+for the full setup flow, then see
+[Development → Environment setup](../development/environment-setup.md) for the
+test-database wiring and worktree bootstrap.
+
+:::tip Working on the code
+The [Development](../development/index.md) section covers the
+[codebase map](../development/codebase-map.md), the
+[feature-module convention](../development/feature-modules.md) every backend
+domain follows, and [testing](../development/testing.md). The
+[API reference](../api/index.md) documents the HTTP surface.
+:::
 
 ## Quality gate
 

--- a/website/docs/development/_category_.json
+++ b/website/docs/development/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Development",
+  "position": 8
+}

--- a/website/docs/development/codebase-map.md
+++ b/website/docs/development/codebase-map.md
@@ -1,0 +1,136 @@
+---
+title: Codebase map
+sidebar_position: 3
+---
+
+# Codebase map
+
+Where to look for what. The goal is to shorten the gap between "I want to
+change X" and "I have the right file open".
+
+## Top level
+
+| Path | Contains |
+|------|----------|
+| `backend/` | The FastAPI application (`news_dashboard` package) and its tests. |
+| `frontend/` | The React + TypeScript single-page app. |
+| `website/` | The Docusaurus documentation site published at [docs.lihor.ro](https://docs.lihor.ro). |
+| `docs/` | Repository-local technical docs and ADRs. |
+| `helm/` | The `news-dashboard` Helm chart. |
+| `deploy/` | Host-level deployment assets (Caddy config, Keycloak theme). |
+| `e2e/` | Playwright end-to-end specs. |
+| `scripts/` | Development, release, and CI helper scripts. |
+| `android/`, `desktop/` | The mobile and desktop client shells. |
+| `.github/workflows/` | CI, release, nightly, and security workflows. |
+
+## Backend
+
+The package is `backend/news_dashboard/`. `main.py` is app assembly — CORS,
+middleware, the three top-level routers, and `include_router(...)` calls.
+
+Most domains are **feature-module packages** with the same three-file shape:
+
+```
+news_dashboard/<module>/
+  __init__.py   # package docstring only
+  router.py     # APIRouter + endpoint handlers
+  service.py    # business logic and DB access
+  models.py     # Pydantic request/response models
+```
+
+This convention, and the rules that go with it, are documented in
+[Feature modules](feature-modules.md).
+
+### Finding a domain
+
+Module names map onto the API surface, so the fastest route from an endpoint
+to its code is the path segment:
+
+| Area | Module |
+|------|--------|
+| Articles, search, highlights | `articles/` |
+| Feeds and sources | `sources/` |
+| Ingestion and the scheduler | `ingest/`, `scheduler/` |
+| Briefings and email digests | `briefings/`, `briefing_email/` |
+| Lessons and learning | `learn_from_link/`, `lesson_recaps/`, `quizzes/` |
+| Recaps | `recaps/` |
+| Assistant, agent actions | `assistant/` |
+| Recommendations, personalization | `recommendations_routes/`, `personalization/` |
+| AI memory, feedback, stats | `ai_memory/`, `ai_feedback/`, `ai_stats/` |
+| Tags, reading list, watchlists | `tags_routes/`, `reading_list/`, `watchlists/` |
+| Sharing | `shares/` |
+| Auth and users | `auth.py`, `auth_routes/`, `user_settings/` |
+| Admin | `admin_routes/` |
+| Health, version, config | `system/` |
+| Aggregates for charts | `stats/` |
+| MCP and Google Reader | `mcp/`, `greader.py` |
+| Onboarding | `onboarding/` |
+
+Cross-cutting modules that are not feature packages:
+
+| File | Responsibility |
+|------|----------------|
+| `auth.py` | Sessions, Keycloak SSO, `require_auth` / `require_admin`. |
+| `graph_store.py` | Neo4j boundary. Optional; faked in tests. |
+| `entities.py` | Entity extraction feeding the knowledge graph. |
+| `email.py` | Outbound mail. |
+
+### Migration in progress
+
+`main.py` was ~2,600 lines mounting 117 endpoints before the feature-module
+split. Extraction is incremental, so `main.py` still holds a mix of extracted
+and not-yet-extracted domains. If a route is not in a feature package, it is
+still in `main.py` — that is expected, not an oversight.
+
+## Frontend
+
+```
+frontend/src/
+  api/         # API client functions
+  components/  # Reusable components
+  contexts/    # React contexts
+  hooks/       # Custom hooks
+  lib/         # Utilities, i18n setup
+  locales/     # Translation resources
+  pages/       # Route-level pages (~35)
+  types/       # Shared TypeScript types
+  __tests__/   # Vitest suites
+```
+
+Pages are named for what they render — `InboxPage`, `FeedsPage`,
+`LessonDetailPage`, `AdminPage` — so the UI route usually names its own file.
+
+All user-facing strings must be externalized for translation. Add keys to
+`frontend/src/locales/en/translation.json` using nested, descriptive names
+(`feature.action.label`) and printf-style placeholders for interpolation.
+Avoid building sentences by concatenation — it does not survive translation.
+
+## Common tasks
+
+| I want to… | Start at |
+|------------|----------|
+| Add a feed source or scraper | `backend/news_dashboard/ingest/` |
+| Add a backend endpoint | The relevant feature module's `router.py` |
+| Add a new backend domain | [Feature modules](feature-modules.md) |
+| Work on UI components | `frontend/src/components/`, `frontend/src/pages/` |
+| Add or fix translations | `frontend/src/locales/` |
+| Write backend tests | `backend/tests/` |
+| Change Docker or Helm packaging | `helm/`, `Dockerfile`, `docker-compose.yml` |
+| Edit the published docs | `website/docs/` |
+| Change CI | `.github/workflows/` |
+
+## CI workflows
+
+| Workflow | Runs |
+|----------|------|
+| `ci.yml` | The `make check` gate on pull requests. |
+| `nightly.yml` | The full suite with coverage. |
+| `release.yml` | Version derivation, image build, release publication. |
+| `docs.yml` | Builds and deploys the documentation site. |
+| `codeql.yml`, `trivy-scan.yml`, `dependency-review.yml` | Security scanning. |
+| `android.yml`, `desktop.yml` | Client builds. |
+
+Several `scripts/test_*.py` files test the workflows and packaging themselves —
+`test_release_sync_workflow.py`, `test_helm_postgres_backup.py`,
+`test_ci_deploy_namespace.py` and others. If you change a workflow or chart,
+check whether a script asserts on it.

--- a/website/docs/development/environment-setup.md
+++ b/website/docs/development/environment-setup.md
@@ -1,0 +1,133 @@
+---
+title: Environment setup
+sidebar_position: 2
+---
+
+# Environment setup
+
+What you need installed, how the local database is expected to be wired, and
+the setup mistakes that produce confusing failures later.
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| Python | 3.14+ |
+| Node.js | LTS |
+| PostgreSQL | 16+ with the [pgvector](https://github.com/pgvector/pgvector) extension |
+
+Use the `pgvector/pgvector:pg16` image rather than stock `postgres:16` — plain
+PostgreSQL lacks the `vector` extension, and the failure surfaces late, as a
+migration or query error rather than a connection error.
+
+A pre-configured **Dev Container** and **GitHub Codespace** are available and
+skip the manual steps below.
+
+## Install
+
+```bash
+make install
+```
+
+This installs the backend in editable mode with dev extras, installs frontend
+dependencies, and registers pre-commit hooks.
+
+Use `make ci-install` when you need reproducibility — it runs `npm ci` against
+`package-lock.json` instead of `npm install`, so the lockfile is respected
+rather than updated.
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill it in. The database can be configured
+two ways:
+
+- `DATABASE_URL` pointing at PostgreSQL, or
+- `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, and
+  `POSTGRES_PASSWORD`.
+
+`.env` is git-ignored. It is not copied into new worktrees automatically —
+see [Worktrees](#worktrees) below.
+
+## The test database
+
+Backend tests need a live PostgreSQL instance. The project convention is a
+**dedicated container**, deliberately not the Postgres you might already run
+on port 5432:
+
+| Setting | Value |
+|---------|-------|
+| Container | `nd-test-pg` (`postgres:16`) |
+| Host port | **55432** |
+| Database | `news_dashboard_test` |
+| Role | `news_dashboard` |
+
+Check it is running:
+
+```bash
+podman ps --filter name=nd-test-pg
+```
+
+Both `DATABASE_URL` and `TEST_DATABASE_URL` in `.env` must point at
+`localhost:55432/news_dashboard_test` as role `news_dashboard`.
+
+:::warning Pointing at the wrong instance is the most common setup failure
+If these point at an unrelated native PostgreSQL on 5432, tests do **not** fail
+with a connection error. They connect successfully and then fail with
+`InsufficientPrivilege` or ownership errors, because the role does not own the
+objects. If you are seeing permission errors from a database that is clearly
+reachable, check the port before anything else.
+:::
+
+Run backend tests with the environment loaded:
+
+```bash
+source .env && make test
+```
+
+## Running the app
+
+The README covers the full local run. In short: the backend serves the API,
+and the frontend dev server proxies to it. `make build` produces the
+production frontend bundle that the backend serves in container deployments.
+
+## Worktrees
+
+A fresh `git worktree` has no `.venv`, no `node_modules`, and no `.env` —
+`.env` is ignored, so git does not carry it across. Bootstrap before testing
+or committing:
+
+```bash
+scripts/bootstrap-worktree.sh
+```
+
+The script copies `.env` from the main checkout, creates the virtualenv with
+`uv sync --frozen --all-extras` (which leaves `uv.lock` untouched, unlike
+`make install`), runs `npm ci`, and verifies that `DATABASE_URL` and
+`TEST_DATABASE_URL` are actually set — failing loudly rather than letting you
+discover it during a test run. It is safe to re-run.
+
+Keep `.venv/bin` on `PATH` in the worktree so pre-commit hooks find their
+tools — several hooks invoke `.venv/bin/<tool>` directly.
+
+## Pre-commit hooks
+
+`make install` registers the pre-commit stage. Hooks are scoped by file type,
+so a docs-only commit does not run mypy or ESLint.
+
+To also gate pushes:
+
+```bash
+pre-commit install --hook-type pre-push
+```
+
+The pre-push stage re-runs linters and type checkers — so a push is blocked
+even if individual commits skipped hooks — and adds the test suites, which are
+too slow for every commit.
+
+Do not use `git push --no-verify`.
+
+Run everything manually with:
+
+```bash
+pre-commit run --all-files
+```

--- a/website/docs/development/feature-modules.md
+++ b/website/docs/development/feature-modules.md
@@ -1,0 +1,150 @@
+---
+title: Feature modules
+sidebar_position: 4
+---
+
+# Feature modules
+
+Backend domains are organized as **feature-module packages**. This page is the
+practical guide; the reasoning is recorded in
+[ADR 0003](https://github.com/lihor-hub/news-dashboard/blob/main/docs/adr/0003-feature-module-packages.md).
+
+## Why
+
+`main.py` had grown to roughly 2,600 lines mounting 117 endpoints across three
+routers, with handlers, Pydantic models, and business logic interleaved. It was
+a merge-conflict hotspot with no consistent home for a domain's models.
+
+Feature modules give every domain the same shape and collapse `main.py` toward
+pure app assembly.
+
+## The shape
+
+```
+news_dashboard/<module>/
+  __init__.py   # package docstring; do NOT re-export `router`
+  router.py     # APIRouter + endpoint handlers; thin, delegates to service
+  service.py    # business logic, DB access, external calls
+  models.py     # Pydantic request/response models
+```
+
+`quizzes/` (reading goals and weekly quizzes) is the reference implementation.
+`sources/` is a good second example.
+
+The split is a real boundary, not a filing convention:
+
+- `router.py` handles HTTP — parsing, validation, status codes. It should stay
+  thin.
+- `service.py` holds the logic and owns database access. It should be callable
+  without a request object.
+- `models.py` holds the Pydantic models for that domain and nothing else.
+
+## Rules
+
+### The router carries no auth dependency of its own
+
+A feature router is mounted onto an existing router in `main.py` and inherits
+that router's gate:
+
+```python
+api.include_router(quizzes_router)   # inherits require_auth
+```
+
+Do not add a blanket `dependencies=[Depends(require_auth)]` to the feature
+router itself. Handlers still declare `Depends(require_auth)` individually
+where they need the current user object.
+
+Mount points:
+
+| Router in `main.py` | Gate |
+|---------------------|------|
+| `api` | `require_auth` — the normal case. |
+| `admin` | `require_admin`, prefix `/api/admin`. |
+| `public_router` | No session required. Use deliberately. |
+
+### Import the router from the submodule
+
+```python
+from news_dashboard.quizzes.router import router as quizzes_router
+```
+
+`__init__.py` deliberately does **not** re-export `router`. Re-exporting it
+would shadow the `router` submodule name and break this import.
+
+### Migrations are behavior-preserving
+
+When extracting an existing domain out of `main.py`, do not change route paths,
+status codes, or auth semantics in the same change. Move the code, keep the
+behavior. Functional changes belong in a separate, reviewable commit.
+
+### One domain per pull request
+
+Extract one domain at a time and update its importers and tests in the same PR.
+
+## Adding a new domain
+
+1. Create `backend/news_dashboard/<module>/` with the four files.
+2. Define the `APIRouter` in `router.py` with no blanket auth dependency.
+3. Put logic and DB access in `service.py`, request/response models in
+   `models.py`.
+4. Import the router in `main.py` and mount it on `api` (or `admin`).
+5. Add tests under `backend/tests/`.
+6. Run `make check`.
+
+### Writing the database layer
+
+Runtime SQL is PostgreSQL-specific and uses psycopg `%s` placeholders:
+
+```python
+cur.execute(
+    "SELECT id, title FROM articles WHERE user_id = %s AND state = %s",
+    (user_id, state),
+)
+```
+
+No SQLite fallbacks, no database-type sniffing, no placeholder translation.
+See [ADR 0001](https://github.com/lihor-hub/news-dashboard/blob/main/docs/adr/0001-postgresql-only-runtime.md).
+
+### Returning collections
+
+List endpoints return the standard envelope. Compute `has_more` by fetching one
+row past the limit rather than issuing a second `COUNT` query:
+
+```python
+items = service.list_things(limit=limit + 1, offset=offset)
+return {
+    "items": items[:limit],
+    "limit": limit,
+    "offset": offset,
+    "has_more": len(items) > limit,
+}
+```
+
+Bound `limit` in the signature so out-of-range values are rejected with `422`
+by FastAPI rather than reaching the service:
+
+```python
+limit: Annotated[int, Query(ge=1, le=500)] = 100,
+offset: Annotated[int, Query(ge=0)] = 0,
+```
+
+### Bound untrusted input
+
+Anything user-supplied that reaches retrieval, prompt construction, or storage
+needs an explicit ceiling, so a malformed client cannot generate oversized LLM
+requests. Existing limits to follow as precedent: OPML import is capped at
+5 MiB and 1000 outlines; account import at 20 MiB.
+
+## Testing feature modules
+
+Routers mount lazily as `_IncludedRouter` objects. Assertions about routes must
+target the **resolved OpenAPI paths**, not `app.routes`:
+
+```python
+paths = app.openapi()["paths"]
+assert "/api/quizzes/{quiz_id}/submit" in paths
+```
+
+Inspecting `app.routes` directly gives misleading results for lazily mounted
+routers — this is the single most common surprise when writing route tests
+here.

--- a/website/docs/development/index.md
+++ b/website/docs/development/index.md
@@ -1,0 +1,99 @@
+---
+title: Development
+sidebar_position: 1
+---
+
+# Development
+
+Working documentation for people changing the code: how the repository is
+organized, how to get a local environment that matches CI, and the conventions
+a change is expected to follow.
+
+This complements rather than repeats the other sections:
+
+| If you want to… | Read |
+|-----------------|------|
+| Submit a change and get it merged | [Contributing](../contributing/index.md) |
+| Understand the runtime shape of the system | [Architecture](../architecture/index.md) |
+| Run an instance | [Self-hosting](../self-hosting/index.md) |
+| Call the HTTP API | [API reference](../api/index.md) |
+| Change code | this section |
+
+## Pages
+
+| Page | Covers |
+|------|--------|
+| [Environment setup](environment-setup.md) | Toolchain, `.env`, the test database, worktrees. |
+| [Codebase map](codebase-map.md) | Where things live in backend, frontend, and infra. |
+| [Feature modules](feature-modules.md) | The router/service/models convention for backend domains. |
+| [Testing](testing.md) | Test lanes, markers, and the failure modes worth recognizing. |
+| [Release process](release-process.md) | How versions are derived and released. |
+
+## Shape of the system
+
+News Dashboard is a **modular monolith**, not a microservice platform. One
+FastAPI application serves the JSON API and, in container and Kubernetes
+deployments, also serves the built React frontend. Scheduled ingestion runs as
+a separate batch workload.
+
+That has direct consequences for development:
+
+- There is one backend process to run locally. You do not need a service mesh
+  or a docker-compose stack of interdependent services to work on a feature.
+- Backend domains are separated by **package boundaries**, not network
+  boundaries — see [Feature modules](feature-modules.md).
+- The frontend talks to the same API documented in the
+  [API reference](../api/index.md). There is no private back channel, so
+  anything the UI can do can be reproduced with `curl`.
+
+## Two constraints worth knowing before you start
+
+Both are enforced in review and encoded in tooling. They are stated here so
+they do not come as a surprise mid-change.
+
+### PostgreSQL only, at runtime
+
+Runtime database code must be written for PostgreSQL and psycopg: `%s`
+parameters, PostgreSQL functions and operators, `ON CONFLICT` upserts.
+
+Do not add SQLite fallbacks, database-type sniffing, placeholder translation
+layers, or generic multi-database SQL. SQLite appears in this repository only
+as an *input format* for legacy migration tooling that reads an old local
+database and writes into PostgreSQL.
+
+This is recorded as
+[ADR 0001](https://github.com/lihor-hub/news-dashboard/blob/main/docs/adr/0001-postgresql-only-runtime.md).
+PostgreSQL must also have the [pgvector](https://github.com/pgvector/pgvector)
+extension available — embeddings live in `articles.embedding_vec` and
+similarity search runs as SQL `<=>` queries over an HNSW index.
+
+### `make check` is the gate
+
+```bash
+make check
+```
+
+runs lint, type checking, tests, and the production frontend build — the same
+set CI runs. If it passes locally, CI should be green.
+
+Individual lanes are documented in [Testing](testing.md).
+
+## Where decisions are recorded
+
+Significant technical decisions live in
+[`docs/adr/`](https://github.com/lihor-hub/news-dashboard/tree/main/docs/adr)
+as Architecture Decision Records. Read the relevant ADR before proposing a
+change that contradicts one — the record states the context and the
+alternatives that were rejected, which is usually the fastest way to find out
+whether your case is genuinely new.
+
+Current records:
+
+| ADR | Decision |
+|-----|----------|
+| 0001 | PostgreSQL-only runtime. |
+| 0002 | LLM gateway with fallback. |
+| 0003 | Feature-module packages (`router` / `service` / `models`). |
+
+Adding one: copy `docs/adr/0000-template.md`, number it sequentially, and
+include it in the PR that implements the decision.

--- a/website/docs/development/release-process.md
+++ b/website/docs/development/release-process.md
@@ -1,0 +1,89 @@
+---
+title: Release process
+sidebar_position: 6
+---
+
+# Release process
+
+How a version number is decided, where it comes from at runtime, and why you
+should not hardcode one.
+
+## Git tags are the source of truth
+
+Versions are **derived from git tags**, not stored in a file that gets bumped
+by hand. `scripts/next_version.sh` computes the next semantic version from the
+latest `v*` tag plus the Conventional Commits since it, and falls back to the
+`VERSION` file only when no tags exist.
+
+It is stateless — nothing is committed. It prints:
+
+```
+version=1.2.3
+code=1002003
+tag=v1.2.3
+bumped=true|false
+```
+
+`bumped=false` means only `ci`, `docs`, `test`, or `chore` commits have landed
+since the last tag, so no release is warranted.
+
+The same script is shared by `ci.yml` (which bakes the version into the image)
+and `release.yml` (which tags and builds artifacts), so CI builds and releases
+can never disagree about what version they are.
+
+This is why [commit conventions](../contributing/index.md) matter mechanically
+rather than stylistically: a `feat:` commit and a `fix:` commit produce
+different version bumps.
+
+## The `VERSION` file
+
+`VERSION` at the repository root is the single source of truth *for the running
+application*.
+
+It is intentionally **not** committed with a bumped value between releases —
+it is written at release time. Do not bump it by hand in a feature PR.
+`pyproject.toml`'s `version` field is synced to it at release time.
+
+## How the version reaches runtime
+
+The backend reads `VERSION` once at startup
+(`news_dashboard.main._read_app_version`) and uses it for the FastAPI
+`app.version`. That single value drives:
+
+- the OpenAPI `info.version` shown at `/docs`
+- the `/api/version` endpoint
+
+Because they share one source, the documented version and the reported version
+cannot drift apart.
+
+:::warning Never hardcode a version literal
+Read `VERSION`, or `app.version` at runtime. A hardcoded literal is exactly the
+drift this arrangement exists to prevent.
+:::
+
+## Release workflow
+
+`release.yml` handles tagging, image build, and publication. `ci.yml` bakes the
+computed version into the image it builds, using the same script.
+
+Supporting scripts:
+
+| Script | Role |
+|--------|------|
+| `next_version.sh` | Compute the next version from tags + commits. |
+| `bump_version.py` | Decide the bump type from Conventional Commits. |
+| `inject_app_version.sh` | Inject the version into build artifacts. |
+| `update_changelog.py` | Update `CHANGELOG.md`. |
+| `humanize_commits.py` | Turn commit subjects into readable release notes. |
+
+Each has a `scripts/test_*.py` counterpart. If you change release behavior,
+expect to update the corresponding test — `test_bump_version.py`,
+`test_release_sync_workflow.py`, `test_update_changelog.py`.
+
+## Changelog
+
+`CHANGELOG.md` is generated from commit history at release time. Write commit
+subjects as the line you would want to read in release notes — they become
+exactly that.
+
+The running instance exposes its own release notes at `/api/changelog`.

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -1,0 +1,129 @@
+---
+title: Testing
+sidebar_position: 5
+---
+
+# Testing
+
+Which lane to run when, and the environment-shaped failures that are worth
+recognizing on sight rather than debugging from scratch.
+
+## Lanes
+
+| Command | Runs |
+|---------|------|
+| `make test` | Backend pytest with coverage + frontend Vitest. The everyday loop. |
+| `make test-smoke` | Fast smoke tests — app boot, health, core API paths. |
+| `make test-backend` | All backend pytest tests. |
+| `make test-frontend` | All frontend Vitest tests. |
+| `make test-e2e` | Playwright end-to-end specs. |
+| `make test-a11y` | Accessibility checks (axe-core, serious/critical). |
+| `make test-nightly` | Full suite with coverage — what nightly CI runs. |
+| `make check` | The complete gate: lint, typecheck, test, build. |
+
+`make check` is what CI runs on a pull request. Run it before pushing.
+
+## Static analysis
+
+`make lint` and `make typecheck` run more tools than most projects:
+
+| Tool | Checks |
+|------|--------|
+| `ruff` | Python lint + format. |
+| `mypy`, `ty`, `pyrefly` | Three Python type checkers, all of which must pass. |
+| `vulture` | Dead Python code (confidence ≥ 80). |
+| `eslint`, `prettier` | Frontend lint and formatting. |
+| `knip` | Dead TypeScript exports and unused dependencies. |
+| `tsc` | TypeScript types. |
+
+Dead-code detection is part of the gate, not advisory. If `vulture` flags a
+symbol you deliberately keep, add it to `backend/vulture_whitelist.py` rather
+than disabling the check.
+
+## Markers
+
+Select or exclude backend tests by marker (`--strict-markers` is on, so unknown
+markers are an error, not a typo that silently passes):
+
+| Marker | Meaning |
+|--------|---------|
+| `smoke` | Fast, high-signal: app boot, health, core API paths. No external services. |
+| `db` | Requires a live PostgreSQL instance. |
+| `postgres` | Alias for `db`. |
+| `perf_serial` | Timing-sensitive benchmarks; should run without xdist load. |
+| `slow` | Expensive; reserved for the nightly suite. |
+
+```bash
+pytest -m smoke -v
+pytest -m "not slow"
+```
+
+Tests run under `pytest-xdist` (`-n auto`) by default.
+
+## Environment-shaped failures
+
+These three account for most "everything is broken" reports. Each has a
+distinctive signature.
+
+### Every DB test fails with `InsufficientPrivilege`
+
+The tests are connected to the **wrong PostgreSQL instance** — typically a
+native server on 5432 instead of the dedicated `nd-test-pg` container on
+**55432**. The connection succeeds, so this does not look like a configuration
+error; it fails on ownership instead.
+
+Check `DATABASE_URL` and `TEST_DATABASE_URL` in `.env`. See
+[Environment setup](environment-setup.md#the-test-database).
+
+### `DiskFull` errors, or Postgres drops into recovery
+
+Leaked shared-memory segments in the test container's `/dev/shm`, caused by
+parallel query workers. This can crash PostgreSQL into recovery and fail 100+
+unrelated tests, which makes it look like a code regression.
+
+Disable parallel query workers before a full run:
+
+```bash
+export PGOPTIONS='-c max_parallel_workers_per_gather=0'
+```
+
+### Every DB test fails with `UndefinedTable` in the truncate fixture
+
+Orphaned tables from an abandoned branch are stuck in the shared test
+container. They are empty — drop them, or reset the container.
+
+## Route assertions
+
+Feature-module routers mount lazily as `_IncludedRouter` objects. Assert
+against resolved OpenAPI paths rather than `app.routes`:
+
+```python
+paths = app.openapi()["paths"]
+assert "/api/sources/{slug}/enabled" in paths
+```
+
+## Optional integrations
+
+Neo4j graph features activate only when `NEO4J_URI`, `NEO4J_USER`, and
+`NEO4J_PASSWORD` are configured. **Unit tests fake the graph boundary** — do
+not make the normal suite require a live Neo4j.
+
+When changing graph behavior, add tests around `graph_store.py`, `entities.py`,
+or the relevant frontend component, then run the targeted backend and Vitest
+suites.
+
+## Packaging tests
+
+`scripts/test_*.py` assert on workflows, the Helm chart, and repository
+metadata — release sync, Postgres backup templates, CI deploy namespace, Trivy
+workflows, agent-skill sync, and others. Changing a workflow or chart template
+often means updating one of these.
+
+Validate the chart directly with:
+
+```bash
+make helm-validate
+```
+
+which lints and renders it under default, production-like, and
+external-database value sets.


### PR DESCRIPTION
## Summary

The published docs already cover getting started, the user guide, self-hosting, configuration, architecture, and contributing. Two gaps remained:

- **No HTTP API documentation at all.** ~200 endpoints across 30 feature modules, with nothing describing them beyond the generated OpenAPI schema.
- **Thin development guidance.** `contributing/index.md` was 74 lines that mostly deferred to the README.

This adds both, as two new sections under `website/docs/`.

## `api/` — official API reference

| Page | Covers |
|------|--------|
| `index.md` | Base URLs, router/auth grouping, the `{items, limit, offset, has_more}` collection envelope, error codes, and the three distinct sources of `403`. |
| `authentication.md` | `nd_session` cookie, Keycloak SSO, email OTP, guest accounts, the CSRF origin guard, and MCP / GReader / podcast-feed tokens. |
| `articles-and-search.md` | Article lifecycle, triage verbs, search parameters, highlights, tags, reading list, AI-derived views. |
| `sources-and-ingestion.md` | Source management, preview, health, OPML, ingestion runs, scheduler, watchlists. |
| `learning-and-briefings.md` | Briefings, lessons, quizzes, recaps, agent actions, AI memory, onboarding. |
| `integrations.md` | MCP tool set with scopes, Google Reader sync, sharing, push notifications. |
| `operations.md` | Health probes, metrics, statistics, admin endpoints. |

The pages point at `/docs` and `/openapi.json` as the source of truth rather than trying to replace them, and explain the conventions and rationale the generated schema cannot express — why `404` is returned in place of `403` for other users' resources, why plan and approve are separate agent calls, why the unsubscribe `GET` only renders a confirmation.

## `development/` — development documentation

| Page | Covers |
|------|--------|
| `index.md` | Orientation, the modular-monolith shape, the two hard constraints, ADR index. |
| `environment-setup.md` | Toolchain, `.env`, the `nd-test-pg` container on port 55432, worktree bootstrap, pre-commit stages. |
| `codebase-map.md` | Backend module → API area table, frontend layout, CI workflows, common-task index. |
| `feature-modules.md` | The `router`/`service`/`models` convention from ADR 0003, with the rules and a walkthrough. |
| `testing.md` | Test lanes, markers, static-analysis tooling, and three environment-shaped failure modes. |
| `release-process.md` | Version derivation from git tags, the `VERSION` file contract, release scripts. |

`testing.md` documents failure signatures that are genuinely hard to diagnose cold — wrong-Postgres runs surfacing as `InsufficientPrivilege` rather than a connection error, `/dev/shm` segment leaks crashing Postgres into recovery, and orphaned tables producing `UndefinedTable` in the truncate fixture.

`feature-modules.md` records the lazily-mounted-router gotcha: route assertions must target resolved OpenAPI paths, not `app.routes`.

## Verification

- `npm run build` in `website/` passes. The config sets `onBrokenLinks: 'throw'`, so this confirms every internal link resolves.
- All 13 pages render into `build/docs/api/` and `build/docs/development/`.
- Sidebar entries come from the autogenerated sidebar plus new `_category_.json` files at positions 7 and 8, so no existing ordering changes.

## Notes

Content was derived by reading the routers, auth middleware, `Makefile`, `pyproject.toml`, `.pre-commit-config.yaml`, and the ADRs — not restated from memory. Route tables were extracted from the actual `@router` decorators.

Docs-only change: no source, test, or packaging files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)