### PR TITLE
fix: migrate to react-router v8 to resolve Dependabot alert #53

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -1,11 +1,6 @@
 import { lazy, Suspense } from 'react';
-import {
-  createBrowserRouter,
-  RouterProvider,
-  Navigate,
-  Link,
-  type RouteObject,
-} from 'react-router-dom';
+import { createBrowserRouter, Navigate, Link, type RouteObject } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 import { Loader2 } from 'lucide-react';
 import { FocusedArticleProvider } from './contexts/focusedArticle';
 import { AuthProvider } from './contexts/auth';

--- a/frontend/src/__tests__/BriefingChat.test.tsx
+++ b/frontend/src/__tests__/BriefingChat.test.tsx
@@ -2,7 +2,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { BriefingChat } from '../components/BriefingChat';
 import * as api from '../api';
 

--- a/frontend/src/__tests__/aiStatsPage.test.tsx
+++ b/frontend/src/__tests__/aiStatsPage.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AiStatsPage } from '../pages/AiStatsPage';
 import * as api from '../api';

--- a/frontend/src/__tests__/appLogo.test.tsx
+++ b/frontend/src/__tests__/appLogo.test.tsx
@@ -6,7 +6,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppLogo } from '../components/AppLogo';
 import { LoginPage } from '../pages/LoginPage';

--- a/frontend/src/__tests__/appRouter.test.tsx
+++ b/frontend/src/__tests__/appRouter.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { createMemoryRouter } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 
 // Stub every page/shell so the route table can be exercised cheaply without
 // pulling in real data fetching. Each stub renders an identifiable marker.
