### PR TITLE
chore: extend Dependabot to website and desktop npm projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,38 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:10"
+      timezone: "Europe/Bucharest"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/desktop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:20"
+      timezone: "Europe/Bucharest"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/scripts/test_repo_metadata.py
+++ b/scripts/test_repo_metadata.py
@@ -61,6 +61,26 @@ class TestVultureWhitelistExists(unittest.TestCase):
         )
 
 
+class TestDependabotNpmProjects(unittest.TestCase):
+    _NPM_UPDATE = re.compile(
+        r'^  - package-ecosystem: "npm"\n(?P<configuration>.*?)(?=^  - |\Z)',
+        re.MULTILINE | re.DOTALL,
+    )
+
+    def test_expected_npm_projects_are_covered_exactly_once(self) -> None:
+        dependabot = (ROOT / ".github" / "dependabot.yml").read_text()
+        directories = [
+            re.search(
+                r'^    directory: "(?P<directory>[^"]+)"$',
+                match.group("configuration"),
+                re.MULTILINE,
+            )["directory"]
+            for match in self._NPM_UPDATE.finditer(dependabot)
+        ]
+
+        assert sorted(directories) == ["/", "/desktop", "/website"]
+
+
 class TestNoDuplicateDocusaurusSourceFiles(unittest.TestCase):
     """A compiled/generated ``.js`` file checked in beside its ``.tsx`` source under
     ``website/src`` makes Docusaurus register the same page or component twice


### PR DESCRIPTION
Closes #1339

## Summary
- add weekly Dependabot npm coverage for the website and desktop lockfiles
- stagger subproject scans while retaining the root npm update policy
- guard all expected npm directories with repository metadata tests

## Tests
- `python3 -m unittest scripts/test_repo_metadata.py`
- `make lint`
- `make typecheck`
- `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)