### PR TITLE
ci: greet first-time contributors and auto-label PRs by area

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,51 @@
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'frontend/**'
+          - 'e2e/**'
+          - 'index.html'
+          - 'vite.config.ts'
+          - 'eslint.config.mjs'
+          - 'tsconfig.json'
+          - 'playwright.config.ts'
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'backend/**'
+          - 'pyproject.toml'
+
+i18n:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'frontend/src/locales/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'website/**'
+          - '*.md'
+
+deploy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'helm/**'
+          - 'deploy/**'
+          - 'Dockerfile'
+          - 'docker-compose*.yml'
+
+android:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'android/**'
+
+desktop:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'desktop/**'
+
+ci-cd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,75 @@
+name: Greet first-time contributors
+
+on:
+  issues:
+    types: [opened]
+  # pull_request_target runs with repo permissions but this job never checks
+  # out or executes PR code — it only posts a comment.
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const isPr = !!context.payload.pull_request;
+            const author = isPr
+              ? context.payload.pull_request.user.login
+              : context.payload.issue.user.login;
+            const number = isPr
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            if (context.payload.sender.type === 'Bot') {
+              core.info(`Skipping bot account ${author}.`);
+              return;
+            }
+
+            const typeFilter = isPr ? 'type:pr' : 'type:issue';
+            const { data: search } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} ${typeFilter} author:${author}`,
+              per_page: 2,
+            });
+            if (search.total_count > 1) {
+              core.info(`${author} has contributed before; no greeting needed.`);
+              return;
+            }
+
+            const contributing = `https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md`;
+            const goodFirst = `https://github.com/${owner}/${repo}/issues?q=is%3Aopen+label%3A%22good+first+issue%22`;
+            const discussions = `https://github.com/${owner}/${repo}/discussions`;
+
+            const body = isPr
+              ? [
+                  `Thanks for opening your first pull request here, @${author}! 🎉`,
+                  '',
+                  `A maintainer will review it soon. In the meantime:`,
+                  '',
+                  `- Run \`make check\` locally — it mirrors CI, so a clean run means green checks.`,
+                  `- [CONTRIBUTING.md](${contributing}) covers conventions and the review flow.`,
+                  `- Stuck or unsure about scope? Ask right here in the PR or in [Discussions](${discussions}) — happy to help.`,
+                ].join('\n')
+              : [
+                  `Thanks for opening your first issue here, @${author}! 👋`,
+                  '',
+                  `A maintainer will triage it soon. If you'd like to try fixing it yourself, we'd love that:`,
+                  '',
+                  `- [CONTRIBUTING.md](${contributing}) walks through setup and landing your first PR.`,
+                  `- [Good first issues](${goodFirst}) lists other beginner-friendly tasks.`,
+                  `- Questions are always welcome in [Discussions](${discussions}).`,
+                ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: number,
+              body,
+            });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: Label PRs by area
+
+on:
+  # pull_request_target runs with repo permissions but this job never checks
+  # out or executes PR code — actions/labeler only reads the diff file list.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false


### PR DESCRIPTION
Closes #1304

Adds two pieces of contributor-experience automation:

- **`.github/workflows/greetings.yml`** — welcomes an author's first issue or first PR with one comment pointing at CONTRIBUTING.md, the `make check` gate, good first issues, and Discussions. Skips bots and repeat contributors (issue/PR search count for the author must be ≤ 1).
- **`.github/labeler.yml` + `.github/workflows/labeler.yml`** — `actions/labeler@v5` applies the existing area labels (frontend, backend, i18n, documentation, deploy, android, desktop, ci-cd) from changed paths. `sync-labels: false` so manually added labels stick.

Both workflows use `pull_request_target` for label/comment permissions but **never check out or execute PR code**.

Verification: prettier and pre-commit YAML checks pass; workflow behavior is exercised by GitHub-hosted actions (not unit-testable locally), so the logic was kept to the minimal well-known patterns above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)