### PR TITLE
feat(mcp): complete secure deployment and operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,6 +205,11 @@ METRICS_ENABLED=false
 # Read-only MCP access is enabled by default. Set false/0/no/off to disable the
 # /mcp endpoint and block creation of new MCP tokens.
 MCP_SERVER_ENABLED=true
+# Optional comma-separated exact Host authorities and Origin URLs accepted by
+# /mcp/. Wildcards are rejected. When unset, APP_BASE_URL supplies the public
+# values; local development otherwise defaults to localhost:8080 variants.
+MCP_ALLOWED_HOSTS=
+MCP_ALLOWED_ORIGINS=
 # Enables the opt-in A2A (Agent2Agent) endpoint exposing the assistant to external
 # agents (1/true/yes/on). Off by default. Uses the same bearer tokens as MCP.
 A2A_SERVER_ENABLED=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,22 @@ jobs:
         run: |
           npm run test:frontend:smoke --silent
 
+  mcp-container-smoke:
+    name: MCP container smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
+          cache: pip
+      - run: pip install -e '.[dev]'
+      - name: Build and probe the supported application container
+        run: scripts/smoke-mcp-container.sh
+
   # ── 3. TEST (BACKEND) ──────────────────────────────────────────────────────
   # On pull requests: runs only when backend files changed (or forced via dispatch).
   # On push to main: always runs.
@@ -275,7 +291,7 @@ jobs:
   # (all-skipped = no relevant files changed, so the check still passes).
   test:
     name: Test & build
-    needs: [test-backend, test-frontend, test-a11y]
+    needs: [test-backend, test-frontend, test-a11y, mcp-container-smoke]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -284,6 +300,7 @@ jobs:
           backend="${{ needs.test-backend.result }}"
           frontend="${{ needs.test-frontend.result }}"
           a11y="${{ needs.test-a11y.result }}"
+          mcp_container="${{ needs.mcp-container-smoke.result }}"
           if [[ "$backend" == "failure" || "$backend" == "cancelled" ]]; then
             echo "Backend tests failed or were cancelled ($backend)" && exit 1
           fi
@@ -293,7 +310,10 @@ jobs:
           if [[ "$a11y" == "failure" || "$a11y" == "cancelled" ]]; then
             echo "Accessibility tests failed or were cancelled ($a11y)" && exit 1
           fi
-          echo "All test lanes passed (backend=$backend, frontend=$frontend, a11y=$a11y)"
+          if [[ "$mcp_container" == "failure" || "$mcp_container" == "cancelled" ]]; then
+            echo "MCP container smoke failed or was cancelled ($mcp_container)" && exit 1
+          fi
+          echo "All test lanes passed (backend=$backend, frontend=$frontend, a11y=$a11y, mcp_container=$mcp_container)"
   # ── 7. COVERAGE UPLOAD ─────────────────────────────────────────────────────
   # Uploads coverage reports to Codecov for PR comments, status checks, and
   # coverage trends. Merge groups run the full test suite, so they also upload

--- a/.superpowers/sdd/2026-08-03-fastmcp-operations/task-1-report.md
+++ b/.superpowers/sdd/2026-08-03-fastmcp-operations/task-1-report.md
@@ -22,3 +22,31 @@ The first focused run failed because the config/factory module and deployment va
 - `git diff --check`: passed.
 
 The shared PostgreSQL container was neither started, stopped, nor reconfigured.
+
+## Review repair
+
+- Added an outer ASGI Host/Origin guard so exact routing-header validation runs
+  before FastMCP authentication. Unconfigured hosts (including implicit test or
+  server hosts) now return a generic 421; an Origin is optional but, when sent,
+  must exactly match an allowlisted scheme and authority or receives a generic
+  403.
+- Changed production Compose to require `APP_BASE_URL` and pass empty optional
+  MCP overrides, allowing the application to derive its exact public host and
+  origin instead of injecting localhost values.
+- Changed Helm MCP allowlist defaults to empty and derive them from
+  `app.publicBaseUrl` or the configured ingress. Localhost values remain only
+  for development renders with no public URL or ingress. The production values
+  now exercise ingress derivation rather than repeating the public hostname.
+- Added regressions for implicit hosts, same-host wrong-scheme origins,
+  production Compose fail-closed configuration, production ingress derivation,
+  and Helm public-base-URL derivation.
+
+Repair verification:
+
+- Focused config/Compose/Helm tests: `50 passed`.
+- All MCP plus deployment tests: `213 passed`; three unrelated workers hit the
+  shared PostgreSQL container's `max_locks_per_transaction` limit. The affected
+  briefing module passed serially: `64 passed`.
+- `make lint`: passed.
+- `make typecheck`: passed.
+- `git diff --check`: passed.

--- a/.superpowers/sdd/2026-08-03-fastmcp-operations/task-1-report.md
+++ b/.superpowers/sdd/2026-08-03-fastmcp-operations/task-1-report.md
@@ -1,0 +1,24 @@
+# Task 1 report: deployment defaults and HTTP guard
+
+## Delivered
+
+- Added immutable `McpHttpConfig` parsing for exact Host and Origin allowlists.
+- Derived public defaults from `APP_BASE_URL`, with safe localhost defaults for local installs.
+- Rejected wildcard allowlist values to keep the transport contract exact.
+- Added `create_mcp_http_app` and enabled FastMCP strict Host/Origin protection.
+- Kept MCP on the existing FastAPI listener and preserved the explicit-false transport/token shutdown behavior.
+- Rendered `MCP_SERVER_ENABLED=true` and Host/Origin settings in all three Compose paths and the Helm chart.
+- Added production Helm values for `news.lihor.ro`; no MCP service, port, or database exposure was added.
+
+## TDD evidence
+
+The first focused run failed because the config/factory module and deployment values did not exist. After the implementation, the same focused test set passed.
+
+## Verification
+
+- Focused MCP, briefing, config, Compose, and Helm tests: `214 passed`.
+- `make lint`: passed (backend and frontend lint/format/dead-code gates).
+- `make typecheck`: passed (mypy, ty, pyrefly, and frontend typecheck).
+- `git diff --check`: passed.
+
+The shared PostgreSQL container was neither started, stopped, nor reconfigured.

--- a/.superpowers/sdd/2026-08-03-fastmcp-operations/task-2-report.md
+++ b/.superpowers/sdd/2026-08-03-fastmcp-operations/task-2-report.md
@@ -1,0 +1,37 @@
+# Task 2 report: health and operational telemetry
+
+## Delivered
+
+- Added public `GET /api/mcp/health` with a content-free contract:
+  `disabled` and `healthy` return 200; PostgreSQL dependency failure returns
+  503 with only `dependency_failure`. Disabled checks never touch PostgreSQL.
+- Added a bounded, read-only PostgreSQL MCP dependency probe using the runtime
+  pool timeout plus a two-second statement timeout and `SELECT 1`.
+- Added fixed-cardinality Prometheus counters for auth, tool outcomes, rate
+  limits, and response limits, plus a tool-duration histogram. Metrics never
+  label token or user identifiers; tool labels are restricted to the seven-tool
+  catalog plus `unknown`.
+- Added exactly-once metadata-only auth, tool, rate-limit, and response-limit
+  events. Successful authenticated events may include only the non-secret
+  numeric token ID. Logs exclude bearer values, rate identities, user IDs,
+  arguments, content, prompts, URLs, provider payloads, and exception text.
+- Wrapped FastMCP response limiting without changing its existing truncation
+  behavior, and preserved the existing generic error and tracing contracts.
+
+## TDD evidence
+
+- Initial operations suite: `6 failed`, proving the health, metrics, auth, and
+  tool contracts were absent.
+- Rate/response short-circuit tests then failed `2` as expected before their
+  observed middleware implementations.
+- An unknown-tool privacy/cardinality regression failed before catalog-name
+  normalization was added.
+
+## Verification
+
+- Focused MCP, briefing, metrics, and health tests: `188 passed`.
+- `make lint`: passed.
+- `make typecheck`: passed (mypy, ty, pyrefly, and frontend typecheck).
+- `git diff --check`: passed.
+
+The shared PostgreSQL container was not started, stopped, or reconfigured.

--- a/.superpowers/sdd/2026-08-03-fastmcp-operations/task-3-report.md
+++ b/.superpowers/sdd/2026-08-03-fastmcp-operations/task-3-report.md
@@ -1,0 +1,28 @@
+# Task 3 report: mounted and container integration
+
+## Outcome
+
+Implemented the deployed-path integration slice in commit `7c80c74a`.
+
+- Added an official FastMCP Client harness that traverses the real mounted `news_dashboard.main.app` route table.
+- Proved exact seven-tool discovery and representative search, article, briefing, and AI-stubbed Ask calls.
+- Proved under-scoped, revoked, missing, invalid, cross-user, disabled, Host, and Origin behavior through the mounted front door.
+- Proved `/mcp/` is reserved before the SPA fallback and never returns the SPA document for transport failures.
+- Added an isolated real-container smoke using the normal Dockerfile/CMD, a private pgvector network, a non-logged bearer, the official external client, disabled-mode restart, and no PostgreSQL host port.
+- Added the container smoke as a merge-group/PR CI lane and made the required `Test & build` rollup fail when it fails.
+
+## TDD evidence
+
+Initial focused run: 3 failed / 1 passed. The failures exposed two real harness boundaries: strict Host protection rejected Starlette's default `testserver`, and FastMCP lifespan teardown wrapped expected client authentication failures in an exception group. The helper was corrected to send the deployed Host and preserve the leaf client error after lifespan shutdown.
+
+Final focused run:
+
+```text
+17 passed, 18 pre-existing Starlette/TestClient deprecation warnings
+```
+
+The run covered `test_mcp_integration.py`, `test_mcp_deployment.py`, `test_mcp_operations.py`, and `test_spa_static.py`. Ruff, Ruff format, mypy, ty, pyrefly, workflow YAML parsing, shell syntax, pre-commit, and `git diff --check` passed.
+
+## Verification limitation
+
+The real container script could not execute locally because Docker Desktop was not running (`Cannot connect to the Docker daemon`). The script is syntax-checked and its safety/wiring contract is tested locally; the new merge-gating Ubuntu CI lane executes the actual Docker build and probes before merge.

--- a/backend/news_dashboard/mcp/auth.py
+++ b/backend/news_dashboard/mcp/auth.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 import secrets
 
 from anyio import to_thread
 from fastmcp.server.auth import AccessToken, TokenVerifier
 
 from news_dashboard.mcp import service
+from news_dashboard.metrics import mcp_auth_attempts_total
 
 _RATE_LIMIT_KEY = secrets.token_bytes(32)
+logger = logging.getLogger("news_dashboard.mcp")
 
 
 def _rate_limit_identity(token: str) -> str:
@@ -21,12 +24,21 @@ class NewsDashboardTokenVerifier(TokenVerifier):
     """Adapt News Dashboard's stored MCP tokens for FastMCP authentication."""
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        authenticated = await to_thread.run_sync(service.authenticate_token, token)
+        try:
+            authenticated = await to_thread.run_sync(service.authenticate_token, token)
+        except Exception:
+            mcp_auth_attempts_total.labels(status="error").inc()
+            logger.info("mcp event=auth status=error")
+            raise
         if authenticated is None:
+            mcp_auth_attempts_total.labels(status="invalid").inc()
+            logger.info("mcp event=auth status=invalid")
             return None
         token_id = int(authenticated["token_id"])
         user_id = int(authenticated["user_id"])
         scopes = sorted(str(scope) for scope in authenticated["scopes"])