@@ -16,7 +17,7 @@ vi.mock('../components/RequireAuth', () => ({
   RequireAuth: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 vi.mock('../components/AppShell', async () => {
-  const { Outlet } = await import('react-router-dom');
+  const { Outlet } = await import('react-router');
   return { AppShell: () => <Outlet /> };
 });
 vi.mock('../contexts/auth', () => ({
@@ -35,7 +36,7 @@ vi.mock('../pages/StarredPage', () => ({ StarredPage: stub('starred-page') }));
 vi.mock('../pages/SearchPage', () => ({ SearchPage: stub('search-page') }));
 vi.mock('../pages/AskPage', () => ({ AskPage: stub('ask-page') }));
 vi.mock('../pages/FeedsPage', async () => {
-  const { Outlet } = await import('react-router-dom');
+  const { Outlet } = await import('react-router');
   return {
     FeedsPage: () => (
       <div>

--- a/frontend/src/__tests__/articleListView.test.tsx
+++ b/frontend/src/__tests__/articleListView.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
 import { ListenQueueProvider } from '../contexts/listenQueue';

--- a/frontend/src/__tests__/articleReader.test.tsx
+++ b/frontend/src/__tests__/articleReader.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ArticlePage } from '../pages/ArticlePage';
 import * as api from '../api';

--- a/frontend/src/__tests__/articleRow.test.tsx
+++ b/frontend/src/__tests__/articleRow.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ArticleRow } from '../components/article/ArticleRow';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 

--- a/frontend/src/__tests__/ask.test.tsx
+++ b/frontend/src/__tests__/ask.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { AskPage } from '../pages/AskPage';
 import * as api from '../api';
 

--- a/frontend/src/__tests__/askPageAgentActions.test.tsx
+++ b/frontend/src/__tests__/askPageAgentActions.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 const apiMock = vi.hoisted(() => ({
   askAI: vi.fn(),

--- a/frontend/src/__tests__/auth.test.tsx
+++ b/frontend/src/__tests__/auth.test.tsx
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useEffect } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider, useAuth } from '../contexts/auth';
 import { RequireAuth } from '../components/RequireAuth';

--- a/frontend/src/__tests__/brandRebrand.test.tsx
+++ b/frontend/src/__tests__/brandRebrand.test.tsx
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '../contexts/auth';
 import { LoginPage } from '../pages/LoginPage';

--- a/frontend/src/__tests__/brief.test.tsx
+++ b/frontend/src/__tests__/brief.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BriefPage } from '../pages/BriefPage';
 import * as api from '../api';

--- a/frontend/src/__tests__/briefingsHistory.test.tsx
+++ b/frontend/src/__tests__/briefingsHistory.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BriefingsHistoryPage } from '../pages/BriefingsHistoryPage';
 import { BriefingDetailPage } from '../pages/BriefingDetailPage';

--- a/frontend/src/__tests__/commandPalette.test.tsx
+++ b/frontend/src/__tests__/commandPalette.test.tsx
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
 import { AuthProvider } from '../contexts/auth';

--- a/frontend/src/__tests__/dailyBriefSettings.test.tsx
+++ b/frontend/src/__tests__/dailyBriefSettings.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/contexts/auth';
 

--- a/frontend/src/__tests__/feedsPages.test.tsx
+++ b/frontend/src/__tests__/feedsPages.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, type ReactElement, type ReactNode } from 'react';
 import type { Source, User } from '../types';

--- a/frontend/src/__tests__/i18n.test.tsx
+++ b/frontend/src/__tests__/i18n.test.tsx
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { I18nextProvider } from 'react-i18next';
 import { AuthProvider } from '@/contexts/auth';
 import userEvent from '@testing-library/user-event';

--- a/frontend/src/__tests__/knowledgeGraph.test.tsx
+++ b/frontend/src/__tests__/knowledgeGraph.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AiStatsPage } from '../pages/AiStatsPage';
 import * as api from '../api';

--- a/frontend/src/__tests__/learnPage.test.tsx
+++ b/frontend/src/__tests__/learnPage.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LearnPage } from '../pages/LearnPage';
 import { HttpError, createLessonFromLink, fetchLesson } from '../api';

--- a/frontend/src/__tests__/lessonDetailPage.test.tsx
+++ b/frontend/src/__tests__/lessonDetailPage.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LessonDetailPage } from '../pages/LessonDetailPage';
 import type { Lesson } from '../api';

--- a/frontend/src/__tests__/lessonLibraryPage.test.tsx
+++ b/frontend/src/__tests__/lessonLibraryPage.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LessonLibraryPage } from '../pages/LessonLibraryPage';
 import type { Lesson } from '../api';

--- a/frontend/src/__tests__/lessonRecapPage.test.tsx
+++ b/frontend/src/__tests__/lessonRecapPage.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import * as api from '../api';
 import { LessonRecapPage } from '../pages/LessonRecapPage';
 import type { LessonRecap } from '../types';

--- a/frontend/src/__tests__/listenQueuePlayer.test.tsx
+++ b/frontend/src/__tests__/listenQueuePlayer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ListenQueueProvider, useListenQueue } from '../contexts/listenQueue';
 import { ListenQueuePlayer } from '../components/ListenQueuePlayer';
 import * as api from '../api';

--- a/frontend/src/__tests__/navLink.test.tsx
+++ b/frontend/src/__tests__/navLink.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { Home } from 'lucide-react';
 import { NavLink } from '../components/NavLink';
 

--- a/frontend/src/__tests__/offlineSavedPage.test.tsx
+++ b/frontend/src/__tests__/offlineSavedPage.test.tsx
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { OfflineSavedPage } from '../pages/OfflineSavedPage';
 import { saveOfflineArticle } from '../lib/offline';
 

--- a/frontend/src/__tests__/palette.test.tsx
+++ b/frontend/src/__tests__/palette.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, type ReactNode } from 'react';
 import { CommandPalette } from '../components/CommandPalette';

--- a/frontend/src/__tests__/quizCandidates.test.tsx
+++ b/frontend/src/__tests__/quizCandidates.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReadingDnaPage } from '../pages/ReadingDnaPage';
 import * as api from '../api';

--- a/frontend/src/__tests__/readingList.test.tsx
+++ b/frontend/src/__tests__/readingList.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { DragEndEvent } from '@dnd-kit/core';
 import { ReadingListPage } from '../pages/ReadingListPage';

--- a/frontend/src/__tests__/recommendationContracts.test.tsx
+++ b/frontend/src/__tests__/recommendationContracts.test.tsx
@@ -10,7 +10,7 @@
 // keep working regardless of an article's recommendation metadata.
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ArticleRow } from '../components/article/ArticleRow';
 import type { WorkflowArticle } from '../lib/workflowTypes';
 

--- a/frontend/src/__tests__/recommendationLabel.test.tsx
+++ b/frontend/src/__tests__/recommendationLabel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ArticleRow } from '../components/article/ArticleRow';
 import {
   recommendationLabel,

--- a/frontend/src/__tests__/routeErrorRecovery.test.tsx
+++ b/frontend/src/__tests__/routeErrorRecovery.test.tsx
@@ -2,7 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 import { RouteErrorRecovery } from '../components/RouteErrorRecovery';
 import * as errorTracking from '../lib/errorTracking';
 

--- a/frontend/src/__tests__/routing.test.tsx
+++ b/frontend/src/__tests__/routing.test.tsx
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@/lib/i18n';
 import { AppShell } from '../components/AppShell';

--- a/frontend/src/__tests__/search.test.tsx
+++ b/frontend/src/__tests__/search.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SearchPage } from '../pages/SearchPage';
 import * as workflowApi from '../api/workflowApi';

