### PR TITLE
feat(mcp): add grounded news question answering

### DIFF
--- a/backend/news_dashboard/a2a/service.py
+++ b/backend/news_dashboard/a2a/service.py
@@ -71,7 +71,7 @@ def build_agent_card() -> AgentCard:
         name="News Dashboard Assistant",
         description=(
             "Answers questions over the token owner's news corpus using retrieval "
-            "over their saved and read articles. Read-only: it cannot modify any "
+            "over their Starred + Done articles. Read-only: it cannot modify any "
             "dashboard state."
         ),
         version=read_app_version(),
@@ -98,8 +98,8 @@ def build_agent_card() -> AgentCard:
                 id=SKILL_ID,
                 name="Ask over news corpus",
                 description=(
-                    "Ask a question answered via retrieval over the articles "
-                    "visible to the token owner."
+                    "Ask a question answered via retrieval over the token owner's "
+                    "Starred + Done articles."
                 ),
                 tags=["news", "rag", "question-answering", "read-only"],
                 examples=["What happened in AI infrastructure this week?"],

--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -200,6 +200,7 @@ def get_openai_client(
     api_key: str,
     base_url: str | None = None,
     timeout_seconds: float | None = None,
+    enable_tracing: bool = True,
 ) -> OpenAI:
     """Return an OpenAI client, Langfuse-wrapped when tracing is configured.
 
@@ -213,7 +214,7 @@ def get_openai_client(
     if base_url is not None:
         kwargs["base_url"] = base_url
 
-    if langfuse_enabled():
+    if enable_tracing and langfuse_enabled():
         _normalise_host_env()
         # Langfuse's drop-in client subclasses openai.OpenAI and traces every
         # request. Resolve it dynamically so this module type-checks whether or
@@ -235,6 +236,7 @@ def get_chat_model(
     max_tokens: int | None = None,
     temperature: float | None = None,
     response_format: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
 ) -> Runnable[LanguageModelInput, AIMessage]:
     """Return a LangChain chat model with the existing OpenAI fallback semantics."""
     from langchain_core.runnables import RunnableConfig, RunnableLambda
@@ -244,7 +246,7 @@ def get_chat_model(
     kwargs: dict[str, Any] = {
         "api_key": api_key,
         "model": model,
-        "timeout": request_timeout_seconds(),
+        "timeout": request_timeout_seconds() if timeout_seconds is None else timeout_seconds,
     }
     if base_url is not None:
         kwargs["base_url"] = base_url
@@ -263,7 +265,7 @@ def get_chat_model(
     fallback_kwargs: dict[str, Any] = {
         "api_key": openai_key,
         "model": model,
-        "timeout": request_timeout_seconds(),
+        "timeout": request_timeout_seconds() if timeout_seconds is None else timeout_seconds,
     }
     if openai_base is not None:
         fallback_kwargs["base_url"] = openai_base
@@ -298,7 +300,7 @@ def response_text(message: AIMessage) -> str:
 
 def _invoke[T](
     primary: OpenAI,
-    fallback: tuple[str, str | None] | None,
+    fallback: tuple[str, str | None, float | None, bool] | None,
     call: Callable[[OpenAI], T],
 ) -> T:
     """Run *call* against *primary*; on OpenAIError retry once on the OpenAI fallback.
@@ -316,15 +318,24 @@ def _invoke[T](
     try:
         return call(primary)
     except OpenAIError as exc:
-        api_key, base_url = fallback
-        logger.warning("free LLM request failed (%s); retrying on OpenAI fallback", exc)
-        return call(get_openai_client(api_key=api_key, base_url=base_url))
+        api_key, base_url, timeout_seconds, enable_tracing = fallback
+        if enable_tracing:
+            logger.warning("free LLM request failed (%s); retrying on OpenAI fallback", exc)
+        else:
+            logger.warning("free LLM request failed; retrying on OpenAI fallback")
+        kwargs: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+        if timeout_seconds is not None:
+            kwargs["timeout_seconds"] = timeout_seconds
+        kwargs["enable_tracing"] = enable_tracing
+        return call(get_openai_client(**kwargs))
 
 
 class _FallbackCompletions:
     """``chat.completions`` shim that routes ``create`` through :func:`_invoke`."""
 
-    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+    def __init__(
+        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+    ) -> None:
         self._primary = primary
         self._fallback = fallback
 
@@ -335,14 +346,18 @@ class _FallbackCompletions:
 class _FallbackChat:
     """``chat`` namespace exposing a fallback-aware ``completions``."""
 
-    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+    def __init__(
+        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+    ) -> None:
         self.completions = _FallbackCompletions(primary, fallback)
 
 
 class _FallbackEmbeddings:
     """``embeddings`` shim that routes ``create`` through :func:`_invoke`."""
 
-    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+    def __init__(
+        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+    ) -> None:
         self._primary = primary
         self._fallback = fallback
 
@@ -358,12 +373,20 @@ class _FallbackClient:
     LLM) client and falls back to OpenAI on failure (see :func:`get_chat_client`).
     """
 
-    def __init__(self, primary: OpenAI, fallback: tuple[str, str | None] | None) -> None:
+    def __init__(
+        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+    ) -> None:
         self.chat = _FallbackChat(primary, fallback)
         self.embeddings = _FallbackEmbeddings(primary, fallback)
 
 
-def get_chat_client(*, api_key: str, base_url: str | None = None) -> OpenAI:
+def get_chat_client(
+    *,
+    api_key: str,
+    base_url: str | None = None,
+    timeout_seconds: float | None = None,
+    enable_tracing: bool = True,
+) -> OpenAI:
     """Return a chat/embedding client that prefers the free LLM gateway.
 
     *api_key* / *base_url* are the primary (free LLM) credentials, as resolved by
@@ -378,11 +401,16 @@ def get_chat_client(*, api_key: str, base_url: str | None = None) -> OpenAI:
     ``chat.completions.create`` and ``embeddings.create`` calls made through it.
     The OpenAI fallback client is built lazily, only on the first failure.
     """
-    primary = get_openai_client(api_key=api_key, base_url=base_url)
+    client_kwargs: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+    if timeout_seconds is not None:
+        client_kwargs["timeout_seconds"] = timeout_seconds
+    if not enable_tracing:
+        client_kwargs["enable_tracing"] = False
+    primary = get_openai_client(**client_kwargs)
     openai_key, openai_base = openai_config()
-    fallback: tuple[str, str | None] | None = None
+    fallback: tuple[str, str | None, float | None, bool] | None = None
     if openai_key and (openai_key, openai_base) != (api_key, base_url):
-        fallback = (openai_key, openai_base)
+        fallback = (openai_key, openai_base, timeout_seconds, enable_tracing)
     return cast("OpenAI", _FallbackClient(primary, fallback))
 
 

--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -40,6 +40,16 @@ _DEFAULT_AI_REQUEST_TIMEOUT_SECONDS = 30.0
 _DEFAULT_AI_TTS_TIMEOUT_SECONDS = 120.0
 
 
+@dataclass(frozen=True)
+class SafeAIObservation:
+    """Metadata-only Langfuse observation for a provider operation."""
+
+    operation: str
+    as_type: Literal["generation", "embedding"]
+    model: str
+    model_parameters: dict[str, str | int | float | bool] = field(default_factory=dict)
+
+
 def _timeout_seconds_from_env(name: str, default: float) -> float:
     value = os.getenv(name)
     if value is None:
@@ -302,6 +312,8 @@ def _invoke[T](
     primary: OpenAI,
     fallback: tuple[str, str | None, float | None, bool] | None,
     call: Callable[[OpenAI], T],
+    observation: SafeAIObservation | None = None,
+    request_attempt: int = 1,
 ) -> T:
     """Run *call* against *primary*; on OpenAIError retry once on the OpenAI fallback.
 
