### PR TITLE
ci: wire the Dify assistant into the production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,6 +651,9 @@ jobs:
           SENTRY_DSN_FRONTEND: ${{ secrets.SENTRY_DSN_FRONTEND }}
           SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          DIFY_CHAT_APP_TOKEN: ${{ secrets.DIFY_CHAT_APP_TOKEN }}
+          DIFY_CHAT_BASE_URL: ${{ vars.DIFY_CHAT_BASE_URL }}
+          DIFY_CHAT_TITLE: ${{ vars.DIFY_CHAT_TITLE }}
         run: |
           set -euo pipefail
 
@@ -768,6 +771,25 @@ jobs:
             sentry_helm_args+=(--set-string "app.sentry.release=news-dashboard@$SHA")
           fi
 
+          # Optional Dify assistant. Both the embed token and a browser-reachable
+          # base URL are required; the chart refuses to render with only one of
+          # them, so skip the feature entirely unless both are configured.
+          # DIFY_CHAT_APP_TOKEN is the Publish -> Embed token, not a service key.
+          dify_helm_args=()
+          if [ -n "$DIFY_CHAT_APP_TOKEN" ] && [ -n "$DIFY_CHAT_BASE_URL" ]; then
+            kubectl -n news-dashboard create secret generic news-dashboard-dify \
+              --from-literal=DIFY_CHAT_APP_TOKEN="$DIFY_CHAT_APP_TOKEN" \
+              --dry-run=client -o yaml | kubectl apply -f -
+            dify_helm_args+=(--set app.dify.enabled=true)
+            dify_helm_args+=(--set-string "app.dify.baseUrl=$DIFY_CHAT_BASE_URL")
+            dify_helm_args+=(--set app.dify.existingSecret=news-dashboard-dify)
+            if [ -n "$DIFY_CHAT_TITLE" ]; then
+              dify_helm_args+=(--set-string "app.dify.title=$DIFY_CHAT_TITLE")
+            fi
+          elif [ -n "$DIFY_CHAT_APP_TOKEN" ] || [ -n "$DIFY_CHAT_BASE_URL" ]; then
+            echo "Dify assistant needs both DIFY_CHAT_APP_TOKEN and DIFY_CHAT_BASE_URL; leaving it disabled." >&2
+          fi
+
           # Sync Helm chart changes from main. Avoid relying on the deploy
           # host clone's branch/upstream config, which may point at a deleted
           # feature branch.
@@ -793,6 +815,7 @@ jobs:
             "${push_helm_args[@]}"
             "${email_helm_args[@]}"
             "${sentry_helm_args[@]}"
+            "${dify_helm_args[@]}"
           )
           helm "${helm_args[@]}"
 


### PR DESCRIPTION
## Summary

#1293 added `app.dify.*` to the Helm chart, but the production deploy job never passes those values. That job runs `helm upgrade --install` **without** `--reuse-values`, so every value is re-supplied from Actions secrets/variables on each run — a manual `helm --set app.dify.enabled=true` would be silently reverted by the next merge to `main`.

This wires the feature into the deploy job, following the existing Sentry/push/email pattern.

## Behaviour

- Disabled unless configured — no change for anyone who sets nothing.
- Requires the token **and** the base URL together. The chart calls `fail` when `enabled=true` with either missing, so a half-configured repo would break the deploy; instead it stays disabled and logs why.
- The token reaches the pod via the `news-dashboard-dify` Secret, never as a literal in the Helm release.

## Configuration

| Name | Kind | Value |
|------|------|-------|
| `DIFY_CHAT_APP_TOKEN` | secret | Dify **Publish → Embed** token — *not* a service/API key |
| `DIFY_CHAT_BASE_URL` | variable | Browser-reachable Dify base URL, HTTPS, separate origin |
| `DIFY_CHAT_TITLE` | variable | Optional; chart defaults to `News Assistant` |

## Verification

- `helm template` with these args renders `DIFY_CHAT_APP_TOKEN` from `secretKeyRef` and the rest as literals.
- Deploy step extracted and exercised against all four gating cases (both set / neither / token only / URL only); correct in each, and the empty-array expansion is safe under `set -u`.
- YAML and `bash -n` syntax checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)