--- a/frontend/src/__tests__/settingsPlatforms.test.tsx
+++ b/frontend/src/__tests__/settingsPlatforms.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/contexts/auth';
 

--- a/frontend/src/__tests__/shareTarget.test.tsx
+++ b/frontend/src/__tests__/shareTarget.test.tsx
@@ -2,7 +2,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as api from '../api';
 import * as readingListApi from '../api/readingListApi';

--- a/frontend/src/__tests__/shared.test.tsx
+++ b/frontend/src/__tests__/shared.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 

--- a/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
+++ b/frontend/src/__tests__/statsSettingsRunsPages.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ── Shared API mock ──────────────────────────────────────────────────────────

--- a/frontend/src/__tests__/topicMapPage.test.tsx
+++ b/frontend/src/__tests__/topicMapPage.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TopicMapPage } from '../pages/TopicMapPage';
 import * as api from '../api';

--- a/frontend/src/__tests__/triagePages.test.tsx
+++ b/frontend/src/__tests__/triagePages.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FocusedArticleProvider } from '../contexts/focusedArticle';
 import { ListenQueueProvider } from '../contexts/listenQueue';

--- a/frontend/src/__tests__/watchlistsSettings.test.tsx
+++ b/frontend/src/__tests__/watchlistsSettings.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/contexts/auth';
 

--- a/frontend/src/components/AppShell.dify.test.tsx
+++ b/frontend/src/components/AppShell.dify.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 const { captureDifyProps } = vi.hoisted(() => ({
   captureDifyProps: vi.fn(),

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate, Outlet, Link } from 'react-router-dom';
+import { useLocation, useNavigate, Outlet, Link } from 'react-router';
 import { useState, useEffect, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';

--- a/frontend/src/components/BriefingChat.tsx
+++ b/frontend/src/components/BriefingChat.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { MessageCircle, Send, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/frontend/src/components/BriefingView.tsx
+++ b/frontend/src/components/BriefingView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { RefreshCw, Headphones, ChevronDown, ChevronUp, Sparkles, AlertCircle } from 'lucide-react';
 import { AiFeedbackThumbs } from '@/components/AiFeedbackThumbs';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/components/CategoryFilter.tsx
+++ b/frontend/src/components/CategoryFilter.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { cn } from '@/lib/utils';
 
 const CATEGORIES = [

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Command } from 'cmdk';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { toast } from 'sonner';

--- a/frontend/src/components/LessonConceptGraph.tsx
+++ b/frontend/src/components/LessonConceptGraph.tsx
@@ -14,7 +14,7 @@ import {
   type NodeProps,
   type OnNodesChange,
 } from '@xyflow/react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { LessonDetail, LessonGraphContext, LessonGraphEntity } from '@/api';
 import { Badge } from '@/components/ui/badge';
 import { forceLayout } from '@/lib/forceLayout';

--- a/frontend/src/components/ListenQueuePlayer.tsx
+++ b/frontend/src/components/ListenQueuePlayer.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Loader2, Pause, Play, SkipBack, SkipForward, X } from 'lucide-react';
 import { useListenQueue } from '@/contexts/listenQueue';
 import { cn } from '@/lib/utils';

--- a/frontend/src/components/NavLink.tsx
+++ b/frontend/src/components/NavLink.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { fetchMe, HttpError, sessionExpiredEvent } from '@/api';
 import { useAuth } from '@/contexts/auth';
 import { AppLogo } from './AppLogo';

--- a/frontend/src/components/RouteErrorRecovery.tsx
+++ b/frontend/src/components/RouteErrorRecovery.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { isRouteErrorResponse, Link, useRevalidator, useRouteError } from 'react-router-dom';
+import { isRouteErrorResponse, Link, useRevalidator, useRouteError } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { reportError } from '@/lib/errorTracking';
 import { isChunkLoadError } from '@/lib/chunkError';

--- a/frontend/src/components/aiStats/EmbeddingMapChart.tsx
+++ b/frontend/src/components/aiStats/EmbeddingMapChart.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { EmbeddingMapCluster, EmbeddingMapPoint } from '@/types';
 import { categoryColorMap, colorForCategory } from '@/lib/categoryColor';
 import { convexHull, hullPath, padHull } from '@/lib/convexHull';

--- a/frontend/src/components/aiStats/KnowledgeGraph.tsx
+++ b/frontend/src/components/aiStats/KnowledgeGraph.tsx
@@ -14,7 +14,7 @@ import {
   type NodeProps,
   type OnNodesChange,
 } from '@xyflow/react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type {
   EntityType,
   KnowledgeGraphEdge,

--- a/frontend/src/components/article/ArticleListView.tsx
+++ b/frontend/src/components/article/ArticleListView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useInfiniteQuery, type QueryKey } from '@tanstack/react-query';
 import { Headphones, type LucideIcon } from 'lucide-react';
 import { ArticleRow } from '@/components/article/ArticleRow';

--- a/frontend/src/components/article/ArticleRow.tsx
+++ b/frontend/src/components/article/ArticleRow.tsx
@@ -1,6 +1,6 @@
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Star, Info, Siren } from 'lucide-react';
 import type { WorkflowArticle } from '@/lib/workflowTypes';
 import { relativeTime, signalLabel } from '@/lib/format';

--- a/frontend/src/components/settings/DeleteAccountSection.tsx
+++ b/frontend/src/components/settings/DeleteAccountSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RefreshCw, Trash2 } from 'lucide-react';
 import { useAuth } from '@/contexts/auth';
 import { deleteOwnAccount } from '@/api';

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { logoutUser } from '@/api';
 import { useAuth } from '@/contexts/auth';
 