@@ -311,12 +323,26 @@ def _invoke[T](
     runs directly against *primary* and any error propagates unchanged.
     """
     if fallback is None:
-        return call(primary)
+        return _safe_provider_call(
+            primary,
+            call,
+            observation,
+            provider="primary",
+            attempt=1,
+            request_attempt=request_attempt,
+        )
 
     from openai import OpenAIError  # lazy import — optional dep at import time
 
     try:
-        return call(primary)
+        return _safe_provider_call(
+            primary,
+            call,
+            observation,
+            provider="primary",
+            attempt=1,
+            request_attempt=request_attempt,
+        )
     except OpenAIError as exc:
         api_key, base_url, timeout_seconds, enable_tracing = fallback
         if enable_tracing:
@@ -326,43 +352,146 @@ def _invoke[T](
         kwargs: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
         if timeout_seconds is not None:
             kwargs["timeout_seconds"] = timeout_seconds
-        kwargs["enable_tracing"] = enable_tracing
-        return call(get_openai_client(**kwargs))
+        if not enable_tracing:
+            kwargs["enable_tracing"] = False
+        fallback_client = get_openai_client(**kwargs)
+        return _safe_provider_call(
+            fallback_client,
+            call,
+            observation,
+            provider="fallback",
+            attempt=2,
+            request_attempt=request_attempt,
+        )
+
+
+def _usage_details(response: Any) -> dict[str, int]:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return {}
+    fields = {
+        "input": getattr(usage, "prompt_tokens", None),
+        "output": getattr(usage, "completion_tokens", None),
+        "total": getattr(usage, "total_tokens", None),
+    }
+    return {name: value for name, value in fields.items() if isinstance(value, int)}
+
+
+def _cost_details(response: Any) -> dict[str, float]:
+    usage = getattr(response, "usage", None)
+    cost = getattr(usage, "cost", None)
+    return {"total": cost} if isinstance(cost, float) else {}
+
+
+def _safe_provider_call[T](
+    client: OpenAI,
+    call: Callable[[OpenAI], T],
+    observation: SafeAIObservation | None,
+    *,
+    provider: str,
+    attempt: int,
+    request_attempt: int,
+) -> T:
+    if observation is None or not langfuse_enabled():
+        return call(client)
+    metadata = {
+        "operation": observation.operation,
+        "provider": provider,
+        "attempt": attempt,
+        "retry": request_attempt - 1,
+    }
+    with _client().start_as_current_observation(
+        name=f"{observation.operation}-{provider}",
+        as_type=observation.as_type,
+        input=None,
+        model=observation.model,
+        model_parameters=observation.model_parameters,
+        metadata=metadata,
+    ) as provider_observation:
+        try:
+            response = call(client)
+        except Exception:
+            provider_observation.update(
+                output={"status": "error"},
+                level="ERROR",
+                status_message="provider request failed",
+                metadata={**metadata, "outcome": "failure"},
+            )
+            raise
+        update: dict[str, Any] = {
+            "output": {"status": "ok"},
+            "usage_details": _usage_details(response),
+            "metadata": {**metadata, "outcome": "success"},
+        }
+        cost_details = _cost_details(response)
+        if cost_details:
+            update["cost_details"] = cost_details
+        provider_observation.update(
+            **update,
+        )
+        return response
 
 
 class _FallbackCompletions:
     """``chat.completions`` shim that routes ``create`` through :func:`_invoke`."""
 
     def __init__(
-        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+        self,
+        primary: OpenAI,
+        fallback: tuple[str, str | None, float | None, bool] | None,
+        observation: SafeAIObservation | None,
     ) -> None:
         self._primary = primary
         self._fallback = fallback
+        self._observation = observation
+        self._request_attempt = 0
 
     def create(self, **kwargs: Any) -> Any:
-        return _invoke(self._primary, self._fallback, lambda c: c.chat.completions.create(**kwargs))
+        self._request_attempt += 1
+        return _invoke(
+            self._primary,
+            self._fallback,
+            lambda c: c.chat.completions.create(**kwargs),
+            self._observation,
+            self._request_attempt,
+        )
 
 
 class _FallbackChat:
     """``chat`` namespace exposing a fallback-aware ``completions``."""
 
     def __init__(
-        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+        self,
+        primary: OpenAI,
+        fallback: tuple[str, str | None, float | None, bool] | None,
+        observation: SafeAIObservation | None,
     ) -> None:
-        self.completions = _FallbackCompletions(primary, fallback)
+        self.completions = _FallbackCompletions(primary, fallback, observation)
 
 
 class _FallbackEmbeddings:
     """``embeddings`` shim that routes ``create`` through :func:`_invoke`."""
 
     def __init__(
-        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+        self,
+        primary: OpenAI,
+        fallback: tuple[str, str | None, float | None, bool] | None,
+        observation: SafeAIObservation | None,
     ) -> None:
         self._primary = primary
         self._fallback = fallback
+        self._observation = observation
+        self._request_attempt = 0
 
     def create(self, **kwargs: Any) -> Any:
-        return _invoke(self._primary, self._fallback, lambda c: c.embeddings.create(**kwargs))
+        self._request_attempt += 1
+        return _invoke(
+            self._primary,
+            self._fallback,
+            lambda c: c.embeddings.create(**kwargs),
+            self._observation,
+            self._request_attempt,
+        )
 
 
 class _FallbackClient:
@@ -374,10 +503,13 @@ class _FallbackClient:
     """
 
     def __init__(
-        self, primary: OpenAI, fallback: tuple[str, str | None, float | None, bool] | None
+        self,
+        primary: OpenAI,
+        fallback: tuple[str, str | None, float | None, bool] | None,
+        observation: SafeAIObservation | None,
     ) -> None:
-        self.chat = _FallbackChat(primary, fallback)
-        self.embeddings = _FallbackEmbeddings(primary, fallback)
+        self.chat = _FallbackChat(primary, fallback, observation)
+        self.embeddings = _FallbackEmbeddings(primary, fallback, observation)
 
 
 def get_chat_client(
@@ -386,6 +518,7 @@ def get_chat_client(
     base_url: str | None = None,
     timeout_seconds: float | None = None,
     enable_tracing: bool = True,
+    safe_observation: SafeAIObservation | None = None,
 ) -> OpenAI:
     """Return a chat/embedding client that prefers the free LLM gateway.
 
@@ -411,7 +544,32 @@ def get_chat_client(
     fallback: tuple[str, str | None, float | None, bool] | None = None
     if openai_key and (openai_key, openai_base) != (api_key, base_url):
         fallback = (openai_key, openai_base, timeout_seconds, enable_tracing)
-    return cast("OpenAI", _FallbackClient(primary, fallback))
+    return cast("OpenAI", _FallbackClient(primary, fallback, safe_observation))
+
+
+def record_mcp_ask_result(
+    trace_id: str,
+    *,
+    citation_count: int,
+    truncated: bool,
+    status: str,
+) -> None:
+    """Attach final MCP response-shaping metadata to an existing Ask trace."""
+    if not langfuse_enabled():
+        return
+    try:
+        observation = _client().start_observation(
+            trace_context={"trace_id": trace_id},
+            name="mcp-result",
+            as_type="span",
+            input=None,
+            metadata={"surface": "mcp", "operation": "ask-result"},
+        )
+        observation.end(
+            output={"citation_count": citation_count, "truncated": truncated, "status": status}
+        )
+    except Exception:
+        logger.warning("Failed to record MCP result observation")
 
 
 # ── Trace context ────────────────────────────────────────────────────────

--- a/backend/news_dashboard/ai_client.py
+++ b/backend/news_dashboard/ai_client.py
@@ -400,6 +400,9 @@ def _safe_provider_call[T](
         "attempt": attempt,
         "retry": request_attempt - 1,
     }
+    response: T | None = None
+    failure: BaseException | None = None
+    failure_traceback = None
     with _client().start_as_current_observation(
         name=f"{observation.operation}-{provider}",
         as_type=observation.as_type,
@@ -410,26 +413,32 @@ def _safe_provider_call[T](
     ) as provider_observation:
         try:
             response = call(client)
-        except Exception:
+        except BaseException as exc:
             provider_observation.update(
                 output={"status": "error"},
                 level="ERROR",
                 status_message="provider request failed",
                 metadata={**metadata, "outcome": "failure"},
             )
-            raise
-        update: dict[str, Any] = {
-            "output": {"status": "ok"},
-            "usage_details": _usage_details(response),
-            "metadata": {**metadata, "outcome": "success"},
-        }
-        cost_details = _cost_details(response)
-        if cost_details:
-            update["cost_details"] = cost_details
-        provider_observation.update(
-            **update,
-        )
-        return response
+            response = None
+            failure = exc
+            failure_traceback = exc.__traceback__
+        else:
+            update: dict[str, Any] = {
+                "output": {"status": "ok"},
+                "usage_details": _usage_details(response),
+                "metadata": {**metadata, "outcome": "success"},
+            }
+            cost_details = _cost_details(response)
+            if cost_details:
+                update["cost_details"] = cost_details
+            provider_observation.update(**update)
+    if failure is not None:
+        raise failure.with_traceback(failure_traceback)
+    if response is None:
+        message = "Provider returned no response"
+        raise RuntimeError(message)
+    return response
 
 
 class _FallbackCompletions:

--- a/backend/news_dashboard/assistant/service.py
+++ b/backend/news_dashboard/assistant/service.py
@@ -2,18 +2,54 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from news_dashboard.agent_actions import AgentActionError, AgentActionNotFoundError
 from news_dashboard.embeddings import EmbeddingUnavailableError
 
 
+@dataclass(frozen=True)
+class AskExecutionPolicy:
+    """Optional execution limits and trace privacy controls for Ask AI."""
+
+    backfill_limit: int | None = None
+    retrieval_limit: int = 8
+    answer_max_tokens: int | None = None
+    provider_timeout_seconds: float | None = None
+    trace_content: bool = True
+    trace_surface: str | None = None
+
+    @classmethod
+    def mcp(cls) -> AskExecutionPolicy:
+        return cls(
+            backfill_limit=16,
+            retrieval_limit=8,
+            answer_max_tokens=512,
+            provider_timeout_seconds=20.0,
+            trace_content=False,
+            trace_surface="mcp",
+        )
+
+
 def ask(
-    query: str, *, include_all: bool, user_id: int, session_id: str | None = None
+    query: str,
+    *,
+    include_all: bool,
+    user_id: int,
+    session_id: str | None = None,
+    execution_policy: AskExecutionPolicy | None = None,
 ) -> dict[str, Any]:
     from news_dashboard.embeddings import ask as ask_impl
 
-    return ask_impl(query, include_all=include_all, user_id=user_id, session_id=session_id)
+    kwargs: dict[str, Any] = {
+        "include_all": include_all,
+        "user_id": user_id,
+        "session_id": session_id,
+    }
+    if execution_policy is not None:
+        kwargs["execution_policy"] = execution_policy
+    return ask_impl(query, **kwargs)
 
 
 def plan_actions(query: str, *, user_id: int, is_admin: bool) -> dict[str, Any]:
@@ -78,6 +114,7 @@ def record_feedback(*, user_id: int, trace_id: str, helpful: bool, comment: str 
 __all__ = [
     "AgentActionError",
     "AgentActionNotFoundError",
+    "AskExecutionPolicy",
     "EmbeddingUnavailableError",
     "approve_run",
     "ask",

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletion
+
     from news_dashboard.assistant.service import AskExecutionPolicy
 
 logger = logging.getLogger(__name__)
@@ -118,7 +120,11 @@ def _is_retryable_embedding_error(exc: Exception) -> bool:
 
 
 def _embed(
-    text: str, *, timeout_seconds: float | None = None, trace_content: bool = True
+    text: str,
+    *,
+    timeout_seconds: float | None = None,
+    trace_content: bool = True,
+    operation: str = "query-embedding",
 ) -> list[float]:
     """Embed *text* via the configured OpenAI-compatible endpoint.
 
@@ -127,7 +133,7 @@ def _embed(
     the raw provider exception so callers can distinguish "provider is
     rate-limiting us" from other failures (e.g. bad credentials).
     """
-    from news_dashboard.ai_client import get_chat_client, trace_params
+    from news_dashboard.ai_client import SafeAIObservation, get_chat_client, trace_params
 
     api_key, base_url, model = _embeddings_ai_config()
     client_kwargs: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
@@ -135,6 +141,11 @@ def _embed(
         client_kwargs["timeout_seconds"] = timeout_seconds
     if not trace_content:
         client_kwargs["enable_tracing"] = False
+        client_kwargs["safe_observation"] = SafeAIObservation(
+            operation=operation,
+            as_type="embedding",
+            model=model,
+        )
     client = get_chat_client(**client_kwargs)
 
     attempt = 0
@@ -173,21 +184,56 @@ def _answer(
     *,
     max_tokens: int | None = None,
     timeout_seconds: float | None = None,
+    trace_content: bool = True,
 ) -> str:
     """Generate an answer with a vanilla LangChain prompt/model/parser pipeline."""
     from langchain_core.messages import SystemMessage
     from langchain_core.output_parsers import StrOutputParser
     from langchain_core.prompts import ChatPromptTemplate
 
-    from news_dashboard.ai_client import free_llm_config, get_chat_model
+    from news_dashboard.ai_client import (
+        SafeAIObservation,
+        free_llm_config,
+        get_chat_client,
+        get_chat_model,
+    )
 
     api_key, base_url = free_llm_config()
     if not api_key:
         _require_env("FREE_LLM_API_KEY", "use Ask AI")
+    model_name = os.getenv("OPENAI_ANSWER_MODEL", DEFAULT_ANSWER_MODEL)
+    if not trace_content:
+        client = get_chat_client(
+            api_key=api_key,
+            base_url=base_url,
+            timeout_seconds=timeout_seconds,
+            enable_tracing=False,
+            safe_observation=SafeAIObservation(
+                operation="answer-generation",
+                as_type="generation",
+                model=model_name,
+                model_parameters={"max_tokens": max_tokens} if max_tokens is not None else {},
+            ),
+        )
+        request: dict[str, Any] = {
+            "model": model_name,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        }
+        if max_tokens is not None:
+            request["max_tokens"] = max_tokens
+        response = cast("ChatCompletion", client.chat.completions.create(**request))
+        content = response.choices[0].message.content
+        if not isinstance(content, str):
+            message = "AI response must contain string content"
+            raise TypeError(message)
+        return content
     model_kwargs: dict[str, Any] = {
         "api_key": api_key,
         "base_url": base_url,
-        "model": os.getenv("OPENAI_ANSWER_MODEL", DEFAULT_ANSWER_MODEL),
+        "model": model_name,
     }
     if max_tokens is not None:
         model_kwargs["max_tokens"] = max_tokens
@@ -278,6 +324,7 @@ def _answer_with_policy(
         user_prompt,
         max_tokens=execution_policy.answer_max_tokens,
         timeout_seconds=execution_policy.provider_timeout_seconds,
+        trace_content=execution_policy.trace_content,
     )
 
 
@@ -309,7 +356,7 @@ def _generate_answer(
     client = _client()
     if not trace_content:
         with client.start_as_current_observation(
-            name="ask-ai",
+            name="answer-pipeline",
             as_type="chain",
             input=trace_input,
             prompt=prompt.langfuse_prompt,
@@ -462,9 +509,14 @@ def embed_all_eligible(
                     text,
                     timeout_seconds=provider_timeout_seconds,
                     trace_content=trace_content,
+                    operation="article-backfill",
                 )
                 if provider_timeout_seconds is not None
-                else (_embed(text) if trace_content else _embed(text, trace_content=False))
+                else (
+                    _embed(text)
+                    if trace_content
+                    else _embed(text, trace_content=False, operation="article-backfill")
+                )
             )
             from news_dashboard.db import connect as _connect
 
@@ -675,14 +727,27 @@ def ask(
 
     from langfuse import propagate_attributes
 
+    from news_dashboard.ai_client import _client
+
     corpus = "all_visible" if include_all else "saved_and_read"
-    with propagate_attributes(
-        user_id=str(user_id) if user_id is not None else None,
-        tags=["ask-ai", "mcp"],
-        metadata={"surface": execution_policy.trace_surface, "corpus": corpus},
-        trace_name="ask-news",
+    with (
+        propagate_attributes(
+            user_id=str(user_id) if user_id is not None else None,
+            tags=["ask-ai", "mcp"],
+            metadata={"surface": execution_policy.trace_surface, "corpus": corpus},
+            trace_name="ask-news",
+        ),
+        _client().start_as_current_observation(
+            name="ask-ai",
+            as_type="chain",
+            input={
+                "question_chars": len(query),
+                "corpus": corpus,
+                "retrieval_limit": execution_policy.retrieval_limit,
+            },
+        ) as root,
     ):
-        return _ask_impl(
+        result = _ask_impl(
             query,
             db_path,
             include_all=include_all,
@@ -690,3 +755,11 @@ def ask(
             session_id=session_id,
             execution_policy=execution_policy,
         )
+        root.update(
+            output={
+                "answer_chars": len(str(result.get("answer", ""))),
+                "source_count": len(result.get("sources", [])),
+                "status": "ok",
+            }
+        )
+        return result

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -355,15 +355,35 @@ def _generate_answer(
     )
     client = _client()
     if not trace_content:
+        failure: BaseException | None = None
+        failure_traceback = None
+        answer: str | None = None
+        trace_id: str | None = None
         with client.start_as_current_observation(
             name="answer-pipeline",
             as_type="chain",
             input=trace_input,
             prompt=prompt.langfuse_prompt,
         ) as root:
-            answer = _answer_with_policy(prompt.text, user_prompt, execution_policy)
-            root.update(output={"answer_chars": len(answer), "status": "ok"})
-            return answer, client.get_current_trace_id()
+            try:
+                answer = _answer_with_policy(prompt.text, user_prompt, execution_policy)
+            except BaseException as exc:
+                failure = exc
+                failure_traceback = exc.__traceback__
+                root.update(
+                    output={"status": "error"},
+                    level="ERROR",
+                    status_message="answer generation failed",
+                )
+            else:
+                root.update(output={"answer_chars": len(answer), "status": "ok"})
+                trace_id = client.get_current_trace_id()
+        if failure is not None:
+            raise failure.with_traceback(failure_traceback)
+        if answer is None:
+            message = "Answer generation returned no result"
+            raise RuntimeError(message)
+        return answer, trace_id
 
     attribute_kwargs: dict[str, Any] = {
         "user_id": str(user_id) if user_id is not None else None,
@@ -730,6 +750,9 @@ def ask(
     from news_dashboard.ai_client import _client
 
     corpus = "all_visible" if include_all else "saved_and_read"
+    failure: BaseException | None = None
+    failure_traceback = None
+    result: dict[str, Any] | None = None
     with (
         propagate_attributes(
             user_id=str(user_id) if user_id is not None else None,
@@ -747,19 +770,36 @@ def ask(
             },
         ) as root,
     ):
-        result = _ask_impl(
-            query,
-            db_path,
-            include_all=include_all,
-            user_id=user_id,
-            session_id=session_id,
-            execution_policy=execution_policy,
-        )
-        root.update(
-            output={
-                "answer_chars": len(str(result.get("answer", ""))),
-                "source_count": len(result.get("sources", [])),
-                "status": "ok",
-            }
-        )
-        return result
+        try:
+            result = _ask_impl(
+                query,
+                db_path,
+                include_all=include_all,
+                user_id=user_id,
+                session_id=session_id,
+                execution_policy=execution_policy,
+            )
+        except BaseException as exc:
+            failure = exc
+            failure_traceback = exc.__traceback__
+            root.update(
+                output={"status": "error"},
+                level="ERROR",
+                status_message="ask failed",
+            )
+        else:
+            if result.get("trace_id") is None:
+                result["trace_id"] = _client().get_current_trace_id()
+            root.update(
+                output={
+                    "answer_chars": len(str(result.get("answer", ""))),
+                    "source_count": len(result.get("sources", [])),
+                    "status": "ok",
+                }
+            )
+    if failure is not None:
+        raise failure.with_traceback(failure_traceback)
+    if result is None:
+        message = "Ask returned no result"
+        raise RuntimeError(message)
+    return result

--- a/backend/news_dashboard/embeddings.py
+++ b/backend/news_dashboard/embeddings.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from news_dashboard.assistant.service import AskExecutionPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +117,9 @@ def _is_retryable_embedding_error(exc: Exception) -> bool:
     return isinstance(exc, APIStatusError) and exc.status_code == 429
 
 
-def _embed(text: str) -> list[float]:
+def _embed(
+    text: str, *, timeout_seconds: float | None = None, trace_content: bool = True
+) -> list[float]:
     """Embed *text* via the configured OpenAI-compatible endpoint.
 
     Retries transient rate-limit (429) errors with exponential backoff. Once
@@ -125,7 +130,12 @@ def _embed(text: str) -> list[float]:
     from news_dashboard.ai_client import get_chat_client, trace_params
 
     api_key, base_url, model = _embeddings_ai_config()
-    client = get_chat_client(api_key=api_key, base_url=base_url)
+    client_kwargs: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+    if timeout_seconds is not None:
+        client_kwargs["timeout_seconds"] = timeout_seconds
+    if not trace_content:
+        client_kwargs["enable_tracing"] = False
+    client = get_chat_client(**client_kwargs)
 
     attempt = 0
     while True:
@@ -133,7 +143,11 @@ def _embed(text: str) -> list[float]:
             response = client.embeddings.create(
                 model=model,
                 input=text,
-                **trace_params("article-embedding", tags=["embedding"], user_id="system"),
+                **(
+                    trace_params("article-embedding", tags=["embedding"], user_id="system")
+                    if trace_content
+                    else {}
+                ),
             )
             return list(response.data[0].embedding)
         except Exception as exc:
@@ -156,6 +170,9 @@ def _embed(text: str) -> list[float]:
 def _answer(
     system_prompt: str,
     user_prompt: str,
+    *,
+    max_tokens: int | None = None,
+    timeout_seconds: float | None = None,
 ) -> str:
     """Generate an answer with a vanilla LangChain prompt/model/parser pipeline."""
     from langchain_core.messages import SystemMessage
@@ -167,10 +184,17 @@ def _answer(
     api_key, base_url = free_llm_config()
     if not api_key:
         _require_env("FREE_LLM_API_KEY", "use Ask AI")
+    model_kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "base_url": base_url,
+        "model": os.getenv("OPENAI_ANSWER_MODEL", DEFAULT_ANSWER_MODEL),
+    }
+    if max_tokens is not None:
+        model_kwargs["max_tokens"] = max_tokens
+    if timeout_seconds is not None:
+        model_kwargs["timeout_seconds"] = timeout_seconds
     model = get_chat_model(
-        api_key=api_key,
-        base_url=base_url,
-        model=os.getenv("OPENAI_ANSWER_MODEL", DEFAULT_ANSWER_MODEL),
+        **model_kwargs,
     )
     chain = (
         ChatPromptTemplate.from_messages(
@@ -242,6 +266,77 @@ def _format_graph_context(context: dict[str, Any] | None) -> str:
     return "Knowledge graph:\n" + "\n".join(lines)
 
 
+def _answer_with_policy(
+    system_prompt: str,
+    user_prompt: str,
+    execution_policy: AskExecutionPolicy | None,
+) -> str:
+    if execution_policy is None:
+        return _answer(system_prompt, user_prompt)
+    return _answer(
+        system_prompt,
+        user_prompt,
+        max_tokens=execution_policy.answer_max_tokens,
+        timeout_seconds=execution_policy.provider_timeout_seconds,
+    )
+
+
+def _generate_answer(
+    *,
+    query: str,
+    include_all: bool,
+    user_id: int | None,
+    session_id: str | None,
+    prompt: Any,
+    user_prompt: str,
+    execution_policy: AskExecutionPolicy | None,
+) -> tuple[str, str | None]:
+    from news_dashboard.ai_client import _client, langfuse_enabled
+
+    if not langfuse_enabled():
+        return _answer_with_policy(prompt.text, user_prompt, execution_policy), None
+
+    from langfuse import propagate_attributes
+
+    trace_content = execution_policy is None or execution_policy.trace_content
+    retrieval_limit = execution_policy.retrieval_limit if execution_policy is not None else TOP_K
+    corpus = "all_visible" if include_all else "saved_and_read"
+    trace_input = (
+        {"query": query, "include_all": include_all}
+        if trace_content
+        else {"question_chars": len(query), "corpus": corpus, "retrieval_limit": retrieval_limit}
+    )
+    client = _client()
+    if not trace_content:
+        with client.start_as_current_observation(
+            name="ask-ai",
+            as_type="chain",
+            input=trace_input,
+            prompt=prompt.langfuse_prompt,
+        ) as root:
+            answer = _answer_with_policy(prompt.text, user_prompt, execution_policy)
+            root.update(output={"answer_chars": len(answer), "status": "ok"})
+            return answer, client.get_current_trace_id()
+
+    attribute_kwargs: dict[str, Any] = {
+        "user_id": str(user_id) if user_id is not None else None,
+        "session_id": session_id,
+        "tags": ["ask-ai"],
+        "prompt": prompt.langfuse_prompt,
+    }
+    with (
+        propagate_attributes(**attribute_kwargs),
+        client.start_as_current_observation(
+            name="ask-ai", as_type="chain", input=trace_input
+        ) as root,
+    ):
+        answer = _answer_with_policy(prompt.text, user_prompt, execution_policy)
+        root.update(
+            output=answer if trace_content else {"answer_chars": len(answer), "status": "ok"}
+        )
+        return answer, client.get_current_trace_id()
+
+
 # ── Cosine similarity ──────────────────────────────────────────────────────
 
 
@@ -289,6 +384,9 @@ def embed_all_eligible(
     *,
     include_all: bool = False,
     user_id: int | None = None,
+    max_articles: int | None = None,
+    provider_timeout_seconds: float | None = None,
+    trace_content: bool = True,
 ) -> int:
     """Embed eligible articles that don't have an embedding yet.
 
@@ -335,13 +433,23 @@ def embed_all_eligible(
                         OR src.owner_user_id = %s
                       )
                 """
-            rows = conn.execute(query, (user_id, user_id, user_id)).fetchall()
+            query += " ORDER BY a.id"
+            params: tuple[Any, ...] = (user_id, user_id, user_id)
+            if max_articles is not None:
+                query += " LIMIT %s"
+                params += (max_articles,)
+            rows = conn.execute(query, params).fetchall()
         else:
             status_filter = "status != 'archived'" if include_all else "status IN ('saved', 'read')"
-            rows = conn.execute(
+            query = (
                 "SELECT id, title, summary, reason, tags FROM articles "
-                f"WHERE {status_filter} AND embedding_vec IS NULL"
-            ).fetchall()
+                f"WHERE {status_filter} AND embedding_vec IS NULL ORDER BY id"
+            )
+            params = ()
+            if max_articles is not None:
+                query += " LIMIT %s"
+                params = (max_articles,)
+            rows = conn.execute(query, params).fetchall()
 
     count = 0
     for row in rows:
@@ -349,7 +457,15 @@ def embed_all_eligible(
         if not text:
             continue
         try:
-            vector = _embed(text)
+            vector = (
+                _embed(
+                    text,
+                    timeout_seconds=provider_timeout_seconds,
+                    trace_content=trace_content,
+                )
+                if provider_timeout_seconds is not None
+                else (_embed(text) if trace_content else _embed(text, trace_content=False))
+            )
             from news_dashboard.db import connect as _connect
 
             with _connect(db_path) as conn:
@@ -359,22 +475,28 @@ def embed_all_eligible(
                 )
             count += 1
         except Exception:
-            logger.warning(
-                "failed to embed article %s during backfill; skipping", row["id"], exc_info=True
-            )
+            if trace_content:
+                logger.warning(
+                    "failed to embed article %s during backfill; skipping",
+                    row["id"],
+                    exc_info=True,
+                )
+            else:
+                logger.warning("failed to embed article during private backfill; skipping")
     return count
 
 
 # ── Main Q&A entry-point ───────────────────────────────────────────────────
 
 
-def ask(
+def _ask_impl(
     query: str,
     db_path: Any = None,
     *,
     include_all: bool = False,
     user_id: int | None = None,
     session_id: str | None = None,
+    execution_policy: AskExecutionPolicy | None = None,
 ) -> dict[str, Any]:
     """Answer *query* using RAG over saved/read articles.
 
@@ -393,13 +515,37 @@ def ask(
     from news_dashboard.db import connect, init_db
 
     # 1. Backfill embeddings for any eligible articles not yet embedded
-    embed_all_eligible(db_path, include_all=include_all, user_id=user_id)
+    backfill_limit = execution_policy.backfill_limit if execution_policy is not None else None
+    provider_timeout = (
+        execution_policy.provider_timeout_seconds if execution_policy is not None else None
+    )
+    retrieval_limit = execution_policy.retrieval_limit if execution_policy is not None else TOP_K
+    if execution_policy is None:
+        embed_all_eligible(db_path, include_all=include_all, user_id=user_id)
+    else:
+        embed_all_eligible(
+            db_path,
+            include_all=include_all,
+            user_id=user_id,
+            max_articles=backfill_limit,
+            provider_timeout_seconds=provider_timeout,
+            trace_content=execution_policy.trace_content,
+        )
 
     # 2. Embed the user's question, then let Postgres rank + return the top-k
     #    nearest articles in one query via the pgvector `<=>` cosine-distance
     #    operator (using the embedding_vec HNSW index), with a COUNT(*) in the
     #    same round trip for the MIN_ARTICLES eligibility check.
-    query_vec = vector_literal(_embed(query))
+    query_embedding = (
+        _embed(query)
+        if execution_policy is None
+        else _embed(
+            query,
+            timeout_seconds=provider_timeout,
+            trace_content=execution_policy.trace_content,
+        )
+    )
+    query_vec = vector_literal(query_embedding)
     init_db(db_path)
     with connect(db_path) as conn:
         if user_id is not None:
@@ -442,7 +588,7 @@ def ask(
                     LIMIT %(top_k)s
                 """
             rows = conn.execute(
-                sql, {"user_id": user_id, "query_vec": query_vec, "top_k": TOP_K}
+                sql, {"user_id": user_id, "query_vec": query_vec, "top_k": retrieval_limit}
             ).fetchall()
         else:
             status_filter = "status != 'archived'" if include_all else "status IN ('saved', 'read')"
@@ -450,7 +596,7 @@ def ask(
                 "SELECT id, title, url, summary, COUNT(*) OVER () AS eligible_count "
                 f"FROM articles WHERE {status_filter} AND embedding_vec IS NOT NULL "
                 "ORDER BY embedding_vec <=> %(query_vec)s::vector LIMIT %(top_k)s",
-                {"query_vec": query_vec, "top_k": TOP_K},
+                {"query_vec": query_vec, "top_k": retrieval_limit},
             ).fetchall()
 
     eligible_count = rows[0]["eligible_count"] if rows else 0
@@ -474,7 +620,7 @@ def ask(
     graph_context = graph_context_for_articles([int(row["id"]) for row in rows])
     graph_context_text = _format_graph_context(graph_context)
 
-    from news_dashboard.ai_client import _client, get_prompt, langfuse_enabled
+    from news_dashboard.ai_client import get_prompt
     from news_dashboard.ai_memory.service import format_memories_for_prompt
 
     prompt = get_prompt("ask-system", fallback=ASK_SYSTEM_PROMPT)
@@ -483,28 +629,15 @@ def ask(
     graph_block = f"\n\n{graph_context_text}" if graph_context_text else ""
     user_prompt = f"{memory_block}Articles:\n\n{context_text}{graph_block}\n\nQuestion: {query}"
 
-    # 6. Call OpenAI for the answer, grouping retrieval + generation under one
-    #    Langfuse trace so its id can carry user feedback (see /api/feedback).
-    trace_id: str | None = None
-    trace_input = {"query": query, "include_all": include_all}
-    if langfuse_enabled():
-        from langfuse import propagate_attributes
-
-        client = _client()
-        with client.start_as_current_observation(
-            name="ask-ai", as_type="chain", input=trace_input
-        ) as root:
-            with propagate_attributes(
-                user_id=str(user_id) if user_id is not None else None,
-                session_id=session_id,
-                tags=["ask-ai"],
-                prompt=prompt.langfuse_prompt,
-            ):
-                answer_text = _answer(prompt.text, user_prompt)
-            root.update(output=answer_text)
-            trace_id = client.get_current_trace_id()
-    else:
-        answer_text = _answer(prompt.text, user_prompt)
+    answer_text, trace_id = _generate_answer(
+        query=query,
+        include_all=include_all,
+        user_id=user_id,
+        session_id=session_id,
+        prompt=prompt,
+        user_prompt=user_prompt,
+        execution_policy=execution_policy,
+    )
 
     # 7. Return answer + source list (top-k order)
     sources = [{"id": row["id"], "title": row["title"], "url": row["url"]} for row in rows]
@@ -516,3 +649,44 @@ def ask(
     if graph_context is not None:
         result["graph_context"] = graph_context
     return result
+
+
+def ask(
+    query: str,
+    db_path: Any = None,
+    *,
+    include_all: bool = False,
+    user_id: int | None = None,
+    session_id: str | None = None,
+    execution_policy: AskExecutionPolicy | None = None,
+) -> dict[str, Any]:
+    """Answer a question over the caller's authorized article corpus."""
+    from news_dashboard.ai_client import langfuse_enabled
+
+    if execution_policy is None or execution_policy.trace_content or not langfuse_enabled():
+        return _ask_impl(
+            query,
+            db_path,
+            include_all=include_all,
+            user_id=user_id,
+            session_id=session_id,
+            execution_policy=execution_policy,
+        )
+
+    from langfuse import propagate_attributes
+
+    corpus = "all_visible" if include_all else "saved_and_read"
+    with propagate_attributes(
+        user_id=str(user_id) if user_id is not None else None,
+        tags=["ask-ai", "mcp"],
+        metadata={"surface": execution_policy.trace_surface, "corpus": corpus},
+        trace_name="ask-news",
+    ):
+        return _ask_impl(
+            query,
+            db_path,
+            include_all=include_all,
+            user_id=user_id,
+            session_id=session_id,
+            execution_policy=execution_policy,
+        )

--- a/backend/news_dashboard/mcp/ask.py
+++ b/backend/news_dashboard/mcp/ask.py
@@ -13,7 +13,7 @@ from news_dashboard.ingest.service import canonicalize_url
 ASK_STRUCTURED_CONTENT_BYTES = 4_800
 _MAX_CITATION_TITLE_BYTES = 512
 _MAX_CITATION_URL_BYTES = 2_048
-_BRACKET_POSITION = re.compile(r"\[([1-9][0-9]{0,18})\]")
+_BRACKET_POSITION = re.compile(r"(?<!\[)\[([1-9][0-9]{0,18})\](?!\])")
 _TRACE_ID = re.compile(r"[0-9a-fA-F]{32}")
 
 
@@ -83,10 +83,11 @@ def _safe_http_url_parts(value: str) -> SplitResult | None:
 
 
 def _normalized_url(value: object) -> tuple[str | None, bool]:
+    if isinstance(value, str) and len(value) > 16_384:
+        return None, True
     if (
         not isinstance(value, str)
         or not value
-        or len(value) > 16_384
         or "\\" in value
         or any(character.isspace() or ord(character) < 32 for character in value)
         or _safe_http_url_parts(value) is None

--- a/backend/news_dashboard/mcp/ask.py
+++ b/backend/news_dashboard/mcp/ask.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, TypedDict
+from urllib.parse import SplitResult, urlsplit
+
+from news_dashboard.ingest.service import canonicalize_url
+
+ASK_STRUCTURED_CONTENT_BYTES = 4_800
+_MAX_CITATION_TITLE_BYTES = 512
+_MAX_CITATION_URL_BYTES = 2_048
+_BRACKET_POSITION = re.compile(r"\[([0-9]+)\]")
+_TRACE_ID = re.compile(r"[0-9a-fA-F]{32}")
+
+
+class AskCitation(TypedDict):
+    id: int
+    title: str
+    url: str
+
+
+class AskNewsResult(TypedDict):
+    answer: str
+    citations: list[AskCitation]
+    trace_id: str | None
+    truncated: bool
+
+
+def _utf8_prefix(value: str, max_bytes: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _safe_http_url_parts(value: str) -> SplitResult | None:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or parsed.hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return None
+    return parsed
+
+
+def _normalized_url(value: object) -> tuple[str, bool] | None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 16_384
+        or "\\" in value
+        or any(character.isspace() or ord(character) < 32 for character in value)
+        or _safe_http_url_parts(value) is None
+    ):
+        return None
+    normalized = canonicalize_url(value)
+    if _safe_http_url_parts(normalized) is None:
+        return None
+    bounded = _utf8_prefix(normalized, _MAX_CITATION_URL_BYTES)
+    if _safe_http_url_parts(bounded) is None:
+        return None
+    return bounded, bounded != normalized
+
+
+def _citation(source: object) -> tuple[AskCitation, bool] | None:
+    if not isinstance(source, dict):
+        return None
+    article_id = source.get("id")
+    title = source.get("title")
+    if (
+        isinstance(article_id, bool)
+        or not isinstance(article_id, int)
+        or article_id <= 0
+        or not isinstance(title, str)
+        or not title.strip()
+    ):
+        return None
+    normalized = _normalized_url(source.get("url"))
+    if normalized is None:
+        return None
+    url, url_truncated = normalized
+    stripped_title = title.strip()
+    bounded_title = _utf8_prefix(stripped_title, _MAX_CITATION_TITLE_BYTES).strip()
+    if not bounded_title:
+        return None
+    return (
+        {"id": article_id, "title": bounded_title, "url": url},
+        url_truncated or bounded_title != stripped_title,
+    )
+
+
+def _structured_size(result: AskNewsResult) -> int:
+    return len(json.dumps(result, ensure_ascii=True, separators=(",", ":")).encode("utf-8"))
+
+
+def _bounded_answer(result: AskNewsResult, answer: str) -> str:
+    low = 0
+    high = len(answer)
+    best = ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = answer[:middle]
+        result["answer"] = candidate
+        if _structured_size(result) <= ASK_STRUCTURED_CONTENT_BYTES:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    result["answer"] = best
+    return best
+
+
+def shape_ask_result(raw_result: dict[str, Any]) -> AskNewsResult:
+    """Validate untrusted generated citations and return a bounded typed result."""
+    raw_answer = raw_result.get("answer")
+    answer = raw_answer if isinstance(raw_answer, str) else ""
+    raw_sources = raw_result.get("sources")
+    sources = raw_sources if isinstance(raw_sources, list) else []
+    citations: list[AskCitation] = []
+    cited_article_ids: set[int] = set()
+    truncated = False
+    for match in _BRACKET_POSITION.finditer(answer):
+        position = int(match.group(1))
+        if position <= 0 or position > len(sources):
+            continue
+        accepted = _citation(sources[position - 1])
+        if accepted is None:
+            continue
+        citation, citation_truncated = accepted
+        if citation["id"] in cited_article_ids:
+            continue
+        cited_article_ids.add(citation["id"])
+        citations.append(citation)
+        truncated = truncated or citation_truncated
+
+    raw_trace_id = raw_result.get("trace_id")
+    trace_id = (
+        raw_trace_id.lower()
+        if isinstance(raw_trace_id, str) and _TRACE_ID.fullmatch(raw_trace_id)
+        else None
+    )
+    result: AskNewsResult = {
+        "answer": answer,
+        "citations": citations,
+        "trace_id": trace_id,
+        "truncated": truncated,
+    }
+    while citations and _structured_size(result) > ASK_STRUCTURED_CONTENT_BYTES:
+        citations.pop()
+        result["truncated"] = True
+    if _structured_size(result) > ASK_STRUCTURED_CONTENT_BYTES:
+        result["truncated"] = True
+        _bounded_answer(result, answer)
+    return result

--- a/backend/news_dashboard/mcp/ask.py
+++ b/backend/news_dashboard/mcp/ask.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import ipaddress
 import json
 import re
 from typing import Any, TypedDict
 from urllib.parse import SplitResult, urlsplit
+
+import idna
 
 from news_dashboard.ingest.service import canonicalize_url
 
 ASK_STRUCTURED_CONTENT_BYTES = 4_800
 _MAX_CITATION_TITLE_BYTES = 512
 _MAX_CITATION_URL_BYTES = 2_048
-_BRACKET_POSITION = re.compile(r"\[([0-9]+)\]")
+_BRACKET_POSITION = re.compile(r"\[([1-9][0-9]{0,18})\]")
 _TRACE_ID = re.compile(r"[0-9a-fA-F]{32}")
 
 
@@ -34,22 +37,52 @@ def _utf8_prefix(value: str, max_bytes: int) -> str:
     return encoded[:max_bytes].decode("utf-8", errors="ignore")
 
 
+def _valid_host(host: str) -> bool:
+    if ":" in host:
+        try:
+            ipaddress.IPv6Address(host)
+        except ValueError:
+            return False
+        return True
+    if all(character.isdigit() or character == "." for character in host):
+        try:
+            ipaddress.IPv4Address(host)
+        except ValueError:
+            return False
+        return True
+    candidate = host[:-1] if host.endswith(".") else host
+    try:
+        ascii_host = idna.encode(candidate, uts46=False, std3_rules=True)
+    except idna.IDNAError:
+        return False
+    return bool(ascii_host) and len(ascii_host) <= 253
+
+
 def _safe_http_url_parts(value: str) -> SplitResult | None:
     try:
         parsed = urlsplit(value)
-    except ValueError:
+        hostname = parsed.hostname
+        port = parsed.port
+    except (UnicodeError, ValueError):
         return None
+    empty_port = parsed.netloc.endswith(":")
+    if parsed.netloc.startswith("[") and "]" in parsed.netloc:
+        empty_port = parsed.netloc.partition("]")[2] == ":"
     if (
         parsed.scheme.lower() not in {"http", "https"}
-        or parsed.hostname is None
+        or hostname is None
         or parsed.username is not None
         or parsed.password is not None
+        or "%" in parsed.netloc
+        or empty_port
+        or (port is not None and not 1 <= port <= 65_535)
+        or not _valid_host(hostname)
     ):
         return None
     return parsed
 
 
-def _normalized_url(value: object) -> tuple[str, bool] | None:
+def _normalized_url(value: object) -> tuple[str | None, bool]:
     if (
         not isinstance(value, str)
         or not value
@@ -58,19 +91,21 @@ def _normalized_url(value: object) -> tuple[str, bool] | None:
         or any(character.isspace() or ord(character) < 32 for character in value)
         or _safe_http_url_parts(value) is None
     ):
-        return None
-    normalized = canonicalize_url(value)
+        return None, False
+    try:
+        normalized = canonicalize_url(value)
+    except (UnicodeError, ValueError):
+        return None, False
     if _safe_http_url_parts(normalized) is None:
-        return None
-    bounded = _utf8_prefix(normalized, _MAX_CITATION_URL_BYTES)
-    if _safe_http_url_parts(bounded) is None:
-        return None
-    return bounded, bounded != normalized
+        return None, False
+    if len(normalized.encode("utf-8")) > _MAX_CITATION_URL_BYTES:
+        return None, True
+    return normalized, False
 
 
-def _citation(source: object) -> tuple[AskCitation, bool] | None:
+def _citation(source: object) -> tuple[AskCitation | None, bool]:
     if not isinstance(source, dict):
-        return None
+        return None, False
     article_id = source.get("id")
     title = source.get("title")
     if (
@@ -80,18 +115,17 @@ def _citation(source: object) -> tuple[AskCitation, bool] | None:
         or not isinstance(title, str)
         or not title.strip()
     ):
-        return None
-    normalized = _normalized_url(source.get("url"))
-    if normalized is None:
-        return None
-    url, url_truncated = normalized
+        return None, False
+    url, url_omitted = _normalized_url(source.get("url"))
+    if url is None:
+        return None, url_omitted
     stripped_title = title.strip()
     bounded_title = _utf8_prefix(stripped_title, _MAX_CITATION_TITLE_BYTES).strip()
     if not bounded_title:
-        return None
+        return None, False
     return (
         {"id": article_id, "title": bounded_title, "url": url},
-        url_truncated or bounded_title != stripped_title,
+        bounded_title != stripped_title,
     )
 
 
@@ -127,12 +161,12 @@ def shape_ask_result(raw_result: dict[str, Any]) -> AskNewsResult:
     truncated = False
     for match in _BRACKET_POSITION.finditer(answer):
         position = int(match.group(1))
-        if position <= 0 or position > len(sources):
+        if position > len(sources):
             continue
-        accepted = _citation(sources[position - 1])
-        if accepted is None:
+        citation, citation_truncated = _citation(sources[position - 1])
+        truncated = truncated or citation_truncated
+        if citation is None:
             continue
-        citation, citation_truncated = accepted
         if citation["id"] in cited_article_ids:
             continue
         cited_article_ids.add(citation["id"])

--- a/backend/news_dashboard/mcp/models.py
+++ b/backend/news_dashboard/mcp/models.py
@@ -29,6 +29,11 @@ PositiveArticleId = Annotated[
     ),
 ]
 SearchQuery = Annotated[str, StringConstraints(strip_whitespace=True, max_length=MAX_QUERY_LENGTH)]
+AskQuestion = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=MAX_QUERY_LENGTH),
+]
+AskCorpus = Literal["saved_and_read", "all_visible"]
 SearchLimit = Annotated[int, Field(ge=1, le=MAX_RESULT_LIMIT)]
 SearchOffset = Annotated[int, Field(ge=0, le=MAX_SEARCH_OFFSET)]
 BriefingId = Annotated[int, Field(strict=True, ge=1)]

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import html
 import json
 import logging
+import secrets
 import time
 from collections import OrderedDict
 from collections.abc import Callable
@@ -22,12 +25,23 @@ from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddlewa
 from fastmcp.tools.base import ToolResult
 from mcp import McpError
 from mcp.types import CallToolRequestParams, ErrorData
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    PermissionDeniedError,
+)
+from openai import (
+    RateLimitError as OpenAIRateLimitError,
+)
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from news_dashboard.assistant.service import AskExecutionPolicy
 from news_dashboard.body_fetch import fetch_and_cache_body
 from news_dashboard.briefings import service as briefing_service
+from news_dashboard.embeddings import EmbeddingUnavailableError, MissingAICredentialsError
 from news_dashboard.ingest.service import clean_html, search_articles
 from news_dashboard.mcp import service
 from news_dashboard.mcp.ask import AskNewsResult, shape_ask_result
@@ -244,29 +258,48 @@ _ASK_PUBLIC_ERRORS = {
     "ask_rate_limited": "News answering rate limit exceeded; retry later.",
     "ask_unavailable": "News answering is temporarily unavailable.",
 }
+_ASK_ERROR_PROVENANCE_KEY = secrets.token_bytes(32)
+_ASK_ERROR_MARKER = "ndask-error:"
 
 
-def _fixed_ask_error(code: str) -> ToolError:
-    return ToolError(f"{code}: {_ASK_PUBLIC_ERRORS[code]}")
+class _PrivateAskError(ToolError):
+    """Internal provenance-bearing error converted to public text at transport."""
 
 
-def _public_ask_error(exc: Exception) -> ToolError:
-    from openai import (
-        APIConnectionError,
-        APIStatusError,
-        APITimeoutError,
-        AuthenticationError,
-        PermissionDeniedError,
-    )
-    from openai import (
-        RateLimitError as OpenAIRateLimitError,
-    )
+def _signed_ask_error_text(code: str) -> str:
+    public_text = f"{code}: {_ASK_PUBLIC_ERRORS[code]}"
+    signature = hmac.new(
+        _ASK_ERROR_PROVENANCE_KEY,
+        public_text.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{_ASK_ERROR_MARKER}{signature}:{public_text}"
 
-    from news_dashboard.embeddings import (
-        EmbeddingUnavailableError,
-        MissingAICredentialsError,
-    )
 
+def _verified_public_ask_error(value: object) -> str | None:
+    if not isinstance(value, str) or not value.startswith(_ASK_ERROR_MARKER):
+        return None
+    signed_value = value.removeprefix(_ASK_ERROR_MARKER)
+    signature, separator, public_text = signed_value.partition(":")
+    if not separator or len(signature) != 64:
+        return None
+    expected_signature = hmac.new(
+        _ASK_ERROR_PROVENANCE_KEY,
+        public_text.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected_signature):
+        return None
+    if public_text not in {f"{code}: {message}" for code, message in _ASK_PUBLIC_ERRORS.items()}:
+        return None
+    return public_text
+
+
+def _fixed_ask_error(code: str) -> _PrivateAskError:
+    return _PrivateAskError(_signed_ask_error_text(code))
+
+
+def _public_ask_error(exc: Exception) -> _PrivateAskError:
     if isinstance(exc, MissingAICredentialsError):
         code = "ask_not_configured"
     elif isinstance(exc, EmbeddingUnavailableError):
@@ -344,7 +377,7 @@ def _is_safe_ask_tool_error(result: ToolResult) -> bool:
     if len(result.content) != 1:
         return False
     text = getattr(result.content[0], "text", None)
-    return text in {f"{code}: {message}" for code, message in _ASK_PUBLIC_ERRORS.items()}
+    return _verified_public_ask_error(text) is not None
 
 
 class _SafeToolTelemetryMiddleware(Middleware):
@@ -359,18 +392,21 @@ class _SafeToolTelemetryMiddleware(Middleware):
             result = await call_next(context)
             if result.is_error:
                 status = "error"
-                if _is_safe_ask_tool_error(result):
+                if context.message.name == "ask_news" and _is_safe_ask_tool_error(result):
                     return result
                 return ToolResult(
                     content=_INTERNAL_ERROR_MESSAGE,
                     is_error=True,
                 )
             return result
+        except _PrivateAskError:
+            status = "error"
+            if context.message.name == "ask_news":
+                raise
+            raise McpError(ErrorData(code=-32603, message=_INTERNAL_ERROR_MESSAGE)) from None
         except ToolError as exc:
             status = "error"
-            if str(exc) == _BRIEFING_NOT_FOUND_MESSAGE or str(exc) in {
-                f"{code}: {message}" for code, message in _ASK_PUBLIC_ERRORS.items()
-            }:
+            if str(exc) == _BRIEFING_NOT_FOUND_MESSAGE:
                 raise
             raise McpError(ErrorData(code=-32603, message=_INTERNAL_ERROR_MESSAGE)) from None
         except McpError:
@@ -768,8 +804,6 @@ async def ask_news(
                 status="ok",
             )
         return response
-    except (McpError, ToolError):
-        raise
     except Exception as exc:
         trace_id = _safe_trace_id(result)
         if trace_id is not None:
@@ -849,13 +883,14 @@ def _sanitize_mcp_response_body(body: bytes) -> bytes:
         and len(content) == 1
         and isinstance(content[0], dict)
         and content[0].get("type") == "text"
-        and content[0].get("text")
-        in {
-            _BRIEFING_NOT_FOUND_MESSAGE,
-            *(f"{code}: {message}" for code, message in _ASK_PUBLIC_ERRORS.items()),
-        }
     ):
-        return body
+        if content[0].get("text") == _BRIEFING_NOT_FOUND_MESSAGE:
+            return body
+        public_error = _verified_public_ask_error(content[0].get("text"))
+        if public_error is not None:
+            content[0]["text"] = public_error
+            sanitized = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+            return body[:data_start] + sanitized + body[data_end:]
     result["content"] = [{"type": "text", "text": _INTERNAL_ERROR_MESSAGE}]
     sanitized = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
     return body[:data_start] + sanitized + body[data_end:]

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -38,6 +38,8 @@ from news_dashboard.mcp.briefings import (
 from news_dashboard.mcp.models import (
     MAX_FILTER_VALUE_LENGTH,
     MAX_RESULT_LIMIT,
+    AskCorpus,
+    AskQuestion,
     BriefingId,
     BriefingLimit,
     BriefingOffset,
@@ -251,6 +253,19 @@ class NewsArticleBody(TypedDict):
 class GetNewsArticleResult(TypedDict):
     found: bool
     article: NewsArticleBody | None
+    truncated: bool
+
+
+class AskCitation(TypedDict):
+    id: int
+    title: str
+    url: str
+
+
+class AskNewsResult(TypedDict):
+    answer: str
+    citations: list[AskCitation]
+    trace_id: str | None
     truncated: bool
 
 
@@ -556,6 +571,38 @@ def search_news(  # noqa: PLR0913, PLR0917
         user_id=_current_user_id(),
     )
     return _bounded_articles(articles)
+
+
+@mcp.tool(auth=require_scopes("ask"))
+async def ask_news(
+    question: AskQuestion,
+    corpus: AskCorpus = "saved_and_read",
+) -> AskNewsResult:
+    """Answer a question over the authenticated owner's news corpus."""
+    from news_dashboard.assistant import service as assistant_service
+
+    user_id = _current_user_id()
+    result = await to_thread.run_sync(
+        lambda: assistant_service.ask(
+            question,
+            include_all=corpus == "all_visible",
+            user_id=user_id,
+        )
+    )
+    sources = cast("list[dict[str, Any]]", result.get("sources", []))
+    return {
+        "answer": str(result.get("answer", "")),
+        "citations": [
+            {
+                "id": int(source["id"]),
+                "title": str(source["title"]),
+                "url": str(source["url"]),
+            }
+            for source in sources
+        ],
+        "trace_id": cast("str | None", result.get("trace_id")),
+        "truncated": False,
+    }
 
 
 @mcp.tool(auth=require_scopes("read"))

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -890,9 +890,10 @@ def _sanitize_mcp_response_body(body: bytes) -> bytes:
         public_error = _verified_public_ask_error(content[0].get("text"))
         if public_error is not None:
             content[0]["text"] = public_error
-            sanitized = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
-            return body[:data_start] + sanitized + body[data_end:]
-    result["content"] = [{"type": "text", "text": _INTERNAL_ERROR_MESSAGE}]
+        else:
+            result["content"] = [{"type": "text", "text": _INTERNAL_ERROR_MESSAGE}]
+    else:
+        result["content"] = [{"type": "text", "text": _INTERNAL_ERROR_MESSAGE}]
     sanitized = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
     return body[:data_start] + sanitized + body[data_end:]
 

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -5,12 +5,13 @@ import json
 import logging
 import time
 from collections import OrderedDict
+from collections.abc import Callable
 from contextvars import ContextVar
 from datetime import datetime
 from functools import partial
 from typing import Any, Literal, TypedDict, cast
 
-from anyio import to_thread
+from anyio import fail_after, to_thread
 from fastmcp import FastMCP
 from fastmcp.exceptions import AuthorizationError, ToolError
 from fastmcp.server.auth import require_scopes
@@ -61,6 +62,9 @@ MCP_BURST_CAPACITY = 10
 MCP_MAX_RESPONSE_BYTES = 16_384
 MCP_STRUCTURED_CONTENT_BYTES = 4_800
 MCP_MAX_RATE_LIMIT_IDENTITIES = 4_096
+MCP_ASK_BURST_CAPACITY = 2
+MCP_ASK_REFILL_SECONDS = 30.0
+MCP_ASK_FOREGROUND_TIMEOUT_SECONDS = 30.0
 MCP_ASK_EXECUTION_POLICY = AskExecutionPolicy.mcp()
 _INTERNAL_ERROR_MESSAGE = "Internal server error"
 _ARTICLE_FIELD_BYTE_CAPS = {
@@ -134,8 +138,8 @@ def _rate_limit_client_id(_context: MiddlewareContext[Any]) -> str:
     if token is None or not token.client_id:
         return "unauthenticated"
     rate_limit_id = token.claims.get("rate_limit_id")
-    if isinstance(rate_limit_id, str) and rate_limit_id.startswith("mcp-rate:"):
-        return rate_limit_id
+    if _valid_rate_limit_identity(rate_limit_id):
+        return cast("str", rate_limit_id)
     message = "Authorization required"
     raise AuthorizationError(message)
 
@@ -178,6 +182,171 @@ class _BoundedRateLimitingMiddleware(Middleware):
         return await call_next(context)
 
 
+class _AskBucket(TypedDict):
+    tokens: float
+    updated_at: float
+
+
+def _valid_rate_limit_identity(identity: object) -> bool:
+    if not isinstance(identity, str) or not identity.startswith("mcp-rate:"):
+        return False
+    digest = identity.removeprefix("mcp-rate:")
+    return len(digest) == 64 and all(character in "0123456789abcdef" for character in digest)
+
+
+class _AskRateLimiter:
+    """Small deterministic LRU token bucket dedicated to generation."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        max_identities: int = MCP_MAX_RATE_LIMIT_IDENTITIES,
+    ) -> None:
+        self._clock = clock
+        self._max_identities = max_identities
+        self._buckets: OrderedDict[str, _AskBucket] = OrderedDict()
+
+    def __len__(self) -> int:
+        return len(self._buckets)
+
+    def consume(self, identity: object) -> bool:
+        if not _valid_rate_limit_identity(identity):
+            message = "Authorization required"
+            raise AuthorizationError(message)
+        identity = cast("str", identity)
+        now = self._clock()
+        bucket = self._buckets.pop(identity, None)
+        if bucket is None:
+            bucket = _AskBucket(tokens=float(MCP_ASK_BURST_CAPACITY), updated_at=now)
+        else:
+            elapsed = max(0.0, now - bucket["updated_at"])
+            bucket["tokens"] = min(
+                float(MCP_ASK_BURST_CAPACITY),
+                bucket["tokens"] + elapsed / MCP_ASK_REFILL_SECONDS,
+            )
+            bucket["updated_at"] = now
+        allowed = bucket["tokens"] >= 1.0
+        if allowed:
+            bucket["tokens"] -= 1.0
+        self._buckets[identity] = bucket
+        if len(self._buckets) > self._max_identities:
+            self._buckets.popitem(last=False)
+        return allowed
+
+
+_ASK_PUBLIC_ERRORS = {
+    "ask_not_configured": "News answering is not configured.",
+    "embedding_unavailable": "News retrieval is temporarily unavailable.",
+    "provider_authentication_failed": "News answering provider authentication failed.",
+    "provider_rate_limited": "News answering provider is rate limited; retry later.",
+    "ask_timeout": "News answering timed out; retry later.",
+    "ask_rate_limited": "News answering rate limit exceeded; retry later.",
+    "ask_unavailable": "News answering is temporarily unavailable.",
+}
+
+
+def _fixed_ask_error(code: str) -> ToolError:
+    return ToolError(f"{code}: {_ASK_PUBLIC_ERRORS[code]}")
+
+
+def _public_ask_error(exc: Exception) -> ToolError:
+    from openai import (
+        APIConnectionError,
+        APIStatusError,
+        APITimeoutError,
+        AuthenticationError,
+        PermissionDeniedError,
+    )
+    from openai import (
+        RateLimitError as OpenAIRateLimitError,
+    )
+
+    from news_dashboard.embeddings import (
+        EmbeddingUnavailableError,
+        MissingAICredentialsError,
+    )
+
+    if isinstance(exc, MissingAICredentialsError):
+        code = "ask_not_configured"
+    elif isinstance(exc, EmbeddingUnavailableError):
+        code = "embedding_unavailable"
+    elif isinstance(exc, (AuthenticationError, PermissionDeniedError)):
+        code = "provider_authentication_failed"
+    elif isinstance(exc, OpenAIRateLimitError):
+        code = "provider_rate_limited"
+    elif isinstance(exc, (TimeoutError, APITimeoutError)):
+        code = "ask_timeout"
+    elif isinstance(exc, (APIConnectionError, APIStatusError)):
+        code = "ask_unavailable"
+    else:
+        code = "ask_unavailable"
+    return _fixed_ask_error(code)
+
+
+def _ask_rate_limit_identity() -> str:
+    token = get_access_token()
+    identity = token.claims.get("rate_limit_id") if token is not None else None
+    if not _valid_rate_limit_identity(identity):
+        message = "Authorization required"
+        raise AuthorizationError(message)
+    return cast("str", identity)
+
+
+def _safe_trace_id(result: object) -> str | None:
+    if not isinstance(result, dict):
+        return None
+    trace_id = result.get("trace_id")
+    if (
+        not isinstance(trace_id, str)
+        or len(trace_id) != 32
+        or any(character not in "0123456789abcdefABCDEF" for character in trace_id)
+    ):
+        return None
+    return trace_id.lower()
+
+
+def _record_ask_result(
+    trace_id: str,
+    *,
+    citation_count: int,
+    truncated: bool,
+    status: Literal["ok", "error"],
+) -> None:
+    from news_dashboard.ai_client import record_mcp_ask_result
+
+    record_mcp_ask_result(
+        trace_id,
+        citation_count=citation_count,
+        truncated=truncated,
+        status=status,
+    )
+
+
+class _AskRateLimitingMiddleware(Middleware):
+    def __init__(self, *, limiter: _AskRateLimiter | None = None) -> None:
+        self._limiter = limiter or _AskRateLimiter()
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[CallToolRequestParams],
+        call_next: CallNext[CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        if context.message.name != "ask_news":
+            return await call_next(context)
+        if not self._limiter.consume(_ask_rate_limit_identity()):
+            code = "ask_rate_limited"
+            raise _fixed_ask_error(code)
+        return await call_next(context)
+
+
+def _is_safe_ask_tool_error(result: ToolResult) -> bool:
+    if len(result.content) != 1:
+        return False
+    text = getattr(result.content[0], "text", None)
+    return text in {f"{code}: {message}" for code, message in _ASK_PUBLIC_ERRORS.items()}
+
+
 class _SafeToolTelemetryMiddleware(Middleware):
     async def on_call_tool(
         self,
@@ -190,6 +359,8 @@ class _SafeToolTelemetryMiddleware(Middleware):
             result = await call_next(context)
             if result.is_error:
                 status = "error"
+                if _is_safe_ask_tool_error(result):
+                    return result
                 return ToolResult(
                     content=_INTERNAL_ERROR_MESSAGE,
                     is_error=True,
@@ -197,7 +368,9 @@ class _SafeToolTelemetryMiddleware(Middleware):
             return result
         except ToolError as exc:
             status = "error"
-            if str(exc) == _BRIEFING_NOT_FOUND_MESSAGE:
+            if str(exc) == _BRIEFING_NOT_FOUND_MESSAGE or str(exc) in {
+                f"{code}: {message}" for code, message in _ASK_PUBLIC_ERRORS.items()
+            }:
                 raise
             raise McpError(ErrorData(code=-32603, message=_INTERNAL_ERROR_MESSAGE)) from None
         except McpError:
@@ -224,6 +397,7 @@ mcp = FastMCP(
 )
 mcp.add_middleware(_SafeToolTelemetryMiddleware())
 mcp.add_middleware(_BoundedRateLimitingMiddleware())
+mcp.add_middleware(_AskRateLimitingMiddleware())
 mcp.add_middleware(ResponseLimitingMiddleware(max_size=MCP_MAX_RESPONSE_BYTES))
 
 
@@ -572,26 +746,40 @@ async def ask_news(
     from news_dashboard.assistant import service as assistant_service
 
     user_id = _current_user_id()
-    result = await to_thread.run_sync(
-        lambda: assistant_service.ask(
-            question,
-            include_all=corpus == "all_visible",
-            user_id=user_id,
-            execution_policy=MCP_ASK_EXECUTION_POLICY,
-        )
-    )
-    response = shape_ask_result(result)
-    trace_id = response["trace_id"]
-    if trace_id is not None:
-        from news_dashboard.ai_client import record_mcp_ask_result
-
-        record_mcp_ask_result(
-            trace_id,
-            citation_count=len(response["citations"]),
-            truncated=response["truncated"],
-            status="ok",
-        )
-    return response
+    result: dict[str, Any] | None = None
+    try:
+        with fail_after(MCP_ASK_FOREGROUND_TIMEOUT_SECONDS):
+            result = await to_thread.run_sync(
+                lambda: assistant_service.ask(
+                    question,
+                    include_all=corpus == "all_visible",
+                    user_id=user_id,
+                    execution_policy=MCP_ASK_EXECUTION_POLICY,
+                ),
+                abandon_on_cancel=True,
+            )
+        response = shape_ask_result(result)
+        trace_id = response["trace_id"]
+        if trace_id is not None:
+            _record_ask_result(
+                trace_id,
+                citation_count=len(response["citations"]),
+                truncated=response["truncated"],
+                status="ok",
+            )
+        return response
+    except (McpError, ToolError):
+        raise
+    except Exception as exc:
+        trace_id = _safe_trace_id(result)
+        if trace_id is not None:
+            _record_ask_result(
+                trace_id,
+                citation_count=0,
+                truncated=False,
+                status="error",
+            )
+        raise _public_ask_error(exc) from None
 
 
 @mcp.tool(auth=require_scopes("read"))
@@ -661,7 +849,11 @@ def _sanitize_mcp_response_body(body: bytes) -> bytes:
         and len(content) == 1
         and isinstance(content[0], dict)
         and content[0].get("type") == "text"
-        and content[0].get("text") == _BRIEFING_NOT_FOUND_MESSAGE
+        and content[0].get("text")
+        in {
+            _BRIEFING_NOT_FOUND_MESSAGE,
+            *(f"{code}: {message}" for code, message in _ASK_PUBLIC_ERRORS.items()),
+        }
     ):
         return body
     result["content"] = [{"type": "text", "text": _INTERNAL_ERROR_MESSAGE}]

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -29,6 +29,7 @@ from news_dashboard.body_fetch import fetch_and_cache_body
 from news_dashboard.briefings import service as briefing_service
 from news_dashboard.ingest.service import clean_html, search_articles
 from news_dashboard.mcp import service
+from news_dashboard.mcp.ask import AskNewsResult, shape_ask_result
 from news_dashboard.mcp.auth import NewsDashboardTokenVerifier
 from news_dashboard.mcp.briefings import (
     BriefingGetResult,
@@ -255,19 +256,6 @@ class NewsArticleBody(TypedDict):
 class GetNewsArticleResult(TypedDict):
     found: bool
     article: NewsArticleBody | None
-    truncated: bool
-
-
-class AskCitation(TypedDict):
-    id: int
-    title: str
-    url: str
-
-
-class AskNewsResult(TypedDict):
-    answer: str
-    citations: list[AskCitation]
-    trace_id: str | None
     truncated: bool
 
 
@@ -592,20 +580,7 @@ async def ask_news(
             execution_policy=MCP_ASK_EXECUTION_POLICY,
         )
     )
-    sources = cast("list[dict[str, Any]]", result.get("sources", []))
-    response: AskNewsResult = {
-        "answer": str(result.get("answer", "")),
-        "citations": [
-            {
-                "id": int(source["id"]),
-                "title": str(source["title"]),
-                "url": str(source["url"]),
-            }
-            for source in sources
-        ],
-        "trace_id": cast("str | None", result.get("trace_id")),
-        "truncated": False,
-    }
+    response = shape_ask_result(result)
     trace_id = response["trace_id"]
     if trace_id is not None:
         from news_dashboard.ai_client import record_mcp_ask_result

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -143,6 +143,7 @@ for _extraction_logger_name in (
     "news_dashboard.body_fetch",
     "news_dashboard.selenium_client",
     "news_dashboard.ai_client",
+    "news_dashboard.embeddings",
 ):
     logging.getLogger(_extraction_logger_name).addFilter(_DropExtractionDetailsDuringMcp())
 

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -593,7 +593,7 @@ async def ask_news(
         )
     )
     sources = cast("list[dict[str, Any]]", result.get("sources", []))
-    return {
+    response: AskNewsResult = {
         "answer": str(result.get("answer", "")),
         "citations": [
             {
@@ -606,6 +606,17 @@ async def ask_news(
         "trace_id": cast("str | None", result.get("trace_id")),
         "truncated": False,
     }
+    trace_id = response["trace_id"]
+    if trace_id is not None:
+        from news_dashboard.ai_client import record_mcp_ask_result
+
+        record_mcp_ask_result(
+            trace_id,
+            citation_count=len(response["citations"]),
+            truncated=response["truncated"],
+            status="ok",
+        )
+    return response
 
 
 @mcp.tool(auth=require_scopes("read"))

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -24,6 +24,7 @@ from mcp.types import CallToolRequestParams, ErrorData
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from news_dashboard.assistant.service import AskExecutionPolicy
 from news_dashboard.body_fetch import fetch_and_cache_body
 from news_dashboard.briefings import service as briefing_service
 from news_dashboard.ingest.service import clean_html, search_articles
@@ -59,6 +60,7 @@ MCP_BURST_CAPACITY = 10
 MCP_MAX_RESPONSE_BYTES = 16_384
 MCP_STRUCTURED_CONTENT_BYTES = 4_800
 MCP_MAX_RATE_LIMIT_IDENTITIES = 4_096
+MCP_ASK_EXECUTION_POLICY = AskExecutionPolicy.mcp()
 _INTERNAL_ERROR_MESSAGE = "Internal server error"
 _ARTICLE_FIELD_BYTE_CAPS = {
     "title": 512,
@@ -587,6 +589,7 @@ async def ask_news(
             question,
             include_all=corpus == "all_visible",
             user_id=user_id,
+            execution_policy=MCP_ASK_EXECUTION_POLICY,
         )
     )
     sources = cast("list[dict[str, Any]]", result.get("sources", []))

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -113,6 +113,8 @@ def test_agent_card_is_spec_valid(monkeypatch: pytest.MonkeyPatch) -> None:
     # Exactly one read-only Q&A skill.
     assert len(card.skills) == 1
     assert card.skills[0].id == "ask_news"
+    assert "Starred + Done" in card.description
+    assert "Starred + Done" in card.skills[0].description
     # Bearer auth must be declared.
     schemes = dict(card.security_schemes)
     assert any(s.WhichOneof("scheme") == "http_auth_security_scheme" for s in schemes.values())

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -247,12 +247,26 @@ def test_safe_provider_observations_record_primary_failure_and_fallback(
 
     failed = MagicMock()
     succeeded = MagicMock()
-    failed_context = MagicMock()
-    failed_context.__enter__.return_value = failed
-    succeeded_context = MagicMock()
-    succeeded_context.__enter__.return_value = succeeded
+    escaped: list[BaseException | None] = []
+
+    class CleanExitContext:
+        def __init__(self, observation: MagicMock) -> None:
+            self.observation = observation
+
+        def __enter__(self) -> MagicMock:
+            return self.observation
+
+        def __exit__(
+            self, _kind: Any, error: BaseException | None, _traceback: Any
+        ) -> Literal[False]:
+            escaped.append(error)
+            return False
+
     langfuse = MagicMock()
-    langfuse.start_as_current_observation.side_effect = [failed_context, succeeded_context]
+    langfuse.start_as_current_observation.side_effect = [
+        CleanExitContext(failed),
+        CleanExitContext(succeeded),
+    ]
     primary = MagicMock()
     primary.embeddings.create.side_effect = openai.APIConnectionError(
         request=httpx.Request("POST", "https://provider.invalid")
@@ -283,6 +297,7 @@ def test_safe_provider_observations_record_primary_failure_and_fallback(
     assert failed.update.call_args.kwargs["output"] == {"status": "error"}
     assert failed.update.call_args.kwargs["status_message"] == "provider request failed"
     assert succeeded.update.call_args.kwargs["usage_details"] == {"input": 2, "total": 2}
+    assert escaped == [None, None]
     rendered = repr((langfuse.mock_calls, failed.mock_calls, succeeded.mock_calls))
     for secret in ("PRIVATE", "primary-secret", "fallback-secret", "provider.invalid"):
         assert secret not in rendered

--- a/backend/tests/test_ai_client.py
+++ b/backend/tests/test_ai_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -206,6 +207,85 @@ def test_observe_is_noop_without_credentials() -> None:
 def test_create_score_and_trace_url_noop_without_credentials() -> None:
     assert create_score("trace-1", name="user-thumbs", value=1, data_type="BOOLEAN") is False
     assert get_trace_url("trace-1") is None
+
+
+def test_records_final_mcp_result_on_returned_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard import ai_client
+
+    observation = MagicMock()
+    client = MagicMock()
+    client.start_observation.return_value = observation
+    monkeypatch.setattr(ai_client, "langfuse_enabled", lambda: True)
+    monkeypatch.setattr(ai_client, "_client", lambda: client)
+
+    ai_client.record_mcp_ask_result(
+        "0123456789abcdef0123456789abcdef",
+        citation_count=3,
+        truncated=True,
+        status="ok",
+    )
+
+    client.start_observation.assert_called_once_with(
+        trace_context={"trace_id": "0123456789abcdef0123456789abcdef"},
+        name="mcp-result",
+        as_type="span",
+        input=None,
+        metadata={"surface": "mcp", "operation": "ask-result"},
+    )
+    observation.end.assert_called_once_with(
+        output={"citation_count": 3, "truncated": True, "status": "ok"}
+    )
+
+
+def test_safe_provider_observations_record_primary_failure_and_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+    import openai
+
+    from news_dashboard import ai_client
+
+    failed = MagicMock()
+    succeeded = MagicMock()
+    failed_context = MagicMock()
+    failed_context.__enter__.return_value = failed
+    succeeded_context = MagicMock()
+    succeeded_context.__enter__.return_value = succeeded
+    langfuse = MagicMock()
+    langfuse.start_as_current_observation.side_effect = [failed_context, succeeded_context]
+    primary = MagicMock()
+    primary.embeddings.create.side_effect = openai.APIConnectionError(
+        request=httpx.Request("POST", "https://provider.invalid")
+    )
+    response = SimpleNamespace(
+        data=[SimpleNamespace(embedding=[0.1])],
+        usage=SimpleNamespace(prompt_tokens=2, total_tokens=2),
+    )
+    fallback = MagicMock()
+    fallback.embeddings.create.return_value = response
+    clients = iter((primary, fallback))
+    monkeypatch.setenv("OPENAI_API_KEY", "fallback-secret")
+    monkeypatch.setattr(ai_client, "langfuse_enabled", lambda: True)
+    monkeypatch.setattr(ai_client, "_client", lambda: langfuse)
+    monkeypatch.setattr(ai_client, "get_openai_client", lambda **_kwargs: next(clients))
+
+    client: Any = ai_client.get_chat_client(
+        api_key="primary-secret",
+        enable_tracing=False,
+        safe_observation=ai_client.SafeAIObservation(
+            operation="query-embedding", as_type="embedding", model="embed-model"
+        ),
+    )
+    assert client.embeddings.create(model="embed-model", input="PRIVATE") is response
+
+    names = [call.kwargs["name"] for call in langfuse.start_as_current_observation.call_args_list]
+    assert names == ["query-embedding-primary", "query-embedding-fallback"]
+    assert failed.update.call_args.kwargs["output"] == {"status": "error"}
+    assert failed.update.call_args.kwargs["status_message"] == "provider request failed"
+    assert succeeded.update.call_args.kwargs["usage_details"] == {"input": 2, "total": 2}
+    rendered = repr((langfuse.mock_calls, failed.mock_calls, succeeded.mock_calls))
+    for secret in ("PRIVATE", "primary-secret", "fallback-secret", "provider.invalid"):
+        assert secret not in rendered
 
 
 @pytest.mark.usefixtures("_no_langfuse")

--- a/backend/tests/test_ask_scope.py
+++ b/backend/tests/test_ask_scope.py
@@ -29,7 +29,7 @@ def _test_vector(value: float = 0.1, dims: int = 10) -> str:
     return vector_literal(vec)
 
 
-def _seed_source(db_path: Path, slug: str = "test-source", name: str = "TestSource") -> None:
+def _seed_source(db_path: Any, slug: str = "test-source", name: str = "TestSource") -> None:
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -244,7 +244,7 @@ def test_ask_include_all_widens_corpus(tmp_path: Path, monkeypatch: pytest.Monke
 # ─── User-scoped retrieval tests ──────────────────────────────────────────────
 
 
-def _seed_user(db_path: Path, username: str) -> int:
+def _seed_user(db_path: Any, username: str) -> int:
     """Insert a user and return the generated id."""
     with connect(db_path) as conn:
         row = conn.execute(
@@ -255,7 +255,7 @@ def _seed_user(db_path: Path, username: str) -> int:
 
 
 def _seed_article_with_embedding(
-    db_path: Path,
+    db_path: Any,
     article_id: int,
     source_slug: str = "test-source",
     source_name: str = "TestSource",
@@ -290,7 +290,7 @@ def _seed_article_with_embedding(
         )
 
 
-def _set_user_article_state(db_path: Path, user_id: int, article_id: int, state: str) -> None:
+def _set_user_article_state(db_path: Any, user_id: int, article_id: int, state: str) -> None:
     with connect(db_path) as conn:
         conn.execute(
             "INSERT INTO user_article_state(user_id, article_id, state) VALUES (%s, %s, %s)"
@@ -408,6 +408,75 @@ def test_ask_respects_disabled_user_sources(
     assert result["answer"] == "filtered answer"
     source_ids = {s["id"] for s in result["sources"]}
     assert 6 not in source_ids
+
+
+def test_mcp_policy_preserves_exact_two_user_visibility_corpora(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP bounds must not weaken the canonical per-user visibility predicates."""
+    from news_dashboard.assistant.service import AskExecutionPolicy
+    from news_dashboard.embeddings import ask
+
+    init_db(pg_clean)
+    alice = _seed_user(pg_clean, "alice-policy")
+    bob = _seed_user(pg_clean, "bob-policy")
+    _seed_source(pg_clean, "global", "Global")
+    _seed_source(pg_clean, "disabled", "Disabled")
+    _seed_source(pg_clean, "alice-private", "Alice Private")
+    _seed_source(pg_clean, "bob-private", "Bob Private")
+    with connect(database_url=pg_clean) as conn:
+        conn.execute("UPDATE sources SET owner_user_id=%s WHERE slug='alice-private'", (alice,))
+        conn.execute("UPDATE sources SET owner_user_id=%s WHERE slug='bob-private'", (bob,))
+        conn.execute(
+            "INSERT INTO user_sources(user_id, source_slug, enabled) "
+            "VALUES (%s, 'disabled', FALSE)",
+            (alice,),
+        )
+
+    article_sources = {
+        1: "global",
+        2: "global",
+        3: "global",
+        4: "global",
+        5: "global",
+        6: "global",
+        7: "disabled",
+        8: "alice-private",
+        9: "alice-private",
+        10: "bob-private",
+    }
+    for article_id, source_slug in article_sources.items():
+        _seed_article_with_embedding(
+            pg_clean,
+            article_id,
+            source_slug=source_slug,
+            source_name=source_slug,
+        )
+    for article_id in (1, 2, 3, 4, 5, 7, 8, 10):
+        _set_user_article_state(pg_clean, alice, article_id, "done")
+    _set_user_article_state(pg_clean, alice, 6, "archived")
+    with connect(database_url=pg_clean) as conn:
+        conn.execute(
+            "UPDATE user_article_state SET starred=TRUE WHERE user_id=%s AND article_id IN (2, 8)",
+            (alice,),
+        )
+
+    _make_openai_stub(monkeypatch, answer="bounded answer")
+    policy = AskExecutionPolicy.mcp()
+    saved = ask("question", pg_clean, user_id=alice, execution_policy=policy)
+    visible = ask(
+        "question",
+        pg_clean,
+        user_id=alice,
+        include_all=True,
+        execution_policy=policy,
+    )
+
+    assert {source["id"] for source in saved["sources"]} == {1, 2, 3, 4, 5, 8}
+    assert {source["id"] for source in visible["sources"]} == {1, 2, 3, 4, 5, 8, 9}
+    forbidden = {6, 7, 10}
+    assert forbidden.isdisjoint(source["id"] for source in saved["sources"])
+    assert forbidden.isdisjoint(source["id"] for source in visible["sources"])
 
 
 # ── POST /api/ask — payload bounds (#602) ────────────────────────────────────

--- a/backend/tests/test_ask_scope.py
+++ b/backend/tests/test_ask_scope.py
@@ -260,8 +260,10 @@ def _seed_article_with_embedding(
     source_slug: str = "test-source",
     source_name: str = "TestSource",
     legacy_status: str = "new",
+    *,
+    embedded: bool = True,
 ) -> None:
-    embedding = _test_vector()
+    embedding = _test_vector() if embedded else None
     with connect(db_path) as conn:
         conn.execute(
             """
@@ -451,6 +453,7 @@ def test_mcp_policy_preserves_exact_two_user_visibility_corpora(
             article_id,
             source_slug=source_slug,
             source_name=source_slug,
+            embedded=False,
         )
     for article_id in (1, 2, 3, 4, 5, 7, 8, 10):
         _set_user_article_state(pg_clean, alice, article_id, "done")
@@ -461,9 +464,63 @@ def test_mcp_policy_preserves_exact_two_user_visibility_corpora(
             (alice,),
         )
 
-    _make_openai_stub(monkeypatch, answer="bounded answer")
+    embedded_inputs: list[str] = []
+    answer_messages: list[dict[str, str]] = []
+
+    class FakeEmbeddings:
+        def create(self, **kwargs: Any) -> Any:
+            embedded_inputs.append(str(kwargs["input"]))
+            return type(
+                "EmbeddingResponse",
+                (),
+                {
+                    "data": [
+                        type(
+                            "EmbeddingData",
+                            (),
+                            {"embedding": [0.1] * EMBEDDING_DIMENSIONS},
+                        )()
+                    ],
+                    "usage": type("Usage", (), {"prompt_tokens": 1, "total_tokens": 1})(),
+                },
+            )()
+
+    class FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            answer_messages.extend(kwargs["messages"])
+            return type(
+                "ChatResponse",
+                (),
+                {
+                    "choices": [
+                        type(
+                            "Choice",
+                            (),
+                            {"message": type("Message", (), {"content": "bounded answer"})()},
+                        )()
+                    ],
+                    "usage": type(
+                        "Usage",
+                        (),
+                        {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+                    )(),
+                },
+            )()
+
+    client = type(
+        "FakeOpenAI",
+        (),
+        {
+            "embeddings": FakeEmbeddings(),
+            "chat": type("Chat", (), {"completions": FakeCompletions()})(),
+        },
+    )()
+    monkeypatch.setenv("FREE_LLM_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr("news_dashboard.ai_client.get_openai_client", lambda **_kwargs: client)
     policy = AskExecutionPolicy.mcp()
     saved = ask("question", pg_clean, user_id=alice, execution_policy=policy)
+    first_backfill = [text for text in embedded_inputs if text.startswith("Article")]
     visible = ask(
         "question",
         pg_clean,
@@ -477,6 +534,19 @@ def test_mcp_policy_preserves_exact_two_user_visibility_corpora(
     forbidden = {6, 7, 10}
     assert forbidden.isdisjoint(source["id"] for source in saved["sources"])
     assert forbidden.isdisjoint(source["id"] for source in visible["sources"])
+    assert len(first_backfill) <= 16
+    second_backfill = [
+        text for text in embedded_inputs[len(first_backfill) :] if text.startswith("Article")
+    ]
+    assert len(second_backfill) <= 16
+    provider_content = repr((embedded_inputs, answer_messages))
+    for forbidden_id in forbidden:
+        for secret in (
+            f"Article {forbidden_id}",
+            f"Summary {forbidden_id}",
+            f"https://example.com/{forbidden_id}",
+        ):
+            assert secret not in provider_content
 
 
 # ── POST /api/ask — payload bounds (#602) ────────────────────────────────────

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -6,7 +6,7 @@ import logging
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import MagicMock
 
 import httpx
@@ -417,6 +417,90 @@ def test_private_answer_records_safe_generation_usage_at_client_boundary(
     rendered = repr((langfuse.mock_calls, observation.mock_calls))
     for secret in ("PRIVATE SYSTEM", "PRIVATE USER PROMPT", "PRIVATE ANSWER", "secret"):
         assert secret not in rendered
+
+
+def test_private_ask_root_exits_cleanly_and_returns_trace_for_small_corpus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard import ai_client
+    from news_dashboard.assistant.service import AskExecutionPolicy
+
+    escaped: list[BaseException | None] = []
+    root = MagicMock()
+
+    class CleanExitContext:
+        def __enter__(self) -> MagicMock:
+            return root
+
+        def __exit__(
+            self, _kind: Any, error: BaseException | None, _traceback: Any
+        ) -> Literal[False]:
+            escaped.append(error)
+            return False
+
+    client = MagicMock()
+    client.start_as_current_observation.return_value = CleanExitContext()
+    client.get_current_trace_id.return_value = "0123456789abcdef0123456789abcdef"
+    monkeypatch.setattr(ai_client, "langfuse_enabled", lambda: True)
+    monkeypatch.setattr(ai_client, "_client", lambda: client)
+    monkeypatch.setattr(
+        embeddings_mod,
+        "_ask_impl",
+        lambda *_args, **_kwargs: {
+            "answer": "Not enough articles",
+            "sources": [],
+            "trace_id": None,
+        },
+    )
+
+    result = embeddings_mod.ask(
+        "PRIVATE QUESTION", user_id=7, execution_policy=AskExecutionPolicy.mcp()
+    )
+
+    assert escaped == [None]
+    assert result["trace_id"] == "0123456789abcdef0123456789abcdef"
+    root.update.assert_called_once_with(
+        output={"answer_chars": 19, "source_count": 0, "status": "ok"}
+    )
+
+
+def test_private_ask_root_reraises_only_after_clean_observation_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard import ai_client
+    from news_dashboard.assistant.service import AskExecutionPolicy
+
+    escaped: list[BaseException | None] = []
+    root = MagicMock()
+
+    class CleanExitContext:
+        def __enter__(self) -> MagicMock:
+            return root
+
+        def __exit__(
+            self, _kind: Any, error: BaseException | None, _traceback: Any
+        ) -> Literal[False]:
+            escaped.append(error)
+            return False
+
+    client = MagicMock()
+    client.start_as_current_observation.return_value = CleanExitContext()
+    monkeypatch.setattr(ai_client, "langfuse_enabled", lambda: True)
+    monkeypatch.setattr(ai_client, "_client", lambda: client)
+    hostile = "provider=https://secret sql=SELECT bearer=private"
+
+    def fail(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError(hostile)
+
+    monkeypatch.setattr(embeddings_mod, "_ask_impl", fail)
+    with pytest.raises(RuntimeError, match="provider=https://secret"):
+        embeddings_mod.ask("PRIVATE QUESTION", user_id=7, execution_policy=AskExecutionPolicy.mcp())
+
+    assert escaped == [None]
+    root.update.assert_called_once_with(
+        output={"status": "error"}, level="ERROR", status_message="ask failed"
+    )
+    assert hostile not in repr(root.mock_calls)
 
 
 # ── /api/ask surfaces a clean error on persistent embedding failure ────────

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import httpx
 import openai
@@ -297,9 +299,124 @@ def test_private_backfill_logs_no_article_or_provider_content(
         )
 
     assert count == 0
-    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    rendered = caplog.text
     assert hostile not in rendered
     assert str(ids[0]) not in rendered
+
+
+def test_private_embedding_records_safe_provider_usage_at_client_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard import ai_client
+
+    observation = MagicMock()
+    context = MagicMock()
+    context.__enter__.return_value = observation
+    client = MagicMock()
+    client.start_as_current_observation.return_value = context
+    response = SimpleNamespace(
+        data=[SimpleNamespace(embedding=[0.1, 0.2])],
+        usage=SimpleNamespace(prompt_tokens=7, total_tokens=7),
+    )
+    plain = MagicMock()
+    plain.embeddings.create.return_value = response
+    monkeypatch.setattr(ai_client, "langfuse_enabled", lambda: True)
+    monkeypatch.setattr(ai_client, "_client", lambda: client)
+    monkeypatch.setattr(ai_client, "get_openai_client", lambda **_kwargs: plain)
+    monkeypatch.setattr(
+        embeddings_mod, "_embeddings_ai_config", lambda: ("secret", None, "embed-model")
+    )
+
+    vector = embeddings_mod._embed("PRIVATE INPUT", timeout_seconds=20.0, trace_content=False)
+
+    assert vector == [0.1, 0.2]
+    client.start_as_current_observation.assert_called_once_with(
+        name="query-embedding-primary",
+        as_type="embedding",
+        input=None,
+        model="embed-model",
+        model_parameters={},
+        metadata={
+            "operation": "query-embedding",
+            "provider": "primary",
+            "attempt": 1,
+            "retry": 0,
+        },
+    )
+    observation.update.assert_called_once_with(
+        output={"status": "ok"},
+        usage_details={"input": 7, "total": 7},
+        metadata={
+            "operation": "query-embedding",
+            "provider": "primary",
+            "attempt": 1,
+            "retry": 0,
+            "outcome": "success",
+        },
+    )
+    rendered = repr((client.mock_calls, observation.mock_calls))
+    assert "PRIVATE INPUT" not in rendered
+    assert "secret" not in rendered
+
+
+def test_private_answer_records_safe_generation_usage_at_client_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard import ai_client
+
+    observation = MagicMock()
+    context = MagicMock()
+    context.__enter__.return_value = observation
+    langfuse = MagicMock()
+    langfuse.start_as_current_observation.return_value = context
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="PRIVATE ANSWER"))],
+        usage=SimpleNamespace(prompt_tokens=11, completion_tokens=4, total_tokens=15, cost=0.002),
+    )
+    plain = MagicMock()
+    plain.chat.completions.create.return_value = response
+    monkeypatch.setattr(ai_client, "langfuse_enabled", lambda: True)
+    monkeypatch.setattr(ai_client, "_client", lambda: langfuse)
+    monkeypatch.setattr(ai_client, "get_openai_client", lambda **_kwargs: plain)
+    monkeypatch.setattr(ai_client, "free_llm_config", lambda: ("secret", None))
+
+    answer = embeddings_mod._answer(
+        "PRIVATE SYSTEM",
+        "PRIVATE USER PROMPT",
+        max_tokens=512,
+        timeout_seconds=20.0,
+        trace_content=False,
+    )
+
+    assert answer == "PRIVATE ANSWER"
+    langfuse.start_as_current_observation.assert_called_once_with(
+        name="answer-generation-primary",
+        as_type="generation",
+        input=None,
+        model="gpt-4o-mini",
+        model_parameters={"max_tokens": 512},
+        metadata={
+            "operation": "answer-generation",
+            "provider": "primary",
+            "attempt": 1,
+            "retry": 0,
+        },
+    )
+    observation.update.assert_called_once_with(
+        output={"status": "ok"},
+        usage_details={"input": 11, "output": 4, "total": 15},
+        metadata={
+            "operation": "answer-generation",
+            "provider": "primary",
+            "attempt": 1,
+            "retry": 0,
+            "outcome": "success",
+        },
+        cost_details={"total": 0.002},
+    )
+    rendered = repr((langfuse.mock_calls, observation.mock_calls))
+    for secret in ("PRIVATE SYSTEM", "PRIVATE USER PROMPT", "PRIVATE ANSWER", "secret"):
+        assert secret not in rendered
 
 
 # ── /api/ask surfaces a clean error on persistent embedding failure ────────

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,8 @@ import httpx
 import openai
 import pytest
 from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableLambda
 
 from news_dashboard import embeddings as embeddings_mod
 from news_dashboard.auth import require_auth
@@ -144,7 +147,7 @@ def _seed_source(db_path: Path, slug: str = "test-source") -> None:
         )
 
 
-def _seed_unembedded_articles(db_path: Path, count: int) -> list[int]:
+def _seed_unembedded_articles(db_path: Any, count: int) -> list[int]:
     init_db(db_path)
     _seed_source(db_path)
     ids = []
@@ -202,6 +205,101 @@ def test_embed_all_eligible_skips_failing_article_and_continues(
             ).fetchall()
         }
     assert embedded_ids == {ids[0], ids[2]}
+
+
+def test_embed_all_eligible_limits_backfill_in_postgres(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ids = _seed_unembedded_articles(pg_clean, count=20)
+    monkeypatch.setattr(
+        embeddings_mod,
+        "_embed",
+        lambda _text, **_kwargs: [0.1] * EMBEDDING_DIMENSIONS,
+    )
+
+    count = embed_all_eligible(pg_clean, max_articles=16)
+
+    assert count == 16
+    with connect(database_url=pg_clean) as conn:
+        embedded = [
+            row["id"]
+            for row in conn.execute(
+                "SELECT id FROM articles WHERE embedding_vec IS NOT NULL ORDER BY id"
+            ).fetchall()
+        ]
+    assert embedded == ids[:16]
+
+
+def test_mcp_execution_policy_bounds_provider_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.assistant.service import AskExecutionPolicy
+
+    captured_client: dict[str, Any] = {}
+    captured_model: dict[str, Any] = {}
+
+    class FakeEmbeddingData:
+        def __init__(self) -> None:
+            self.embedding = [0.1]
+
+    class FakeEmbeddings:
+        def create(self, **_kwargs: Any) -> Any:
+            return type("Response", (), {"data": [FakeEmbeddingData()]})()
+
+    class FakeClient:
+        embeddings = FakeEmbeddings()
+
+    def fake_client(**kwargs: Any) -> FakeClient:
+        captured_client.update(kwargs)
+        return FakeClient()
+
+    monkeypatch.setattr(embeddings_mod, "_embeddings_ai_config", lambda: ("key", None, "embed"))
+    monkeypatch.setattr("news_dashboard.ai_client.get_chat_client", fake_client)
+    embeddings_mod._embed("question", timeout_seconds=20.0, trace_content=False)
+    assert captured_client["timeout_seconds"] == 20.0
+    assert captured_client["enable_tracing"] is False
+
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setattr(
+        "news_dashboard.ai_client.get_chat_model",
+        lambda **kwargs: (
+            captured_model.update(kwargs)
+            or RunnableLambda(lambda _value: AIMessage(content="answer"))
+        ),
+    )
+    policy = AskExecutionPolicy.mcp()
+    embeddings_mod._answer(
+        "system",
+        "user",
+        max_tokens=policy.answer_max_tokens,
+        timeout_seconds=policy.provider_timeout_seconds,
+    )
+    assert captured_model["max_tokens"] == 512
+    assert captured_model["timeout_seconds"] == 20.0
+
+
+def test_private_backfill_logs_no_article_or_provider_content(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ids = _seed_unembedded_articles(pg_clean, count=1)
+    hostile = "PRIVATE PROVIDER BODY"
+
+    def fail_privately(_text: str, **_kwargs: Any) -> list[float]:
+        raise RuntimeError(hostile)
+
+    monkeypatch.setattr(embeddings_mod, "_embed", fail_privately)
+    with caplog.at_level(logging.WARNING, logger="news_dashboard.embeddings"):
+        count = embed_all_eligible(
+            pg_clean,
+            max_articles=16,
+            provider_timeout_seconds=20.0,
+            trace_content=False,
+        )
+
+    assert count == 0
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert hostile not in rendered
+    assert str(ids[0]) not in rendered
 
 
 # ── /api/ask surfaces a clean error on persistent embedding failure ────────

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -2233,6 +2233,7 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
     expected_include_all: bool,
 ) -> None:
     from news_dashboard.mcp import service
+    from news_dashboard.mcp.server import MCP_ASK_EXECUTION_POLICY
 
     monkeypatch.setenv("DATABASE_URL", pg_clean)
     user_id = _make_user(pg_clean, f"ask-call-{expected_include_all}")
@@ -2265,6 +2266,7 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
         "question": expected_question,
         "include_all": expected_include_all,
         "user_id": user_id,
+        "execution_policy": MCP_ASK_EXECUTION_POLICY,
     }
 
 

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -2110,6 +2110,164 @@ def test_fastmcp_discovers_article_tool_only_with_read_scope(
     asyncio.run(exercise())
 
 
+@pytest.mark.parametrize(
+    ("scopes", "expected"),
+    [
+        (("ask",), ["ask_news"]),
+        (
+            ("ask", "search"),
+            ["ask_news", "list_latest_news", "list_news_sources", "search_news"],
+        ),
+        (("ask", "read"), ["ask_news", "get_news_article"]),
+    ],
+)
+def test_fastmcp_discovers_ask_news_only_with_ask_scope(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+    scopes: tuple[str, ...],
+    expected: list[str],
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, f"ask-discovery-{'-'.join(scopes)}")
+    token = service.create_token(user_id, "client", scopes=scopes, database_url=pg_clean)["token"]
+
+    async def exercise() -> None:
+        async with _mcp_client(token) as mcp_client:
+            tools = await mcp_client.list_tools()
+        assert sorted(tool.name for tool in tools) == expected
+
+    asyncio.run(exercise())
+
+
+def test_ask_news_is_hidden_and_denied_without_ask_scope(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, "ask-scope-denied")
+    token = service.create_token(user_id, "client", scopes=("read",), database_url=pg_clean)[
+        "token"
+    ]
+
+    async def exercise() -> None:
+        async with _mcp_client(token) as mcp_client:
+            assert [tool.name for tool in await mcp_client.list_tools()] == ["get_news_article"]
+            result = await mcp_client.call_tool(
+                "ask_news", {"question": "What happened?"}, raise_on_error=False
+            )
+        assert result.is_error is True
+
+    asyncio.run(exercise())
+
+
+def test_ask_news_schema_exposes_only_bounded_question_and_corpus(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, "ask-schema")
+    token = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)["token"]
+
+    async def exercise() -> None:
+        async with _mcp_client(token) as mcp_client:
+            [tool] = await mcp_client.list_tools()
+        assert tool.name == "ask_news"
+        schema = tool.inputSchema
+        assert schema["required"] == ["question"]
+        assert set(schema["properties"]) == {"question", "corpus"}
+        assert schema["properties"]["question"]["minLength"] == 1
+        assert schema["properties"]["question"]["maxLength"] == 2_000
+        assert schema["properties"]["corpus"]["enum"] == ["saved_and_read", "all_visible"]
+        assert schema["properties"]["corpus"]["default"] == "saved_and_read"
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("question", ["   ", "x" * 2_001])
+def test_ask_news_rejects_invalid_question_before_calling_assistant(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+    question: str,
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, f"ask-invalid-{len(question)}")
+    token = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)["token"]
+
+    def unexpected_ask(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        pytest.fail("assistant service must not run for an invalid question")
+
+    monkeypatch.setattr("news_dashboard.assistant.service.ask", unexpected_ask)
+
+    async def exercise() -> None:
+        async with _mcp_client(token) as mcp_client:
+            result = await mcp_client.call_tool(
+                "ask_news", {"question": question}, raise_on_error=False
+            )
+        assert result.is_error is True
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_question", "expected_include_all"),
+    [
+        ({"question": "  What changed?  "}, "What changed?", False),
+        (
+            {"question": "Show everything", "corpus": "all_visible"},
+            "Show everything",
+            True,
+        ),
+    ],
+)
+def test_ask_news_calls_canonical_assistant_with_token_identity(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+    arguments: dict[str, str],
+    expected_question: str,
+    expected_include_all: bool,
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, f"ask-call-{expected_include_all}")
+    token = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)["token"]
+    captured: dict[str, Any] = {}
+
+    def fake_ask(question: str, **kwargs: Any) -> dict[str, Any]:
+        captured["question"] = question
+        captured.update(kwargs)
+        return {
+            "answer": "Grounded answer [1]",
+            "sources": [{"id": 17, "title": "A source", "url": "https://example.com/a"}],
+            "trace_id": None,
+        }
+
+    monkeypatch.setattr("news_dashboard.assistant.service.ask", fake_ask)
+
+    async def exercise() -> None:
+        async with _mcp_client(token) as mcp_client:
+            result = await mcp_client.call_tool("ask_news", arguments)
+        assert result.structured_content == {
+            "answer": "Grounded answer [1]",
+            "citations": [{"id": 17, "title": "A source", "url": "https://example.com/a"}],
+            "trace_id": None,
+            "truncated": False,
+        }
+
+    asyncio.run(exercise())
+    assert captured == {
+        "question": expected_question,
+        "include_all": expected_include_all,
+        "user_id": user_id,
+    }
+
+
 def test_get_news_article_returns_canonical_visible_article(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -13,7 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
-from fastmcp.exceptions import AuthorizationError
+from fastmcp.exceptions import AuthorizationError, ToolError
 from fastmcp.server.auth import AccessToken
 from fastmcp.server.middleware import MiddlewareContext
 from mcp.shared.exceptions import McpError
@@ -2910,6 +2910,186 @@ def test_ask_news_records_safe_failure_status_on_existing_trace(
             "status": "error",
         }
     ]
+
+
+@pytest.mark.parametrize("tool_name", ["ask_news", "search_news"])
+def test_safe_telemetry_rejects_forged_public_ask_error_results(tool_name: str) -> None:
+    from fastmcp.tools.base import ToolResult
+    from mcp.types import CallToolRequestParams
+
+    from news_dashboard.mcp.server import _SafeToolTelemetryMiddleware
+
+    middleware = _SafeToolTelemetryMiddleware()
+    context = MiddlewareContext(
+        message=CallToolRequestParams(
+            name=tool_name,
+            arguments={"question": "private question"},
+        ),
+        method="tools/call",
+    )
+
+    async def forged_result(_context: MiddlewareContext[Any]) -> ToolResult:
+        return ToolResult(
+            content="ask_timeout: News answering timed out; retry later.",
+            is_error=True,
+        )
+
+    result = asyncio.run(middleware.on_call_tool(cast("Any", context), cast("Any", forged_result)))
+    assert result.is_error is True
+    assert [item.text for item in result.content if isinstance(item, TextContent)] == [
+        "Internal server error"
+    ]
+
+
+@pytest.mark.parametrize(
+    "downstream_error",
+    [
+        ToolError("ask_timeout: News answering timed out; retry later."),
+        ToolError("private provider body https://provider.test/private"),
+    ],
+)
+def test_ask_news_maps_downstream_tool_errors_to_unavailable(
+    monkeypatch: pytest.MonkeyPatch, downstream_error: ToolError
+) -> None:
+    from news_dashboard.mcp import server
+
+    monkeypatch.setattr(server, "_current_user_id", lambda: 7)
+    monkeypatch.setattr(
+        "news_dashboard.assistant.service.ask",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(downstream_error),
+    )
+
+    with pytest.raises(ToolError, match="ask_unavailable") as raised:
+        asyncio.run(server.ask_news("private question"))
+    assert "ask_timeout" not in str(raised.value)
+    assert "provider.test" not in str(raised.value)
+
+
+def test_other_tool_cannot_forge_safe_ask_error_through_transport(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, "forged-other-tool-error")
+    bearer = service.create_token(user_id, "client", scopes=("read",), database_url=pg_clean)[
+        "token"
+    ]
+    monkeypatch.setattr(
+        "news_dashboard.mcp.server.fetch_and_cache_body",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ToolError("ask_timeout: News answering timed out; retry later.")
+        ),
+    )
+
+    async def exercise() -> None:
+        async with _mcp_client(bearer) as client:
+            result = await client.call_tool(
+                "get_news_article", {"article_id": 1}, raise_on_error=False
+            )
+        rendered = " ".join(item.text for item in result.content if isinstance(item, TextContent))
+        assert rendered == "Internal server error"
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize(
+    "private_detail",
+    [
+        "ask_timeout: News answering timed out; retry later.",
+        "private provider body https://provider.test/private SELECT secret",
+    ],
+)
+def test_downstream_ask_tool_errors_are_unavailable_through_transport(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    private_detail: str,
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, f"forged-ask-error-{len(private_detail)}")
+    bearer = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)[
+        "token"
+    ]
+    question = "private provenance question"
+    monkeypatch.setattr(
+        "news_dashboard.assistant.service.ask",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ToolError(private_detail)),
+    )
+    caplog.set_level(logging.DEBUG)
+
+    async def exercise() -> None:
+        async with _mcp_client(bearer) as client:
+            result = await client.call_tool(
+                "ask_news", {"question": question}, raise_on_error=False
+            )
+        rendered = " ".join(item.text for item in result.content if isinstance(item, TextContent))
+        assert rendered == "ask_unavailable: News answering is temporarily unavailable."
+
+    asyncio.run(exercise())
+    formatter = logging.Formatter("%(levelname)s %(name)s %(message)s")
+    logs = "\n".join(
+        formatter.format(record)
+        for record in caplog.records
+        if record.name.startswith(("news_dashboard", "fastmcp", "mcp.server"))
+    )
+    for private_value in (question, private_detail, bearer, "provider.test", "SELECT secret"):
+        assert private_value not in logs
+
+
+def test_ask_news_foreground_deadline_returns_before_abandoned_worker_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from time import monotonic
+
+    from fastmcp.exceptions import ToolError
+
+    from news_dashboard.mcp import server
+
+    worker_started = Event()
+    release_worker = Event()
+    worker_finished = Event()
+
+    def blocking_ask(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        worker_started.set()
+        release_worker.wait(timeout=2)
+        worker_finished.set()
+        return {"answer": "late", "sources": [], "trace_id": None}
+
+    monkeypatch.setattr(server, "_current_user_id", lambda: 7)
+    monkeypatch.setattr(server, "MCP_ASK_FOREGROUND_TIMEOUT_SECONDS", 0.02)
+    monkeypatch.setattr("news_dashboard.assistant.service.ask", blocking_ask)
+
+    async def exercise() -> None:
+        started_at = monotonic()
+        with pytest.raises(ToolError, match="ask_timeout"):
+            await server.ask_news("private question")
+        elapsed = monotonic() - started_at
+        assert worker_started.is_set()
+        assert elapsed < 0.5
+        assert worker_finished.is_set() is False
+        release_worker.set()
+
+    asyncio.run(exercise())
+    assert worker_finished.wait(timeout=1)
+
+
+def test_ask_news_lru_access_refreshes_true_recency() -> None:
+    from news_dashboard.mcp.server import _AskRateLimiter
+
+    limiter = _AskRateLimiter(clock=lambda: 100.0, max_identities=3)
+    identities = [f"mcp-rate:{index:064x}" for index in range(1, 5)]
+    for identity in identities[:3]:
+        assert limiter.consume(identity) is True
+        assert limiter.consume(identity) is True
+        assert limiter.consume(identity) is False
+    assert limiter.consume(identities[0]) is False
+    assert limiter.consume(identities[3]) is True
+    assert limiter.consume(identities[0]) is False
+    assert limiter.consume(identities[1]) is True
 
 
 def test_ask_news_timeout_error_is_stable_through_real_transport(

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -2301,6 +2301,171 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
         assert private_value not in server_logs
 
 
+@pytest.mark.parametrize(
+    ("answer", "expected_ids"),
+    [
+        ("First [2], then [1], then [2].", [22, 11]),
+        ("Invalid [0] [-1] [3] [x] [ 1 ].", []),
+        ("A positive decimal may have leading zeroes: [01].", [11]),
+    ],
+)
+def test_ask_result_uses_only_valid_bracket_positions_in_first_cited_order(
+    answer: str, expected_ids: list[int]
+) -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result(
+        {
+            "answer": answer,
+            "sources": [
+                {"id": 11, "title": "One", "url": "https://one.test/story"},
+                {"id": 22, "title": "Two", "url": "https://two.test/story"},
+            ],
+            "trace_id": None,
+        }
+    )
+
+    assert [citation["id"] for citation in result["citations"]] == expected_ids
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        {"id": True, "title": "Boolean", "url": "https://example.test/1"},
+        {"id": 0, "title": "Zero", "url": "https://example.test/1"},
+        {"id": -1, "title": "Negative", "url": "https://example.test/1"},
+        {"id": 1, "title": "   ", "url": "https://example.test/1"},
+        {"id": 1, "title": "Title", "url": 123},
+        {"id": 1, "title": "Title", "url": "javascript:alert(1)"},
+        {"id": 1, "title": "Title", "url": "file:///etc/passwd"},
+        {"id": 1, "title": "Title", "url": "https://user:pass@example.test/story"},
+        {"id": 1, "title": "Title", "url": "https://example.test\\@evil.test/story"},
+        {"id": 1, "title": "Title", "url": "https:///missing-host"},
+    ],
+)
+def test_ask_result_omits_invalid_citation_records(source: dict[str, object]) -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result({"answer": "Claim [1]", "sources": [source], "trace_id": None})
+
+    assert result["citations"] == []
+
+
+def test_ask_result_normalizes_urls_and_deduplicates_article_ids() -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result(
+        {
+            "answer": "Claims [1], [2], and [3].",
+            "sources": [
+                {
+                    "id": 7,
+                    "title": " First title ",
+                    "url": "HTTPS://Example.TEST/story/?utm_source=mcp&b=2&a=1#fragment",
+                },
+                {"id": 7, "title": "Duplicate", "url": "https://duplicate.test"},
+                {"id": 8, "title": "HTTP stays HTTP", "url": "http://HTTP.test/path/"},
+            ],
+            "trace_id": "ABCDEF0123456789ABCDEF0123456789",
+        }
+    )
+
+    assert result == {
+        "answer": "Claims [1], [2], and [3].",
+        "citations": [
+            {
+                "id": 7,
+                "title": "First title",
+                "url": "https://example.test/story?a=1&b=2",
+            },
+            {"id": 8, "title": "HTTP stays HTTP", "url": "http://http.test/path"},
+        ],
+        "trace_id": "abcdef0123456789abcdef0123456789",
+        "truncated": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("trace_id", "expected"),
+    [
+        ("0123456789abcdef0123456789abcdef", "0123456789abcdef0123456789abcdef"),
+        ("ABCDEF0123456789ABCDEF0123456789", "abcdef0123456789abcdef0123456789"),
+        ("trace-local", None),
+        ("0" * 31, None),
+        (123, None),
+    ],
+)
+def test_ask_result_validates_trace_id(trace_id: object, expected: str | None) -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result({"answer": "Answer", "sources": [], "trace_id": trace_id})
+
+    assert result["trace_id"] == expected
+
+
+def test_ask_result_is_utf8_safe_and_within_structured_budget() -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+    from news_dashboard.mcp.server import MCP_STRUCTURED_CONTENT_BYTES
+
+    result = shape_ask_result(
+        {
+            "answer": '🙂雪\\"' * 8_000 + " [1] [2]",
+            "sources": [
+                {
+                    "id": 1,
+                    "title": 'Title 🙂雪\\"' * 1_000,
+                    "url": "https://example.test/" + "safe" * 1_000,
+                },
+                {"id": 2, "title": "Second", "url": "https://second.test/story"},
+            ],
+            "trace_id": "a" * 32,
+        }
+    )
+    encoded = json.dumps(result, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+
+    assert len(encoded) <= MCP_STRUCTURED_CONTENT_BYTES
+    assert result["truncated"] is True
+    assert result["answer"]
+    result["answer"].encode("utf-8").decode("utf-8")
+    assert all(set(citation) == {"id", "title", "url"} for citation in result["citations"])
+
+
+def test_ask_news_transport_stays_within_wire_budget(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, "ask-wire-budget")
+    token = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)["token"]
+    monkeypatch.setattr(
+        "news_dashboard.assistant.service.ask",
+        lambda *_args, **_kwargs: {
+            "answer": '🙂\\"' * 20_000 + " [1]",
+            "sources": [
+                {
+                    "id": 1,
+                    "title": "雪" * 4_000,
+                    "url": "https://example.test/" + "x" * 5_000,
+                }
+            ],
+            "trace_id": None,
+        },
+    )
+    response_bodies: list[bytes] = []
+
+    async def exercise() -> None:
+        async with _mcp_client(token, response_bodies=response_bodies) as mcp_client:
+            result = await mcp_client.call_tool("ask_news", {"question": "Question"})
+        assert result.structured_content is not None
+        assert result.structured_content["truncated"] is True
+
+    asyncio.run(exercise())
+    tool_response = next(body for body in response_bodies if b'"structuredContent"' in body)
+    assert len(tool_response) <= 16_384
+    json.loads(tool_response.split(b"data: ", 1)[1].splitlines()[0])
+
+
 def test_get_news_article_returns_canonical_visible_article(
     pg_clean: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -422,7 +422,9 @@ async def _mcp_client(
 
 def _decode_sse_json_response(body: bytes) -> dict[str, Any]:
     lines = body.splitlines()
-    assert lines[0] == b"event: message"
+    # FastMCP may emit an SSE keepalive comment before the response event when
+    # a bounded tool call takes longer than its ping interval.
+    assert b"event: message" in lines
     data_line = next(line for line in lines if line.startswith(b"data: "))
     payload = json.loads(data_line.removeprefix(b"data: "))
     assert isinstance(payload, dict)

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -2329,6 +2329,47 @@ def test_ask_result_uses_only_valid_bracket_positions_in_first_cited_order(
 
 
 @pytest.mark.parametrize(
+    "answer",
+    [
+        "Nested [[1]]",
+        "Extra opener [[1]",
+        "Extra closer [1]]",
+        "Deep [[[1]]]",
+        "Mixed [ [1]] and [[1] ]",
+    ],
+)
+def test_ask_result_rejects_references_embedded_in_extra_brackets(answer: str) -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result(
+        {
+            "answer": answer,
+            "sources": [{"id": 1, "title": "One", "url": "https://one.test/story"}],
+            "trace_id": None,
+        }
+    )
+
+    assert result["citations"] == []
+
+
+def test_ask_result_accepts_adjacent_references_and_punctuation() -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result(
+        {
+            "answer": "Adjacent [1][2]; punctuation ([2]), [1].",
+            "sources": [
+                {"id": 1, "title": "One", "url": "https://one.test/story"},
+                {"id": 2, "title": "Two", "url": "https://two.test/story"},
+            ],
+            "trace_id": None,
+        }
+    )
+
+    assert [citation["id"] for citation in result["citations"]] == [1, 2]
+
+
+@pytest.mark.parametrize(
     "source",
     [
         {"id": True, "title": "Boolean", "url": "https://example.test/1"},
@@ -2432,6 +2473,33 @@ def test_ask_result_omits_overlong_url_instead_of_rewriting_destination() -> Non
     assert result["citations"] == []
     assert result["truncated"] is True
     assert overlong_url[:2_048] not in json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    "overlong_url",
+    [
+        "https://example.test/" + "x" * 16_385,
+        "https://example.test/" + "é" * 1_100,
+    ],
+)
+def test_ask_result_marks_capacity_omission_while_preserving_other_citations(
+    overlong_url: str,
+) -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result(
+        {
+            "answer": "Oversized [1], valid [2].",
+            "sources": [
+                {"id": 1, "title": "Oversized", "url": overlong_url},
+                {"id": 2, "title": "Valid", "url": "https://valid.test/story"},
+            ],
+            "trace_id": None,
+        }
+    )
+
+    assert result["citations"] == [{"id": 2, "title": "Valid", "url": "https://valid.test/story"}]
+    assert result["truncated"] is True
 
 
 def test_ask_result_fails_closed_when_url_normalization_raises(
@@ -2557,6 +2625,8 @@ def test_ask_news_transport_stays_within_wire_budget(
     )
     assert len(tool_response) <= 16_384
     payload = _decode_sse_json_response(tool_response)
+    assert payload["jsonrpc"] == "2.0"
+    assert isinstance(payload["id"], int)
     structured = payload["result"]["structuredContent"]
     assert set(structured) == {"answer", "citations", "trace_id", "truncated"}
     assert structured["answer"] == answer_sentinel

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import AsyncIterator, Generator
 from contextlib import asynccontextmanager
 from threading import Event
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -274,7 +274,9 @@ def test_reused_database_token_id_gets_fresh_opaque_rate_limit_identity(
     asyncio.run(exercise())
 
 
-@pytest.mark.parametrize("rate_limit_id", [None, "", "mcp-token:7", 7])
+@pytest.mark.parametrize(
+    "rate_limit_id", [None, "", "mcp-token:7", "mcp-rate:", "mcp-rate:not-hex", 7]
+)
 def test_rate_limiter_fails_closed_without_valid_internal_identity(
     monkeypatch: pytest.MonkeyPatch, rate_limit_id: object
 ) -> None:
@@ -2633,6 +2635,329 @@ def test_ask_news_transport_stays_within_wire_budget(
     assert isinstance(structured["citations"], list)
     assert structured["trace_id"] is None
     assert structured["truncated"] is True
+
+
+def test_ask_news_dedicated_bucket_refills_without_sleep() -> None:
+    from news_dashboard.mcp.server import _AskRateLimiter
+
+    now = [100.0]
+    limiter = _AskRateLimiter(clock=lambda: now[0])
+    identity = "mcp-rate:" + "a" * 64
+
+    assert limiter.consume(identity) is True
+    assert limiter.consume(identity) is True
+    assert limiter.consume(identity) is False
+    now[0] += 29.999
+    assert limiter.consume(identity) is False
+    now[0] += 0.001
+    assert limiter.consume(identity) is True
+
+
+def test_ask_news_dedicated_bucket_isolates_tokens_and_bounds_lru() -> None:
+    from news_dashboard.mcp.server import _AskRateLimiter
+
+    limiter = _AskRateLimiter(clock=lambda: 100.0, max_identities=4_096)
+    first_identity = "mcp-rate:" + "a" * 64
+    second_identity = "mcp-rate:" + "b" * 64
+    assert limiter.consume(first_identity) is True
+    assert limiter.consume(first_identity) is True
+    assert limiter.consume(first_identity) is False
+    assert limiter.consume(second_identity) is True
+
+    for index in range(4_096):
+        assert limiter.consume(f"mcp-rate:{index:064x}") is True
+    assert len(limiter) == 4_096
+    assert limiter.consume(first_identity) is True
+
+
+@pytest.mark.parametrize("identity", [None, "", "mcp-token:1", "mcp-rate:", "mcp-rate:not-hex", 1])
+def test_ask_news_dedicated_bucket_fails_closed_for_invalid_identity(identity: object) -> None:
+    from news_dashboard.mcp.server import _AskRateLimiter
+
+    limiter = _AskRateLimiter(clock=lambda: 100.0)
+    with pytest.raises(AuthorizationError, match="Authorization required"):
+        limiter.consume(identity)
+
+
+def test_ask_news_dedicated_middleware_ignores_non_ask_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp import server
+
+    middleware = server._AskRateLimitingMiddleware(
+        limiter=server._AskRateLimiter(clock=lambda: 100.0)
+    )
+    opaque_value = "-".join(("private", "bearer"))
+    token = AccessToken(
+        token=opaque_value,
+        client_id="mcp-token:5",
+        subject="7",
+        scopes=["search"],
+        claims={"user_id": 7},
+    )
+    monkeypatch.setattr(server, "get_access_token", lambda: token)
+    context = MiddlewareContext(
+        message=type("Params", (), {"name": "search_news"})(), method="tools/call"
+    )
+
+    from fastmcp.tools.base import ToolResult
+
+    async def call_next(_context: MiddlewareContext[Any]) -> ToolResult:
+        return ToolResult(content="ok")
+
+    result = asyncio.run(middleware.on_call_tool(cast("Any", context), cast("Any", call_next)))
+    assert result.is_error is False
+
+
+def test_ask_news_uses_foreground_timeout_and_abandonable_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastmcp.exceptions import ToolError
+
+    from news_dashboard.mcp import server
+
+    calls: dict[str, object] = {}
+
+    class ImmediateTimeout:
+        def __enter__(self) -> None:
+            raise TimeoutError
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        server, "fail_after", lambda seconds: (calls.update(seconds=seconds), ImmediateTimeout())[1]
+    )
+    monkeypatch.setattr(server, "_current_user_id", lambda: 7)
+    monkeypatch.setattr(server, "_ask_rate_limit_identity", lambda: "mcp-rate:" + "a" * 64)
+
+    with pytest.raises(ToolError, match="ask_timeout"):
+        asyncio.run(server.ask_news("Question"))
+    assert calls == {"seconds": 30.0}
+
+
+@pytest.mark.parametrize(
+    ("exception_factory", "code", "message"),
+    [
+        (
+            lambda: __import__(
+                "news_dashboard.embeddings", fromlist=["MissingAICredentialsError"]
+            ).MissingAICredentialsError("SECRET"),
+            "ask_not_configured",
+            "News answering is not configured.",
+        ),
+        (
+            lambda: __import__(
+                "news_dashboard.embeddings", fromlist=["EmbeddingUnavailableError"]
+            ).EmbeddingUnavailableError("provider body"),
+            "embedding_unavailable",
+            "News retrieval is temporarily unavailable.",
+        ),
+    ],
+)
+def test_ask_news_maps_application_errors_to_fixed_public_errors(
+    exception_factory: Any, code: str, message: str
+) -> None:
+    from news_dashboard.mcp.server import _public_ask_error
+
+    private_error = exception_factory()
+    public_error = _public_ask_error(private_error)
+    rendered = str(public_error)
+    assert code in rendered
+    assert message in rendered
+    assert str(private_error) not in rendered
+
+
+@pytest.mark.parametrize(
+    ("error_name", "expected_code"),
+    [
+        ("AuthenticationError", "provider_authentication_failed"),
+        ("PermissionDeniedError", "provider_authentication_failed"),
+        ("RateLimitError", "provider_rate_limited"),
+        ("APITimeoutError", "ask_timeout"),
+        ("APIConnectionError", "ask_unavailable"),
+        ("APIStatusError", "ask_unavailable"),
+    ],
+)
+def test_ask_news_maps_provider_errors_without_provider_details(
+    error_name: str, expected_code: str
+) -> None:
+    import openai
+
+    from news_dashboard.mcp.server import _public_ask_error
+
+    request = httpx.Request("POST", "https://provider.test/private")
+    if error_name in {"APITimeoutError", "APIConnectionError"}:
+        private_error = getattr(openai, error_name)(request=request)
+    else:
+        response = httpx.Response(503, request=request)
+        private_error = getattr(openai, error_name)(
+            "private provider response", response=response, body={"secret": "body"}
+        )
+    rendered = str(_public_ask_error(private_error))
+    assert expected_code in rendered
+    for private_value in ("provider.test", "private provider response", "secret", "body"):
+        assert private_value not in rendered
+
+
+def test_ask_news_preserves_cancellation_and_requests_abandonable_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp import server
+
+    captured: dict[str, object] = {}
+
+    async def cancelled_run_sync(
+        _function: Any, *, abandon_on_cancel: bool = False
+    ) -> dict[str, Any]:
+        captured["abandon_on_cancel"] = abandon_on_cancel
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr("news_dashboard.mcp.server.to_thread.run_sync", cancelled_run_sync)
+    monkeypatch.setattr(server, "_current_user_id", lambda: 7)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(server.ask_news("Question"))
+    assert captured == {"abandon_on_cancel": True}
+
+
+def test_ask_news_dedicated_rate_is_distinct_from_provider_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastmcp.exceptions import ToolError
+    from fastmcp.tools.base import ToolResult
+
+    from news_dashboard.mcp import server
+
+    limiter = server._AskRateLimiter(clock=lambda: 100.0)
+    middleware = server._AskRateLimitingMiddleware(limiter=limiter)
+    opaque_value = "-".join(("private", "bearer"))
+    token = AccessToken(
+        token=opaque_value,
+        client_id="public-db-token-id",
+        subject="7",
+        scopes=["ask"],
+        claims={"user_id": 7, "rate_limit_id": "mcp-rate:" + "a" * 64},
+    )
+    monkeypatch.setattr(server, "get_access_token", lambda: token)
+    context = MiddlewareContext(
+        message=type("Params", (), {"name": "ask_news"})(), method="tools/call"
+    )
+
+    async def call_next(_context: MiddlewareContext[Any]) -> ToolResult:
+        return ToolResult(content="ok")
+
+    assert (
+        asyncio.run(middleware.on_call_tool(cast("Any", context), cast("Any", call_next))).is_error
+        is False
+    )
+    assert (
+        asyncio.run(middleware.on_call_tool(cast("Any", context), cast("Any", call_next))).is_error
+        is False
+    )
+    with pytest.raises(ToolError, match="ask_rate_limited"):
+        asyncio.run(middleware.on_call_tool(cast("Any", context), cast("Any", call_next)))
+    assert "provider_rate_limited" in str(
+        server._public_ask_error(
+            __import__("openai").RateLimitError(
+                "upstream private body",
+                response=httpx.Response(
+                    429, request=httpx.Request("POST", "https://provider.test/private")
+                ),
+                body=None,
+            )
+        )
+    )
+
+
+def test_ask_news_records_safe_failure_status_on_existing_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastmcp.exceptions import ToolError
+
+    from news_dashboard.mcp import server
+
+    trace_id = "0123456789abcdef0123456789abcdef"
+    recorded: list[dict[str, object]] = []
+    monkeypatch.setattr(server, "_current_user_id", lambda: 7)
+    monkeypatch.setattr(
+        "news_dashboard.assistant.service.ask",
+        lambda *_args, **_kwargs: {
+            "answer": "private answer",
+            "sources": [],
+            "trace_id": trace_id,
+        },
+    )
+    monkeypatch.setattr(
+        server,
+        "shape_ask_result",
+        lambda _result: (_ for _ in ()).throw(ValueError("private shaping detail")),
+    )
+    monkeypatch.setattr(
+        "news_dashboard.ai_client.record_mcp_ask_result",
+        lambda recorded_trace_id, **kwargs: recorded.append(
+            {"trace_id": recorded_trace_id, **kwargs}
+        ),
+    )
+
+    with pytest.raises(ToolError, match="ask_unavailable"):
+        asyncio.run(server.ask_news("private question"))
+    assert recorded == [
+        {
+            "trace_id": trace_id,
+            "citation_count": 0,
+            "truncated": False,
+            "status": "error",
+        }
+    ]
+
+
+def test_ask_news_timeout_error_is_stable_through_real_transport(
+    pg_clean: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    user_id = _make_user(pg_clean, "ask-stable-timeout")
+    bearer = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)[
+        "token"
+    ]
+    private_values = (
+        "private question",
+        "private context",
+        "private answer",
+        bearer,
+        "https://provider.test/private",
+        "SELECT private FROM secrets",
+    )
+
+    def timed_out(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise TimeoutError(" ".join(private_values))
+
+    monkeypatch.setattr("news_dashboard.assistant.service.ask", timed_out)
+    caplog.set_level(logging.DEBUG)
+
+    async def exercise() -> None:
+        async with _mcp_client(bearer) as client:
+            result = await client.call_tool(
+                "ask_news", {"question": private_values[0]}, raise_on_error=False
+            )
+        assert result.is_error is True
+        rendered = " ".join(item.text for item in result.content if isinstance(item, TextContent))
+        assert "ask_timeout" in rendered
+        assert "News answering timed out; retry later." in rendered
+
+    asyncio.run(exercise())
+    formatter = logging.Formatter("%(levelname)s %(name)s %(message)s")
+    logs = "\n".join(
+        formatter.format(record)
+        for record in caplog.records
+        if record.name.startswith(("news_dashboard", "fastmcp", "mcp.server"))
+    )
+    for private_value in private_values:
+        assert private_value not in logs
 
 
 def test_get_news_article_returns_canonical_visible_article(

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -2228,6 +2228,7 @@ def test_ask_news_rejects_invalid_question_before_calling_assistant(
 def test_ask_news_calls_canonical_assistant_with_token_identity(
     pg_clean: str,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
     arguments: dict[str, str],
     expected_question: str,
     expected_include_all: bool,
@@ -2239,6 +2240,8 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
     user_id = _make_user(pg_clean, f"ask-call-{expected_include_all}")
     token = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)["token"]
     captured: dict[str, Any] = {}
+    recorded: list[dict[str, Any]] = []
+    trace_id = "0123456789abcdef0123456789abcdef"
 
     def fake_ask(question: str, **kwargs: Any) -> dict[str, Any]:
         captured["question"] = question
@@ -2246,10 +2249,17 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
         return {
             "answer": "Grounded answer [1]",
             "sources": [{"id": 17, "title": "A source", "url": "https://example.com/a"}],
-            "trace_id": None,
+            "trace_id": trace_id,
         }
 
     monkeypatch.setattr("news_dashboard.assistant.service.ask", fake_ask)
+    monkeypatch.setattr(
+        "news_dashboard.ai_client.record_mcp_ask_result",
+        lambda recorded_trace_id, **kwargs: recorded.append(
+            {"trace_id": recorded_trace_id, **kwargs}
+        ),
+    )
+    caplog.set_level(logging.DEBUG)
 
     async def exercise() -> None:
         async with _mcp_client(token) as mcp_client:
@@ -2257,7 +2267,7 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
         assert result.structured_content == {
             "answer": "Grounded answer [1]",
             "citations": [{"id": 17, "title": "A source", "url": "https://example.com/a"}],
-            "trace_id": None,
+            "trace_id": trace_id,
             "truncated": False,
         }
 
@@ -2268,6 +2278,27 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
         "user_id": user_id,
         "execution_policy": MCP_ASK_EXECUTION_POLICY,
     }
+    assert recorded == [
+        {
+            "trace_id": trace_id,
+            "citation_count": 1,
+            "truncated": False,
+            "status": "ok",
+        }
+    ]
+    formatter = logging.Formatter("%(levelname)s %(name)s %(message)s")
+    server_logs = "\n".join(
+        formatter.format(record)
+        for record in caplog.records
+        if record.name.startswith(("news_dashboard", "fastmcp", "mcp.server"))
+    )
+    for private_value in (
+        expected_question,
+        "Grounded answer [1]",
+        "https://example.com/a",
+        token,
+    ):
+        assert private_value not in server_logs
 
 
 def test_get_news_article_returns_canonical_visible_article(

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -1506,7 +1506,10 @@ def test_get_news_article_suppresses_real_body_fetch_diagnostics_during_mcp(
 
 def test_mcp_extraction_log_filters_are_request_scoped_and_reset(
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from news_dashboard import embeddings
+    from news_dashboard.graph_store import GraphUnavailableError
     from news_dashboard.mcp.server import _SanitizeMcpResponses
 
     extraction_loggers = tuple(
@@ -1515,8 +1518,15 @@ def test_mcp_extraction_log_filters_are_request_scoped_and_reset(
             "news_dashboard.body_fetch",
             "news_dashboard.selenium_client",
             "news_dashboard.ai_client",
+            "news_dashboard.embeddings",
         )
     )
+    graph_detail = "neo4j=https://private graph-article-781 connection-secret"
+
+    def fail_graph_store() -> None:
+        raise GraphUnavailableError(graph_detail)
+
+    monkeypatch.setattr("news_dashboard.graph_store.graph_store_from_env", fail_graph_store)
     mcp_started = asyncio.Event()
     allow_mcp_to_log = asyncio.Event()
 
@@ -1525,6 +1535,7 @@ def test_mcp_extraction_log_filters_are_request_scoped_and_reset(
         await allow_mcp_to_log.wait()
         for extraction_logger in extraction_loggers:
             extraction_logger.warning("mcp-private-url provider-private-detail")
+        assert embeddings.graph_context_for_articles([781]) is None
 
     async def raising_mcp_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
         extraction_loggers[0].warning("mcp-error-private-detail")
@@ -1560,6 +1571,7 @@ def test_mcp_extraction_log_filters_are_request_scoped_and_reset(
         with pytest.raises(asyncio.CancelledError):
             await _SanitizeMcpResponses(cancelled_mcp_app)(scope, receive, send)
         extraction_loggers[1].warning("visible-after-cancellation")
+        assert embeddings.graph_context_for_articles([781]) is None
 
     asyncio.run(exercise())
     rendered = caplog.text
@@ -1570,6 +1582,7 @@ def test_mcp_extraction_log_filters_are_request_scoped_and_reset(
     assert "provider-private-detail" not in rendered
     assert "mcp-error-private-detail" not in rendered
     assert "mcp-cancel-private-detail" not in rendered
+    assert rendered.count(graph_detail) == 1
 
 
 def test_latest_news_returns_compact_articles_visible_to_token_owner(

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -2306,7 +2306,7 @@ def test_ask_news_calls_canonical_assistant_with_token_identity(
     [
         ("First [2], then [1], then [2].", [22, 11]),
         ("Invalid [0] [-1] [3] [x] [ 1 ].", []),
-        ("A positive decimal may have leading zeroes: [01].", [11]),
+        ("A canonical positive decimal: [1].", [11]),
     ],
 )
 def test_ask_result_uses_only_valid_bracket_positions_in_first_cited_order(
@@ -2341,6 +2341,15 @@ def test_ask_result_uses_only_valid_bracket_positions_in_first_cited_order(
         {"id": 1, "title": "Title", "url": "https://user:pass@example.test/story"},
         {"id": 1, "title": "Title", "url": "https://example.test\\@evil.test/story"},
         {"id": 1, "title": "Title", "url": "https:///missing-host"},
+        {"id": 1, "title": "Title", "url": "https://example.test:/story"},
+        {"id": 1, "title": "Title", "url": "https://example.test:0/story"},
+        {"id": 1, "title": "Title", "url": "https://example.test:65536/story"},
+        {"id": 1, "title": "Title", "url": "https://example.test:notaport/story"},
+        {"id": 1, "title": "Title", "url": "https://%65xample.test/story"},
+        {"id": 1, "title": "Title", "url": "https://exa_mple.test/story"},
+        {"id": 1, "title": "Title", "url": "https://-example.test/story"},
+        {"id": 1, "title": "Title", "url": "https://example..test/story"},
+        {"id": 1, "title": "Title", "url": "https://[not-ipv6]/story"},
     ],
 )
 def test_ask_result_omits_invalid_citation_records(source: dict[str, object]) -> None:
@@ -2383,6 +2392,83 @@ def test_ask_result_normalizes_urls_and_deduplicates_article_ids() -> None:
         "trace_id": "abcdef0123456789abcdef0123456789",
         "truncated": False,
     }
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://192.0.2.1/story", "https://192.0.2.1/story"),
+        ("https://[2001:db8::1]/story", "https://[2001:db8::1]/story"),
+        ("https://BÜCHER.example/story", "https://bücher.example/story"),
+        ("https://XN--BCHER-KVA.example/story", "https://xn--bcher-kva.example/story"),
+    ],
+)
+def test_ask_result_preserves_valid_normalized_ip_and_idna_hosts(url: str, expected: str) -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result(
+        {
+            "answer": "Claim [1]",
+            "sources": [{"id": 1, "title": "Title", "url": url}],
+            "trace_id": None,
+        }
+    )
+
+    assert result["citations"] == [{"id": 1, "title": "Title", "url": expected}]
+
+
+def test_ask_result_omits_overlong_url_instead_of_rewriting_destination() -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    overlong_url = "https://example.test/" + "x" * 2_100
+    result = shape_ask_result(
+        {
+            "answer": "Claim [1]",
+            "sources": [{"id": 1, "title": "Title", "url": overlong_url}],
+            "trace_id": None,
+        }
+    )
+
+    assert result["citations"] == []
+    assert result["truncated"] is True
+    assert overlong_url[:2_048] not in json.dumps(result)
+
+
+def test_ask_result_fails_closed_when_url_normalization_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp import ask
+
+    monkeypatch.setattr(
+        ask,
+        "canonicalize_url",
+        lambda _url: (_ for _ in ()).throw(ValueError("private normalization detail")),
+    )
+
+    result = ask.shape_ask_result(
+        {
+            "answer": "Claim [1]",
+            "sources": [{"id": 1, "title": "Title", "url": "https://example.test/a"}],
+            "trace_id": None,
+        }
+    )
+
+    assert result["citations"] == []
+
+
+@pytest.mark.parametrize("reference", ["[" + "9" * 5_000 + "]", "[0001]"])
+def test_ask_result_ignores_ambiguous_or_oversized_decimal_references(reference: str) -> None:
+    from news_dashboard.mcp.ask import shape_ask_result
+
+    result = shape_ask_result(
+        {
+            "answer": f"Ordinary text {reference}",
+            "sources": [{"id": 1, "title": "Title", "url": "https://example.test/a"}],
+            "trace_id": None,
+        }
+    )
+
+    assert result["citations"] == []
 
 
 @pytest.mark.parametrize(
@@ -2438,16 +2524,18 @@ def test_ask_news_transport_stays_within_wire_budget(
     monkeypatch.setenv("DATABASE_URL", pg_clean)
     user_id = _make_user(pg_clean, "ask-wire-budget")
     token = service.create_token(user_id, "client", scopes=("ask",), database_url=pg_clean)["token"]
+    answer_sentinel = "wire-budget-answer " + " ".join(f"[{index}]" for index in range(1, 13))
     monkeypatch.setattr(
         "news_dashboard.assistant.service.ask",
         lambda *_args, **_kwargs: {
-            "answer": '🙂\\"' * 20_000 + " [1]",
+            "answer": answer_sentinel,
             "sources": [
                 {
-                    "id": 1,
+                    "id": index,
                     "title": "雪" * 4_000,
-                    "url": "https://example.test/" + "x" * 5_000,
+                    "url": f"https://example.test/{index}",
                 }
+                for index in range(1, 13)
             ],
             "trace_id": None,
         },
@@ -2458,12 +2546,23 @@ def test_ask_news_transport_stays_within_wire_budget(
         async with _mcp_client(token, response_bodies=response_bodies) as mcp_client:
             result = await mcp_client.call_tool("ask_news", {"question": "Question"})
         assert result.structured_content is not None
+        assert result.structured_content["answer"] == answer_sentinel
         assert result.structured_content["truncated"] is True
 
     asyncio.run(exercise())
-    tool_response = next(body for body in response_bodies if b'"structuredContent"' in body)
+    tool_response = next(
+        body
+        for body in response_bodies
+        if b'"structuredContent"' in body and answer_sentinel.encode() in body
+    )
     assert len(tool_response) <= 16_384
-    json.loads(tool_response.split(b"data: ", 1)[1].splitlines()[0])
+    payload = _decode_sse_json_response(tool_response)
+    structured = payload["result"]["structuredContent"]
+    assert set(structured) == {"answer", "citations", "trace_id", "truncated"}
+    assert structured["answer"] == answer_sentinel
+    assert isinstance(structured["citations"], list)
+    assert structured["trace_id"] is None
+    assert structured["truncated"] is True
 
 
 def test_get_news_article_returns_canonical_visible_article(

--- a/backend/tests/test_user_attribution.py
+++ b/backend/tests/test_user_attribution.py
@@ -264,6 +264,86 @@ def test_ask_uses_native_langfuse_user_and_session_attributes() -> None:
     span.update.assert_called_once_with(output="answer")
 
 
+def test_mcp_ask_trace_contains_only_safe_operational_metadata() -> None:
+    from contextlib import contextmanager
+
+    from news_dashboard import embeddings
+    from news_dashboard.assistant.service import AskExecutionPolicy
+
+    question = "PRIVATE QUESTION"
+    article_text = "PRIVATE ARTICLE"
+    answer = "PRIVATE ANSWER"
+    article_url = "https://private.example/secret"
+    captured: dict[str, Any] = {}
+    span = MagicMock()
+    client = MagicMock()
+    client.get_current_trace_id.return_value = "0123456789abcdef0123456789abcdef"
+
+    @contextmanager
+    def attributes(**kwargs: Any) -> Any:
+        captured["attributes"] = kwargs
+        yield
+
+    @contextmanager
+    def observation(**kwargs: Any) -> Any:
+        captured["observation"] = kwargs
+        yield span
+
+    client.start_as_current_observation.side_effect = observation
+    rows = [
+        {
+            "id": i,
+            "title": f"Title {i}",
+            "url": article_url,
+            "summary": article_text,
+            "eligible_count": 5,
+        }
+        for i in range(1, 6)
+    ]
+    with (
+        patch("news_dashboard.ai_client.langfuse_enabled", return_value=True),
+        patch("news_dashboard.ai_client._client", return_value=client),
+        patch("langfuse.propagate_attributes", side_effect=attributes),
+        patch.object(embeddings, "embed_all_eligible", return_value=0),
+        patch.object(embeddings, "_embed", return_value=[]),
+        patch("news_dashboard.db.init_db"),
+        patch("news_dashboard.db.connect") as connect,
+        patch.object(embeddings, "graph_context_for_articles", return_value=None),
+        patch("news_dashboard.ai_client.get_prompt") as get_prompt,
+        patch("news_dashboard.ai_memory.service.format_memories_for_prompt", return_value=""),
+        patch.object(embeddings, "_answer", return_value=answer),
+    ):
+        fetchall = connect.return_value.__enter__.return_value.execute.return_value.fetchall
+        fetchall.return_value = rows
+        get_prompt.return_value.text = "PRIVATE PROMPT"
+        get_prompt.return_value.langfuse_prompt = object()
+        result = embeddings.ask(
+            question,
+            user_id=7,
+            execution_policy=AskExecutionPolicy.mcp(),
+        )
+
+    assert result["trace_id"] == "0123456789abcdef0123456789abcdef"
+    assert captured["attributes"] | captured["observation"] == {
+        "user_id": "7",
+        "tags": ["ask-ai", "mcp"],
+        "metadata": {"surface": "mcp", "corpus": "saved_and_read"},
+        "trace_name": "ask-news",
+        "name": "ask-ai",
+        "as_type": "chain",
+        "prompt": get_prompt.return_value.langfuse_prompt,
+        "input": {
+            "question_chars": len(question),
+            "corpus": "saved_and_read",
+            "retrieval_limit": 8,
+        },
+    }
+    span.update.assert_called_once_with(output={"answer_chars": len(answer), "status": "ok"})
+    rendered = repr((captured, span.update.call_args))
+    for secret in (question, article_text, article_url, answer, "PRIVATE PROMPT"):
+        assert secret not in rendered
+
+
 # ── body_fetch: AI body extraction threads user_id ────────────────────────────
 
 

--- a/backend/tests/test_user_attribution.py
+++ b/backend/tests/test_user_attribution.py
@@ -275,7 +275,7 @@ def test_mcp_ask_trace_contains_only_safe_operational_metadata() -> None:
     answer = "PRIVATE ANSWER"
     article_url = "https://private.example/secret"
     captured: dict[str, Any] = {}
-    span = MagicMock()
+    observations: list[tuple[dict[str, Any], MagicMock]] = []
     client = MagicMock()
     client.get_current_trace_id.return_value = "0123456789abcdef0123456789abcdef"
 
@@ -286,7 +286,8 @@ def test_mcp_ask_trace_contains_only_safe_operational_metadata() -> None:
 
     @contextmanager
     def observation(**kwargs: Any) -> Any:
-        captured["observation"] = kwargs
+        span = MagicMock()
+        observations.append((kwargs, span))
         yield span
 
     client.start_as_current_observation.side_effect = observation
@@ -324,22 +325,36 @@ def test_mcp_ask_trace_contains_only_safe_operational_metadata() -> None:
         )
 
     assert result["trace_id"] == "0123456789abcdef0123456789abcdef"
-    assert captured["attributes"] | captured["observation"] == {
+    assert captured["attributes"] | observations[0][0] == {
         "user_id": "7",
         "tags": ["ask-ai", "mcp"],
         "metadata": {"surface": "mcp", "corpus": "saved_and_read"},
         "trace_name": "ask-news",
         "name": "ask-ai",
         "as_type": "chain",
-        "prompt": get_prompt.return_value.langfuse_prompt,
         "input": {
             "question_chars": len(question),
             "corpus": "saved_and_read",
             "retrieval_limit": 8,
         },
     }
-    span.update.assert_called_once_with(output={"answer_chars": len(answer), "status": "ok"})
-    rendered = repr((captured, span.update.call_args))
+    assert observations[1][0] == {
+        "name": "answer-pipeline",
+        "as_type": "chain",
+        "input": {
+            "question_chars": len(question),
+            "corpus": "saved_and_read",
+            "retrieval_limit": 8,
+        },
+        "prompt": get_prompt.return_value.langfuse_prompt,
+    }
+    observations[0][1].update.assert_called_once_with(
+        output={"answer_chars": len(answer), "source_count": 5, "status": "ok"}
+    )
+    observations[1][1].update.assert_called_once_with(
+        output={"answer_chars": len(answer), "status": "ok"}
+    )
+    rendered = repr((captured, observations))
     for secret in (question, article_text, article_url, answer, "PRIVATE PROMPT"):
         assert secret not in rendered
 

--- a/docs/superpowers/plans/2026-08-03-fastmcp-ask.md
+++ b/docs/superpowers/plans/2026-08-03-fastmcp-ask.md
@@ -1,0 +1,66 @@
+# Grounded FastMCP Ask News Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans task-by-task. Use the repository Langfuse skill for tracing work.
+
+**Goal:** Add an authenticated, grounded, privacy-preserving `ask_news` FastMCP tool with bounded cost, capacity, citations, tracing, and stable errors, closing #1370.
+
+**Architecture:** Keep `assistant.service.ask -> embeddings.ask` as the only RAG path. Add an optional execution policy so MCP can bound SQL backfill, retrieval, provider timeout, output tokens, and trace content without changing browser/A2A defaults. The async MCP adapter supplies token identity, a typed corpus enum, dedicated opaque-token rate limiting, citation validation over the already-authorized ordered source list, schema-valid response packing, and fixed public errors.
+
+## Global constraints
+
+- PostgreSQL/pgvector canonical retrieval only; no second MCP query or prompt.
+- `ask` scope and token-derived identity only; MCP and A2A flags/routes remain independent.
+- `saved_and_read` means Starred + Done; `all_visible` means all visible non-archived articles.
+- No bearer/question/article/prompt/URL/answer/provider-body content in logs or Langfuse metadata/I/O.
+- Preserve cancellation; foreground timeout is paired with provider timeout and bounded spend.
+- Record RED before implementation and mock Langfuse locally—never use credentials/data.
+
+### Task 1: Add typed tool shell and canonical call
+
+**Files:** `backend/news_dashboard/mcp/models.py`, `backend/news_dashboard/mcp/server.py`, `backend/tests/test_mcp.py`
+
+- [ ] Add official-client RED tests for ask-only discovery, under-scope hiding/direct denial, generated question/corpus schema, invalid questions, corpus translation, token user ID, and structured success.
+- [ ] Add trimmed 1..2,000 question and `saved_and_read|all_visible` corpus aliases.
+- [ ] Register async `ask_news` with `require_scopes("ask")`, initially calling only `assistant.service.ask` with `include_all` and token user.
+- [ ] Return typed `{answer,citations,trace_id,truncated}` shell; no extra model/prompt/user arguments.
+- [ ] Run focused MCP/A2A/auth tests, lint/typecheck; commit `feat(mcp): add ask news tool shell`.
+
+### Task 2: Add bounded canonical execution and privacy tracing
+
+**Files:** `backend/news_dashboard/assistant/service.py`, `backend/news_dashboard/embeddings.py`, `backend/news_dashboard/ai_client.py`, relevant ask/embedding/MCP tests
+
+- [ ] Add RED tests for exact Starred+Done/all-visible cross-user corpus, bounded SQL backfill 16, retrieval 8, answer 512 tokens, provider 20s timeout, and unchanged browser/A2A defaults.
+- [ ] Add optional frozen execution policy threaded through canonical service/embed/answer/client calls; `None` preserves existing behavior.
+- [ ] MCP policy disables raw trace content, propagates authenticated string user early, tags/metadata only with surface/corpus/character counts, and returns the active 32-hex trace ID.
+- [ ] Prove raw question, article text, prompt, URLs, answer, bearer/token identifiers never enter trace attributes/I/O or app logs.
+- [ ] Run ask/embedding/MCP/A2A tests, lint/typecheck; commit `feat(ai): bound MCP news answering`.
+
+### Task 3: Validate citations and bound structured results
+
+**Files:** preferably create `backend/news_dashboard/mcp/ask.py`, modify server/tests
+
+- [ ] Add table-driven RED tests for bracket-position parsing, duplicates, invalid/out-of-range references, missing fields/IDs, unsafe/malformed URLs, normalization, invalid trace IDs, oversized answer/titles/URLs, Unicode/escaping, exact 4,800-byte structured and 16 KiB wire bounds.
+- [ ] Treat brackets as 1-based positions into the authorized service source list, then dedupe by article ID in first-cited order.
+- [ ] Normalize and fail closed to HTTP(S) citations; never invent or trust generated database IDs.
+- [ ] Keep complete citation objects and UTF-8-safe answer prefixes within required schema; set truncation flag.
+- [ ] Run focused/general MCP tests, lint/typecheck; commit `fix(mcp): validate grounded news answers`.
+
+### Task 4: Add dedicated generation controls and stable errors
+
+**Files:** `backend/news_dashboard/mcp/server.py`, optional `mcp/errors.py`, tests
+
+- [ ] Add deterministic RED tests for ask-only opaque per-token bucket (burst 2, refill 1/30s), identity isolation, LRU 4,096 eviction, non-ask independence, foreground 30s timeout, and provider policy propagation.
+- [ ] Add request-specific limiter keyed only by internal `rate_limit_id`; never bearer/public DB token ID.
+- [ ] Use AnyIO thread offload with abandonment plus provider timeout and bounded work; preserve cancellation.
+- [ ] Map configuration, embedding, provider auth/rate/timeout, dedicated rate, and unexpected failures to fixed allowlisted errors with no exception text; scan fully formatted logs.
+- [ ] Run MCP/ask/A2A/auth suites, lint/typecheck; commit `fix(mcp): protect news answering capacity`.
+
+### Task 5: Document, verify, review, and publish #1370
+
+**Files:** `website/docs/configuration/mcp-server.md`, `website/docs/api/integrations.md`, `website/docs/api/authentication.md`, A2A regression/docs only where needed
+
+- [ ] Document signature/corpus semantics, `ask` scope, answer/citations/trace/truncation, AI requirements, fixed limits/errors/retry, privacy boundary, and independent opt-in A2A surface; remove planned-Q&A wording.
+- [ ] Prove A2A card/default Starred+Done behavior remains unchanged.
+- [ ] Build docs and scan stale claims; run lint/typecheck/full guarded tests/audits/hygiene.
+- [ ] Independently review every task and whole branch; resolve Critical/Important findings.
+- [ ] Rebase current `origin/main`, rerun affected gates/review, push, open `Closes #1370` PR, enable squash auto-merge, monitor CI, and confirm closure.

--- a/website/docs/api/authentication.md
+++ b/website/docs/api/authentication.md
@@ -115,11 +115,14 @@ The server is enabled by default; setting `MCP_SERVER_ENABLED` to `false`, `0`,
 Existing tokens remain stored so access can resume if the feature is enabled
 again, and revocation invalidates a token immediately.
 
-Scopes are enforced per MCP tool: `search` grants current-news listing and
-`read` grants single-article retrieval. The `ask` scope is used separately by
-the optional A2A question-answering endpoint; it does not grant MCP article
-access. Prefer separate least-privilege tokens for clients that do not need
-both surfaces.
+Scopes are enforced per tool: `search` grants MCP listing, source discovery,
+and search; `read` grants MCP single-article retrieval; and `ask` grants MCP
+`ask_news`. The same `ask` scope can authorize the optional A2A
+question-answering endpoint when A2A is separately enabled. The scope is
+shared, but the routes and feature flags are independent: MCP uses
+`MCP_SERVER_ENABLED`, while A2A remains disabled unless
+`A2A_SERVER_ENABLED=true`. Enabling one does not enable the other. Prefer
+separate least-privilege tokens for clients that do not need both surfaces.
 
 ### Google Reader tokens
 

--- a/website/docs/api/integrations.md
+++ b/website/docs/api/integrations.md
@@ -31,15 +31,16 @@ revoked under `/api/users/me/mcp-tokens` — see
 | `list_news_sources` | `search` | Page through the token owner's subscribed, enabled, searchable sources. |
 | `search_news` | `search` | Search visible articles with typed filters and offset pagination. |
 | `get_news_article` | `read` | Retrieve one visible article by a strict positive integer ID. |
+| `ask_news` | `ask` | Answer a question over Starred + Done or all visible news, with validated citations. |
 | `list_briefings` | `briefings` | Page through complete saved briefings owned by the token user. |
 | `get_briefing` | `briefings` | Read one owned, complete saved briefing and its currently visible citations. |
 
 Each tool requires its own **scope**, and a token only carries the scopes it
 was minted with. News and source tools require `search`; saved-briefing tools
-require `briefings`; `get_news_article` requires `read`. Under-scoped tokens do
-not discover those tools. MCP question answering is planned; clients should
-rely on MCP tool discovery until it is available. The separate opt-in A2A
-surface remains ask-only and does not advertise briefing tools.
+require `briefings`; `get_news_article` requires `read`; and `ask_news` requires
+`ask`. Under-scoped tokens do not discover those tools. Clients should rely on
+MCP tool discovery. The separate opt-in A2A surface remains ask-only and does
+not advertise briefing tools.
 
 `list_news_sources` returns `{sources, truncated, next_cursor}` in deterministic
 category, descending priority, name, then slug order. Each source contains only
@@ -133,6 +134,31 @@ briefings, mutate them, chat, email, create podcasts, schedule delivery, or
 inspect or launch agent runs. They omit ownership, status, model, error,
 prompt, script, delivery, trace, workflow, article-body, and source-owner
 fields.
+
+`ask_news(question, corpus="saved_and_read")` accepts a non-empty question of
+at most 2,000 characters. `saved_and_read` means **Starred + Done**;
+`all_visible` means all non-archived articles available through owned private
+sources and enabled global-source subscriptions. It returns `answer`, validated
+`citations`, a nullable Langfuse `trace_id`, and `truncated`. Citation brackets
+such as `[1]` are authorized retrieval positions, not article IDs; only complete
+citations with validated HTTP(S) URLs are returned.
+
+MCP answering is bounded to 16 embedding backfills, 8 retrieved articles, 512
+answer tokens, a 20-second provider timeout, and a 30-second foreground
+deadline. Its per-token bucket has burst 2 and refills one request every 30
+seconds. Stable errors distinguish configuration, retrieval, provider
+authentication/rate limiting, timeout, local rate limiting, and temporary
+availability failures; the exact messages and retry guidance are in
+[Configuration → MCP server](../configuration/mcp-server.md#ask-a-question-about-news).
+
+Langfuse retains privacy-safe model, token usage, provider-reported cost,
+counts, timing, corpus, and status metadata, but no question, article, prompt,
+citation title/URL, answer, bearer token, provider body, or exception text.
+`ask_news` does not mutate dashboard data.
+
+The independently opt-in A2A endpoint may use the same `ask` scope but requires
+`A2A_SERVER_ENABLED=true`, keeps its `ask_news` agent-card skill ID, and always
+uses Starred + Done. MCP and A2A do not enable one another.
 
 The server is enabled when `MCP_SERVER_ENABLED` is unset. Set it to `false`,
 `0`, `no`, or `off` to disable `/mcp` and new token creation.

--- a/website/docs/configuration/mcp-server.md
+++ b/website/docs/configuration/mcp-server.md
@@ -28,7 +28,7 @@ curl -X POST https://your-instance/api/users/me/mcp-tokens \
 
 The plaintext `ndmcp_` token appears once. News Dashboard stores only its SHA-256 hash and a short display prefix. Each user can hold up to 10 active tokens and can revoke one immediately from Settings or `DELETE /api/users/me/mcp-tokens/{token_id}`.
 
-Available token scopes are `search`, `read`, `ask`, and `briefings`. Omitting `scopes` grants all four; prefer an explicit subset. News discovery and search tools require `search`; `get_news_article` requires `read`; saved-briefing tools require `briefings`. MCP question answering using `ask` is planned and is not available yet.
+Available token scopes are `search`, `read`, `ask`, and `briefings`. Omitting `scopes` grants all four; prefer an explicit subset. News discovery and search tools require `search`; `get_news_article` requires `read`; `ask_news` requires `ask`; saved-briefing tools require `briefings`.
 
 MCP authentication is independent of Keycloak and browser login. The bearer token alone identifies the MCP user; clients never send a user ID as a tool argument.
 
@@ -50,6 +50,7 @@ Use HTTPS outside a trusted local development environment. Do not put the token 
 | `list_news_sources` | `search` | Pages through the token owner's subscribed, enabled sources that can be used with `search_news`. |
 | `search_news` | `search` | Searches visible articles with typed filters and offset pagination. An empty query returns a filtered recent listing. |
 | `get_news_article` | `read` | Retrieves one visible article by its positive integer article ID. |
+| `ask_news` | `ask` | Answers a question from a bounded, user-visible news corpus and returns validated citations. |
 | `list_briefings` | `briefings` | Pages through complete saved briefings owned by the token user. |
 | `get_briefing` | `briefings` | Retrieves one complete saved briefing owned by the token user, including safe visible citations. |
 
@@ -116,6 +117,32 @@ If the visible article has no cached body, retrieval may fetch and populate the 
 
 `body_truncated` means the body was shortened. Top-level `truncated` means any returned text field was shortened to keep the complete structured result within its 4,800-byte limit; the outer transport remains capped at 16 KiB. Required fields remain present when truncation occurs.
 
+### Ask a question about news
+
+Call `ask_news` with a non-empty `question` of at most 2,000 characters and optional `corpus`. `corpus` is `saved_and_read` (the default) or `all_visible`. `saved_and_read` is the public API name for the current product's **Starred + Done** set; it does not mean every article ever opened. `all_visible` widens retrieval to all non-archived articles available through the owner's private sources and enabled global-source subscriptions. Neither option includes another user's private sources, disabled subscriptions, archived articles, or share-only access.
+
+The result contains `answer`, `citations`, nullable `trace_id`, and `truncated`. Citation brackets are positions in the authorized retrieval result, not article database IDs. Only canonical positive brackets such as `[1]` can create a citation. News Dashboard validates the corresponding already-authorized source, permits only well-formed HTTP(S) URLs, removes tracking parameters and fragments, and deduplicates by article ID in first-cited order. Unsupported or ambiguous brackets remain answer text but never become authoritative citations.
+
+`trace_id` is a 32-character Langfuse trace ID when tracing is configured and available; otherwise it is `null`. `truncated: true` means the answer or complete citation list was shortened to fit the 4,800-byte structured-result budget. Citation URLs are validated whole and omitted rather than shortened to a different destination.
+
+The instance needs `FREE_LLM_API_KEY` (preferred) or `OPENAI_API_KEY`, plus the corresponding optional base URL. MCP answering backfills at most 16 missing embeddings, retrieves 8 articles, caps answers at 512 model tokens, uses a 20-second provider timeout, and has a 30-second foreground deadline. A timed-out foreground call abandons the waiting thread; the provider timeout and work caps remain the underlying cost bounds.
+
+The dedicated per-token generation bucket permits a burst of 2 and refills one request every 30 seconds. This is separate from the general MCP limit. Stable errors are:
+
+| Code | Stable public message | Retry guidance |
+|------|-----------------------|----------------|
+| `ask_not_configured` | `News answering is not configured.` | Configure AI credentials; do not retry unchanged. |
+| `embedding_unavailable` | `News retrieval is temporarily unavailable.` | Retry with backoff. |
+| `provider_authentication_failed` | `News answering provider authentication failed.` | Repair provider credentials; do not retry unchanged. |
+| `provider_rate_limited` | `News answering provider is rate limited; retry later.` | Retry with provider-aware backoff. |
+| `ask_timeout` | `News answering timed out; retry later.` | Retry with backoff. |
+| `ask_rate_limited` | `News answering rate limit exceeded; retry later.` | Wait at least 30 seconds before retrying. |
+| `ask_unavailable` | `News answering is temporarily unavailable.` | Retry with backoff. |
+
+When Langfuse is enabled, MCP Ask traces contain operational metadata only: authenticated user attribution, surface and corpus tags, model, token usage, provider-reported cost, character and citation counts, timing, and status. They exclude bearer tokens, questions, article text, prompts, source titles/URLs, generated answers, provider response bodies, and exception details. Application logs follow the same content-free boundary.
+
+MCP `ask_news` and the optional A2A endpoint can share an `ask`-scoped token, but their routes and flags are independent. `/mcp/` follows `MCP_SERVER_ENABLED`; the A2A agent card and `/api/a2a` require `A2A_SERVER_ENABLED=true`. Enabling either does not enable the other. A2A retains its canonical Starred + Done corpus and does not expose MCP's `corpus` selector.
+
 ### Saved briefings
 
 `list_briefings` accepts an integer `limit` from 1 through 25 (default 10) and an integer `offset` from 0 through 10,000 (default 0). Values outside these ranges, booleans, and non-integers are rejected. Results contain only the authenticated token owner's saved briefings whose status is complete, ordered newest first by creation time and then descending briefing ID.
@@ -178,7 +205,7 @@ Citation access is evaluated when the briefing is read, not frozen when it was s
 
 The briefing tools only read previously saved results. They cannot generate or regenerate a briefing, mutate content, chat with a briefing, send email, create a podcast, change a schedule, trigger delivery, or inspect or start agent runs. Internal fields such as owner, status, model, errors, prompts, scripts, delivery data, trace IDs, workflow state, article bodies, and source ownership are not returned.
 
-MCP question answering is planned as a separate addition. MCP clients should use tool discovery instead of assuming that tool exists. The separately configured A2A endpoint remains an ask-only surface and does not advertise briefing tools.
+MCP clients should use tool discovery rather than assuming a deployment exposes every tool. The separately configured A2A endpoint remains ask-only and does not advertise briefing tools.
 
 ## Security boundaries
 


### PR DESCRIPTION
Closes #1370

## Summary

- add ask-scoped `ask_news` over the canonical PostgreSQL/pgvector Ask AI path
- expose typed Starred+Done and all-visible corpora with token-derived user isolation
- bound SQL embedding backfill, retrieval, answer tokens, provider timeout, foreground timeout, and dedicated per-token generation capacity
- validate bracket-position citations only against authorized retrieval results, with strict HTTP(S)/IP/IDNA handling and bounded structured responses
- preserve metadata-only Langfuse model/usage/cost telemetry, authenticated user attribution, trace IDs, and same-trace final outcomes without questions, context, prompts, URLs, answers, or provider bodies
- provide provenance-bound stable public errors while sanitizing forged/downstream failures
- preserve all six existing MCP tools and independent opt-in A2A behavior
- document corpora, citations, limits, errors, privacy, tracing, and retry guidance

## Verification

- full guarded suite — backend 3,359 passed / 2 skipped; frontend 1,043 passed
- combined MCP/Ask/briefing/article/search/A2A/auth — 354 passed
- lint, all typecheckers, Docusaurus build, uv lock, and Python audit
- stale, conflict, secret, artifact, and diff-scope scans
- independent task/fix/whole-branch/post-rebase reviews: no Critical or Important findings

Existing npm audit advisories are unchanged from `main`; this PR modifies no npm manifest or lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)