### PR TITLE
ci: allowlist unfixable npm audit advisories via audit-ci

### DIFF
--- a/.audit-ci.jsonc
+++ b/.audit-ci.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  // Fail the CI gate on moderate or higher advisories, matching the old
+  // `npm audit --audit-level=moderate` behavior.
+  "moderate": true,
+  // Each allowlist entry must state why it is excluded and where it is
+  // tracked. Remove the entry to re-arm the gate for that advisory.
+  "allowlist": [
+    // Blanket advisory: every brace-expansion release <= 5.0.7 is marked
+    // vulnerable (DoS via unbounded expansion). Our copies sit under
+    // dev-only build tooling (vite-plugin-pwa -> workbox-build -> jake /
+    // ejs / minimatch) whose version constraints have no patched release
+    // yet. Not shipped to production. Remove once the upstream chain
+    // publishes patched lines.
+    "GHSA-mh99-v99m-4gvg",
+    // react-router RSC-mode CSRF; only patched in react-router 8.3.0.
+    // This Vite SPA does not use RSC mode. The v7 -> v8 migration is
+    // tracked in https://github.com/lihor-hub/news-dashboard/issues/1329
+    // — remove this entry when it lands.
+    "GHSA-qwww-vcr4-c8h2",
+  ],
+}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,9 +26,12 @@ jobs:
         with:
           node-version: '26'
 
+      # audit-ci wraps `npm audit` so known-unfixable advisories can be
+      # allowlisted with a tracked justification in .audit-ci.jsonc instead
+      # of leaving the gate permanently red. New advisories still fail.
       - name: npm audit (root, moderate+)
-        run: npm audit --audit-level=moderate
+        run: npx audit-ci@^7 --config .audit-ci.jsonc
 
       - name: npm audit (website, moderate+)
         working-directory: website
-        run: npm audit --audit-level=moderate
+        run: npx audit-ci@^7 --config ../.audit-ci.jsonc


### PR DESCRIPTION
Closes #1335

The `npm audit` steps in `dependency-review.yml` fail **every PR** (even docs-only ones) on two advisories that no lockfile bump can fix today:

- GHSA-mh99-v99m-4gvg — blanket advisory marking all brace-expansion ≤ 5.0.7 vulnerable; our copies are in the dev-only vite-plugin-pwa → workbox-build chain with no patched upstream lines
- GHSA-qwww-vcr4-c8h2 — react-router, patched only in v8 (migration tracked in #1329)

This swaps raw `npm audit` for [audit-ci](https://github.com/IBM/audit-ci) with a committed `.audit-ci.jsonc` that allowlists exactly those two advisories, each with a comment saying why and when to remove it. Any **new** moderate+ advisory still fails the gate.

Verification (local):
- root without allowlist → exit 1 (both advisories reported)
- root with allowlist → "Passed npm security audit" (allowlisted advisories surfaced as warnings)
- website with allowlist → passes (website tree is clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)