--- a/frontend/src/pages/ArchivePage.tsx
+++ b/frontend/src/pages/ArchivePage.tsx
@@ -1,5 +1,5 @@
 import { Archive as ArchiveIcon } from 'lucide-react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { ArticleListView } from '@/components/article/ArticleListView';
 import { fetchTriageArticles } from '@/api/workflowApi';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';

--- a/frontend/src/pages/ArticlePage.tsx
+++ b/frontend/src/pages/ArticlePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';

--- a/frontend/src/pages/AskPage.tsx
+++ b/frontend/src/pages/AskPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   Sparkles,
   Loader2,

--- a/frontend/src/pages/BriefPage.tsx
+++ b/frontend/src/pages/BriefPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { Newspaper, RefreshCw, AlertCircle, Inbox, History, Wand2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/pages/BriefingDetailPage.tsx
+++ b/frontend/src/pages/BriefingDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, AlertCircle, Newspaper } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/pages/BriefingsHistoryPage.tsx
+++ b/frontend/src/pages/BriefingsHistoryPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Newspaper, AlertCircle, ChevronRight, Check, Copy, RefreshCw, Rss } from 'lucide-react';
 import { toast } from 'sonner';

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { Tag as TagIcon } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { ArticleListView } from '@/components/article/ArticleListView';

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Tag as TagIcon, Trash2 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';

--- a/frontend/src/pages/FeedsPage.tsx
+++ b/frontend/src/pages/FeedsPage.tsx
@@ -1,4 +1,4 @@
-import { Outlet, NavLink, useLocation } from 'react-router-dom';
+import { Outlet, NavLink, useLocation } from 'react-router';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/auth';
 

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -1,5 +1,5 @@
 import { Inbox } from 'lucide-react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { ArticleListView } from '@/components/article/ArticleListView';
 import { FeedNudgeBanner } from '@/components/FeedNudgeBanner';
 import { fetchTriageArticles } from '@/api/workflowApi';

--- a/frontend/src/pages/LessonDetailPage.tsx
+++ b/frontend/src/pages/LessonDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { LessonDetailView } from '@/components/LessonDetailView';

--- a/frontend/src/pages/LessonLibraryPage.tsx
+++ b/frontend/src/pages/LessonLibraryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { AlertCircle, ExternalLink, GraduationCap, Loader2, Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/pages/LessonRecapPage.tsx
+++ b/frontend/src/pages/LessonRecapPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AlertCircle, GraduationCap, Headphones, Loader2 } from 'lucide-react';
 import { fetchLessonRecaps, generateLessonRecap, generateLessonRecapPodcast } from '../api';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type FormEvent } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   HttpError,

