### PR TITLE
fix: read social posts from feed content

### DIFF
--- a/backend/news_dashboard/body_fetch.py
+++ b/backend/news_dashboard/body_fetch.py
@@ -27,6 +27,7 @@ from news_dashboard.content_extraction import (
 )
 from news_dashboard.db import connect, init_db, row_to_dict
 from news_dashboard.scraper import TIMEOUT_SECS, USER_AGENT
+from news_dashboard.social_posts import canonical_x_status_url
 from news_dashboard.url_safety import (
     UnsafeUrlError,
     open_server_fetch_url,
@@ -584,10 +585,21 @@ def _article_from_row(row: Any, conn: Any, article_id: int, user_id: int | None)
     d = row_to_dict(row)
     d.pop("embedding_vec", None)
     d.pop("fts_vector", None)
+    if d.get("kind") == "nitter_feed":
+        d["url"] = canonical_x_status_url(str(d.get("url") or ""))
     if user_id is not None:
         _merge_user_state(d, conn, article_id, user_id)
         _merge_user_recommendation(d, conn, article_id, user_id)
     return d
+
+
+def _complete_stored_nitter_post(article: dict[str, Any]) -> str:
+    """Select complete feed-derived text without accepting truncated UI copy."""
+    for field in ("summary", "title"):
+        candidate = str(article.get(field) or "").strip()
+        if candidate and candidate != "Untitled" and not candidate.endswith(("…", "...")):
+            return candidate
+    return ""
 
 
 def get_article(
@@ -674,6 +686,34 @@ def fetch_and_cache_body(
         row_d = row_to_dict(row)
         if row_d.get("body_status") == "ok":
             return _article_from_row(row, conn, article_id, user_id)
+        if row_d.get("kind") == "nitter_feed":
+            stored_post = _complete_stored_nitter_post(row_d)
+            if stored_post:
+                conn.execute(
+                    """
+                    UPDATE articles
+                       SET body = %s,
+                           original_body = %s,
+                           body_status = 'ok',
+                           updated_at = CURRENT_TIMESTAMP
+                     WHERE id = %s
+                    """,
+                    (
+                        stored_post,
+                        row_d.get("original_title")
+                        if row_d.get("detected_lang") not in {None, "en"}
+                        else None,
+                        article_id,
+                    ),
+                )
+                row_d["body"] = stored_post
+                row_d["original_body"] = (
+                    row_d.get("original_title")
+                    if row_d.get("detected_lang") not in {None, "en"}
+                    else None
+                )
+                row_d["body_status"] = "ok"
+                return _article_from_row(row_d, conn, article_id, user_id)
 
     url = row_d["url"]
     extraction: Any = (

--- a/backend/news_dashboard/ingest/service.py
+++ b/backend/news_dashboard/ingest/service.py
@@ -25,6 +25,7 @@ from news_dashboard.db import connect, init_db, insert_article_sql, placeholders
 from news_dashboard.ingest_events import ingest_events
 from news_dashboard.prompt_catalog import get_chat_prompt
 from news_dashboard.recommendations import COLD_START_MODEL_VERSION
+from news_dashboard.social_posts import canonical_x_status_url
 from news_dashboard.sources.service import DEFAULT_SOURCES, SourceDefinition
 from news_dashboard.url_safety import (
     UnsafeUrlError,
@@ -610,6 +611,14 @@ def _nitter_handle(url: str) -> str:
     return url.rstrip("/").split("/")[-1]
 
 
+def _nitter_feed_body(entry: dict[str, Any]) -> str:
+    """Return complete post text already supplied by the Nitter RSS entry."""
+    description = clean_html(str(entry.get("description") or ""))
+    if description:
+        return description
+    return clean_html(str(entry.get("title") or ""))
+
+
 def _fetch_nitter_feed(source: SourceDefinition) -> list[dict[str, Any]]:
     """Fetch an X/Twitter account via Nitter RSS, trying instances in order."""
     handle = _nitter_handle(source.url)
@@ -627,6 +636,9 @@ def _fetch_nitter_feed(source: SourceDefinition) -> list[dict[str, Any]]:
         # as failed and try the next rather than ingesting the placeholder.
         tweets = [e for e in entries if "/status/" in (e.get("url") or "")]
         if tweets:
+            for tweet in tweets:
+                tweet["feed_body"] = _nitter_feed_body(tweet)
+                tweet["url"] = canonical_x_status_url(str(tweet["url"]))
             return tweets
         msg = f"Nitter {instance} returned no tweets for @{handle} (placeholder or blocked)"
         logger.warning(msg)
@@ -958,6 +970,16 @@ def _persist_entry(  # noqa: PLR0913, PLR0917
                     detected_lang,
                 ),
             )
+            feed_body = clean_html(str(entry.get("feed_body") or ""))
+            if cursor.rowcount and feed_body:
+                conn.execute(
+                    """
+                    UPDATE articles
+                       SET body = %s, original_body = %s, body_status = 'ok'
+                     WHERE url = %s
+                    """,
+                    (feed_body, entry.get("original_feed_body"), url),
+                )
             return int(cursor.rowcount)
     except psycopg.Error as exc:
         logger.warning(
@@ -1022,6 +1044,14 @@ def _ingest_source(
                 translated_title, translated_desc, detected_lang, original_title = (
                     detect_and_translate_article(title, description, source.lang)
                 )
+                feed_body = clean_html(str(entry.get("feed_body") or ""))
+                if feed_body:
+                    entry["feed_body"] = (
+                        translated_desc if clean_html(description) else translated_title
+                    )
+                    entry["original_feed_body"] = (
+                        feed_body if detected_lang not in {None, "en"} else None
+                    )
 
                 if not _should_include(translated_title, translated_desc, source.slug):
                     continue

--- a/backend/news_dashboard/social_posts.py
+++ b/backend/news_dashboard/social_posts.py
@@ -1,0 +1,17 @@
+"""Helpers shared by social-feed ingestion and article presentation."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+_NITTER_STATUS_PATH = re.compile(r"^/([^/]+)/status/(\d+)")
+
+
+def canonical_x_status_url(url: str) -> str:
+    """Normalize a Nitter/X status permalink to the publisher's canonical host."""
+    match = _NITTER_STATUS_PATH.match(urlparse(url).path)
+    if match is None:
+        return url
+    handle, status_id = match.groups()
+    return f"https://x.com/{handle}/status/{status_id}"

--- a/backend/tests/test_body_fetch.py
+++ b/backend/tests/test_body_fetch.py
@@ -339,6 +339,119 @@ def test_fetch_and_cache_body_fetch_error(tmp_path: Path) -> None:
     assert result["body"] is None
 
 
+def test_fetch_and_cache_body_recovers_nitter_post_from_stored_title(tmp_path: Path) -> None:
+    db_path = _db(tmp_path)
+    article_id = _seed_article(db_path)
+    post = (
+        "This is a willfully misleading narrative from OpenAI. "
+        "The guards on AI were lowered by humans, and this complete social post "
+        "was already preserved by the feed before the item page became unavailable."
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE articles
+               SET kind = 'nitter_feed',
+                   url = 'https://nitter.net/pentagoniac/status/2082297695591710911',
+                   canonical_url = 'https://nitter.net/pentagoniac/status/2082297695591710911',
+                   title = %s,
+                   summary = 'This is a willfully misleading narrative…',
+                   body = NULL,
+                   body_status = 'error'
+             WHERE id = %s
+            """,
+            (f"RT by @ylecun: {post}", article_id),
+        )
+
+    with patch("news_dashboard.body_fetch.extract_public_content") as extract:
+        result = fetch_and_cache_body(article_id, db_path=db_path)
+
+    assert result is not None
+    assert result["body_status"] == "ok"
+    assert result["body"] == f"RT by @ylecun: {post}"
+    assert result["url"] == "https://x.com/pentagoniac/status/2082297695591710911"
+    extract.assert_not_called()
+
+
+def test_fetch_and_cache_body_accepts_short_stored_nitter_post(tmp_path: Path) -> None:
+    db_path = _db(tmp_path)
+    article_id = _seed_article(db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE articles
+               SET kind = 'nitter_feed',
+                   title = 'A short but complete post.',
+                   summary = '',
+                   body = NULL,
+                   body_status = 'missing'
+             WHERE id = %s
+            """,
+            (article_id,),
+        )
+
+    with patch("news_dashboard.body_fetch.extract_public_content") as extract:
+        result = fetch_and_cache_body(article_id, db_path=db_path)
+
+    assert result is not None
+    assert result["body_status"] == "ok"
+    assert result["body"] == "A short but complete post."
+    extract.assert_not_called()
+
+
+def test_fetch_and_cache_body_prefers_complete_nitter_summary(tmp_path: Path) -> None:
+    db_path = _db(tmp_path)
+    article_id = _seed_article(db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE articles
+               SET kind = 'nitter_feed',
+                   title = 'Title copy from the feed.',
+                   summary = 'Complete summary copy from the feed.',
+                   body = NULL,
+                   body_status = 'missing'
+             WHERE id = %s
+            """,
+            (article_id,),
+        )
+
+    with patch("news_dashboard.body_fetch.extract_public_content") as extract:
+        result = fetch_and_cache_body(article_id, db_path=db_path)
+
+    assert result is not None
+    assert result["body"] == "Complete summary copy from the feed."
+    extract.assert_not_called()
+
+
+def test_fetch_and_cache_body_rejects_truncated_stored_nitter_text(tmp_path: Path) -> None:
+    db_path = _db(tmp_path)
+    article_id = _seed_article(db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE articles
+               SET kind = 'nitter_feed',
+                   title = 'Truncated title…',
+                   summary = 'Truncated summary...',
+                   body = NULL,
+                   body_status = 'missing'
+             WHERE id = %s
+            """,
+            (article_id,),
+        )
+
+    with patch(
+        "news_dashboard.body_fetch.extract_public_content",
+        return_value=("Fetched fallback body.", "ok"),
+    ) as extract:
+        result = fetch_and_cache_body(article_id, db_path=db_path)
+
+    assert result is not None
+    assert result["body"] == "Fetched fallback body."
+    extract.assert_called_once()
+
+
 def test_fetch_and_cache_body_not_found(tmp_path: Path) -> None:
     db_path = _db(tmp_path)
     init_db(db_path)

--- a/backend/tests/test_nitter_feed.py
+++ b/backend/tests/test_nitter_feed.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 import pytest
 
+from news_dashboard.db import connect
 from news_dashboard.ingest.service import (
     _FEED_AGENT,
     _NITTER_INSTANCES,
@@ -17,7 +18,9 @@ from news_dashboard.ingest.service import (
     FeedFetchError,
     _fetch_feed_content,
     _fetch_nitter_feed,
+    _ingest_source,
     _nitter_handle,
+    sync_sources,
 )
 from news_dashboard.sources.service import DEFAULT_SOURCES, SourceDefinition
 
@@ -311,6 +314,86 @@ def test_fetch_nitter_succeeds_on_first_instance(monkeypatch: pytest.MonkeyPatch
     # Only one network call — no unnecessary fallback
     assert len(calls) == 1
     assert f"{_NITTER_INSTANCES[0]}/AnthropicAI/rss" in calls[0]
+
+
+def test_fetch_nitter_normalizes_status_url_and_preserves_feed_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post = (
+        "This is a willfully misleading narrative from OpenAI. "
+        "The complete social post is already present in the RSS entry."
+    )
+
+    def fake_parse_url(_url: str) -> list[dict[str, object]]:
+        return [
+            {
+                "url": "https://nitter.net/pentagoniac/status/2082297695591710911#m",
+                "title": f"RT by @ylecun: {post}",
+                "description": f"<p>{post}</p>",
+                "date": None,
+            }
+        ]
+
+    monkeypatch.setattr("news_dashboard.ingest.service._parse_feed_url", fake_parse_url)
+
+    entries = _fetch_nitter_feed(_make_source("ylecun"))
+
+    assert entries[0]["url"] == "https://x.com/pentagoniac/status/2082297695591710911"
+    assert entries[0]["feed_body"] == post
+
+
+def test_fetch_nitter_preserves_short_feed_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_parse_url(_url: str) -> list[dict[str, object]]:
+        return [
+            {
+                "url": "https://xcancel.com/sama/status/42",
+                "title": "A short but complete post.",
+                "description": "",
+                "date": None,
+            }
+        ]
+
+    monkeypatch.setattr("news_dashboard.ingest.service._parse_feed_url", fake_parse_url)
+
+    entries = _fetch_nitter_feed(_make_source("sama"))
+
+    assert entries[0]["feed_body"] == "A short but complete post."
+
+
+def test_ingest_nitter_stores_feed_body_without_webpage_fetch(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = next(item for item in DEFAULT_SOURCES if item.slug == "x-ylecun")
+    sync_sources(pg_clean)
+    monkeypatch.setattr(
+        "news_dashboard.ingest.service._fetch_entries_by_kind",
+        lambda _source: [
+            {
+                "url": "https://x.com/pentagoniac/status/2082297695591710911",
+                "title": "RT by @ylecun: Complete post from the feed.",
+                "description": "<p>Complete post from the feed.</p>",
+                "feed_body": "Complete post from the feed.",
+                "date": None,
+            }
+        ],
+    )
+
+    outcome = _ingest_source(source, pg_clean)
+
+    assert outcome.articles_new == 1
+    with connect(pg_clean) as conn:
+        row = conn.execute(
+            """
+            SELECT body, body_status
+              FROM articles
+             WHERE url = %s
+            """,
+            ("https://x.com/pentagoniac/status/2082297695591710911",),
+        ).fetchone()
+    assert row is not None
+    assert row["body"] == "Complete post from the feed."
+    assert row["body_status"] == "ok"
 
 
 def test_fetch_nitter_normalises_missing_title(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #1301

## Summary
- preserve complete Nitter RSS content as the cached article body during ingestion
- recover existing failed social posts from complete stored fields without scraping an unstable mirror
- normalize presented status links to canonical x.com URLs
- reject truncated stored candidates and retain normal extraction as fallback

## Verification
- `make lint`
- `make typecheck`
- `dotenv run -- make test` (2,891 backend passed, 2 skipped; 1,015 frontend passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)