+        mcp_auth_attempts_total.labels(status="success").inc()
+        logger.info("mcp event=auth status=success token_id=%s", token_id)
         return AccessToken(
             token=token,
             client_id=f"mcp-token:{token_id}",

--- a/backend/news_dashboard/mcp/config.py
+++ b/backend/news_dashboard/mcp/config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+_LOCAL_HOSTS = ("localhost:8080", "127.0.0.1:8080", "[::1]:8080")
+_LOCAL_ORIGINS = (
+    "http://localhost:8080",
+    "http://127.0.0.1:8080",
+    "http://[::1]:8080",
+)
+
+
+def _comma_separated_environment(name: str) -> tuple[str, ...] | None:
+    raw_value = os.getenv(name)
+    if raw_value is None or not raw_value.strip():
+        return None
+    values = tuple(value.strip() for value in raw_value.split(",") if value.strip())
+    if any("*" in value for value in values):
+        message = f"{name} must contain exact values; wildcards are not allowed"
+        raise ValueError(message)
+    return values
+
+
+def _public_host_and_origin() -> tuple[tuple[str, ...], tuple[str, ...]] | None:
+    public_base_url = (os.getenv("APP_BASE_URL") or "").strip()
+    if not public_base_url:
+        return None
+    parsed = urlsplit(public_base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        message = "APP_BASE_URL must be an absolute HTTP(S) URL when used for MCP protection"
+        raise ValueError(message)
+    return (parsed.netloc,), (f"{parsed.scheme}://{parsed.netloc}",)
+
+
+@dataclass(frozen=True, slots=True)
+class McpHttpConfig:
+    """Exact Host and Origin values accepted by the MCP HTTP transport."""
+
+    allowed_hosts: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
+
+    @classmethod
+    def from_environment(cls) -> McpHttpConfig:
+        public_values = _public_host_and_origin()
+        default_hosts, default_origins = public_values or (_LOCAL_HOSTS, _LOCAL_ORIGINS)
+        return cls(
+            allowed_hosts=_comma_separated_environment("MCP_ALLOWED_HOSTS") or default_hosts,
+            allowed_origins=_comma_separated_environment("MCP_ALLOWED_ORIGINS") or default_origins,
+        )

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -73,6 +73,7 @@ from news_dashboard.mcp.models import (
     WorkflowStates,
 )
 from news_dashboard.metrics import (
+    mcp_auth_attempts_total,
     mcp_rate_limits_total,
     mcp_response_limits_total,
     mcp_tool_calls_total,
@@ -997,8 +998,36 @@ class _RequireMcpEnabled:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http" and not service.mcp_enabled():
+            mcp_auth_attempts_total.labels(status="disabled").inc()
+            logger.info("mcp event=auth status=disabled")
             await PlainTextResponse("Not Found", status_code=404)(scope, receive, send)
             return
+        await self.app(scope, receive, send)
+
+
+class _ObservePreVerifierAuthentication:
+    """Record credentials FastMCP rejects before invoking the token verifier."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            authorization = [
+                value for name, value in scope["headers"] if name.lower() == b"authorization"
+            ]
+            status: str | None = None
+            if not authorization:
+                status = "missing"
+            elif len(authorization) != 1:
+                status = "invalid"
+            else:
+                scheme, separator, credential = authorization[0].partition(b" ")
+                if not separator or scheme.lower() != b"bearer" or not credential.strip():
+                    status = "invalid"
+            if status is not None:
+                mcp_auth_attempts_total.labels(status=status).inc()
+                logger.info("mcp event=auth status=%s", status)
         await self.app(scope, receive, send)
 
 
@@ -1047,6 +1076,7 @@ def create_mcp_http_app(server: FastMCP[Any], *, config: McpHttpConfig) -> Starl
         allowed_hosts=list(config.allowed_hosts),
         allowed_origins=list(config.allowed_origins),
     )
+    http_app.add_middleware(_ObservePreVerifierAuthentication)
     http_app.add_middleware(_RequireMcpEnabled)
     http_app.add_middleware(_SanitizeMcpResponses)
     http_app.add_middleware(

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from functools import partial
 from typing import Any, Literal, TypedDict, cast
 
+import pydantic_core
 from anyio import fail_after, to_thread
 from fastmcp import FastMCP
 from fastmcp.exceptions import AuthorizationError, ToolError
@@ -71,6 +72,12 @@ from news_dashboard.mcp.models import (
     SourceCursor,
     WorkflowStates,
 )
+from news_dashboard.metrics import (
+    mcp_rate_limits_total,
+    mcp_response_limits_total,
+    mcp_tool_calls_total,
+    mcp_tool_duration_seconds,
+)
 from news_dashboard.sources.service import list_sources_for_user
 
 MCP_RATE_PER_SECOND = 2.0
@@ -108,6 +115,17 @@ _ARTICLE_REDUCTION_ORDER = (
     "discovered_at",
 )
 _BRIEFING_NOT_FOUND_MESSAGE = "Briefing not found"
+_TELEMETRY_TOOL_NAMES = frozenset(
+    {
+        "ask_news",
+        "get_briefing",
+        "get_news_article",
+        "list_briefings",
+        "list_latest_news",
+        "list_news_sources",
+        "search_news",
+    }
+)
 
 logger = logging.getLogger("news_dashboard.mcp")
 _mcp_transport_logging = ContextVar("mcp_transport_logging", default=False)
@@ -161,6 +179,27 @@ def _rate_limit_client_id(_context: MiddlewareContext[Any]) -> str:
     raise AuthorizationError(message)
 
 
+def _telemetry_token_id() -> int | None:
+    """Return only the non-secret numeric token identifier for telemetry."""
+    token = get_access_token()
+    if token is None:
+        return None
+    token_id = token.claims.get("token_id")
+    return token_id if isinstance(token_id, int) else None
+
+
+def _telemetry_tool_name(name: str) -> str:
+    return name if name in _TELEMETRY_TOOL_NAMES else "unknown"
+
+
+def _log_bounded_event(message: str, *args: object) -> None:
+    token_id = _telemetry_token_id()
+    if token_id is None:
+        logger.info(message, *args)
+    else:
+        logger.info("%s token_id=%s", message % args, token_id)
+
+
 class _BoundedTokenBuckets:
     def __init__(self, *, max_identities: int, capacity: int, refill_rate: float) -> None:
         self._max_identities = max_identities
@@ -194,9 +233,39 @@ class _BoundedRateLimitingMiddleware(Middleware):
     ) -> Any:
         client_id = _rate_limit_client_id(context)
         if not await self._buckets.for_client(client_id).consume():
+            mcp_rate_limits_total.labels(status="limited").inc()
+            _log_bounded_event("mcp event=rate_limit status=limited")
             message = "Rate limit exceeded"
             raise RateLimitError(message)
         return await call_next(context)
+
+
+class _ObservedResponseLimitingMiddleware(ResponseLimitingMiddleware):
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[CallToolRequestParams],
+        call_next: CallNext[CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        result = await call_next(context)
+        if self.tools is not None and context.message.name not in self.tools:
+            return result
+        if len(pydantic_core.to_json(result, fallback=str)) <= self.max_size:
+            return result
+
+        tool_name = _telemetry_tool_name(context.message.name)
+        mcp_response_limits_total.labels(tool=tool_name).inc()
+        _log_bounded_event(
+            "mcp event=response_limit tool=%s status=limited",
+            tool_name,
+        )
+
+        async def return_result(
+            _context: MiddlewareContext[CallToolRequestParams],
+        ) -> ToolResult:
+            return result
+
+        typed_next = cast("CallNext[CallToolRequestParams, ToolResult]", return_result)
+        return await super().on_call_tool(context, typed_next)
 
 
 class _AskBucket(TypedDict):
@@ -420,9 +489,14 @@ class _SafeToolTelemetryMiddleware(Middleware):
             raise McpError(ErrorData(code=-32603, message=_INTERNAL_ERROR_MESSAGE)) from None
         finally:
             duration_ms = (time.perf_counter() - started_at) * 1_000
-            logger.info(
-                "mcp tool=%s status=%s duration_ms=%.2f",
-                context.message.name,
+            tool_name = _telemetry_tool_name(context.message.name)
+            mcp_tool_calls_total.labels(tool=tool_name, status=status).inc()
+            mcp_tool_duration_seconds.labels(tool=tool_name, status=status).observe(
+                duration_ms / 1_000
+            )
+            _log_bounded_event(
+                "mcp tool=%s status=%s duration_ms=%.2f event=tool",
+                tool_name,
                 status,
                 duration_ms,
             )
@@ -437,7 +511,7 @@ mcp = FastMCP(
 mcp.add_middleware(_SafeToolTelemetryMiddleware())
 mcp.add_middleware(_BoundedRateLimitingMiddleware())
 mcp.add_middleware(_AskRateLimitingMiddleware())
-mcp.add_middleware(ResponseLimitingMiddleware(max_size=MCP_MAX_RESPONSE_BYTES))
+mcp.add_middleware(_ObservedResponseLimitingMiddleware(max_size=MCP_MAX_RESPONSE_BYTES))
 
 
 class ArticleListResult(TypedDict):

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -928,6 +928,41 @@ class _RequireMcpEnabled:
         await self.app(scope, receive, send)
 
 
+class _ExactMcpHostOrigin:
+    """Reject untrusted routing headers before FastMCP authentication runs."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        allowed_hosts: tuple[str, ...],
+        allowed_origins: tuple[str, ...],
+    ) -> None:
+        self.app = app
+        self.allowed_hosts = frozenset(allowed_hosts)
+        self.allowed_origins = frozenset(allowed_origins)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = {name.lower(): value for name, value in scope["headers"]}
+        host = headers.get(b"host", b"").decode("latin-1")
+        if host not in self.allowed_hosts:
+            await PlainTextResponse("Misdirected Request", status_code=421)(scope, receive, send)
+            return
+
+        origin_value = headers.get(b"origin")
+        if origin_value is not None:
+            origin = origin_value.decode("latin-1")
+            if origin not in self.allowed_origins:
+                await PlainTextResponse("Forbidden", status_code=403)(scope, receive, send)
+                return
+
+        await self.app(scope, receive, send)
+
+
 def create_mcp_http_app(server: FastMCP[Any], *, config: McpHttpConfig) -> StarletteWithLifespan:
     """Build the guarded MCP ASGI application mounted by FastAPI."""
     http_app = server.http_app(
@@ -940,6 +975,11 @@ def create_mcp_http_app(server: FastMCP[Any], *, config: McpHttpConfig) -> Starl
     )
     http_app.add_middleware(_RequireMcpEnabled)
     http_app.add_middleware(_SanitizeMcpResponses)
+    http_app.add_middleware(
+        _ExactMcpHostOrigin,
+        allowed_hosts=config.allowed_hosts,
+        allowed_origins=config.allowed_origins,
+    )
     return http_app
 
 

--- a/backend/news_dashboard/mcp/server.py
+++ b/backend/news_dashboard/mcp/server.py
@@ -19,6 +19,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import AuthorizationError, ToolError
 from fastmcp.server.auth import require_scopes
 from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.http import StarletteWithLifespan
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.server.middleware.rate_limiting import RateLimitError, TokenBucketRateLimiter
 from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
@@ -52,6 +53,7 @@ from news_dashboard.mcp.briefings import (
     build_briefing_get_result,
     build_briefing_list_result,
 )
+from news_dashboard.mcp.config import McpHttpConfig
 from news_dashboard.mcp.models import (
     MAX_FILTER_VALUE_LENGTH,
     MAX_RESULT_LIMIT,
@@ -926,6 +928,19 @@ class _RequireMcpEnabled:
         await self.app(scope, receive, send)
 
 
-mcp_http_app = mcp.http_app(path="/", stateless_http=True, transport="http")
-mcp_http_app.add_middleware(_RequireMcpEnabled)
-mcp_http_app.add_middleware(_SanitizeMcpResponses)
+def create_mcp_http_app(server: FastMCP[Any], *, config: McpHttpConfig) -> StarletteWithLifespan:
+    """Build the guarded MCP ASGI application mounted by FastAPI."""
+    http_app = server.http_app(
+        path="/",
+        stateless_http=True,
+        transport="http",
+        host_origin_protection=True,
+        allowed_hosts=list(config.allowed_hosts),
+        allowed_origins=list(config.allowed_origins),
+    )
+    http_app.add_middleware(_RequireMcpEnabled)
+    http_app.add_middleware(_SanitizeMcpResponses)
+    return http_app
+
+
+mcp_http_app = create_mcp_http_app(mcp, config=McpHttpConfig.from_environment())

--- a/backend/news_dashboard/mcp/service.py
+++ b/backend/news_dashboard/mcp/service.py
@@ -6,7 +6,9 @@ import secrets
 from collections.abc import Mapping
 from typing import Any
 
-from news_dashboard.db import connect, init_db, row_to_dict
+import psycopg
+
+from news_dashboard.db import active_database_url, connect, init_db, row_to_dict
 
 TOKEN_PREFIX = "ndmcp_"  # noqa: S105 -- token prefix, not a credential
 DEFAULT_SCOPES = ("search", "read", "ask", "briefings")
@@ -26,9 +28,9 @@ def mcp_enabled() -> bool:
 
 
 def check_mcp_dependency() -> None:
-    """Run the bounded, read-only PostgreSQL probe required by MCP."""
-    with connect() as conn:
-        conn.execute("SET LOCAL statement_timeout = '2s'")
+    """Run a health-specific bounded, read-only PostgreSQL probe."""
+    with psycopg.connect(active_database_url(), connect_timeout=2) as conn:
+        conn.execute("SET statement_timeout = '2s'")
         conn.execute("SELECT 1")
 
 

--- a/backend/news_dashboard/mcp/service.py
+++ b/backend/news_dashboard/mcp/service.py
@@ -25,6 +25,13 @@ def mcp_enabled() -> bool:
     }
 
 
+def check_mcp_dependency() -> None:
+    """Run the bounded, read-only PostgreSQL probe required by MCP."""
+    with connect() as conn:
+        conn.execute("SET LOCAL statement_timeout = '2s'")
+        conn.execute("SELECT 1")
+
+
 def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 

--- a/backend/news_dashboard/metrics.py
+++ b/backend/news_dashboard/metrics.py
@@ -62,6 +62,41 @@ source_health_checks_total = Counter(
     registry=registry,
 )
 
+mcp_auth_attempts_total = Counter(
+    "news_dashboard_mcp_auth_attempts_total",
+    "MCP authentication attempts by bounded outcome.",
+    ["status"],
+    registry=registry,
+)
+
+mcp_tool_calls_total = Counter(
+    "news_dashboard_mcp_tool_calls_total",
+    "MCP tool calls by catalog tool and bounded outcome.",
+    ["tool", "status"],
+    registry=registry,
+)
+
+mcp_tool_duration_seconds = Histogram(
+    "news_dashboard_mcp_tool_duration_seconds",
+    "MCP tool execution duration by catalog tool and bounded outcome.",
+    ["tool", "status"],
+    registry=registry,
+)
+
+mcp_rate_limits_total = Counter(
+    "news_dashboard_mcp_rate_limits_total",
+    "MCP requests rejected by the bounded rate limiter.",
+    ["status"],
+    registry=registry,
+)
+
+mcp_response_limits_total = Counter(
+    "news_dashboard_mcp_response_limits_total",
+    "MCP tool responses truncated at the transport response limit.",
+    ["tool"],
+    registry=registry,
+)
+
 
 def metrics_enabled() -> bool:
     return os.getenv("METRICS_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
@@ -77,6 +112,11 @@ __all__ = [
     "http_requests_total",
     "ingest_articles_new_total",
     "ingest_runs_total",
+    "mcp_auth_attempts_total",
+    "mcp_rate_limits_total",
+    "mcp_response_limits_total",
+    "mcp_tool_calls_total",
+    "mcp_tool_duration_seconds",
     "metrics_enabled",
     "render_metrics",
     "scheduler_job_runs_total",

--- a/backend/news_dashboard/system/router.py
+++ b/backend/news_dashboard/system/router.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
 
+from news_dashboard.mcp import service as mcp_service
 from news_dashboard.system import service
 
 router = APIRouter()
@@ -33,6 +35,18 @@ def readiness() -> dict[str, Any]:
     except Exception as exc:
         raise HTTPException(status_code=503, detail="database unavailable") from exc
     return {"status": "ok"}
+
+
+@router.get("/api/mcp/health")
+def mcp_health() -> JSONResponse:
+    """Report MCP availability without exposing tokens, tools, or content."""
+    if not mcp_service.mcp_enabled():
+        return JSONResponse({"status": "disabled"})
+    try:
+        mcp_service.check_mcp_dependency()
+    except Exception:
+        return JSONResponse({"status": "dependency_failure"}, status_code=503)
+    return JSONResponse({"status": "healthy"})
 
 
 @router.get("/metrics")

--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -34,6 +34,31 @@ def _render_chart(*set_values: str) -> str:
     return res.stdout
 
 
+def _render_production_chart() -> str:
+    assert HELM_BIN is not None
+    res = subprocess.run(  # noqa: S603
+        [
+            HELM_BIN,
+            "template",
+            "news-dashboard",
+            str(CHART_DIR),
+            "--values",
+            str(CHART_DIR / "values-production.yaml"),
+            "--set",
+            "app.auth.sessionSecret=dummy-session-secret",
+            "--set-string",
+            "postgresql.password=dummy-postgres-password-for-render-only",
+            "--set-string",
+            "image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0, f"helm template failed: {res.stderr}"
+    return res.stdout
+
+
 def _manifest_for_kind(output: str, kind: str) -> str:
     for manifest in output.split("---"):
         if f"\nkind: {kind}\n" in f"\n{manifest}\n":
@@ -111,6 +136,26 @@ def test_helm_template_mcp_defaults_to_enabled_with_local_allowlists() -> None:
     assert "http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080" in _env_entry(
         deployment_env, "MCP_ALLOWED_ORIGINS"
     )
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_production_mcp_uses_public_ingress_allowlists() -> None:
+    output = _render_production_chart()
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert 'value: "news.lihor.ro"' in _env_entry(deployment_env, "MCP_ALLOWED_HOSTS")
+    assert 'value: "https://news.lihor.ro"' in _env_entry(deployment_env, "MCP_ALLOWED_ORIGINS")
+    assert "localhost" not in _env_entry(deployment_env, "MCP_ALLOWED_HOSTS")
+    assert "localhost" not in _env_entry(deployment_env, "MCP_ALLOWED_ORIGINS")
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_mcp_derives_allowlists_from_public_base_url() -> None:
+    output = _render_chart("app.publicBaseUrl=https://news.example.com/dashboard")
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert 'value: "news.example.com"' in _env_entry(deployment_env, "MCP_ALLOWED_HOSTS")
+    assert 'value: "https://news.example.com"' in _env_entry(deployment_env, "MCP_ALLOWED_ORIGINS")
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")

--- a/backend/tests/test_chart_render.py
+++ b/backend/tests/test_chart_render.py
@@ -98,6 +98,36 @@ def test_helm_template_default() -> None:
 
 
 @pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_mcp_defaults_to_enabled_with_local_allowlists() -> None:
+    output = _render_chart()
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert _env_entry(deployment_env, "MCP_SERVER_ENABLED") == (
+        '- name: MCP_SERVER_ENABLED\n  value: "true"'
+    )
+    assert "localhost:8080,127.0.0.1:8080,[::1]:8080" in _env_entry(
+        deployment_env, "MCP_ALLOWED_HOSTS"
+    )
+    assert "http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080" in _env_entry(
+        deployment_env, "MCP_ALLOWED_ORIGINS"
+    )
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
+def test_helm_template_mcp_accepts_explicit_shutdown_and_public_allowlists() -> None:
+    output = _render_chart(
+        "app.config.mcpServerEnabled=false",
+        "app.config.mcpAllowedHosts=news.example.com",
+        "app.config.mcpAllowedOrigins=https://news.example.com",
+    )
+    deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))
+
+    assert 'value: "false"' in _env_entry(deployment_env, "MCP_SERVER_ENABLED")
+    assert 'value: "news.example.com"' in _env_entry(deployment_env, "MCP_ALLOWED_HOSTS")
+    assert 'value: "https://news.example.com"' in _env_entry(deployment_env, "MCP_ALLOWED_ORIGINS")
+
+
+@pytest.mark.skipif(HELM_BIN is None, reason="helm binary not found on path")
 def test_helm_template_dify_chat_is_disabled_by_default() -> None:
     output = _render_chart()
     deployment_env = _env_block(_manifest_for_kind(output, "Deployment"))

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import cast
 
+import pytest
 import yaml  # type: ignore[import-untyped]
 
 REPO_ROOT = Path(__file__).parent.parent.parent
@@ -207,3 +208,20 @@ def test_compose_prod_app_healthcheck_configured() -> None:
 
 def test_compose_demo_app_healthcheck_configured() -> None:
     _assert_app_healthcheck_uses_no_extra_tools(COMPOSE_DEMO_FILE)
+
+
+@pytest.mark.parametrize("compose_file", [COMPOSE_FILE, COMPOSE_PROD_FILE, COMPOSE_DEMO_FILE])
+def test_compose_mcp_is_default_enabled_on_existing_app_listener(compose_file: Path) -> None:
+    compose = yaml.safe_load(compose_file.read_text())
+    app = compose["services"]["news-dashboard"]
+    environment = app["environment"]
+
+    assert environment["MCP_SERVER_ENABLED"] == "${MCP_SERVER_ENABLED:-true}"
+    assert environment["MCP_ALLOWED_HOSTS"] == (
+        "${MCP_ALLOWED_HOSTS:-localhost:8080,127.0.0.1:8080,[::1]:8080}"
+    )
+    assert environment["MCP_ALLOWED_ORIGINS"] == (
+        "${MCP_ALLOWED_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080}"
+    )
+    assert list(app["ports"]) == ["8080:8080"]
+    assert "mcp" not in compose["services"]

--- a/backend/tests/test_compose_auth_env.py
+++ b/backend/tests/test_compose_auth_env.py
@@ -210,7 +210,7 @@ def test_compose_demo_app_healthcheck_configured() -> None:
     _assert_app_healthcheck_uses_no_extra_tools(COMPOSE_DEMO_FILE)
 
 
-@pytest.mark.parametrize("compose_file", [COMPOSE_FILE, COMPOSE_PROD_FILE, COMPOSE_DEMO_FILE])
+@pytest.mark.parametrize("compose_file", [COMPOSE_FILE, COMPOSE_DEMO_FILE])
 def test_compose_mcp_is_default_enabled_on_existing_app_listener(compose_file: Path) -> None:
     compose = yaml.safe_load(compose_file.read_text())
     app = compose["services"]["news-dashboard"]
@@ -223,5 +223,18 @@ def test_compose_mcp_is_default_enabled_on_existing_app_listener(compose_file: P
     assert environment["MCP_ALLOWED_ORIGINS"] == (
         "${MCP_ALLOWED_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080}"
     )
+    assert list(app["ports"]) == ["8080:8080"]
+    assert "mcp" not in compose["services"]
+
+
+def test_production_compose_requires_public_base_url_and_does_not_inject_local_allowlists() -> None:
+    compose = yaml.safe_load(COMPOSE_PROD_FILE.read_text())
+    app = compose["services"]["news-dashboard"]
+    environment = app["environment"]
+
+    assert environment["MCP_SERVER_ENABLED"] == "${MCP_SERVER_ENABLED:-true}"
+    assert environment["APP_BASE_URL"] == "${APP_BASE_URL:?APP_BASE_URL is required}"
+    assert environment["MCP_ALLOWED_HOSTS"] == "${MCP_ALLOWED_HOSTS:-}"
+    assert environment["MCP_ALLOWED_ORIGINS"] == "${MCP_ALLOWED_ORIGINS:-}"
     assert list(app["ports"]) == ["8080:8080"]
     assert "mcp" not in compose["services"]

--- a/backend/tests/test_env_example.py
+++ b/backend/tests/test_env_example.py
@@ -23,11 +23,17 @@ _ENV_EXAMPLE_LINE_PATTERN = re.compile(r"^([A-Z][A-Z0-9_]*)=")
 # Vars documented in .env.example but intentionally absent from backend Python source:
 #   TOKEN_SECRET       - read dynamically via a tuple loop in digest.py; the
 #                        literal-string scan below cannot discover it.
+#   MCP_ALLOWED_*      - read through the typed MCP config helper by dynamic name.
 #   SENTRY_DSN_DESKTOP - consumed exclusively by the Electron desktop main
 #                        process (desktop/src/instrument.js), never by the
 #                        backend; documented here so operators have a single
 #                        reference for all DSN variables.
-_BACKEND_EXEMPT_VARS = {"TOKEN_SECRET", "SENTRY_DSN_DESKTOP"}
+_BACKEND_EXEMPT_VARS = {
+    "MCP_ALLOWED_HOSTS",
+    "MCP_ALLOWED_ORIGINS",
+    "SENTRY_DSN_DESKTOP",
+    "TOKEN_SECRET",
+}
 
 
 def _vars_read_in_source() -> set[str]:

--- a/backend/tests/test_main_feature_modules.py
+++ b/backend/tests/test_main_feature_modules.py
@@ -228,6 +228,7 @@ EXPECTED_METHOD_PATHS = {
     ("GET", "/auth/login"),
     ("GET", "/auth/logout"),
     ("GET", "/auth/register"),
+    ("GET", "/api/mcp/health"),
     ("GET", "/metrics"),
 }
 

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -397,7 +397,7 @@ async def _mcp_client(
     ) -> httpx.AsyncClient:
         return httpx.AsyncClient(
             transport=httpx.ASGITransport(app=transport_app),
-            base_url="http://mcp.test",
+            base_url="http://localhost:8080",
             headers=headers,
             timeout=timeout,
             auth=auth,
@@ -405,7 +405,7 @@ async def _mcp_client(
         )
 
     transport = StreamableHttpTransport(
-        "http://mcp.test/mcp/",
+        "http://localhost:8080/mcp/",
         auth=token,
         httpx_client_factory=httpx_client_factory,
     )

--- a/backend/tests/test_mcp_briefings.py
+++ b/backend/tests/test_mcp_briefings.py
@@ -71,7 +71,7 @@ async def _briefing_client(
     ) -> httpx.AsyncClient:
         return httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
-            base_url="http://mcp.test",
+            base_url="http://localhost:8080",
             headers=headers,
             timeout=timeout,
             auth=auth,
@@ -79,7 +79,7 @@ async def _briefing_client(
         )
 
     transport = StreamableHttpTransport(
-        "http://mcp.test/mcp/", auth=token, httpx_client_factory=client_factory
+        "http://localhost:8080/mcp/", auth=token, httpx_client_factory=client_factory
     )
     async with app.router.lifespan_context(app), Client(transport) as client:
         yield client

--- a/backend/tests/test_mcp_deployment.py
+++ b/backend/tests/test_mcp_deployment.py
@@ -1,0 +1,55 @@
+"""Repository-level contract for the real application-container MCP smoke."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+ROOT = Path(__file__).resolve().parents[2]
+SMOKE_SCRIPT = ROOT / "scripts" / "smoke-mcp-container.sh"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_container_smoke_uses_supported_image_and_keeps_database_private() -> None:
+    script = SMOKE_SCRIPT.read_text()
+
+    assert "docker build" in script
+    assert '"${image_name}"' in script
+    assert "pgvector/pgvector:pg16" in script
+    assert 'docker port "${postgres_name}" 5432/tcp' in script
+    assert "-p 5432:5432" not in script
+    assert "-p 127.0.0.1::8080" in script
+
+
+def test_container_smoke_probes_mounted_transport_and_never_echoes_bearer() -> None:
+    script = SMOKE_SCRIPT.read_text()
+
+    for required in (
+        "StreamableHttpTransport",
+        "/mcp/",
+        "list_tools",
+        "list_latest_news",
+        "<!doctype html",
+        "MCP_SERVER_ENABLED",
+        "attacker.example",
+        "MCP_SMOKE_TOKEN",
+    ):
+        assert required in script
+    assert 'echo "${smoke_token}"' not in script
+    assert "set -x" not in script
+
+
+def test_ci_runs_container_smoke_without_printing_environment() -> None:
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    job = workflow["jobs"]["mcp-container-smoke"]
+    steps = job["steps"]
+    rollup = workflow["jobs"]["test"]
+
+    assert job["timeout-minutes"] == 20
+    assert "merge_group" in job["if"]
+    assert any(step.get("run") == "pip install -e '.[dev]'" for step in steps)
+    assert any(step.get("run") == "scripts/smoke-mcp-container.sh" for step in steps)
+    assert all("printenv" not in step.get("run", "") for step in steps)
+    assert "mcp-container-smoke" in rollup["needs"]
+    assert "needs.mcp-container-smoke.result" in rollup["steps"][0]["run"]

--- a/backend/tests/test_mcp_deployment.py
+++ b/backend/tests/test_mcp_deployment.py
@@ -37,6 +37,7 @@ def test_container_smoke_probes_mounted_transport_and_never_echoes_bearer() -> N
     ):
         assert required in script
     assert 'echo "${smoke_token}"' not in script
+    assert "Authorization: Bearer ${smoke_token}" not in script
     assert "set -x" not in script
 
 

--- a/backend/tests/test_mcp_documentation.py
+++ b/backend/tests/test_mcp_documentation.py
@@ -32,7 +32,8 @@ def test_published_mcp_docs_cover_operational_and_client_contracts() -> None:
         "/api/mcp/health",
         "/metrics",
         "https://news.example.com/mcp/",
-        "MCP_TOKEN",
+        "NEWS_DASHBOARD_MCP_URL",
+        "NEWS_DASHBOARD_MCP_TOKEN",
         "Langfuse",
         "Keycloak",
     ):
@@ -49,3 +50,6 @@ def test_published_mcp_docs_have_no_legacy_or_stale_availability_claims() -> Non
         "tokens are read-only and disabled by default",
     ):
         assert stale not in combined
+
+    assert "export MCP_TOKEN='ndmcp_" not in combined
+    assert "read -rsp" in combined

--- a/backend/tests/test_mcp_documentation.py
+++ b/backend/tests/test_mcp_documentation.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+MCP_DOCS = (
+    ROOT / "website/docs/configuration/mcp-server.md",
+    ROOT / "website/docs/api/integrations.md",
+    ROOT / "website/docs/api/authentication.md",
+    ROOT / "website/docs/api/index.md",
+)
+TOOLS = (
+    "list_latest_news",
+    "list_news_sources",
+    "search_news",
+    "ask_news",
+    "get_news_article",
+    "list_briefings",
+    "get_briefing",
+)
+
+
+def test_published_mcp_docs_cover_operational_and_client_contracts() -> None:
+    combined = "\n".join(path.read_text() for path in MCP_DOCS)
+
+    for tool in TOOLS:
+        assert tool in combined
+    for contract in (
+        "MCP_SERVER_ENABLED=false",
+        "MCP_ALLOWED_HOSTS",
+        "MCP_ALLOWED_ORIGINS",
+        "/api/mcp/health",
+        "/metrics",
+        "https://news.example.com/mcp/",
+        "MCP_TOKEN",
+        "Langfuse",
+        "Keycloak",
+    ):
+        assert contract in combined
+
+
+def test_published_mcp_docs_have_no_legacy_or_stale_availability_claims() -> None:
+    combined = "\n".join(path.read_text().lower() for path in MCP_DOCS)
+
+    for stale in (
+        "/api/mcp/tools",
+        "/api/mcp/rpc",
+        "mcp question answering is planned",
+        "tokens are read-only and disabled by default",
+    ):
+        assert stale not in combined

--- a/backend/tests/test_mcp_http_config.py
+++ b/backend/tests/test_mcp_http_config.py
@@ -96,8 +96,14 @@ def test_mcp_http_app_factory_enforces_host_and_origin() -> None:
 
     allowed = asyncio.run(request(host="news.example.com"))
     bad_host = asyncio.run(request(host="evil.example.com"))
+    implicit_local_host = asyncio.run(request(host="testserver"))
     bad_origin = asyncio.run(request(host="news.example.com", origin="https://evil.example.com"))
+    wrong_scheme = asyncio.run(request(host="news.example.com", origin="http://news.example.com"))
 
     assert allowed.status_code != 421
     assert bad_host.status_code == 421
+    assert implicit_local_host.status_code == 421
     assert bad_origin.status_code == 403
+    assert wrong_scheme.status_code == 403
+    assert bad_host.text == "Misdirected Request"
+    assert bad_origin.text == "Forbidden"

--- a/backend/tests/test_mcp_http_config.py
+++ b/backend/tests/test_mcp_http_config.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+
+def test_mcp_http_config_uses_safe_local_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp.config import McpHttpConfig
+
+    for name in ("APP_BASE_URL", "MCP_ALLOWED_HOSTS", "MCP_ALLOWED_ORIGINS"):
+        monkeypatch.delenv(name, raising=False)
+
+    config = McpHttpConfig.from_environment()
+
+    assert config.allowed_hosts == ("localhost:8080", "127.0.0.1:8080", "[::1]:8080")
+    assert config.allowed_origins == (
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+        "http://[::1]:8080",
+    )
+
+
+def test_mcp_http_config_derives_exact_values_from_public_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp.config import McpHttpConfig
+
+    monkeypatch.setenv("APP_BASE_URL", "https://news.example.com/dashboard")
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("MCP_ALLOWED_ORIGINS", raising=False)
+
+    config = McpHttpConfig.from_environment()
+
+    assert config.allowed_hosts == ("news.example.com",)
+    assert config.allowed_origins == ("https://news.example.com",)
+
+
+def test_mcp_http_config_explicit_allowlists_override_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp.config import McpHttpConfig
+
+    monkeypatch.setenv("APP_BASE_URL", "https://ignored.example.com")
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "news.example.com, news.internal:8080")
+    monkeypatch.setenv(
+        "MCP_ALLOWED_ORIGINS",
+        "https://news.example.com,https://admin.example.com",
+    )
+
+    config = McpHttpConfig.from_environment()
+
+    assert config.allowed_hosts == ("news.example.com", "news.internal:8080")
+    assert config.allowed_origins == (
+        "https://news.example.com",
+        "https://admin.example.com",
+    )
+
+
+def test_mcp_http_config_rejects_wildcards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp.config import McpHttpConfig
+
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "*.example.com")
+
+    with pytest.raises(ValueError, match="exact values"):
+        McpHttpConfig.from_environment()
+
+
+def test_mcp_http_app_factory_enforces_host_and_origin() -> None:
+    from news_dashboard.mcp.config import McpHttpConfig
+    from news_dashboard.mcp.server import create_mcp_http_app, mcp
+
+    config = McpHttpConfig(
+        allowed_hosts=("news.example.com",),
+        allowed_origins=("https://news.example.com",),
+    )
+    guarded_app = create_mcp_http_app(mcp, config=config)
+    outer_app = Starlette(routes=[Mount("/mcp", app=guarded_app)])
+
+    async def request(*, host: str, origin: str | None = None) -> httpx.Response:
+        headers = {"host": host, "accept": "application/json, text/event-stream"}
+        if origin is not None:
+            headers["origin"] = origin
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=outer_app),
+            base_url="https://internal.test",
+        ) as client:
+            return await client.post("/mcp/", headers=headers, json={})
+
+    allowed = asyncio.run(request(host="news.example.com"))
+    bad_host = asyncio.run(request(host="evil.example.com"))
+    bad_origin = asyncio.run(request(host="news.example.com", origin="https://evil.example.com"))
+
+    assert allowed.status_code != 421
+    assert bad_host.status_code == 421
+    assert bad_origin.status_code == 403

--- a/backend/tests/test_mcp_integration.py
+++ b/backend/tests/test_mcp_integration.py
@@ -1,0 +1,310 @@
+"""Deployed-front-door integration coverage for the mounted FastMCP server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+from mcp.shared.exceptions import McpError
+
+from news_dashboard.db import connect
+from news_dashboard.main import app
+
+_ALL_TOOLS = {
+    "ask_news",
+    "get_briefing",
+    "get_news_article",
+    "list_briefings",
+    "list_latest_news",
+    "list_news_sources",
+    "search_news",
+}
+
+
+def _make_user(database_url: str, username: str) -> int:
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            "INSERT INTO users(username, password_hash) VALUES (%s, 'hash') RETURNING id",
+            (username,),
+        ).fetchone()
+    return int(row["id"])
+
+
+def _seed_private_news(database_url: str, user_id: int, *, slug: str, article_id: int) -> None:
+    with connect(database_url=database_url) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources(
+                slug, name, url, category, kind, priority, enabled, owner_user_id
+            ) VALUES (%s, %s, %s, 'engineering', 'rss', 50, TRUE, %s)
+            """,
+            (slug, slug, f"https://example.test/{slug}.xml", user_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO articles(
+                id, url, canonical_url, title, source_slug, source_name,
+                category, kind, status, importance_score, summary, reason, tags,
+                body, body_status
+            ) VALUES (
+                %s, %s, %s, %s, %s, %s,
+                'engineering', 'rss', 'new', 0.8, %s, '', '', %s, 'ok'
+            )
+            """,
+            (
+                article_id,
+                f"https://example.test/articles/{article_id}",
+                f"https://example.test/articles/{article_id}",
+                f"Private article {article_id}",
+                slug,
+                slug,
+                f"Private summary {article_id}",
+                f"Private body {article_id}",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO user_article_state(user_id, article_id, state, starred)
+            VALUES (%s, %s, 'done', TRUE)
+            """,
+            (user_id, article_id),
+        )
+
+
+def _seed_briefing(database_url: str, user_id: int, *, title: str) -> int:
+    content = {
+        "sections": [{"title": "Top", "body": "Saved body", "citations": []}],
+        "worth_opening": [],
+    }
+    with connect(database_url=database_url) as conn:
+        row = conn.execute(
+            """
+            INSERT INTO briefings(
+                title, summary, content, status, scope, model, user_id
+            ) VALUES (%s, 'Saved summary', %s::jsonb, 'complete', 'day', 'model', %s)
+            RETURNING id
+            """,
+            (title, json.dumps(content), user_id),
+        ).fetchone()
+    return int(row["id"])
+
+
+@asynccontextmanager
+async def _mounted_client(token: str | None) -> AsyncIterator[Client[Any]]:
+    """Use the official client through the real FastAPI route table."""
+    from news_dashboard.mcp.server import mcp_http_app
+
+    def client_factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+        *,
+        follow_redirects: bool = True,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://localhost:8080",
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
+            follow_redirects=follow_redirects,
+        )
+
+    transport = StreamableHttpTransport(
+        "http://localhost:8080/mcp/",
+        auth=token,
+        httpx_client_factory=client_factory,
+    )
+    client_error: BaseException | None = None
+    async with mcp_http_app.router.lifespan_context(mcp_http_app):
+        try:
+            async with Client(transport) as client:
+                yield client
+        except BaseException as exc:
+            client_error = exc
+    if client_error is not None:
+        raise client_error
+
+
+def test_mounted_fastapi_exposes_complete_catalog_and_representative_workflow(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    user_id = _make_user(pg_clean, "mcp-mounted-complete")
+    _seed_private_news(pg_clean, user_id, slug="mounted-private", article_id=81_001)
+    briefing_id = _seed_briefing(pg_clean, user_id, title="Mounted briefing")
+    created = service.create_token(user_id, "mounted-client", database_url=pg_clean)
+    captured: dict[str, Any] = {}
+
+    def offline_ask(question: str, **kwargs: Any) -> dict[str, Any]:
+        captured.update({"question": question, **kwargs})
+        return {
+            "answer": "The private article is relevant [1].",
+            "sources": [
+                {
+                    "id": 81_001,
+                    "title": "Private article 81001",
+                    "url": "https://example.test/articles/81001",
+                }
+            ],
+            "trace_id": None,
+        }
+
+    monkeypatch.setattr("news_dashboard.assistant.service.ask", offline_ask)
+
+    async def exercise() -> None:
+        async with _mounted_client(created["token"]) as client:
+            assert {tool.name for tool in await client.list_tools()} == _ALL_TOOLS
+
+            latest = await client.call_tool("list_latest_news", {"limit": 1})
+            article = await client.call_tool("get_news_article", {"article_id": 81_001})
+            briefings = await client.call_tool("list_briefings", {"limit": 1})
+            briefing = await client.call_tool("get_briefing", {"briefing_id": briefing_id})
+            answer = await client.call_tool(
+                "ask_news",
+                {"question": "What is relevant?", "corpus": "saved_and_read"},
+            )
+
+        assert latest.structured_content is not None
+        assert latest.structured_content["articles"][0]["id"] == 81_001
+        assert article.structured_content is not None
+        assert article.structured_content["article"]["body"] == "Private body 81001"
+        assert briefings.structured_content is not None
+        assert briefings.structured_content["briefings"][0]["id"] == briefing_id
+        assert briefing.structured_content is not None
+        assert briefing.structured_content["briefing"]["id"] == briefing_id
+        assert answer.structured_content == {
+            "answer": "The private article is relevant [1].",
+            "citations": [
+                {
+                    "id": 81_001,
+                    "title": "Private article 81001",
+                    "url": "https://example.test/articles/81001",
+                }
+            ],
+            "trace_id": None,
+            "truncated": False,
+        }
+
+    asyncio.run(exercise())
+    assert captured["question"] == "What is relevant?"
+    assert captured["include_all"] is False
+    assert captured["user_id"] == user_id
+
+
+def test_mounted_fastapi_preserves_scope_revocation_and_cross_user_isolation(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    alice = _make_user(pg_clean, "mcp-mounted-alice")
+    bob = _make_user(pg_clean, "mcp-mounted-bob")
+    _seed_private_news(pg_clean, bob, slug="bob-mounted-private", article_id=81_002)
+    bob_briefing = _seed_briefing(pg_clean, bob, title="Bob private briefing")
+    alice_token = service.create_token(alice, "alice-read", scopes=("read",), database_url=pg_clean)
+
+    async def exercise() -> None:
+        async with _mounted_client(alice_token["token"]) as client:
+            assert [tool.name for tool in await client.list_tools()] == ["get_news_article"]
+            hidden_article = await client.call_tool("get_news_article", {"article_id": 81_002})
+            denied_briefing = await client.call_tool(
+                "get_briefing", {"briefing_id": bob_briefing}, raise_on_error=False
+            )
+        assert hidden_article.structured_content == {
+            "found": False,
+            "article": None,
+            "truncated": False,
+        }
+        assert denied_briefing.is_error is True
+
+        service.revoke_token(alice, alice_token["id"], database_url=pg_clean)
+        with pytest.raises(httpx.HTTPStatusError) as revoked:
+            async with _mounted_client(alice_token["token"]):
+                pass
+        assert revoked.value.response.status_code == 401
+
+        for unavailable in (None, "ndmcp_invalid-mounted-token"):
+            with pytest.raises(httpx.HTTPStatusError) as rejected:
+                async with _mounted_client(unavailable):
+                    pass
+            assert rejected.value.response.status_code == 401
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.smoke
+def test_application_front_door_reserves_mcp_before_spa_and_enforces_transport_guards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    client = TestClient(app, follow_redirects=False)
+    initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "front-door-smoke", "version": "1"},
+        },
+    }
+    headers = {
+        "accept": "application/json, text/event-stream",
+        "content-type": "application/json",
+        "host": "localhost:8080",
+        "mcp-protocol-version": "2025-06-18",
+    }
+
+    missing_auth = client.post("/mcp/", json=initialize, headers=headers)
+    assert missing_auth.status_code == 401
+    assert "text/html" not in missing_auth.headers.get("content-type", "")
+    assert "<!doctype html" not in missing_auth.text.lower()
+
+    bad_host = client.post(
+        "/mcp/", json=initialize, headers={**headers, "host": "attacker.example"}
+    )
+    assert bad_host.status_code == 421
+
+    bad_origin = client.post(
+        "/mcp/",
+        json=initialize,
+        headers={**headers, "origin": "https://attacker.example"},
+    )
+    assert bad_origin.status_code == 403
+
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "false")
+    disabled = client.post("/mcp/", json=initialize, headers=headers)
+    assert disabled.status_code == 404
+    assert "<!doctype html" not in disabled.text.lower()
+
+
+def test_disabled_mounted_client_cannot_initialize(
+    pg_clean: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("DATABASE_URL", pg_clean)
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    user_id = _make_user(pg_clean, "mcp-mounted-disabled")
+    token = service.create_token(user_id, "disabled", database_url=pg_clean)["token"]
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "false")
+
+    async def exercise() -> None:
+        with pytest.raises(McpError):
+            async with _mounted_client(token):
+                pass
+
+    asyncio.run(exercise())

--- a/backend/tests/test_mcp_operations.py
+++ b/backend/tests/test_mcp_operations.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, cast
+
+import pytest
+from fastapi.testclient import TestClient
+
+from news_dashboard.main import app
+
+
+def test_mcp_health_reports_disabled_without_touching_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "false")
+
+    def unexpected_check() -> None:
+        message = "disabled MCP health must not touch PostgreSQL"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(service, "check_mcp_dependency", unexpected_check)
+
+    response = TestClient(app).get("/api/mcp/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "disabled"}
+
+
+def test_mcp_health_reports_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.mcp import service
+
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+    monkeypatch.setattr(service, "check_mcp_dependency", lambda: None)
+
+    response = TestClient(app).get("/api/mcp/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+def test_mcp_health_hides_dependency_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    from news_dashboard.mcp import service
+
+    private_detail = "postgresql://private-user:private-password@database/internal"
+    monkeypatch.setenv("MCP_SERVER_ENABLED", "true")
+
+    def failed_check() -> None:
+        raise RuntimeError(private_detail)
+
+    monkeypatch.setattr(service, "check_mcp_dependency", failed_check)
+
+    response = TestClient(app, raise_server_exceptions=False).get("/api/mcp/health")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "dependency_failure"}
+    assert private_detail not in response.text
+
+
+def test_mcp_metrics_have_only_fixed_cardinality_labels() -> None:
+    from news_dashboard.metrics import (
+        mcp_auth_attempts_total,
+        mcp_rate_limits_total,
+        mcp_response_limits_total,
+        mcp_tool_calls_total,
+        mcp_tool_duration_seconds,
+    )
+
+    assert tuple(mcp_auth_attempts_total._labelnames) == ("status",)
+    assert tuple(mcp_tool_calls_total._labelnames) == ("tool", "status")
+    assert tuple(mcp_tool_duration_seconds._labelnames) == ("tool", "status")
+    assert tuple(mcp_rate_limits_total._labelnames) == ("status",)
+    assert tuple(mcp_response_limits_total._labelnames) == ("tool",)
+
+
+def test_token_verifier_records_one_metadata_only_auth_event(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from news_dashboard.mcp import auth
+    from news_dashboard.metrics import mcp_auth_attempts_total
+
+    bearer_token = "ndmcp_private-bearer"  # noqa: S105 -- synthetic test credential
+    monkeypatch.setattr(
+        "news_dashboard.mcp.auth.service.authenticate_token",
+        lambda _token: {"token_id": 41, "user_id": 9, "scopes": {"search"}},
+    )
+    before = mcp_auth_attempts_total.labels(status="success")._value.get()
+    caplog.set_level(logging.INFO, logger="news_dashboard.mcp")
+
+    result = asyncio.run(auth.NewsDashboardTokenVerifier().verify_token(bearer_token))
+
+    assert result is not None
+    assert mcp_auth_attempts_total.labels(status="success")._value.get() == before + 1
+    events = [
+        record.getMessage() for record in caplog.records if "event=auth" in record.getMessage()
+    ]
+    assert events == ["mcp event=auth status=success token_id=41"]
+    assert bearer_token not in caplog.text
+    assert "user_id=9" not in caplog.text
+
+
+def test_tool_telemetry_records_one_event_and_excludes_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from fastmcp.server.middleware import CallNext, MiddlewareContext
+    from fastmcp.tools.base import ToolResult
+    from mcp.types import CallToolRequestParams
+
+    from news_dashboard.mcp.server import _SafeToolTelemetryMiddleware
+    from news_dashboard.metrics import mcp_tool_calls_total
+
+    private_content = "private prompt and article body"
+    context = type(
+        "Context",
+        (),
+        {
+            "message": CallToolRequestParams(
+                name="list_latest_news", arguments={"q": private_content}
+            )
+        },
+    )()
+    before = mcp_tool_calls_total.labels(tool="list_latest_news", status="success")._value.get()
+    caplog.set_level(logging.INFO, logger="news_dashboard.mcp")
+
+    async def call_next(_context: Any) -> ToolResult:
+        return ToolResult(content=private_content)
+
+    typed_context = cast("MiddlewareContext[CallToolRequestParams]", context)
+    typed_next = cast("CallNext[CallToolRequestParams, ToolResult]", call_next)
+    result = asyncio.run(_SafeToolTelemetryMiddleware().on_call_tool(typed_context, typed_next))
+
+    assert result.is_error is False
+    assert (
+        mcp_tool_calls_total.labels(tool="list_latest_news", status="success")._value.get()
+        == before + 1
+    )
+    events = [
+        record.getMessage() for record in caplog.records if "event=tool" in record.getMessage()
+    ]
+    assert len(events) == 1
+    assert "tool=list_latest_news status=success duration_ms=" in events[0]
+    assert private_content not in caplog.text
+
+
+def test_tool_telemetry_normalizes_unknown_tool_names(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from fastmcp.server.middleware import CallNext, MiddlewareContext
+    from fastmcp.tools.base import ToolResult
+    from mcp.types import CallToolRequestParams
+
+    from news_dashboard.mcp.server import _SafeToolTelemetryMiddleware
+    from news_dashboard.metrics import mcp_tool_calls_total
+
+    private_tool_name = "private-user-controlled-tool-name"
+    context = type(
+        "Context",
+        (),
+        {"message": CallToolRequestParams(name=private_tool_name, arguments={})},
+    )()
+    before = mcp_tool_calls_total.labels(tool="unknown", status="success")._value.get()
+    caplog.set_level(logging.INFO, logger="news_dashboard.mcp")
+
+    async def call_next(_context: Any) -> ToolResult:
+        return ToolResult(content="safe")
+
+    typed_context = cast("MiddlewareContext[CallToolRequestParams]", context)
+    typed_next = cast("CallNext[CallToolRequestParams, ToolResult]", call_next)
+    asyncio.run(_SafeToolTelemetryMiddleware().on_call_tool(typed_context, typed_next))
+
+    assert mcp_tool_calls_total.labels(tool="unknown", status="success")._value.get() == before + 1
+    assert "tool=unknown" in caplog.text
+    assert private_tool_name not in caplog.text
+
+
+def test_rate_limit_short_circuit_records_one_metadata_only_event(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from fastmcp.server.middleware import CallNext, MiddlewareContext
+    from fastmcp.server.middleware.rate_limiting import RateLimitError
+
+    from news_dashboard.mcp import server
+    from news_dashboard.metrics import mcp_rate_limits_total
+
+    private_identity = "mcp-rate:private-bearer-derived-value"
+    middleware = server._BoundedRateLimitingMiddleware()
+
+    class ExhaustedBucket:
+        async def consume(self) -> bool:
+            return False
+
+    monkeypatch.setattr(server, "_rate_limit_client_id", lambda _context: private_identity)
+    monkeypatch.setattr(server, "_telemetry_token_id", lambda: 41)
+    monkeypatch.setattr(middleware._buckets, "for_client", lambda _client_id: ExhaustedBucket())
+    before = mcp_rate_limits_total.labels(status="limited")._value.get()
+    caplog.set_level(logging.INFO, logger="news_dashboard.mcp")
+
+    async def call_next(_context: Any) -> None:
+        message = "rate-limited request must short-circuit"
+        raise AssertionError(message)
+
+    context = cast("MiddlewareContext[Any]", object())
+    typed_next = cast("CallNext[Any, Any]", call_next)
+    with pytest.raises(RateLimitError, match="Rate limit exceeded"):
+        asyncio.run(middleware.on_request(context, typed_next))
+
+    assert mcp_rate_limits_total.labels(status="limited")._value.get() == before + 1
+    events = [
+        record.getMessage()
+        for record in caplog.records
+        if "event=rate_limit" in record.getMessage()
+    ]
+    assert events == ["mcp event=rate_limit status=limited token_id=41"]
+    assert private_identity not in caplog.text
+
+
+def test_response_limit_records_one_metadata_only_event(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from fastmcp.server.middleware import CallNext, MiddlewareContext
+    from fastmcp.tools.base import ToolResult
+    from mcp.types import CallToolRequestParams
+
+    from news_dashboard.mcp import server
+    from news_dashboard.metrics import mcp_response_limits_total
+
+    private_content = "private article body " * 100
+    context = type(
+        "Context",
+        (),
+        {"message": CallToolRequestParams(name="get_news_article", arguments={})},
+    )()
+    middleware = server._ObservedResponseLimitingMiddleware(max_size=200)
+    monkeypatch.setattr(server, "_telemetry_token_id", lambda: 41)
+    before = mcp_response_limits_total.labels(tool="get_news_article")._value.get()
+    caplog.set_level(logging.INFO, logger="news_dashboard.mcp")
+
+    async def call_next(_context: Any) -> ToolResult:
+        return ToolResult(content=private_content)
+
+    typed_context = cast("MiddlewareContext[CallToolRequestParams]", context)
+    typed_next = cast("CallNext[CallToolRequestParams, ToolResult]", call_next)
+    result = asyncio.run(middleware.on_call_tool(typed_context, typed_next))
+
+    assert private_content not in str(result.content)
+    assert mcp_response_limits_total.labels(tool="get_news_article")._value.get() == before + 1
+    events = [
+        record.getMessage()
+        for record in caplog.records
+        if "event=response_limit" in record.getMessage()
+    ]
+    assert events == ["mcp event=response_limit tool=get_news_article status=limited token_id=41"]
+    assert private_content not in caplog.text

--- a/backend/tests/test_mcp_operations.py
+++ b/backend/tests/test_mcp_operations.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.routing import Mount
 
 from news_dashboard.main import app
 
@@ -57,6 +59,79 @@ def test_mcp_health_hides_dependency_failures(monkeypatch: pytest.MonkeyPatch) -
     assert response.status_code == 503
     assert response.json() == {"status": "dependency_failure"}
     assert private_detail not in response.text
+
+
+def test_mcp_health_uses_independent_connection_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from news_dashboard.mcp import service
+
+    captured: dict[str, object] = {}
+    queries: list[str] = []
+
+    class Connection:
+        def __enter__(self) -> Connection:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def execute(self, query: str) -> None:
+            queries.append(query)
+
+    def connect(dsn: str, *, connect_timeout: int) -> Connection:
+        captured.update(dsn=dsn, connect_timeout=connect_timeout)
+        return Connection()
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://health.example/news")
+    monkeypatch.setenv("DB_POOL_TIMEOUT_SECONDS", "300")
+    monkeypatch.setenv("DB_CONNECT_MAX_ATTEMPTS", "300")
+    monkeypatch.setattr("news_dashboard.mcp.service.psycopg.connect", connect)
+
+    service.check_mcp_dependency()
+
+    assert captured["dsn"] == "postgresql://health.example/news"
+    assert captured["connect_timeout"] == 2
+    assert queries == ["SET statement_timeout = '2s'", "SELECT 1"]
+
+
+@pytest.mark.parametrize(
+    ("authorization", "status"),
+    [(None, "missing"), ("Basic private-credential", "invalid")],
+)
+def test_http_auth_boundary_records_pre_verifier_failures_once(
+    authorization: str | None,
+    status: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from news_dashboard.mcp.config import McpHttpConfig
+    from news_dashboard.mcp.server import create_mcp_http_app, mcp
+    from news_dashboard.metrics import mcp_auth_attempts_total
+
+    http_app = create_mcp_http_app(
+        mcp,
+        config=McpHttpConfig(
+            allowed_hosts=("mcp.test",),
+            allowed_origins=("https://mcp.test",),
+        ),
+    )
+    mounted = Starlette(routes=[Mount("/mcp", app=http_app)], lifespan=http_app.lifespan)
+    headers = {"host": "mcp.test"}
+    if authorization is not None:
+        headers["authorization"] = authorization
+    before = mcp_auth_attempts_total.labels(status=status)._value.get()
+    caplog.set_level(logging.INFO, logger="news_dashboard.mcp")
+
+    with TestClient(mounted, raise_server_exceptions=False) as client:
+        response = client.post("/mcp/", headers=headers, json={"jsonrpc": "2.0", "id": 1})
+
+    assert response.status_code == 401
+    assert mcp_auth_attempts_total.labels(status=status)._value.get() == before + 1
+    events = [
+        record.getMessage() for record in caplog.records if "event=auth" in record.getMessage()
+    ]
+    assert events == [f"mcp event=auth status={status}"]
+    assert "private-credential" not in caplog.text
 
 
 def test_mcp_metrics_have_only_fixed_cardinality_labels() -> None:

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -26,6 +26,9 @@ services:
       POSTGRES_PASSWORD: demo-only-password
       SESSION_SECRET: demo-only-session-secret-not-for-real-deployments
       DEMO_MODE: "1"
+      MCP_SERVER_ENABLED: ${MCP_SERVER_ENABLED:-true}
+      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-localhost:8080,127.0.0.1:8080,[::1]:8080}
+      MCP_ALLOWED_ORIGINS: ${MCP_ALLOWED_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,11 +49,11 @@ services:
       OTP_SMTP_PASS: ${OTP_SMTP_PASS:-}
       OTP_SMTP_FROM: ${OTP_SMTP_FROM:-}
       OTP_SMTP_TLS: ${OTP_SMTP_TLS:-}
-      APP_BASE_URL: ${APP_BASE_URL:-}
-      # Set the public values in production; APP_BASE_URL is the fallback source.
+      APP_BASE_URL: ${APP_BASE_URL:?APP_BASE_URL is required}
+      # Optional exact overrides; empty values derive from required APP_BASE_URL.
       MCP_SERVER_ENABLED: ${MCP_SERVER_ENABLED:-true}
-      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-localhost:8080,127.0.0.1:8080,[::1]:8080}
-      MCP_ALLOWED_ORIGINS: ${MCP_ALLOWED_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080}
+      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-}
+      MCP_ALLOWED_ORIGINS: ${MCP_ALLOWED_ORIGINS:-}
       # Legacy credential aliases remain available to the OTP mailer.
       SMTP_USERNAME: ${SMTP_USERNAME:-}
       SMTP_PASSWORD: ${SMTP_PASSWORD:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,6 +50,10 @@ services:
       OTP_SMTP_FROM: ${OTP_SMTP_FROM:-}
       OTP_SMTP_TLS: ${OTP_SMTP_TLS:-}
       APP_BASE_URL: ${APP_BASE_URL:-}
+      # Set the public values in production; APP_BASE_URL is the fallback source.
+      MCP_SERVER_ENABLED: ${MCP_SERVER_ENABLED:-true}
+      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-localhost:8080,127.0.0.1:8080,[::1]:8080}
+      MCP_ALLOWED_ORIGINS: ${MCP_ALLOWED_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080}
       # Legacy credential aliases remain available to the OTP mailer.
       SMTP_USERNAME: ${SMTP_USERNAME:-}
       SMTP_PASSWORD: ${SMTP_PASSWORD:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,10 @@ services:
       OTP_SMTP_FROM: ${OTP_SMTP_FROM:-}
       OTP_SMTP_TLS: ${OTP_SMTP_TLS:-}
       APP_BASE_URL: ${APP_BASE_URL:-}
+      # FastMCP shares the app listener and is enabled unless explicitly disabled.
+      MCP_SERVER_ENABLED: ${MCP_SERVER_ENABLED:-true}
+      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-localhost:8080,127.0.0.1:8080,[::1]:8080}
+      MCP_ALLOWED_ORIGINS: ${MCP_ALLOWED_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080}
       # Legacy credential aliases remain available to the OTP mailer.
       SMTP_USERNAME: ${SMTP_USERNAME:-}
       SMTP_PASSWORD: ${SMTP_PASSWORD:-}

--- a/docs/superpowers/plans/2026-08-03-fastmcp-operations.md
+++ b/docs/superpowers/plans/2026-08-03-fastmcp-operations.md
@@ -1,0 +1,57 @@
+# FastMCP operations and documentation implementation plan
+
+Issue: #1372
+
+## Goal
+
+Finish the default-enabled FastMCP deployment story on the existing FastAPI listener at `/mcp/`. Add strict HTTP transport protection, privacy-safe health and telemetry, deployed-path integration coverage, and complete operator/client documentation for the seven-tool catalog. MCP remains independent of Keycloak and `MCP_SERVER_ENABLED=false` remains the global shutdown control.
+
+## Locked contracts
+
+- No separate MCP service, port, database exposure, legacy RPC compatibility, or Keycloak credential flow.
+- Compose and Helm render `MCP_SERVER_ENABLED=true` unless explicitly set false.
+- FastMCP validates exact configured Host and Origin values. Server-to-server clients may omit Origin; a supplied Origin must match.
+- `GET /api/mcp/health` returns only `disabled`, `healthy`, or `dependency_failure`; disabled and healthy are HTTP 200, dependency failure is HTTP 503. It exposes no token, catalog, or content.
+- Prometheus labels are fixed-cardinality. Non-secret numeric token IDs may occur only in metadata-only structured logs, never metric labels.
+- The canonical remote URL is `https://news.example.com/mcp/`, with HTTPS and the path preserved by the reverse proxy.
+
+## Task 1: Deployment defaults and HTTP guard
+
+Write failing tests, then:
+
+- Add typed MCP Host/Origin allowlist configuration and a focused HTTP-app factory.
+- Enable FastMCP Host/Origin protection.
+- Render the feature flag and safe defaults/overrides in every supported Compose and Helm path.
+- Prove false disables transport and token creation, and prove no extra service or port is introduced.
+- Cover allowed and rejected Host/Origin requests at the mounted HTTP boundary.
+
+## Task 2: Health and operational telemetry
+
+Write failing tests, then:
+
+- Add the public, content-free MCP health contract with a bounded PostgreSQL readiness check.
+- Add fixed-cardinality authentication, tool outcome, duration, rate-limit, and response-limit metrics.
+- Add metadata-only structured events without bearer values, arguments, content, prompts, provider bodies, URLs, or exception text.
+- Ensure events and counters occur exactly once across middleware short-circuits.
+
+## Task 3: Mounted and deployed-path integration coverage
+
+Write an integration matrix using the official FastMCP client against the real mounted FastAPI app:
+
+- discover exactly the seven authorized tools;
+- invoke deterministic tools and an AI-stubbed `ask_news`;
+- reject missing, invalid, revoked, and under-scoped tokens;
+- preserve cross-user isolation, bounds, rate limits, sanitized errors, strict Host/Origin behavior, and disabled mode;
+- exercise the supported application container/front door and prove the SPA fallback does not intercept `/mcp/`.
+
+## Task 4: Complete UI and documentation
+
+- Correct Settings copy to say MCP is default-enabled and read-only, with Ask requiring server-side AI.
+- Document all seven tools and exact scope mapping, token creation/rotation/revocation, limits, Ask configuration, health/metrics/logging, HTTPS proxy requirements, and security boundaries.
+- Add credential-safe FastMCP Python and Claude Code examples using environment placeholders.
+- Remove all legacy `/api/mcp/tools`, `/api/mcp/rpc`, disabled-by-default, and planned-question-answering text.
+- Explicitly state that tools expose no SQL, shell, filesystem, secrets, mutations, or direct Keycloak credentials.
+
+## Verification and delivery
+
+After the Ask PR merges, rebase onto `origin/main`, then run focused MCP/backend/frontend/docs/deployment tests plus the repository lint, typecheck, complete PostgreSQL-backed suite, Helm validation, website build, dependency audit, and secret/stale-reference scans. Obtain a separate code review, push a dedicated branch, open a PR closing #1372, monitor CI, and merge when green under repository policy.

--- a/frontend/src/__tests__/mcpTokensSettings.test.tsx
+++ b/frontend/src/__tests__/mcpTokensSettings.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const { mockFetchMcpTokens } = vi.hoisted(() => ({
+  mockFetchMcpTokens: vi.fn(),
+}));
+
+vi.mock('@/api', () => ({
+  fetchMcpTokens: mockFetchMcpTokens,
+  createMcpToken: vi.fn(),
+  revokeMcpToken: vi.fn(),
+}));
+
+import { McpTokensSection } from '../components/settings/McpTokensSection';
+
+beforeEach(() => {
+  mockFetchMcpTokens.mockResolvedValue({ items: [], enabled: true });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('McpTokensSection', () => {
+  it('describes default-enabled read-only access and the Ask AI boundary', async () => {
+    render(<McpTokensSection />);
+
+    expect(await screen.findByText(/enabled by default/i)).toBeInTheDocument();
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ask requires server-side AI/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/settings/McpTokensSection.tsx
+++ b/frontend/src/components/settings/McpTokensSection.tsx
@@ -80,9 +80,10 @@ export function McpTokensSection() {
       </div>
       <div className="rounded-lg border border-border bg-card p-4 space-y-4">
         <p className="text-xs text-muted-foreground">
-          Create a scoped token to let an external MCP client (e.g. Claude Desktop) search and read
-          articles visible to you. Tokens are read-only and disabled by default; ask an admin to
-          enable the MCP server on this instance.
+          MCP access is enabled by default and read-only. Create a scoped token for an external
+          client such as Claude Code to search, read, or ask about news visible to you. Ask requires
+          server-side AI configuration and sends the question and selected news context to that
+          provider.
         </p>
 
         {!enabled && state !== 'loading' && (

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -40,6 +40,12 @@ spec:
               value: {{ .Values.app.data.dir | quote }}
             - name: ENABLE_HSTS
               value: {{ .Values.app.config.enableHsts | quote }}
+            - name: MCP_SERVER_ENABLED
+              value: {{ .Values.app.config.mcpServerEnabled | quote }}
+            - name: MCP_ALLOWED_HOSTS
+              value: {{ .Values.app.config.mcpAllowedHosts | quote }}
+            - name: MCP_ALLOWED_ORIGINS
+              value: {{ .Values.app.config.mcpAllowedOrigins | quote }}
 {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_HOST
               value: {{ printf "%s-postgres" (include "news-dashboard.fullname" .) | quote }}

--- a/helm/news-dashboard/templates/deployment.yaml
+++ b/helm/news-dashboard/templates/deployment.yaml
@@ -1,6 +1,28 @@
 {{- if and .Values.production (not .Values.app.config.enableHsts) }}
 {{- fail "application HSTS must be enabled in production" }}
 {{- end }}
+{{- $mcpHosts := .Values.app.config.mcpAllowedHosts }}
+{{- $mcpOrigins := .Values.app.config.mcpAllowedOrigins }}
+{{- if not $mcpHosts }}
+  {{- if .Values.app.publicBaseUrl }}
+    {{- $mcpHosts = (urlParse .Values.app.publicBaseUrl).host }}
+  {{- else if .Values.ingress.enabled }}
+    {{- $mcpHosts = .Values.ingress.host }}
+  {{- else }}
+    {{- $mcpHosts = "localhost:8080,127.0.0.1:8080,[::1]:8080" }}
+  {{- end }}
+{{- end }}
+{{- if not $mcpOrigins }}
+  {{- if .Values.app.publicBaseUrl }}
+    {{- $publicUrl := urlParse .Values.app.publicBaseUrl }}
+    {{- $mcpOrigins = printf "%s://%s" $publicUrl.scheme $publicUrl.host }}
+  {{- else if .Values.ingress.enabled }}
+    {{- $scheme := ternary "https" "http" (not (empty .Values.ingress.tls)) }}
+    {{- $mcpOrigins = printf "%s://%s" $scheme .Values.ingress.host }}
+  {{- else }}
+    {{- $mcpOrigins = "http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,9 +65,9 @@ spec:
             - name: MCP_SERVER_ENABLED
               value: {{ .Values.app.config.mcpServerEnabled | quote }}
             - name: MCP_ALLOWED_HOSTS
-              value: {{ .Values.app.config.mcpAllowedHosts | quote }}
+              value: {{ $mcpHosts | quote }}
             - name: MCP_ALLOWED_ORIGINS
-              value: {{ .Values.app.config.mcpAllowedOrigins | quote }}
+              value: {{ $mcpOrigins | quote }}
 {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_HOST
               value: {{ printf "%s-postgres" (include "news-dashboard.fullname" .) | quote }}

--- a/helm/news-dashboard/values-production.yaml
+++ b/helm/news-dashboard/values-production.yaml
@@ -31,5 +31,3 @@ networkPolicy:
 app:
   config:
     enableHsts: true
-    mcpAllowedHosts: news.lihor.ro
-    mcpAllowedOrigins: https://news.lihor.ro

--- a/helm/news-dashboard/values-production.yaml
+++ b/helm/news-dashboard/values-production.yaml
@@ -31,3 +31,5 @@ networkPolicy:
 app:
   config:
     enableHsts: true
+    mcpAllowedHosts: news.lihor.ro
+    mcpAllowedOrigins: https://news.lihor.ro

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -226,8 +226,10 @@ app:
   config:
     # FastMCP is mounted on the existing app listener at /mcp/.
     mcpServerEnabled: true
-    mcpAllowedHosts: "localhost:8080,127.0.0.1:8080,[::1]:8080"
-    mcpAllowedOrigins: "http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080"
+    # Exact overrides. Empty values derive from publicBaseUrl or ingress;
+    # installations without either retain local-development defaults.
+    mcpAllowedHosts: ""
+    mcpAllowedOrigins: ""
     # Serves GET /metrics in Prometheus exposition format. Off by default.
     metricsEnabled: false
     # Serves the interactive API docs (/docs, /redoc, /openapi.json). Off by

--- a/helm/news-dashboard/values.yaml
+++ b/helm/news-dashboard/values.yaml
@@ -224,6 +224,10 @@ app:
     # Optional release identifier, usually set by CI to the deployed commit SHA.
     release: ""
   config:
+    # FastMCP is mounted on the existing app listener at /mcp/.
+    mcpServerEnabled: true
+    mcpAllowedHosts: "localhost:8080,127.0.0.1:8080,[::1]:8080"
+    mcpAllowedOrigins: "http://localhost:8080,http://127.0.0.1:8080,http://[::1]:8080"
     # Serves GET /metrics in Prometheus exposition format. Off by default.
     metricsEnabled: false
     # Serves the interactive API docs (/docs, /redoc, /openapi.json). Off by

--- a/scripts/smoke-mcp-container.sh
+++ b/scripts/smoke-mcp-container.sh
@@ -139,8 +139,7 @@ wait_for_app
 
 disabled_code="$(curl --silent --output /tmp/mcp-smoke-disabled-$$ \
   --write-out '%{http_code}' -H 'Host: localhost:8080' -H "${content_type}" -H "${accept}" \
-  -H "Authorization: Bearer ${smoke_token}" --data "${initialize}" \
-  "http://127.0.0.1:${app_port}/mcp/")"
+  --data "${initialize}" "http://127.0.0.1:${app_port}/mcp/")"
 test "${disabled_code}" = 404
 ! grep -qi '<!doctype html' /tmp/mcp-smoke-disabled-$$
 rm -f /tmp/mcp-smoke-disabled-$$

--- a/scripts/smoke-mcp-container.sh
+++ b/scripts/smoke-mcp-container.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+smoke_suffix="${GITHUB_RUN_ID:-local}-$$"
+network_name="nd-mcp-smoke-${smoke_suffix}"
+postgres_name="nd-mcp-postgres-${smoke_suffix}"
+app_name="nd-mcp-app-${smoke_suffix}"
+image_name="news-dashboard:mcp-smoke-${smoke_suffix}"
+postgres_password="mcp-smoke-postgres-password"
+session_secret="mcp-smoke-session-secret-000000000000000000000000"
+app_port=""
+smoke_token=""
+
+cleanup() {
+  rm -f "/tmp/mcp-smoke-response-$$" "/tmp/mcp-smoke-disabled-$$"
+  docker rm -f "${app_name}" "${postgres_name}" >/dev/null 2>&1 || true
+  docker network rm "${network_name}" >/dev/null 2>&1 || true
+  docker image rm "${image_name}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker network create "${network_name}" >/dev/null
+docker run -d --name "${postgres_name}" --network "${network_name}" \
+  -e POSTGRES_DB=news_dashboard \
+  -e POSTGRES_USER=news_dashboard \
+  -e POSTGRES_PASSWORD="${postgres_password}" \
+  pgvector/pgvector:pg16 >/dev/null
+
+for _attempt in $(seq 1 60); do
+  if docker exec "${postgres_name}" pg_isready -U news_dashboard -d news_dashboard \
+    >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+docker exec "${postgres_name}" pg_isready -U news_dashboard -d news_dashboard >/dev/null
+
+docker build -t "${image_name}" . >/dev/null
+
+start_app() {
+  local enabled="$1"
+  docker run -d --name "${app_name}" --network "${network_name}" \
+    -p 127.0.0.1::8080 \
+    -e POSTGRES_HOST="${postgres_name}" \
+    -e POSTGRES_PORT=5432 \
+    -e POSTGRES_DB=news_dashboard \
+    -e POSTGRES_USER=news_dashboard \
+    -e POSTGRES_PASSWORD="${postgres_password}" \
+    -e SESSION_SECRET="${session_secret}" \
+    -e BOOTSTRAP_ADMIN_USERNAME=mcp-smoke-admin \
+    -e BOOTSTRAP_ADMIN_PASSWORD=mcp-smoke-password \
+    -e MCP_SERVER_ENABLED="${enabled}" \
+    -e MCP_ALLOWED_HOSTS=localhost:8080 \
+    -e MCP_ALLOWED_ORIGINS=http://localhost:8080 \
+    "${image_name}" >/dev/null
+  app_port="$(docker port "${app_name}" 8080/tcp | sed -n 's/.*://p')"
+  test -n "${app_port}"
+}
+
+wait_for_app() {
+  for _attempt in $(seq 1 90); do
+    if curl --fail --silent --show-error \
+      -H 'Host: localhost:8080' \
+      "http://127.0.0.1:${app_port}/api/ready" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  docker logs "${app_name}" >&2
+  return 1
+}
+
+start_app true
+wait_for_app
+
+# Mint inside the container and capture stdout only in memory. The bearer never
+# appears in a command argument, image layer, tracked file, or CI log.
+smoke_token="$(docker exec "${app_name}" python -c '
+from news_dashboard.auth import get_user_by_username
+from news_dashboard.mcp.service import create_token
+user = get_user_by_username("mcp-smoke-admin")
+if user is None:
+    raise SystemExit("bootstrap user missing")
+print(create_token(int(user["id"]), "container smoke", scopes=("search",))["token"])
+')"
+test -n "${smoke_token}"
+
+MCP_SMOKE_PORT="${app_port}" MCP_SMOKE_TOKEN="${smoke_token}" python - <<'PY'
+import asyncio
+import os
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+
+async def main() -> None:
+    port = os.environ["MCP_SMOKE_PORT"]
+    token = os.environ["MCP_SMOKE_TOKEN"]
+    transport = StreamableHttpTransport(
+        f"http://127.0.0.1:{port}/mcp/",
+        auth=token,
+        headers={"Host": "localhost:8080"},
+    )
+    async with Client(transport) as client:
+        names = {tool.name for tool in await client.list_tools()}
+        assert names == {"list_latest_news", "list_news_sources", "search_news"}
+        result = await client.call_tool("list_latest_news", {"limit": 1})
+        assert result.is_error is False
+
+
+asyncio.run(main())
+PY
+
+initialize='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"container-smoke","version":"1"}}}'
+content_type='Content-Type: application/json'
+accept='Accept: application/json, text/event-stream'
+
+unauthenticated_code="$(curl --silent --output /tmp/mcp-smoke-response-$$ \
+  --write-out '%{http_code}' -H 'Host: localhost:8080' -H "${content_type}" -H "${accept}" \
+  --data "${initialize}" "http://127.0.0.1:${app_port}/mcp/")"
+test "${unauthenticated_code}" = 401
+! grep -qi '<!doctype html' /tmp/mcp-smoke-response-$$
+
+bad_host_code="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+  -H 'Host: attacker.example' -H "${content_type}" -H "${accept}" \
+  --data "${initialize}" "http://127.0.0.1:${app_port}/mcp/")"
+test "${bad_host_code}" = 421
+
+bad_origin_code="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+  -H 'Host: localhost:8080' -H 'Origin: https://attacker.example' \
+  -H "${content_type}" -H "${accept}" --data "${initialize}" \
+  "http://127.0.0.1:${app_port}/mcp/")"
+test "${bad_origin_code}" = 403
+
+rm -f /tmp/mcp-smoke-response-$$
+docker rm -f "${app_name}" >/dev/null
+start_app false
+wait_for_app
+
+disabled_code="$(curl --silent --output /tmp/mcp-smoke-disabled-$$ \
+  --write-out '%{http_code}' -H 'Host: localhost:8080' -H "${content_type}" -H "${accept}" \
+  -H "Authorization: Bearer ${smoke_token}" --data "${initialize}" \
+  "http://127.0.0.1:${app_port}/mcp/")"
+test "${disabled_code}" = 404
+! grep -qi '<!doctype html' /tmp/mcp-smoke-disabled-$$
+rm -f /tmp/mcp-smoke-disabled-$$
+
+# PostgreSQL stays private to the Docker network; only the application has a
+# host port binding.
+test -z "$(docker port "${postgres_name}" 5432/tcp 2>/dev/null || true)"
+
+echo "MCP container smoke passed"

--- a/website/docs/api/authentication.md
+++ b/website/docs/api/authentication.md
@@ -19,13 +19,13 @@ Sessions last `SESSION_DAYS` days (default `30`). Expiry is enforced against
 the token's own age at verification time, so shortening `SESSION_DAYS`
 immediately invalidates older cookies.
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/auth/config` | GET | Which login methods this instance offers. |
-| `/api/auth/metadata` | GET | Identity-provider metadata for the client. |
-| `/api/auth/login` | POST | Username/password login; sets the session cookie. |
-| `/api/auth/logout` | GET | Clears the session cookie. |
-| `/api/auth/me` | GET | The current user. Requires a session. |
+| Route                | Method | Purpose                                           |
+| -------------------- | ------ | ------------------------------------------------- |
+| `/api/auth/config`   | GET    | Which login methods this instance offers.         |
+| `/api/auth/metadata` | GET    | Identity-provider metadata for the client.        |
+| `/api/auth/login`    | POST   | Username/password login; sets the session cookie. |
+| `/api/auth/logout`   | GET    | Clears the session cookie.                        |
+| `/api/auth/me`       | GET    | The current user. Requires a session.             |
 
 Call `/api/auth/config` before rendering a login screen — it reports whether
 this instance uses local passwords, SSO, or both, so clients do not hardcode
@@ -35,10 +35,10 @@ an assumption.
 
 Passwordless login by emailed code, in two steps:
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/auth/otp/request` | POST | Sends a one-time code to an email address. |
-| `/api/auth/otp/login` | POST | Exchanges email + code for a session cookie. |
+| Route                   | Method | Purpose                                      |
+| ----------------------- | ------ | -------------------------------------------- |
+| `/api/auth/otp/request` | POST   | Sends a one-time code to an email address.   |
+| `/api/auth/otp/login`   | POST   | Exchanges email + code for a session cookie. |
 
 Both steps are throttled per email address and answer `429` with
 `"Too many code requests; try again later"` or `"Too many code attempts; try
@@ -52,12 +52,12 @@ request step does not reveal whether an address is registered.
 When `KEYCLOAK_AUTH_ENABLED` is set, browser-redirect SSO routes are mounted
 alongside the local flows:
 
-| Route | Purpose |
-|-------|---------|
-| `/auth/login` | Redirect to the identity provider. |
+| Route            | Purpose                                 |
+| ---------------- | --------------------------------------- |
+| `/auth/login`    | Redirect to the identity provider.      |
 | `/auth/register` | Redirect to provider-side registration. |
 | `/auth/callback` | OIDC callback; establishes the session. |
-| `/auth/logout` | Provider-side logout. |
+| `/auth/logout`   | Provider-side logout.                   |
 
 Admin rights can be granted by provider username via
 `KEYCLOAK_ADMIN_USERNAMES`. Configuration is covered in
@@ -102,11 +102,11 @@ are per-user, individually revocable, and scoped to a single integration.
 
 ### MCP tokens
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/users/me/mcp-tokens` | GET | List your MCP tokens. |
-| `/api/users/me/mcp-tokens` | POST | Mint a token. |
-| `/api/users/me/mcp-tokens/{token_id}` | DELETE | Revoke a token. |
+| Route                                 | Method | Purpose               |
+| ------------------------------------- | ------ | --------------------- |
+| `/api/users/me/mcp-tokens`            | GET    | List your MCP tokens. |
+| `/api/users/me/mcp-tokens`            | POST   | Mint a token.         |
+| `/api/users/me/mcp-tokens/{token_id}` | DELETE | Revoke a token.       |
 
 These authenticate the read-only [MCP tool set](integrations.md#mcp-server).
 MCP bearer authentication is independent of Keycloak and browser sessions.
@@ -116,21 +116,28 @@ Existing tokens remain stored so access can resume if the feature is enabled
 again, and revocation invalidates a token immediately.
 
 Scopes are enforced per tool: `search` grants MCP listing, source discovery,
-and search; `read` grants MCP single-article retrieval; and `ask` grants MCP
-`ask_news`. The same `ask` scope can authorize the optional A2A
+and search; `read` grants MCP single-article retrieval; `ask` grants MCP
+`ask_news`; and `briefings` grants complete saved-briefing list and detail.
+The same `ask` scope can authorize the optional A2A
 question-answering endpoint when A2A is separately enabled. The scope is
 shared, but the routes and feature flags are independent: MCP uses
 `MCP_SERVER_ENABLED`, while A2A remains disabled unless
 `A2A_SERVER_ENABLED=true`. Enabling one does not enable the other. Prefer
 separate least-privilege tokens for clients that do not need both surfaces.
 
+The plaintext `ndmcp_` credential is returned only when it is minted; the
+database stores its SHA-256 hash and display prefix. Rotate a credential by
+creating a replacement with the minimum scopes, updating and verifying the
+client, then revoking the old token. Revocation takes effect immediately.
+Neither the token nor the MCP protocol carries direct Keycloak credentials.
+
 ### Google Reader tokens
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/users/me/greader-tokens` | GET | List sync tokens. |
-| `/api/users/me/greader-tokens` | POST | Mint a token. |
-| `/api/users/me/greader-tokens/{token_id}` | DELETE | Revoke a token. |
+| Route                                     | Method | Purpose           |
+| ----------------------------------------- | ------ | ----------------- |
+| `/api/users/me/greader-tokens`            | GET    | List sync tokens. |
+| `/api/users/me/greader-tokens`            | POST   | Mint a token.     |
+| `/api/users/me/greader-tokens/{token_id}` | DELETE | Revoke a token.   |
 
 These back the [Google Reader-compatible sync
 API](integrations.md#google-reader-sync) used by third-party feed readers.
@@ -140,10 +147,10 @@ API](integrations.md#google-reader-sync) used by third-party feed readers.
 Podcast feeds are consumed by player apps that cannot log in, so the feed URL
 carries its own capability token:
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/briefings/podcast-feed-token` | GET | Fetch the current feed token. |
-| `/api/briefings/podcast-feed-token/regenerate` | POST | Rotate it. |
+| Route                                          | Method | Purpose                       |
+| ---------------------------------------------- | ------ | ----------------------------- |
+| `/api/briefings/podcast-feed-token`            | GET    | Fetch the current feed token. |
+| `/api/briefings/podcast-feed-token/regenerate` | POST   | Rotate it.                    |
 
 The token grants read access to that user's generated podcast audio and
 nothing else. Regenerating invalidates the previous URL — that is the only way
@@ -151,11 +158,11 @@ to revoke a feed that has been shared.
 
 ## Account lifecycle
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/users/me/export` | GET | Export your data. |
-| `/api/users/me/import` | POST | Import a previously exported archive. |
-| `/api/users/me` | DELETE | Delete your account and associated data. |
+| Route                  | Method | Purpose                                  |
+| ---------------------- | ------ | ---------------------------------------- |
+| `/api/users/me/export` | GET    | Export your data.                        |
+| `/api/users/me/import` | POST   | Import a previously exported archive.    |
+| `/api/users/me`        | DELETE | Delete your account and associated data. |
 
 Import accepts JSON archives up to 20 MiB. Administrative user management is
 separate and documented under [Operations](operations.md#user-administration).

--- a/website/docs/api/index.md
+++ b/website/docs/api/index.md
@@ -19,11 +19,11 @@ replacement for it.
 The backend publishes an OpenAPI document derived directly from the route
 handlers. When this page and the schema disagree, the schema is right.
 
-| Endpoint | What it serves |
-|----------|----------------|
-| `/docs` | Interactive Swagger UI for the running instance. |
-| `/openapi.json` | The raw OpenAPI document. |
-| `/api/version` | The running application version. |
+| Endpoint        | What it serves                                   |
+| --------------- | ------------------------------------------------ |
+| `/docs`         | Interactive Swagger UI for the running instance. |
+| `/openapi.json` | The raw OpenAPI document.                        |
+| `/api/version`  | The running application version.                 |
 
 The OpenAPI `info.version` and `/api/version` are both read from the `VERSION`
 file at startup, so the documented version always matches the deployed build.
@@ -37,14 +37,15 @@ self-hosted deployment at `https://news.example.com`, the article list is
 Routes are grouped by the router they mount on, which determines their auth
 behavior:
 
-| Prefix | Router | Access |
-|--------|--------|--------|
-| `/api/*` | authenticated `api` router | Requires a valid session. |
-| `/api/admin/*` | `admin` router | Requires a session belonging to an admin user. |
-| `/api/auth/*`, `/auth/*` | public router | Login, registration, and SSO callbacks. |
-| `/mcp/*` | mounted FastMCP server | Bearer-token authenticated, stateless Streamable HTTP. |
-| `/reader/api/0/*`, `/accounts/ClientLogin` | public GReader router | Google Reader-compatible sync. |
-| `/api/health`, `/api/live`, `/api/ready`, `/metrics` | system router | Unauthenticated probes. |
+| Prefix                                               | Router                     | Access                                                                                 |
+| ---------------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------- |
+| `/api/*`                                             | authenticated `api` router | Requires a valid session.                                                              |
+| `/api/admin/*`                                       | `admin` router             | Requires a session belonging to an admin user.                                         |
+| `/api/auth/*`, `/auth/*`                             | public router              | Login, registration, and SSO callbacks.                                                |
+| `/mcp/*`                                             | mounted FastMCP server     | Bearer-token authenticated, stateless Streamable HTTP.                                 |
+| `/api/mcp/health`                                    | MCP readiness probe        | Unauthenticated, content-free status (`disabled`, `healthy`, or `dependency_failure`). |
+| `/reader/api/0/*`, `/accounts/ClientLogin`           | public GReader router      | Google Reader-compatible sync.                                                         |
+| `/api/health`, `/api/live`, `/api/ready`, `/metrics` | system router              | Unauthenticated probes.                                                                |
 
 ## Response conventions
 
@@ -82,15 +83,15 @@ Errors use FastAPI's standard envelope:
 For request-validation failures (`422`), `detail` is an array of per-field
 objects identifying the offending parameter and the rule it broke.
 
-| Status | Meaning |
-|--------|---------|
-| `400` | The request was understood but rejected by a domain rule. |
-| `401` | No valid session, token, or credential was presented. |
-| `403` | Authenticated, but not permitted — see below. |
-| `404` | The resource does not exist, or is not visible to you. |
-| `422` | Request validation failed (bad query parameter, malformed body). |
-| `429` | A rate limit or generation quota was exceeded. |
-| `5xx` | Server-side failure. |
+| Status | Meaning                                                          |
+| ------ | ---------------------------------------------------------------- |
+| `400`  | The request was understood but rejected by a domain rule.        |
+| `401`  | No valid session, token, or credential was presented.            |
+| `403`  | Authenticated, but not permitted — see below.                    |
+| `404`  | The resource does not exist, or is not visible to you.           |
+| `422`  | Request validation failed (bad query parameter, malformed body). |
+| `429`  | A rate limit or generation quota was exceeded.                   |
+| `5xx`  | Server-side failure.                                             |
 
 `404` is used deliberately in place of `403` for resources that exist but
 belong to another user, so the API does not leak their existence.
@@ -111,14 +112,14 @@ apart:
 
 ## Sections
 
-| Page | Covers |
-|------|--------|
-| [Authentication](authentication.md) | Sessions, SSO, OTP, guests, CSRF, and the token types. |
-| [Articles and search](articles-and-search.md) | The article lifecycle, triage, search, highlights, and tags. |
-| [Sources and ingestion](sources-and-ingestion.md) | Feed management, OPML, ingestion runs, and the scheduler. |
+| Page                                                | Covers                                                       |
+| --------------------------------------------------- | ------------------------------------------------------------ |
+| [Authentication](authentication.md)                 | Sessions, SSO, OTP, guests, CSRF, and the token types.       |
+| [Articles and search](articles-and-search.md)       | The article lifecycle, triage, search, highlights, and tags. |
+| [Sources and ingestion](sources-and-ingestion.md)   | Feed management, OPML, ingestion runs, and the scheduler.    |
 | [Learning and briefings](learning-and-briefings.md) | Briefings, lessons, quizzes, recaps, and podcast generation. |
-| [Integrations](integrations.md) | MCP tools, Google Reader sync, sharing, and podcast feeds. |
-| [Operations](operations.md) | Health probes, metrics, statistics, and admin endpoints. |
+| [Integrations](integrations.md)                     | MCP tools, Google Reader sync, sharing, and podcast feeds.   |
+| [Operations](operations.md)                         | Health probes, metrics, statistics, and admin endpoints.     |
 
 ## Stability
 

--- a/website/docs/api/integrations.md
+++ b/website/docs/api/integrations.md
@@ -12,12 +12,13 @@ or user-initiated.
 ## MCP server
 
 An intentionally narrow, **read-only** FastMCP server lets an MCP-aware AI
-client read news visible to one user. It exposes no mutation, SQL, shell, or
-file-system access and is independent of Keycloak authentication.
+client read news visible to one user. It exposes no mutation, SQL, shell,
+file-system, secret, or direct Keycloak credential access and is independent
+of Keycloak authentication.
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/mcp/` | POST | Stateless Streamable HTTP MCP transport. |
+| Route   | Method | Purpose                                  |
+| ------- | ------ | ---------------------------------------- |
+| `/mcp/` | POST   | Stateless Streamable HTTP MCP transport. |
 
 Authenticate with an MCP token as a bearer credential. Tokens are minted and
 revoked under `/api/users/me/mcp-tokens` — see
@@ -25,15 +26,15 @@ revoked under `/api/users/me/mcp-tokens` — see
 
 ### Available tools
 
-| Tool | Scope | Does |
-|------|-------|------|
-| `list_latest_news` | `search` | List up to 25 recent articles visible to the token owner. |
-| `list_news_sources` | `search` | Page through the token owner's subscribed, enabled, searchable sources. |
-| `search_news` | `search` | Search visible articles with typed filters and offset pagination. |
-| `get_news_article` | `read` | Retrieve one visible article by a strict positive integer ID. |
-| `ask_news` | `ask` | Answer a question over Starred + Done or all visible news, with validated citations. |
-| `list_briefings` | `briefings` | Page through complete saved briefings owned by the token user. |
-| `get_briefing` | `briefings` | Read one owned, complete saved briefing and its currently visible citations. |
+| Tool                | Scope       | Does                                                                                 |
+| ------------------- | ----------- | ------------------------------------------------------------------------------------ |
+| `list_latest_news`  | `search`    | List up to 25 recent articles visible to the token owner.                            |
+| `list_news_sources` | `search`    | Page through the token owner's subscribed, enabled, searchable sources.              |
+| `search_news`       | `search`    | Search visible articles with typed filters and offset pagination.                    |
+| `get_news_article`  | `read`      | Retrieve one visible article by a strict positive integer ID.                        |
+| `ask_news`          | `ask`       | Answer a question over Starred + Done or all visible news, with validated citations. |
+| `list_briefings`    | `briefings` | Page through complete saved briefings owned by the token user.                       |
+| `get_briefing`      | `briefings` | Read one owned, complete saved briefing and its currently visible citations.         |
 
 Each tool requires its own **scope**, and a token only carries the scopes it
 was minted with. News and source tools require `search`; saved-briefing tools
@@ -165,6 +166,10 @@ The server is enabled when `MCP_SERVER_ENABLED` is unset. Set it to `false`,
 
 Setup instructions for specific clients live in
 [Configuration → MCP server](../configuration/mcp-server.md).
+That guide also covers the canonical HTTPS proxy path, exact Host/Origin
+allowlists, `MCP_SERVER_ENABLED=false` shutdown, token rotation, the
+content-free `/api/mcp/health` probe, fixed-cardinality `/metrics`, and
+metadata-only logs.
 
 ## Google Reader sync
 
@@ -175,16 +180,16 @@ support.
 Authenticate with a GReader token from
 `/api/users/me/greader-tokens`. Most readers expect the ClientLogin flow:
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/accounts/ClientLogin` | POST | Exchange credentials for a session. |
-| `/reader/api/0/token` | GET | Fetch the write token. |
-| `/reader/api/0/user-info` | GET | Account metadata. |
-| `/reader/api/0/subscription/list` | GET | Subscribed feeds. |
-| `/reader/api/0/stream/contents/{stream_id}` | GET | Items in a stream. |
-| `/reader/api/0/stream/items/ids` | GET | Item IDs in a stream. |
-| `/reader/api/0/stream/items/contents` | POST | Fetch items by ID. |
-| `/reader/api/0/edit-tag` | POST | Add or remove tags — read/starred state. |
+| Route                                       | Method | Purpose                                  |
+| ------------------------------------------- | ------ | ---------------------------------------- |
+| `/accounts/ClientLogin`                     | POST   | Exchange credentials for a session.      |
+| `/reader/api/0/token`                       | GET    | Fetch the write token.                   |
+| `/reader/api/0/user-info`                   | GET    | Account metadata.                        |
+| `/reader/api/0/subscription/list`           | GET    | Subscribed feeds.                        |
+| `/reader/api/0/stream/contents/{stream_id}` | GET    | Items in a stream.                       |
+| `/reader/api/0/stream/items/ids`            | GET    | Item IDs in a stream.                    |
+| `/reader/api/0/stream/items/contents`       | POST   | Fetch items by ID.                       |
+| `/reader/api/0/edit-tag`                    | POST   | Add or remove tags — read/starred state. |
 
 `edit-tag` is how third-party readers mark items read or starred; those changes
 map onto the same triage state used by the web UI, so the two stay in sync.
@@ -198,23 +203,23 @@ the most stable surface here. Configuration details are in
 Sharing sends an article to another user on the same instance, with a threaded
 conversation attached. It is instance-internal — not public link sharing.
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/users` | GET | Users you can share with. |
-| `/api/articles/{article_id}/share` | POST | Share an article. |
-| `/api/shares` | GET | Shares you received. |
-| `/api/shares/sent` | GET | Shares you sent. |
-| `/api/shares/unread_count` | GET | Badge count. |
-| `/api/shares/{share_id}` | GET | One share. |
-| `/api/shares/{share_id}/read` | POST | Mark as read. |
-| `/api/shares/{share_id}/revoke` | POST | Revoke a share you sent. |
+| Route                              | Method | Purpose                   |
+| ---------------------------------- | ------ | ------------------------- |
+| `/api/users`                       | GET    | Users you can share with. |
+| `/api/articles/{article_id}/share` | POST   | Share an article.         |
+| `/api/shares`                      | GET    | Shares you received.      |
+| `/api/shares/sent`                 | GET    | Shares you sent.          |
+| `/api/shares/unread_count`         | GET    | Badge count.              |
+| `/api/shares/{share_id}`           | GET    | One share.                |
+| `/api/shares/{share_id}/read`      | POST   | Mark as read.             |
+| `/api/shares/{share_id}/revoke`    | POST   | Revoke a share you sent.  |
 
 ### Shared article content
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/shares/{share_id}/article` | GET | The shared article. |
-| `/api/shares/{share_id}/article/body` | POST | Extract its body. |
+| Route                                 | Method | Purpose             |
+| ------------------------------------- | ------ | ------------------- |
+| `/api/shares/{share_id}/article`      | GET    | The shared article. |
+| `/api/shares/{share_id}/article/body` | POST   | Extract its body.   |
 
 The recipient reads the article through the **share**, not through
 `/api/articles/{id}`. The share is the grant, so revoking it withdraws access
@@ -222,21 +227,21 @@ rather than leaving a dangling readable article.
 
 ### Discussion
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/shares/{share_id}/messages` | GET / POST | Conversation on a share. |
-| `/api/shares/{share_id}/annotations` | GET / POST | Inline annotations. |
+| Route                                | Method     | Purpose                  |
+| ------------------------------------ | ---------- | ------------------------ |
+| `/api/shares/{share_id}/messages`    | GET / POST | Conversation on a share. |
+| `/api/shares/{share_id}/annotations` | GET / POST | Inline annotations.      |
 
 Messages are share-level discussion; annotations anchor to positions in the
 article body.
 
 ## Push notifications
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/api/notifications/subscribe` | POST | Register a Web Push subscription. |
-| `/api/notifications/subscribe` | DELETE | Unregister it. |
-| `/api/settings/notifications` | GET / PUT | Notification preferences. |
+| Route                          | Method    | Purpose                           |
+| ------------------------------ | --------- | --------------------------------- |
+| `/api/notifications/subscribe` | POST      | Register a Web Push subscription. |
+| `/api/notifications/subscribe` | DELETE    | Unregister it.                    |
+| `/api/settings/notifications`  | GET / PUT | Notification preferences.         |
 
 Notification settings include briefing delivery time, timezone, whether push is
 enabled, weekly recap day, and whether to include reading-list items (capped at
@@ -245,10 +250,10 @@ recap day must be one of `mon`–`sun`.
 
 ## Analytics preferences
 
-| Route | Method | Purpose |
-|-------|--------|---------|
+| Route                     | Method    | Purpose                     |
+| ------------------------- | --------- | --------------------------- |
 | `/api/settings/analytics` | GET / PUT | Opt in or out of analytics. |
-| `/api/events` | POST | Record a client-side event. |
+| `/api/events`             | POST      | Record a client-side event. |
 
 Event recording honors the analytics preference — opting out stops collection
 rather than merely hiding it. See [PRIVACY.md](https://github.com/lihor-hub/news-dashboard/blob/main/PRIVACY.md)

--- a/website/docs/configuration/mcp-server.md
+++ b/website/docs/configuration/mcp-server.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 
 # MCP server
 
-News Dashboard exposes a read-only [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server at `/mcp`. MCP-aware AI clients connect with stateless Streamable HTTP and see only news visible to the token owner.
+News Dashboard exposes a read-only [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server at `/mcp/` on the same listener as the web application. MCP-aware AI clients connect with stateless Streamable HTTP and see only news visible to the token owner.
 
 The server is enabled by default. To shut down MCP access and block creation of new MCP tokens, set:
 
@@ -44,15 +44,15 @@ Use HTTPS outside a trusted local development environment. Do not put the token 
 
 ## Available tools
 
-| Tool | Scope | Description |
-|------|-------|-------------|
-| `list_latest_news` | `search` | Lists recent articles visible to the token owner. Supports source, category, state, archive, and date-range filters. |
-| `list_news_sources` | `search` | Pages through the token owner's subscribed, enabled sources that can be used with `search_news`. |
-| `search_news` | `search` | Searches visible articles with typed filters and offset pagination. An empty query returns a filtered recent listing. |
-| `get_news_article` | `read` | Retrieves one visible article by its positive integer article ID. |
-| `ask_news` | `ask` | Answers a question from a bounded, user-visible news corpus and returns validated citations. |
-| `list_briefings` | `briefings` | Pages through complete saved briefings owned by the token user. |
-| `get_briefing` | `briefings` | Retrieves one complete saved briefing owned by the token user, including safe visible citations. |
+| Tool                | Scope       | Description                                                                                                           |
+| ------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `list_latest_news`  | `search`    | Lists recent articles visible to the token owner. Supports source, category, state, archive, and date-range filters.  |
+| `list_news_sources` | `search`    | Pages through the token owner's subscribed, enabled sources that can be used with `search_news`.                      |
+| `search_news`       | `search`    | Searches visible articles with typed filters and offset pagination. An empty query returns a filtered recent listing. |
+| `get_news_article`  | `read`      | Retrieves one visible article by its positive integer article ID.                                                     |
+| `ask_news`          | `ask`       | Answers a question from a bounded, user-visible news corpus and returns validated citations.                          |
+| `list_briefings`    | `briefings` | Pages through complete saved briefings owned by the token user.                                                       |
+| `get_briefing`      | `briefings` | Retrieves one complete saved briefing owned by the token user, including safe visible citations.                      |
 
 Use `list_news_sources` before filtering by source. It returns only sources that are both subscribed and enabled for the authenticated user, in deterministic category, descending priority, name, then slug order. Sources whose exact slug or category is not a valid search filter value are omitted. Each source has `slug`, `name`, `category`, and `kind`; raw feed URLs, ownership identifiers, and internal state are omitted. The exact `slug` and `category` are valid `search_news` filters. Display-only `name` and `kind` values are capped at 120 characters and may be shortened further when JSON escaping requires it to stay within the 4,800-byte budget.
 
@@ -62,17 +62,17 @@ Every source page uses the `{sources, truncated, next_cursor}` envelope. `trunca
 
 `search_news` accepts these arguments:
 
-| Argument | Type and bounds | Behavior |
-|----------|-----------------|----------|
-| `q` | string, at most 2,000 characters; default `""` | Full-text query. An empty value returns the filtered recent listing in the web search's canonical order. |
-| `sources` | up to 50 non-empty strings, each at most 120 characters | Source slugs from `list_news_sources`. |
-| `categories` | up to 50 non-empty strings, each at most 120 characters | Source categories. |
-| `date_range` | `all`, `day`, `week`, or `month`; default `all` | Filters by discovery time. `day`, `week`, and `month` cover the trailing 1, 7, and 30 days. |
-| `states` | up to 50 values from `today`, `later`, `done`, `skipped`, `archived` | Workflow states belonging to the token owner. |
-| `starred_only` | boolean; default `false` | Returns only articles starred by the token owner. |
-| `include_archived` | boolean; default `false` | Includes archived articles. Explicitly filtering for the `archived` state overrides the default exclusion. |
-| `limit` | integer from 1 through 25; default 10 | Maximum number of articles requested. |
-| `offset` | integer from 0 through 10,000; default 0 | Number of matching articles to skip for pagination. |
+| Argument           | Type and bounds                                                      | Behavior                                                                                                   |
+| ------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `q`                | string, at most 2,000 characters; default `""`                       | Full-text query. An empty value returns the filtered recent listing in the web search's canonical order.   |
+| `sources`          | up to 50 non-empty strings, each at most 120 characters              | Source slugs from `list_news_sources`.                                                                     |
+| `categories`       | up to 50 non-empty strings, each at most 120 characters              | Source categories.                                                                                         |
+| `date_range`       | `all`, `day`, `week`, or `month`; default `all`                      | Filters by discovery time. `day`, `week`, and `month` cover the trailing 1, 7, and 30 days.                |
+| `states`           | up to 50 values from `today`, `later`, `done`, `skipped`, `archived` | Workflow states belonging to the token owner.                                                              |
+| `starred_only`     | boolean; default `false`                                             | Returns only articles starred by the token owner.                                                          |
+| `include_archived` | boolean; default `false`                                             | Includes archived articles. Explicitly filtering for the `archived` state overrides the default exclusion. |
+| `limit`            | integer from 1 through 25; default 10                                | Maximum number of articles requested.                                                                      |
+| `offset`           | integer from 0 through 10,000; default 0                             | Number of matching articles to skip for pagination.                                                        |
 
 Values within one filter group combine with OR; separate filter groups combine with AND. Search results contain complete compact records with `id`, `title`, canonical `url`, `source_slug`, `source_name`, `category`, `published_at`, `summary`, the token owner's `state`, and the token owner's `starred` value. They never contain article bodies.
 
@@ -108,7 +108,7 @@ Call `get_news_article` with one `article_id`: a strict positive integer no larg
 A missing ID and an article outside the token owner's visibility boundary return the same sentinel, without an existence hint:
 
 ```json
-{"found": false, "article": null, "truncated": false}
+{ "found": false, "article": null, "truncated": false }
 ```
 
 The visibility boundary includes private-source ownership and enabled global subscriptions. A private article owned by someone else, an article from a globally disabled subscription, and an article available only through an in-app share are not readable through this tool. Shared content must be read through its separate share capability.
@@ -129,15 +129,15 @@ The instance needs `FREE_LLM_API_KEY` (preferred) or `OPENAI_API_KEY`, plus the 
 
 The dedicated per-token generation bucket permits a burst of 2 and refills one request every 30 seconds. This is separate from the general MCP limit. Stable errors are:
 
-| Code | Stable public message | Retry guidance |
-|------|-----------------------|----------------|
-| `ask_not_configured` | `News answering is not configured.` | Configure AI credentials; do not retry unchanged. |
-| `embedding_unavailable` | `News retrieval is temporarily unavailable.` | Retry with backoff. |
-| `provider_authentication_failed` | `News answering provider authentication failed.` | Repair provider credentials; do not retry unchanged. |
-| `provider_rate_limited` | `News answering provider is rate limited; retry later.` | Retry with provider-aware backoff. |
-| `ask_timeout` | `News answering timed out; retry later.` | Retry with backoff. |
-| `ask_rate_limited` | `News answering rate limit exceeded; retry later.` | Wait at least 30 seconds before retrying. |
-| `ask_unavailable` | `News answering is temporarily unavailable.` | Retry with backoff. |
+| Code                             | Stable public message                                   | Retry guidance                                       |
+| -------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
+| `ask_not_configured`             | `News answering is not configured.`                     | Configure AI credentials; do not retry unchanged.    |
+| `embedding_unavailable`          | `News retrieval is temporarily unavailable.`            | Retry with backoff.                                  |
+| `provider_authentication_failed` | `News answering provider authentication failed.`        | Repair provider credentials; do not retry unchanged. |
+| `provider_rate_limited`          | `News answering provider is rate limited; retry later.` | Retry with provider-aware backoff.                   |
+| `ask_timeout`                    | `News answering timed out; retry later.`                | Retry with backoff.                                  |
+| `ask_rate_limited`               | `News answering rate limit exceeded; retry later.`      | Wait at least 30 seconds before retrying.            |
+| `ask_unavailable`                | `News answering is temporarily unavailable.`            | Retry with backoff.                                  |
 
 When Langfuse is enabled, MCP Ask traces contain operational metadata only: authenticated user attribution, surface and corpus tags, model, token usage, provider-reported cost, character and citation counts, timing, and status. They exclude bearer tokens, questions, article text, prompts, source titles/URLs, generated answers, provider response bodies, and exception details. Application logs follow the same content-free boundary.
 
@@ -207,6 +207,80 @@ The briefing tools only read previously saved results. They cannot generate or r
 
 MCP clients should use tool discovery rather than assuming a deployment exposes every tool. The separately configured A2A endpoint remains ask-only and does not advertise briefing tools.
 
+## Client examples
+
+Keep the one-time bearer value in an environment variable rather than a checked-in file, URL, or command argument:
+
+```bash
+export MCP_TOKEN='ndmcp_replace-with-the-one-time-value'
+```
+
+A FastMCP Python client can read the credential at runtime:
+
+```python
+import asyncio
+import os
+
+from fastmcp import Client
+
+
+async def main() -> None:
+    async with Client(
+        "https://news.example.com/mcp/",
+        auth=os.environ["MCP_TOKEN"],
+    ) as client:
+        result = await client.call_tool("search_news", {"q": "PostgreSQL"})
+        print(result.structured_content)
+
+
+asyncio.run(main())
+```
+
+Claude Code supports an environment placeholder in a project `.mcp.json`. Commit the placeholder, never the resolved token:
+
+```json
+{
+  "mcpServers": {
+    "news-dashboard": {
+      "type": "http",
+      "url": "https://news.example.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${MCP_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+## Deploy behind HTTPS
+
+The canonical public URL is `https://news.example.com/mcp/`. Terminate TLS at the reverse proxy and preserve the `/mcp/` path, request method, `Authorization`, `Host`, and streaming response. Do not rewrite the path to the SPA or publish another service, port, or database endpoint.
+
+Set `APP_BASE_URL=https://news.example.com` to derive the default exact Host and Origin, or configure both allowlists explicitly:
+
+```bash
+MCP_ALLOWED_HOSTS=news.example.com
+MCP_ALLOWED_ORIGINS=https://news.example.com
+```
+
+Values are comma-separated exact authorities or origins; wildcards are rejected. The proxy must forward `Host: news.example.com`. Server-to-server clients may omit `Origin`; a client that supplies it must use exactly `Origin: https://news.example.com`. A Host or supplied Origin outside the allowlist is rejected before MCP initialization. These allowlists are separate from browser CORS configuration.
+
+Compose and Helm enable MCP by default. Set `MCP_SERVER_ENABLED=false` in the application environment or Helm MCP value to shut down `/mcp/` and block new token creation. Existing token hashes remain stored for later re-enablement or explicit revocation.
+
+## Operate and monitor
+
+`GET /api/mcp/health` is an unauthenticated, content-free readiness probe:
+
+| Body                              | HTTP | Meaning                                                                     |
+| --------------------------------- | ---- | --------------------------------------------------------------------------- |
+| `{"status":"disabled"}`           | 200  | MCP is explicitly disabled; PostgreSQL is not checked.                      |
+| `{"status":"healthy"}`            | 200  | MCP is enabled and its bounded PostgreSQL dependency check passed.          |
+| `{"status":"dependency_failure"}` | 503  | The dependency check failed; no exception or connection detail is returned. |
+
+When `METRICS_ENABLED=true`, `/metrics` includes `news_dashboard_mcp_auth_attempts_total`, `news_dashboard_mcp_tool_calls_total`, `news_dashboard_mcp_tool_duration_seconds`, `news_dashboard_mcp_rate_limits_total`, and `news_dashboard_mcp_response_limits_total`. Labels contain only bounded status and catalog tool values—never token IDs, user IDs, arguments, URLs, questions, or content.
+
+Structured application logs record authentication status and a non-secret numeric token ID, or tool name, outcome, and duration. They never record bearer values, tool arguments, article or briefing bodies, questions, prompts, generated answers, provider responses, URLs, or exception text. Rotate a suspected credential by revoking it, creating a least-privilege replacement, updating the client's `MCP_TOKEN`, verifying the replacement, and removing the old secret from the client environment.
+
 ## Security boundaries
 
 - Tokens are individually scoped and revocable; revoked tokens stop authenticating immediately.
@@ -215,5 +289,6 @@ MCP clients should use tool discovery rather than assuming a deployment exposes 
 - Internal failures return a generic error without tracebacks, database details, or provider details.
 - Tools cannot run SQL, shell commands, or file-system operations and cannot read secrets.
 - Mutation tools are absent. MCP access cannot change article state, sources, shares, or settings.
+- MCP tokens neither contain nor expose direct Keycloak credentials and do not reuse browser sessions.
 - Private-source visibility is enforced for the authenticated token owner.
 - Article misses do not distinguish absent IDs from unauthorized IDs.

--- a/website/docs/configuration/mcp-server.md
+++ b/website/docs/configuration/mcp-server.md
@@ -209,10 +209,13 @@ MCP clients should use tool discovery rather than assuming a deployment exposes 
 
 ## Client examples
 
-Keep the one-time bearer value in an environment variable rather than a checked-in file, URL, or command argument:
+Keep the endpoint and one-time bearer value in environment variables rather than a checked-in file, URL, command argument, or shell-history entry. The hidden prompt below does not place the token value in the command itself:
 
 ```bash
-export MCP_TOKEN='ndmcp_replace-with-the-one-time-value'
+export NEWS_DASHBOARD_MCP_URL='https://news.example.com/mcp/'
+read -rsp 'News Dashboard MCP token: ' NEWS_DASHBOARD_MCP_TOKEN
+export NEWS_DASHBOARD_MCP_TOKEN
+printf '\n'
 ```
 
 A FastMCP Python client can read the credential at runtime:
@@ -226,8 +229,8 @@ from fastmcp import Client
 
 async def main() -> None:
     async with Client(
-        "https://news.example.com/mcp/",
-        auth=os.environ["MCP_TOKEN"],
+        os.environ["NEWS_DASHBOARD_MCP_URL"],
+        auth=os.environ["NEWS_DASHBOARD_MCP_TOKEN"],
     ) as client:
         result = await client.call_tool("search_news", {"q": "PostgreSQL"})
         print(result.structured_content)
@@ -243,9 +246,9 @@ Claude Code supports an environment placeholder in a project `.mcp.json`. Commit
   "mcpServers": {
     "news-dashboard": {
       "type": "http",
-      "url": "https://news.example.com/mcp/",
+      "url": "${NEWS_DASHBOARD_MCP_URL}",
       "headers": {
-        "Authorization": "Bearer ${MCP_TOKEN}"
+        "Authorization": "Bearer ${NEWS_DASHBOARD_MCP_TOKEN}"
       }
     }
   }


### PR DESCRIPTION
## Summary

- enable FastMCP explicitly across Compose and Helm on the existing application listener, with exact Host/Origin protection and an explicit shutdown flag
- add content-free MCP health, fixed-cardinality metrics, metadata-only operational logs, and bounded dependency checks
- add mounted seven-tool FastMCP integration coverage plus a merge-gating real-container transport smoke
- complete Settings, operator, reverse-proxy, security, token-lifecycle, FastMCP client, and Claude Code documentation

Closes #1372

## Verification

- `make lint`
- `make typecheck`
- `PGOPTIONS='-c max_parallel_workers_per_gather=0' dotenv run -- make test` — 3,395 backend passed, 2 skipped; 1,044 frontend passed
- focused MCP operations/integration/deployment suites — 88 passed
- `make helm-validate` — 17 security tests passed plus default/production/external renders
- `npm --prefix website run build`
- all supported Compose files render with safe placeholders
- container smoke is merge-gating in Ubuntu CI; local execution unavailable because Docker Desktop daemon is off

## Security notes

- MCP remains independent of Keycloak and exposes no separate service or database port.
- Metrics never label by token/user/content; logs contain only fixed metadata and optional numeric token row IDs.
- Client examples keep bearer values out of tracked files, command arguments, and shell history.
- Existing npm audit baseline remains two high-severity transitive advisories; this change adds no npm dependency.