--- a/frontend/src/pages/OfflineSavedPage.tsx
+++ b/frontend/src/pages/OfflineSavedPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ExternalLink, Trash2, WifiOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { listOfflineArticles, removeOfflineArticle, type OfflineArticle } from '@/lib/offline';

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useEffect, useRef, useState } from 'react';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Search as SearchIcon } from 'lucide-react';

--- a/frontend/src/pages/ShareTargetPage.tsx
+++ b/frontend/src/pages/ShareTargetPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { Bookmark, Loader2, Newspaper, TriangleAlert } from 'lucide-react';
 import { saveSharedUrl } from '@/api';
 import { addReadingListItem } from '@/api/readingListApi';

--- a/frontend/src/pages/SharedDetailPage.tsx
+++ b/frontend/src/pages/SharedDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, ExternalLink, Sparkles, MessageSquare, Highlighter, Send } from 'lucide-react';
 import { fetchShareDetail, postShareMessage } from '@/api';

--- a/frontend/src/pages/SharedPage.tsx
+++ b/frontend/src/pages/SharedPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { Send, ExternalLink, Ban } from 'lucide-react';
 import { toast } from 'sonner';

--- a/frontend/src/pages/StarredPage.tsx
+++ b/frontend/src/pages/StarredPage.tsx
@@ -1,5 +1,5 @@
 import { Star } from 'lucide-react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { ArticleListView } from '@/components/article/ArticleListView';
 import { fetchTriageArticles } from '@/api/workflowApi';
 import { ARTICLES_KEY } from '@/hooks/useTriageMutations';

--- a/frontend/src/pages/TopicMapPage.tsx
+++ b/frontend/src/pages/TopicMapPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Loader2, AlertCircle, Network, RefreshCw } from 'lucide-react';
 import { fetchTopicMap } from '@/api';
 import type { TopicMapArticle } from '@/types';

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-i18next": "^17.0.11",
-        "react-router-dom": "^7.18.2",
+        "react-router": "^8.3.0",
         "recharts": "^3.10.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
@@ -3094,9 +3094,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3112,9 +3109,6 @@
       "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3132,9 +3126,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3150,9 +3141,6 @@
       "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3170,9 +3158,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3188,9 +3173,6 @@
       "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5482,18 +5464,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -9165,41 +9140,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
-      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -9616,12 +9574,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -10919,9 +10871,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10941,9 +10890,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10965,9 +10911,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10987,9 +10930,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-i18next": "^17.0.11",
-    "react-router-dom": "^7.18.2",
+    "react-router": "^8.3.0",
     "recharts": "^3.10.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -105,7 +105,7 @@ export default defineConfig({
         // the app-shell "index" chunk every time application code changes.
         manualChunks(id) {
           if (
-            /node_modules\/(react|react-dom|react-router-dom|i18next|react-i18next|i18next-browser-languagedetector|@tanstack\/react-query|sonner)\//.test(
+            /node_modules\/(react|react-dom|react-router|i18next|react-i18next|i18next-browser-languagedetector|@tanstack\/react-query|sonner)\//.test(
               id
             )
           ) {


### PR DESCRIPTION
Closes #1359

Resolves [Dependabot alert #53](https://github.com/lihor-hub/news-dashboard/security/dependabot/53) (GHSA-qwww-vcr4-c8h2, high severity: RSC-mode CSRF bypass in react-router >= 7.12.0, < 8.3.0).

## What changed

- `react-router-dom@^7.18.2` → `react-router@^8.3.0` in the root `package.json`. The alert can only be resolved at 8.3.0, and v8 removed the `react-router-dom` package (already a pure re-export shim in v7), so the app now depends on `react-router` directly.
- All `from 'react-router-dom'` imports in `frontend/src` (79 files) moved to `react-router`; `RouterProvider` imports moved to `react-router/dom` per v8 guidance (4 files).
- `vite.config.ts` vendor `manualChunks` regex updated for the package rename.
- Lockfile fallout is minimal: react-router 8.3.0 plus its new `cookie-es` dependency; `website/` (react-router 5.x) and `desktop/` lockfiles are untouched.

The app does not use the unstable RSC APIs the CVE targets, so this is vulnerability hygiene rather than an active exposure. v8 baseline requirements (Node 22.22+/React 19.2.7+/ESM-only) are all met — CI runs Node 26 and the app is on React 19.2.8 with Vite 8.

## Verification

- `npm run test:frontend` — 1030 tests / 97 files pass
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm run build` — passes, all 115 chunks within the 500 kB budget, CSP check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)